### PR TITLE
Update Configurations.java - More realistic, less annoying Speeds

### DIFF
--- a/src/main/java/com/minecolonies/coremod/configuration/Configurations.java
+++ b/src/main/java/com/minecolonies/coremod/configuration/Configurations.java
@@ -8,10 +8,10 @@ public class Configurations
     public static       int     townHallPadding              = 20;
     public static       boolean supplyChests                 = true;
     public static       boolean allowInfiniteSupplyChests    = false;
-    public static       int     citizenRespawnInterval       = 30;
+    public static       int     citizenRespawnInterval       = 240;
     public static       boolean builderInfiniteResources     = false;
-    public static       int     builderBuildBlockDelay       = 0;
-    public static       int     blockMiningDelayModifier     = 1000;
+    public static       int     builderBuildBlockDelay       = 15;
+    public static       int     blockMiningDelayModifier     = 125;
 
     public static boolean enableColonyProtection = true;
     public static boolean turnOffExplosionsInColonies = true;


### PR DESCRIPTION
closes #491

This is supposed to make more realistic settings since minecolonies is a realistic mod.

# Changes proposed in this pull request:
``` java
// raised from 30 seconds to 4 minutes since citicens are no Sexmachines
citizenRespawnInterval       = 240;

// lowered to ~4 times slower than by hand instead of 15 times slower
blockMiningDelayModifier     = 125; 

// increased delay between placing a block from 0 to .75 seconds
// since the workers are no time gods
builderBuildBlockDelay       = 15;
```

Review please
