### PR TITLE
Tool restriction

### DIFF
--- a/src/main/java/com/minecolonies/coremod/entity/ai/basic/AbstractEntityAIBasic.java
+++ b/src/main/java/com/minecolonies/coremod/entity/ai/basic/AbstractEntityAIBasic.java
@@ -536,7 +536,7 @@ public abstract class AbstractEntityAIBasic<J extends AbstractJob> extends Abstr
 
         final int hutLevel = worker.getWorkBuilding().getBuildingLevel();
         final InventoryCitizen inventory = worker.getInventoryCitizen();
-        final boolean isUsable = Utils.hasToolLevel(tool, inventory, hutLevel);
+        final boolean isUsable = InventoryUtils.hasToolLevel(tool, inventory, hutLevel);
 
 
         if (!needsTool && isUsable)
@@ -661,7 +661,7 @@ public abstract class AbstractEntityAIBasic<J extends AbstractJob> extends Abstr
 
         final InventoryCitizen inventory = worker.getInventoryCitizen();
         final int hutLevel = worker.getWorkBuilding().getBuildingLevel();
-        final boolean isUsable = Utils.hasToolLevel(Utils.PICKAXE, inventory, hutLevel);
+        final boolean isUsable = InventoryUtils.hasToolLevel(Utils.PICKAXE, inventory, hutLevel);
 
         if (!isUsable)
         {
@@ -1123,7 +1123,7 @@ public abstract class AbstractEntityAIBasic<J extends AbstractJob> extends Abstr
 
             if (level >= required && level < bestLevel)
             {
-                if (tool == null || Utils.verifyToolLevel(item, level, hutLevel))
+                if (tool == null || InventoryUtils.verifyToolLevel(item, level, hutLevel))
                 {
                     bestSlot = i;
                     bestLevel = level;

--- a/src/main/java/com/minecolonies/coremod/entity/ai/basic/AbstractEntityAIBasic.java
+++ b/src/main/java/com/minecolonies/coremod/entity/ai/basic/AbstractEntityAIBasic.java
@@ -31,15 +31,15 @@ public abstract class AbstractEntityAIBasic<J extends AbstractJob> extends Abstr
     /**
      * Time in ticks to wait until the next check for items.
      */
-    private static final int DELAY_RECHECK = 10;
+    private static final int             DELAY_RECHECK           = 10;
     /**
      * The default range for any walking to blocks.
      */
-    private static final int DEFAULT_RANGE_FOR_DELAY = 4;
+    private static final int             DEFAULT_RANGE_FOR_DELAY = 4;
     /**
      * The number of actions done before item dump.
      */
-    private static final int ACTIONS_UNTIL_DUMP = 32;
+    private static final int             ACTIONS_UNTIL_DUMP      = 32;
     /**
      * Hit a block every x ticks when mining.
      */
@@ -519,7 +519,7 @@ public abstract class AbstractEntityAIBasic<J extends AbstractJob> extends Abstr
         return needsShovel;
     }
 
-     /**
+    /**
      * Ensures that we have a tool available.
      *
      * @param tool tool required for block
@@ -639,7 +639,7 @@ public abstract class AbstractEntityAIBasic<J extends AbstractJob> extends Abstr
         return IDLE;
     }
 
-   /**
+    /**
      * Ensures that we have a pickaxe available.
      * Will set {@code needsPickaxe} accordingly.
      *
@@ -683,7 +683,7 @@ public abstract class AbstractEntityAIBasic<J extends AbstractJob> extends Abstr
 
         return needsPickaxe;
     }
-    
+
     /**
      * Looks for a pickaxe to mine a block of {@code minLevel}.
      * The pickaxe will be taken from the chest.
@@ -1107,7 +1107,7 @@ public abstract class AbstractEntityAIBasic<J extends AbstractJob> extends Abstr
      * @param target the Block type to mine
      * @return the slot with the best tool
      */
-   private int getMostEfficientTool(@NotNull final Block target)
+    private int getMostEfficientTool(@NotNull final Block target)
     {
         final String tool = target.getHarvestTool(target.getDefaultState());
         final int required = target.getHarvestLevel(target.getDefaultState());

--- a/src/main/java/com/minecolonies/coremod/entity/ai/basic/AbstractEntityAIBasic.java
+++ b/src/main/java/com/minecolonies/coremod/entity/ai/basic/AbstractEntityAIBasic.java
@@ -552,7 +552,7 @@ public abstract class AbstractEntityAIBasic<J extends AbstractJob> extends Abstr
         {
             return false;
         }
-        chatSpamFilter.talkWithoutSpam(LanguageHandler.format("entity.worker.toolRequest", tool, hutLevel));
+        chatSpamFilter.talkWithoutSpam(LanguageHandler.format("entity.worker.toolRequest", tool, InventoryUtils.swapToolGrade(hutLevel)));
         return true;
     }
 
@@ -678,7 +678,7 @@ public abstract class AbstractEntityAIBasic<J extends AbstractJob> extends Abstr
             {
                 return true;
             }
-            chatSpamFilter.talkWithoutSpam(LanguageHandler.format("entity.worker.pickaxeRequest", minlevel, hutLevel));
+            chatSpamFilter.talkWithoutSpam(LanguageHandler.format("entity.worker.pickaxeRequest", InventoryUtils.swapToolGrade(minlevel), InventoryUtils.swapToolGrade(hutLevel)));
         }
 
         return needsPickaxe;

--- a/src/main/java/com/minecolonies/coremod/entity/ai/basic/AbstractEntityAIBasic.java
+++ b/src/main/java/com/minecolonies/coremod/entity/ai/basic/AbstractEntityAIBasic.java
@@ -525,7 +525,7 @@ public abstract class AbstractEntityAIBasic<J extends AbstractJob> extends Abstr
      * @param tool tool required for block
      * @return true if we have a tool
      */
-   private boolean checkForTool(@NotNull String tool)
+    private boolean checkForTool(@NotNull String tool)
     {
         final boolean needsTool = !InventoryFunctions
                                      .matchFirstInInventory(
@@ -534,8 +534,10 @@ public abstract class AbstractEntityAIBasic<J extends AbstractJob> extends Abstr
                                        InventoryFunctions::doNothing
                                      );
 
-        final boolean isUsable = Utils.hasToolLevel(tool, worker);
         final int hutLevel = worker.getWorkBuilding().getBuildingLevel();
+        final InventoryCitizen inventory = worker.getInventoryCitizen();
+        final boolean isUsable = Utils.hasToolLevel(tool, inventory, hutLevel);
+
 
         if (!needsTool && isUsable)
         {
@@ -644,7 +646,7 @@ public abstract class AbstractEntityAIBasic<J extends AbstractJob> extends Abstr
      * @param minlevel the minimum pickaxe level needed.
      * @return true if we have a pickaxe
      */
-     private boolean checkForPickaxe(final int minlevel)
+    private boolean checkForPickaxe(final int minlevel)
     {
         //Check for a pickaxe
         needsPickaxe = !InventoryFunctions
@@ -657,8 +659,9 @@ public abstract class AbstractEntityAIBasic<J extends AbstractJob> extends Abstr
 
         delay += DELAY_RECHECK;
 
+        final InventoryCitizen inventory = worker.getInventoryCitizen();
         final int hutLevel = worker.getWorkBuilding().getBuildingLevel();
-        final boolean isUsable = Utils.hasToolLevel(Utils.PICKAXE, worker);
+        final boolean isUsable = Utils.hasToolLevel(Utils.PICKAXE, inventory, hutLevel);
 
         if (!isUsable)
         {
@@ -1104,13 +1107,14 @@ public abstract class AbstractEntityAIBasic<J extends AbstractJob> extends Abstr
      * @param target the Block type to mine
      * @return the slot with the best tool
      */
-    private int getMostEfficientTool(@NotNull final Block target)
+   private int getMostEfficientTool(@NotNull final Block target)
     {
         final String tool = target.getHarvestTool(target.getDefaultState());
         final int required = target.getHarvestLevel(target.getDefaultState());
         int bestSlot = -1;
         int bestLevel = Integer.MAX_VALUE;
-        @NotNull InventoryCitizen inventory = worker.getInventoryCitizen();
+        @NotNull final InventoryCitizen inventory = worker.getInventoryCitizen();
+        final int hutLevel = worker.getWorkBuilding().getBuildingLevel();
 
         for (int i = 0; i < inventory.getSizeInventory(); i++)
         {
@@ -1119,7 +1123,7 @@ public abstract class AbstractEntityAIBasic<J extends AbstractJob> extends Abstr
 
             if (level >= required && level < bestLevel)
             {
-                if (tool == null || Utils.verifyToolLevel(item, level, worker))
+                if (tool == null || Utils.verifyToolLevel(item, level, hutLevel))
                 {
                     bestSlot = i;
                     bestLevel = level;

--- a/src/main/java/com/minecolonies/coremod/entity/ai/basic/AbstractEntityAIBasic.java
+++ b/src/main/java/com/minecolonies/coremod/entity/ai/basic/AbstractEntityAIBasic.java
@@ -550,8 +550,7 @@ public abstract class AbstractEntityAIBasic<J extends AbstractJob> extends Abstr
         {
             return false;
         }
-        String message = LanguageHandler.format("entity.worker.toolRequest",tool,hutLevel);
-        chatSpamFilter.talkWithoutSpam(message);
+        chatSpamFilter.talkWithoutSpam(LanguageHandler.format("entity.worker.toolRequest",tool,hutLevel));
         return true;
     }
 
@@ -676,8 +675,7 @@ public abstract class AbstractEntityAIBasic<J extends AbstractJob> extends Abstr
             {
                 return true;
             }
-            String message = LanguageHandler.format("entity.worker.pickaxeRequest",minlevel,hutLevel);
-            chatSpamFilter.talkWithoutSpam(message);
+            chatSpamFilter.talkWithoutSpam(LanguageHandler.format("entity.worker.pickaxeRequest",minlevel,hutLevel));
         }
 
         return needsPickaxe;

--- a/src/main/java/com/minecolonies/coremod/entity/ai/basic/AbstractEntityAIBasic.java
+++ b/src/main/java/com/minecolonies/coremod/entity/ai/basic/AbstractEntityAIBasic.java
@@ -552,7 +552,7 @@ public abstract class AbstractEntityAIBasic<J extends AbstractJob> extends Abstr
         {
             return false;
         }
-        chatSpamFilter.talkWithoutSpam(LanguageHandler.format("entity.worker.toolRequest",tool,hutLevel));
+        chatSpamFilter.talkWithoutSpam(LanguageHandler.format("entity.worker.toolRequest", tool, hutLevel));
         return true;
     }
 
@@ -678,7 +678,7 @@ public abstract class AbstractEntityAIBasic<J extends AbstractJob> extends Abstr
             {
                 return true;
             }
-            chatSpamFilter.talkWithoutSpam(LanguageHandler.format("entity.worker.pickaxeRequest",minlevel,hutLevel));
+            chatSpamFilter.talkWithoutSpam(LanguageHandler.format("entity.worker.pickaxeRequest", minlevel, hutLevel));
         }
 
         return needsPickaxe;

--- a/src/main/java/com/minecolonies/coremod/util/InventoryUtils.java
+++ b/src/main/java/com/minecolonies/coremod/util/InventoryUtils.java
@@ -1,6 +1,6 @@
 package com.minecolonies.coremod.util;
 
-import com.minecolonies.inventory.coremod.InventoryCitizen;
+import com.minecolonies.coremod.inventory.InventoryCitizen;
 import net.minecraft.block.Block;
 import net.minecraft.inventory.IInventory;
 import net.minecraft.item.Item;

--- a/src/main/java/com/minecolonies/coremod/util/InventoryUtils.java
+++ b/src/main/java/com/minecolonies/coremod/util/InventoryUtils.java
@@ -16,10 +16,10 @@ import java.util.List;
  */
 public class InventoryUtils
 {
-    
-    public static final int FREE_TOOL_CHOICE_LEVEL = 4;
+
+    public static final int FREE_TOOL_CHOICE_LEVEL   = 4;
     public static final int EFFECT_TOOL_CHOICE_LEVEL = 2;
-    
+
     /**
      * Private constructor to hide the implicit one.
      */
@@ -627,15 +627,14 @@ public class InventoryUtils
 
         return -1;
     }
-    
-    
+
     /**
      * Verifies if there is one tool with an acceptable level
      * in a worker's inventory.
      *
-     * @param tool   the type of tool needed
+     * @param tool      the type of tool needed
      * @param inventory the worker's inventory
-     * @param hutLevel the worker's hut level
+     * @param hutLevel  the worker's hut level
      * @return true if tool is acceptable
      */
     public static boolean hasToolLevel(final String tool, @NotNull final InventoryCitizen inventory, final int hutLevel)
@@ -656,8 +655,8 @@ public class InventoryUtils
     /**
      * Verifies if an item has an appropriated grade.
      *
-     * @param item   the type of tool needed
-     * @param level  the type of tool needed
+     * @param item     the type of tool needed
+     * @param level    the type of tool needed
      * @param hutLevel the worker's hut level
      * @return true if tool is acceptable
      */
@@ -667,7 +666,7 @@ public class InventoryUtils
         {
             return true;
         }
-        else if (item.hasEffect() && hutLevel <= EFFECT_TOOL_CHOICE_LEVEL )
+        else if (item.hasEffect() && hutLevel <= EFFECT_TOOL_CHOICE_LEVEL)
         {
             return false;
         }
@@ -678,7 +677,7 @@ public class InventoryUtils
 
         return false;
     }
-    
+
     /**
      * Assigns a string containing the grade of the toolGrade.
      *
@@ -687,14 +686,18 @@ public class InventoryUtils
      */
     public static String swapToolGrade(final int toolGrade)
     {
-        switch(toolGrade)
+        switch (toolGrade)
         {
-            case 0: return "Wood or Gold";
-            case 1: return "Stone";
-            case 2: return "Iron";
-            case 3: return "Diamond";
-            default: return "";
+            case 0:
+                return "Wood or Gold";
+            case 1:
+                return "Stone";
+            case 2:
+                return "Iron";
+            case 3:
+                return "Diamond";
+            default:
+                return "";
         }
     }
-    
 }

--- a/src/main/java/com/minecolonies/coremod/util/InventoryUtils.java
+++ b/src/main/java/com/minecolonies/coremod/util/InventoryUtils.java
@@ -1,5 +1,6 @@
 package com.minecolonies.coremod.util;
 
+import com.minecolonies.inventory.coremod.InventoryCitizen;
 import net.minecraft.block.Block;
 import net.minecraft.inventory.IInventory;
 import net.minecraft.item.Item;
@@ -15,6 +16,10 @@ import java.util.List;
  */
 public class InventoryUtils
 {
+    
+    public static final int FREE_TOOL_CHOICE_LEVEL = 4;
+    public static final int EFFECT_TOOL_CHOICE_LEVEL = 2;
+    
     /**
      * Private constructor to hide the implicit one.
      */
@@ -621,5 +626,56 @@ public class InventoryUtils
         }
 
         return -1;
+    }
+    
+    
+    /**
+     * Verifies if there is one tool with an acceptable level
+     * in a worker's inventory.
+     *
+     * @param tool   the type of tool needed
+     * @param inventory the worker's inventory
+     * @param hutLevel the worker's hut level
+     * @return true if tool is acceptable
+     */
+    public static boolean hasToolLevel(final String tool, @NotNull final InventoryCitizen inventory, final int hutLevel)
+    {
+        for (int i = 0; i < inventory.getSizeInventory(); i++)
+        {
+            final ItemStack item = inventory.getStackInSlot(i);
+            final int level = Utils.getMiningLevel(item, tool);
+
+            if (Utils.isTool(item, tool) && verifyToolLevel(item, level, hutLevel))
+            {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
+     * Verifies if an item has an appropriated grade
+     *
+     * @param item   the type of tool needed
+     * @param level  the type of tool needed
+     * @param hutLevel the worker's hut level
+     * @return true if tool is acceptable
+     */
+    public static boolean verifyToolLevel(final ItemStack item, int level, final int hutLevel)
+    {
+        if (item == null || hutLevel > FREE_TOOL_CHOICE_LEVEL)
+        {
+            return true;
+        }
+        else if (item.hasEffect() && hutLevel <= EFFECT_TOOL_CHOICE_LEVEL )
+        {
+            return false;
+        }
+        else if (hutLevel >= level)
+        {
+            return true;
+        }
+
+        return false;
     }
 }

--- a/src/main/java/com/minecolonies/coremod/util/InventoryUtils.java
+++ b/src/main/java/com/minecolonies/coremod/util/InventoryUtils.java
@@ -678,4 +678,23 @@ public class InventoryUtils
 
         return false;
     }
+    
+    /**
+     * Assigns a string containing the grade of the toolGrade.
+     *
+     * @param toolGrade the number of the grade of a tool
+     * @return a string corresponding to the tool
+     */
+    public static String swapToolGrade(final int toolGrade)
+    {
+        switch(toolGrade)
+        {
+            case 0: return "Wood or Gold";
+            case 1: return "Stone";
+            case 2: return "Iron";
+            case 3: return "Diamond";
+            default: return "";
+        }
+    }
+    
 }

--- a/src/main/java/com/minecolonies/coremod/util/InventoryUtils.java
+++ b/src/main/java/com/minecolonies/coremod/util/InventoryUtils.java
@@ -654,7 +654,7 @@ public class InventoryUtils
     }
 
     /**
-     * Verifies if an item has an appropriated grade
+     * Verifies if an item has an appropriated grade.
      *
      * @param item   the type of tool needed
      * @param level  the type of tool needed

--- a/src/main/java/com/minecolonies/coremod/util/Utils.java
+++ b/src/main/java/com/minecolonies/coremod/util/Utils.java
@@ -1,7 +1,6 @@
 package com.minecolonies.coremod.util;
 
 import com.minecolonies.compatibility.Compatibility;
-import com.minecolonies.coremod.inventory.InventoryCitizen;
 import net.minecraft.block.Block;
 import net.minecraft.init.Blocks;
 import net.minecraft.item.ItemHoe;

--- a/src/main/java/com/minecolonies/coremod/util/Utils.java
+++ b/src/main/java/com/minecolonies/coremod/util/Utils.java
@@ -1,13 +1,17 @@
 package com.minecolonies.coremod.util;
 
 import com.minecolonies.compatibility.Compatibility;
+import com.minecolonies.entity.EntityCitizen;
+import com.minecolonies.inventory.InventoryCitizen;
 import net.minecraft.block.Block;
+import net.minecraft.block.SoundType;
 import net.minecraft.init.Blocks;
 import net.minecraft.item.ItemHoe;
 import net.minecraft.item.ItemStack;
 import net.minecraft.item.ItemSword;
 import net.minecraft.item.ItemTool;
 import net.minecraft.nbt.NBTTagList;
+import net.minecraft.util.SoundCategory;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.World;
 import org.jetbrains.annotations.NotNull;

--- a/src/main/java/com/minecolonies/coremod/util/Utils.java
+++ b/src/main/java/com/minecolonies/coremod/util/Utils.java
@@ -9,7 +9,6 @@ import net.minecraft.item.ItemStack;
 import net.minecraft.item.ItemSword;
 import net.minecraft.item.ItemTool;
 import net.minecraft.nbt.NBTTagList;
-import net.minecraft.util.SoundCategory;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.World;
 import org.jetbrains.annotations.NotNull;

--- a/src/main/java/com/minecolonies/coremod/util/Utils.java
+++ b/src/main/java/com/minecolonies/coremod/util/Utils.java
@@ -476,7 +476,7 @@ public final class Utils
     {
         if (item == null)
         {
-            return false;
+            return true;
         }
 
         final int hutLevel = worker.getWorkBuilding().getBuildingLevel();

--- a/src/main/java/com/minecolonies/coremod/util/Utils.java
+++ b/src/main/java/com/minecolonies/coremod/util/Utils.java
@@ -1,8 +1,8 @@
 package com.minecolonies.coremod.util;
 
 import com.minecolonies.compatibility.Compatibility;
-import com.minecolonies.entity.coremod.EntityCitizen;
-import com.minecolonies.inventory.coremod.InventoryCitizen;
+import com.minecolonies.coremod.entity.EntityCitizen;
+import com.minecolonies.coremod.inventory.InventoryCitizen;
 import net.minecraft.block.Block;
 import net.minecraft.block.SoundType;
 import net.minecraft.init.Blocks;

--- a/src/main/java/com/minecolonies/coremod/util/Utils.java
+++ b/src/main/java/com/minecolonies/coremod/util/Utils.java
@@ -1,7 +1,8 @@
 package com.minecolonies.coremod.util;
 
 import com.minecolonies.compatibility.Compatibility;
-import com.minecolonies.entity.EntityCitizen;
+import com.minecolonies.entity.coremod.EntityCitizen;
+import com.minecolonies.inventory.coremod.InventoryCitizen;
 import net.minecraft.block.Block;
 import net.minecraft.block.SoundType;
 import net.minecraft.init.Blocks;

--- a/src/main/java/com/minecolonies/coremod/util/Utils.java
+++ b/src/main/java/com/minecolonies/coremod/util/Utils.java
@@ -1,7 +1,6 @@
 package com.minecolonies.coremod.util;
 
 import com.minecolonies.compatibility.Compatibility;
-import com.minecolonies.entity.EntityCitizen;
 import com.minecolonies.inventory.InventoryCitizen;
 import net.minecraft.block.Block;
 import net.minecraft.block.SoundType;
@@ -439,24 +438,23 @@ public final class Utils
         return fortune;
     }
     
-     /**
+    /**
      * Verifies if there is one tool with an acceptable level
      * in a worker's inventory
      *
      * @param tool   the type of tool needed
-     * @param worker the worker that needs a tool
+     * @param inventory the worker's inventory
+     * @param hutLevel the worker's hut level
      * @return true if tool is acceptable
      */
-    public static boolean hasToolLevel(final String tool, EntityCitizen worker)
+    public static boolean hasToolLevel(final String tool, @NotNull final InventoryCitizen inventory, final int hutLevel)
     {
-        @NotNull final InventoryCitizen inventory = worker.getInventoryCitizen();
-
         for (int i = 0; i < inventory.getSizeInventory(); i++)
         {
             final ItemStack item = inventory.getStackInSlot(i);
             final int level = Utils.getMiningLevel(item, tool);
 
-            if (Utils.isTool(item, tool) && verifyToolLevel(item, level, worker))
+            if (Utils.isTool(item, tool) && verifyToolLevel(item, level, hutLevel))
             {
                 return true;
             }
@@ -469,27 +467,20 @@ public final class Utils
      *
      * @param item   the type of tool needed
      * @param level  the type of tool needed
-     * @param worker the current worker that needs the item
+     * @param hutLevel the worker's hut level
      * @return true if tool is acceptable
      */
-    public static boolean verifyToolLevel(final ItemStack item, int level, EntityCitizen worker)
+    public static boolean verifyToolLevel(final ItemStack item, int level, final int hutLevel)
     {
-        if (item == null)
+        if (item == null || hutLevel > 4)
         {
             return true;
         }
-
-        final int hutLevel = worker.getWorkBuilding().getBuildingLevel();
-
-        if (hutLevel <= 2 && hutLevel >= level && !item.hasEffect())
+        else if (item.hasEffect() && hutLevel <= 2 )
         {
-            return true;
+            return false;
         }
-        else if (hutLevel > 2 && hutLevel <= 4 && hutLevel > level)
-        {
-            return true;
-        }
-        else if (hutLevel > 4)
+        else if (hutLevel >= level)
         {
             return true;
         }

--- a/src/main/java/com/minecolonies/coremod/util/Utils.java
+++ b/src/main/java/com/minecolonies/coremod/util/Utils.java
@@ -26,6 +26,8 @@ public final class Utils
     public static final String SHOVEL  = "shovel";
     public static final String AXE     = "axe";
     public static final String HOE     = "hoe";
+    public static final int FREE_TOOL_CHOICE_LEVEL = 4;
+    public static final int EFFECT_TOOL_CHOICE_LEVEL=2;
 
     /**
      * The compound id for fortune enchantment.
@@ -470,11 +472,11 @@ public final class Utils
      */
     public static boolean verifyToolLevel(final ItemStack item, int level, final int hutLevel)
     {
-        if (item == null || hutLevel > 4)
+        if (item == null || hutLevel > FREE_TOOL_CHOICE_LEVEL)
         {
             return true;
         }
-        else if (item.hasEffect() && hutLevel <= 2 )
+        else if (item.hasEffect() && hutLevel <= EFFECT_TOOL_CHOICE_LEVEL )
         {
             return false;
         }

--- a/src/main/java/com/minecolonies/coremod/util/Utils.java
+++ b/src/main/java/com/minecolonies/coremod/util/Utils.java
@@ -26,8 +26,6 @@ public final class Utils
     public static final String SHOVEL  = "shovel";
     public static final String AXE     = "axe";
     public static final String HOE     = "hoe";
-    public static final int FREE_TOOL_CHOICE_LEVEL = 4;
-    public static final int EFFECT_TOOL_CHOICE_LEVEL=2;
 
     /**
      * The compound id for fortune enchantment.
@@ -436,56 +434,5 @@ public final class Utils
             }
         }
         return fortune;
-    }
-    
-    /**
-     * Verifies if there is one tool with an acceptable level
-     * in a worker's inventory.
-     *
-     * @param tool   the type of tool needed
-     * @param inventory the worker's inventory
-     * @param hutLevel the worker's hut level
-     * @return true if tool is acceptable
-     */
-    public static boolean hasToolLevel(final String tool, @NotNull final InventoryCitizen inventory, final int hutLevel)
-    {
-        for (int i = 0; i < inventory.getSizeInventory(); i++)
-        {
-            final ItemStack item = inventory.getStackInSlot(i);
-            final int level = Utils.getMiningLevel(item, tool);
-
-            if (Utils.isTool(item, tool) && verifyToolLevel(item, level, hutLevel))
-            {
-                return true;
-            }
-        }
-        return false;
-    }
-
-    /**
-     * Verifies if an item has an appropriated grade.
-     *
-     * @param item   the type of tool needed
-     * @param level  the type of tool needed
-     * @param hutLevel the worker's hut level
-     * @return true if tool is acceptable
-     */
-    public static boolean verifyToolLevel(final ItemStack item, int level, final int hutLevel)
-    {
-        if (item == null || hutLevel > FREE_TOOL_CHOICE_LEVEL)
-        {
-            return true;
-        }
-        else if (item.hasEffect() && hutLevel <= EFFECT_TOOL_CHOICE_LEVEL )
-        {
-            return false;
-        }
-        else if (hutLevel >= level)
-        {
-            return true;
-        }
-
-        return false;
-    }
-    
+    }    
 }

--- a/src/main/java/com/minecolonies/coremod/util/Utils.java
+++ b/src/main/java/com/minecolonies/coremod/util/Utils.java
@@ -433,5 +433,5 @@ public final class Utils
             }
         }
         return fortune;
-    }    
+    }
 }

--- a/src/main/java/com/minecolonies/coremod/util/Utils.java
+++ b/src/main/java/com/minecolonies/coremod/util/Utils.java
@@ -1,7 +1,7 @@
 package com.minecolonies.coremod.util;
 
 import com.minecolonies.compatibility.Compatibility;
-import com.minecolonies.inventory.InventoryCitizen;
+import com.minecolonies.entity.EntityCitizen;
 import net.minecraft.block.Block;
 import net.minecraft.block.SoundType;
 import net.minecraft.init.Blocks;

--- a/src/main/java/com/minecolonies/coremod/util/Utils.java
+++ b/src/main/java/com/minecolonies/coremod/util/Utils.java
@@ -1,10 +1,8 @@
 package com.minecolonies.coremod.util;
 
 import com.minecolonies.compatibility.Compatibility;
-import com.minecolonies.coremod.entity.EntityCitizen;
 import com.minecolonies.coremod.inventory.InventoryCitizen;
 import net.minecraft.block.Block;
-import net.minecraft.block.SoundType;
 import net.minecraft.init.Blocks;
 import net.minecraft.item.ItemHoe;
 import net.minecraft.item.ItemStack;

--- a/src/main/java/com/minecolonies/coremod/util/Utils.java
+++ b/src/main/java/com/minecolonies/coremod/util/Utils.java
@@ -434,4 +434,63 @@ public final class Utils
         }
         return fortune;
     }
+    
+     /**
+     * Verifies if there is one tool with an acceptable level
+     * in a worker's inventory
+     *
+     * @param tool   the type of tool needed
+     * @param worker the worker that needs a tool
+     * @return true if tool is acceptable
+     */
+    public static boolean hasToolLevel(final String tool, EntityCitizen worker)
+    {
+        @NotNull final InventoryCitizen inventory = worker.getInventoryCitizen();
+
+        for (int i = 0; i < inventory.getSizeInventory(); i++)
+        {
+            final ItemStack item = inventory.getStackInSlot(i);
+            final int level = Utils.getMiningLevel(item, tool);
+
+            if (Utils.isTool(item, tool) && verifyToolLevel(item, level, worker))
+            {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
+     * Verifies if an item has an appropriated grade
+     *
+     * @param item   the type of tool needed
+     * @param level  the type of tool needed
+     * @param worker the current worker that needs the item
+     * @return true if tool is acceptable
+     */
+    public static boolean verifyToolLevel(final ItemStack item, int level, EntityCitizen worker)
+    {
+        if (item == null)
+        {
+            return false;
+        }
+
+        final int hutLevel = worker.getWorkBuilding().getBuildingLevel();
+
+        if (hutLevel <= 2 && hutLevel >= level && !item.hasEffect())
+        {
+            return true;
+        }
+        else if (hutLevel > 2 && hutLevel <= 4 && hutLevel > level)
+        {
+            return true;
+        }
+        else if (hutLevel > 4)
+        {
+            return true;
+        }
+
+        return false;
+    }
+    
 }

--- a/src/main/java/com/minecolonies/coremod/util/Utils.java
+++ b/src/main/java/com/minecolonies/coremod/util/Utils.java
@@ -440,7 +440,7 @@ public final class Utils
     
     /**
      * Verifies if there is one tool with an acceptable level
-     * in a worker's inventory
+     * in a worker's inventory.
      *
      * @param tool   the type of tool needed
      * @param inventory the worker's inventory
@@ -463,7 +463,7 @@ public final class Utils
     }
 
     /**
-     * Verifies if an item has an appropriated grade
+     * Verifies if an item has an appropriated grade.
      *
      * @param item   the type of tool needed
      * @param level  the type of tool needed

--- a/src/main/resources/assets/minecolonies/lang/en_US.lang
+++ b/src/main/resources/assets/minecolonies/lang/en_US.lang
@@ -242,3 +242,6 @@ com.minecolonies.coremod.workerHuts.recallFail=Recall failed - Please make more 
 
 tile.minecolonies.blockSubstitution.name=Placeholderblock
 tile.minecolonies.blockSolidSubstitution.name=Solid-Placeholderblock
+
+entity.worker.toolRequest=I need a %d of a maximum level of %d.
+entity.worker.pickaxeRequest=I need a pickaxe of at least level %d and at maximum %d.

--- a/src/main/resources/assets/minecolonies/lang/en_US.lang
+++ b/src/main/resources/assets/minecolonies/lang/en_US.lang
@@ -243,5 +243,5 @@ com.minecolonies.coremod.workerHuts.recallFail=Recall failed - Please make more 
 tile.minecolonies.blockSubstitution.name=Placeholderblock
 tile.minecolonies.blockSolidSubstitution.name=Solid-Placeholderblock
 
-entity.worker.toolRequest=I need a %d of a maximum level of %d.
-entity.worker.pickaxeRequest=I need a pickaxe of at least level %d and at maximum %d.
+entity.worker.toolRequest=I need a %s of a maximum grade of %s.
+entity.worker.pickaxeRequest=I need a pickaxe of at least %s grade and at maximum %s grade.


### PR DESCRIPTION
adapted checkfortool / checkforpickaxe / getmostefficienttool to include tools restrictions
added new methods to handle item selection from the inventory

Closes #6 

# Changes proposed in this pull request:
-adaptability of checkfor methods to ensure the worker says an acceptable sentece
-adaptability of getmosteffiecienttool so that for every item he iterates through he will check if the item is the correct tool for the job and if it that tool has the appropriate level
-new method verifyToolLevel to check if a certain item has a certain level
-new method hasToolLevel which calls verifyToolLevel to check if a worker has at least one good item to do the job in his inventory

Review please
