### PR TITLE
Fixbuilderair

### DIFF
--- a/src/main/java/com/minecolonies/coremod/colony/jobs/AbstractJob.java
+++ b/src/main/java/com/minecolonies/coremod/colony/jobs/AbstractJob.java
@@ -289,7 +289,6 @@ public abstract class AbstractJob
     public ItemStack removeItemNeeded(@NotNull final ItemStack stack)
     {
 
-
         @NotNull final ItemStack stackCopy = stack.copy();
         //if stack is AIR, stack.isItemEqual(neededItem) will be always true
         //and itemsNeeded would be empty

--- a/src/main/java/com/minecolonies/coremod/colony/jobs/AbstractJob.java
+++ b/src/main/java/com/minecolonies/coremod/colony/jobs/AbstractJob.java
@@ -6,6 +6,7 @@ import com.minecolonies.coremod.colony.Colony;
 import com.minecolonies.coremod.entity.ai.basic.AbstractAISkeleton;
 import com.minecolonies.coremod.util.Log;
 import net.minecraft.entity.ai.EntityAITasks;
+import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.nbt.NBTTagList;
@@ -287,7 +288,17 @@ public abstract class AbstractJob
     @Nullable
     public ItemStack removeItemNeeded(@NotNull final ItemStack stack)
     {
+
+
         @NotNull final ItemStack stackCopy = stack.copy();
+        //if stack is AIR, stack.isItemEqual(neededItem) will be always true
+        //and itemsNeeded would be empty
+        //There is probably a better way to check for air item
+        if (stack.getItemDamage()==0 && Item.getIdFromItem(stack.getItem()) == 0)
+        {
+            return stackCopy;
+            
+        }
         for (@NotNull final ItemStack neededItem : itemsNeeded)
         {
             if ((stack.getItem().isDamageable() && stack.getItem() == neededItem.getItem()) || stack.isItemEqual(neededItem))

--- a/src/main/java/com/minecolonies/coremod/colony/jobs/AbstractJob.java
+++ b/src/main/java/com/minecolonies/coremod/colony/jobs/AbstractJob.java
@@ -289,10 +289,8 @@ public abstract class AbstractJob
     public ItemStack removeItemNeeded(@NotNull final ItemStack stack)
     {
         @NotNull final ItemStack stackCopy = stack.copy();
-        //if stack is AIR, stack.isItemEqual(neededItem) will be always true
-        //and one itemNeeded would be remove
-        //There is probably a better way to check for air item
-        if (stack.getItemDamage()==0 && Item.getIdFromItem(stack.getItem()) == 0)
+
+        if (stack.isEmpty())
         {
             return stackCopy;
         }

--- a/src/main/java/com/minecolonies/coremod/colony/jobs/AbstractJob.java
+++ b/src/main/java/com/minecolonies/coremod/colony/jobs/AbstractJob.java
@@ -288,16 +288,15 @@ public abstract class AbstractJob
     @Nullable
     public ItemStack removeItemNeeded(@NotNull final ItemStack stack)
     {
-
         @NotNull final ItemStack stackCopy = stack.copy();
         //if stack is AIR, stack.isItemEqual(neededItem) will be always true
-        //and itemsNeeded would be empty
+        //and one itemNeeded would be remove
         //There is probably a better way to check for air item
         if (stack.getItemDamage()==0 && Item.getIdFromItem(stack.getItem()) == 0)
         {
             return stackCopy;
-            
         }
+
         for (@NotNull final ItemStack neededItem : itemsNeeded)
         {
             if ((stack.getItem().isDamageable() && stack.getItem() == neededItem.getItem()) || stack.isItemEqual(neededItem))

--- a/src/main/java/com/minecolonies/coremod/colony/jobs/AbstractJob.java
+++ b/src/main/java/com/minecolonies/coremod/colony/jobs/AbstractJob.java
@@ -6,7 +6,6 @@ import com.minecolonies.coremod.colony.Colony;
 import com.minecolonies.coremod.entity.ai.basic.AbstractAISkeleton;
 import com.minecolonies.coremod.util.Log;
 import net.minecraft.entity.ai.EntityAITasks;
-import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.nbt.NBTTagList;


### PR DESCRIPTION
Closes #457 

# Changes proposed in this pull request:
Sometimes the builder stop building waiting for an item he have in is chest and not on him.

This is because the builder have some AIR item in his inventory, while removing AIR item from the items needed, it will remove the first item, regardless to what it is,

This pr check for AIR item before removing it

The real questions are:
- Why *AIR Item*.isItemEqual(*any item*) is always true ?
- Why does the builder have air item in his inventory ?

Review please
