### PR TITLE
Feature/improve build repair buttons

### DIFF
--- a/src/main/java/com/minecolonies/coremod/client/gui/AbstractWindowBuilding.java
+++ b/src/main/java/com/minecolonies/coremod/client/gui/AbstractWindowBuilding.java
@@ -4,6 +4,7 @@ import com.minecolonies.blockout.controls.Button;
 import com.minecolonies.blockout.controls.Label;
 import com.minecolonies.blockout.views.SwitchView;
 import com.minecolonies.coremod.MineColonies;
+import com.minecolonies.coremod.colony.buildings.AbstractBuilding;
 import com.minecolonies.coremod.colony.buildings.AbstractBuildingHut;
 import com.minecolonies.coremod.colony.buildings.AbstractBuildingWorker;
 import com.minecolonies.coremod.network.messages.BuildRequestMessage;
@@ -25,12 +26,18 @@ public abstract class AbstractWindowBuilding<B extends AbstractBuildingHut.View>
     private static final String BUTTON_PREVPAGE     = "prevPage";
     private static final String BUTTON_NEXTPAGE     = "nextPage";
     private static final String VIEW_PAGES          = "pages";
+    private static final String PAGE_ACTIONS        = "pageActions";
+
     /**
      * Type B is a class that extends {@link AbstractBuildingWorker.View}.
      */
     protected final B building;
+    private final SwitchView switchView;
+    private final Label title;
     private final Button buttonPrevPage;
     private final Button buttonNextPage;
+    private final Button buttonBuild;
+    private final Button buttonRepair;
 
     /**
      * Constructor for the windows that are associated with buildings.
@@ -46,8 +53,13 @@ public abstract class AbstractWindowBuilding<B extends AbstractBuildingHut.View>
         registerButton(BUTTON_BUILD, this::buildClicked);
         registerButton(BUTTON_REPAIR, this::repairClicked);
         registerButton(BUTTON_INVENTORY, this::inventoryClicked);
+        switchView     = findPaneOfTypeByID(VIEW_PAGES, SwitchView.class);
+        title          = findPaneOfTypeByID(LABEL_BUILDING_NAME, Label.class);
         buttonNextPage = findPaneOfTypeByID(BUTTON_NEXTPAGE, Button.class);
         buttonPrevPage = findPaneOfTypeByID(BUTTON_PREVPAGE, Button.class);
+        buttonBuild    = findPaneOfTypeByID(BUTTON_BUILD, Button.class);
+        buttonRepair   = findPaneOfTypeByID(BUTTON_REPAIR, Button.class);
+
     }
 
     /**
@@ -74,43 +86,99 @@ public abstract class AbstractWindowBuilding<B extends AbstractBuildingHut.View>
         MineColonies.getNetwork().sendToServer(new OpenInventoryMessage(building));
     }
 
-    /**
-     * Called when the Window is displayed.
-     */
-    @Override
-    public void onOpened()
+    private void updateButtonBuild(final AbstractBuilding.View buildingView)
     {
-        if (buttonPrevPage != null)
+        if (buttonBuild == null)
         {
-            findPaneOfTypeByID(BUTTON_PREVPAGE, Button.class).setEnabled(false);
+            return;
         }
-        findPaneOfTypeByID(LABEL_BUILDING_NAME, Label.class).setLabelText(LanguageHandler.format(getBuildingName()) + " " + building.getBuildingLevel());
 
-        if (building.getBuildingLevel() == 0)
+        if (buildingView.isBuildingMaxLevel())
         {
-            findPaneOfTypeByID(BUTTON_BUILD, Button.class).setLabel(LanguageHandler.format("com.minecolonies.coremod.gui.workerHuts.build"));
-            findPaneByID(BUTTON_REPAIR).disable();
+            buttonBuild.setLabel(LanguageHandler.format("com.minecolonies.coremod.gui.workerHuts.upgradeUnavailable"));
+            buttonBuild.disable();
         }
-        else if (building.isBuildingMaxLevel())
+        else if (buildingView.isRepairing())
         {
-            final Button button = findPaneOfTypeByID(BUTTON_BUILD, Button.class);
-            button.setLabel(LanguageHandler.format("com.minecolonies.coremod.gui.workerHuts.upgradeUnavailable"));
-            button.disable();
+            buttonBuild.setLabel(LanguageHandler.format("com.minecolonies.coremod.gui.workerHuts.build"));
+            buttonBuild.disable();
+        }
+        else if (buildingView.isBuilding())
+        {
+            if (buildingView.getBuildingLevel() == 0)
+            {
+                buttonBuild.setLabel(LanguageHandler.format("com.minecolonies.coremod.gui.workerHuts.cancelBuild"));
+            }
+            else
+            {
+                buttonBuild.setLabel(LanguageHandler.format("com.minecolonies.coremod.gui.workerHuts.cancelUpgrade"));
+            }
+            buttonBuild.enable();
         }
         else
         {
-            final Button button = findPaneOfTypeByID(BUTTON_BUILD, Button.class);
-            button.setLabel(LanguageHandler.format("com.minecolonies.coremod.gui.workerHuts.upgrade"));
-            button.enable();
+            if (buildingView.getBuildingLevel() == 0)
+            {
+                buttonBuild.setLabel(LanguageHandler.format("com.minecolonies.coremod.gui.workerHuts.build"));
+            }
+            else
+            {
+                buttonBuild.setLabel(LanguageHandler.format("com.minecolonies.coremod.gui.workerHuts.upgrade"));
+            }
+            buttonBuild.enable();
         }
     }
 
-    /**
-     * Returns the name of a building.
-     *
-     * @return Name of a building.
-     */
-    public abstract String getBuildingName();
+
+    private void updateButtonRepair(final AbstractBuilding.View buildingView)
+    {
+        if (buttonRepair == null)
+        {
+            return;
+        }
+
+        if (buildingView.isRepairing())
+        {
+            buttonRepair.setLabel(LanguageHandler.format("com.minecolonies.coremod.gui.workerHuts.cancelRepair"));
+            buttonRepair.enable();
+        }
+        else if (buildingView.isBuilding() || buildingView.getBuildingLevel() == 0)
+        {
+            buttonRepair.setLabel(LanguageHandler.format("com.minecolonies.coremod.gui.workerHuts.repair"));
+            buttonRepair.disable();
+        }
+        else
+        {
+            buttonRepair.setLabel(LanguageHandler.format("com.minecolonies.coremod.gui.workerHuts.repair"));
+            buttonRepair.enable();
+        }
+    }
+
+    @Override
+    public void onUpdate()
+    {
+        super.onUpdate();
+
+        // Check if there is no page switcher
+        // Or that we are on the correct page
+        if (switchView == null || switchView.getCurrentView().getID().equals(PAGE_ACTIONS))
+        {
+            final AbstractBuilding.View buildingView = building.getColony().getBuilding(building.getID());
+
+            if (buttonPrevPage != null)
+            {
+                buttonPrevPage.disable();
+            }
+
+            if (title != null)
+            {
+                title.setLabelText(LanguageHandler.format(getBuildingName()) + " " + buildingView.getBuildingLevel());
+            }
+
+            updateButtonBuild(buildingView);
+            updateButtonRepair(buildingView);
+        }
+    }
 
     @Override
     public void onButtonClicked(@NotNull final Button button)
@@ -132,4 +200,11 @@ public abstract class AbstractWindowBuilding<B extends AbstractBuildingHut.View>
                 break;
         }
     }
+
+    /**
+     * Returns the name of a building.
+     *
+     * @return Name of a building.
+     */
+    public abstract String getBuildingName();
 }

--- a/src/main/java/com/minecolonies/coremod/client/gui/AbstractWindowBuilding.java
+++ b/src/main/java/com/minecolonies/coremod/client/gui/AbstractWindowBuilding.java
@@ -86,6 +86,9 @@ public abstract class AbstractWindowBuilding<B extends AbstractBuildingHut.View>
         MineColonies.getNetwork().sendToServer(new OpenInventoryMessage(building));
     }
 
+    /**
+     * Update the state and label for the Build button.
+     */
     private void updateButtonBuild(final AbstractBuilding.View buildingView)
     {
         if (buttonBuild == null)
@@ -129,7 +132,9 @@ public abstract class AbstractWindowBuilding<B extends AbstractBuildingHut.View>
         }
     }
 
-
+    /**
+     * Update the state and label for the Repair button.
+     */
     private void updateButtonRepair(final AbstractBuilding.View buildingView)
     {
         if (buttonRepair == null)

--- a/src/main/java/com/minecolonies/coremod/client/gui/AbstractWindowBuilding.java
+++ b/src/main/java/com/minecolonies/coremod/client/gui/AbstractWindowBuilding.java
@@ -96,15 +96,10 @@ public abstract class AbstractWindowBuilding<B extends AbstractBuildingHut.View>
             return;
         }
 
+        buttonBuild.setEnabled(!buildingView.isBuildingMaxLevel() && !buildingView.isRepairing());
         if (buildingView.isBuildingMaxLevel())
         {
             buttonBuild.setLabel(LanguageHandler.format("com.minecolonies.coremod.gui.workerHuts.upgradeUnavailable"));
-            buttonBuild.disable();
-        }
-        else if (buildingView.isRepairing())
-        {
-            buttonBuild.setLabel(LanguageHandler.format("com.minecolonies.coremod.gui.workerHuts.build"));
-            buttonBuild.disable();
         }
         else if (buildingView.isBuilding())
         {
@@ -116,7 +111,6 @@ public abstract class AbstractWindowBuilding<B extends AbstractBuildingHut.View>
             {
                 buttonBuild.setLabel(LanguageHandler.format("com.minecolonies.coremod.gui.workerHuts.cancelUpgrade"));
             }
-            buttonBuild.enable();
         }
         else
         {
@@ -128,7 +122,6 @@ public abstract class AbstractWindowBuilding<B extends AbstractBuildingHut.View>
             {
                 buttonBuild.setLabel(LanguageHandler.format("com.minecolonies.coremod.gui.workerHuts.upgrade"));
             }
-            buttonBuild.enable();
         }
     }
 
@@ -142,20 +135,14 @@ public abstract class AbstractWindowBuilding<B extends AbstractBuildingHut.View>
             return;
         }
 
+        buttonRepair.setEnabled(buildingView.getBuildingLevel() != 0 && !buildingView.isBuilding());
         if (buildingView.isRepairing())
         {
             buttonRepair.setLabel(LanguageHandler.format("com.minecolonies.coremod.gui.workerHuts.cancelRepair"));
-            buttonRepair.enable();
-        }
-        else if (buildingView.isBuilding() || buildingView.getBuildingLevel() == 0)
-        {
-            buttonRepair.setLabel(LanguageHandler.format("com.minecolonies.coremod.gui.workerHuts.repair"));
-            buttonRepair.disable();
         }
         else
         {
             buttonRepair.setLabel(LanguageHandler.format("com.minecolonies.coremod.gui.workerHuts.repair"));
-            buttonRepair.enable();
         }
     }
 

--- a/src/main/java/com/minecolonies/coremod/client/gui/WindowHutBuilder.java
+++ b/src/main/java/com/minecolonies/coremod/client/gui/WindowHutBuilder.java
@@ -199,6 +199,8 @@ public class WindowHutBuilder extends AbstractWindowWorkerBuilding<BuildingBuild
     @Override
     public void onUpdate()
     {
+        super.onUpdate();
+
         final String currentPage = findPaneOfTypeByID(VIEW_PAGES, SwitchView.class).getCurrentView().getID();
         if (currentPage.equals(PAGE_RESOURCES))
         {

--- a/src/main/java/com/minecolonies/coremod/client/gui/WindowHutFarmer.java
+++ b/src/main/java/com/minecolonies/coremod/client/gui/WindowHutFarmer.java
@@ -290,6 +290,8 @@ public class WindowHutFarmer extends AbstractWindowWorkerBuilding<BuildingFarmer
     @Override
     public void onUpdate()
     {
+        super.onUpdate();
+
         final String currentPage = findPaneOfTypeByID(VIEW_PAGES, SwitchView.class).getCurrentView().getID();
         if (currentPage.equals(PAGE_FIELDS))
         {

--- a/src/main/java/com/minecolonies/coremod/client/gui/WindowHutGuardTower.java
+++ b/src/main/java/com/minecolonies/coremod/client/gui/WindowHutGuardTower.java
@@ -397,6 +397,8 @@ public class WindowHutGuardTower extends AbstractWindowWorkerBuilding<BuildingGu
     @Override
     public void onUpdate()
     {
+        super.onUpdate();
+
         pullInfoFromHut();
         handleButtons();
 

--- a/src/main/java/com/minecolonies/coremod/client/gui/WindowHutMiner.java
+++ b/src/main/java/com/minecolonies/coremod/client/gui/WindowHutMiner.java
@@ -112,6 +112,8 @@ public class WindowHutMiner extends AbstractWindowWorkerBuilding<BuildingMiner.V
     @Override
     public void onUpdate()
     {
+        super.onUpdate();
+
         final String currentPage = findPaneOfTypeByID(VIEW_PAGES, SwitchView.class).getCurrentView().getID();
         if (currentPage.equals(PAGE_LEVELS))
         {

--- a/src/main/java/com/minecolonies/coremod/client/gui/WindowTownHall.java
+++ b/src/main/java/com/minecolonies/coremod/client/gui/WindowTownHall.java
@@ -606,6 +606,8 @@ public class WindowTownHall extends AbstractWindowBuilding<BuildingTownHall.View
     @Override
     public void onUpdate()
     {
+        super.onUpdate();
+
         final String currentPage = findPaneOfTypeByID(VIEW_PAGES, SwitchView.class).getCurrentView().getID();
         if (currentPage.equals(PAGE_PERMISSIONS))
         {

--- a/src/main/java/com/minecolonies/coremod/colony/WorkManager.java
+++ b/src/main/java/com/minecolonies/coremod/colony/WorkManager.java
@@ -1,6 +1,8 @@
 package com.minecolonies.coremod.colony;
 
+import com.minecolonies.coremod.colony.buildings.AbstractBuilding;
 import com.minecolonies.coremod.colony.workorders.AbstractWorkOrder;
+import com.minecolonies.coremod.colony.workorders.WorkOrderBuild;
 import com.minecolonies.coremod.util.Log;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.nbt.NBTTagList;
@@ -62,8 +64,15 @@ public class WorkManager
      */
     public void removeWorkOrder(final int orderId)
     {
+        final AbstractWorkOrder workOrder = workOrders.get(orderId);
         workOrders.remove(orderId);
         colony.removeWorkOrder(orderId);
+        if (workOrder instanceof WorkOrderBuild)
+        {
+            final WorkOrderBuild wob = (WorkOrderBuild)workOrder;
+            final AbstractBuilding building = colony.getBuilding(wob.getBuildingLocation());
+            building.markDirty();
+        }
     }
 
     /**

--- a/src/main/java/com/minecolonies/coremod/colony/buildings/AbstractBuilding.java
+++ b/src/main/java/com/minecolonies/coremod/colony/buildings/AbstractBuilding.java
@@ -67,7 +67,6 @@ public abstract class AbstractBuilding
      * The tag to store the style of the building.
      */
     private static final String TAG_STYLE = "style";
-
     private static final int NO_WORK_ORDER = 0;
     /**
      * A list of ItemStacks with needed items and their quantity.
@@ -599,15 +598,7 @@ public abstract class AbstractBuilding
     {
         if (buildingLevel < getMaxBuildingLevel())
         {
-            if (getCurrentWorkOrderLevel()==NO_WORK_ORDER)
-            {
-                requestWorkOrder(buildingLevel + 1);
-            }
-            else
-            {
-                removeWorkOrder();
-            }
-
+            requestWorkOrder(buildingLevel + 1);
             markDirty();
         }
     }
@@ -629,6 +620,16 @@ public abstract class AbstractBuilding
         }
 
         return NO_WORK_ORDER;
+    }
+
+    /**
+     * Checks if this building have a work order.
+     *
+     * @return true if the building is building, upgrading or repairing.
+     */
+    public boolean hasWorkOrder()
+    {
+        return getCurrentWorkOrderLevel() == NO_WORK_ORDER;
     }
 
     /**
@@ -675,15 +676,7 @@ public abstract class AbstractBuilding
     {
         if (buildingLevel > 0)
         {
-            if (getCurrentWorkOrderLevel()==NO_WORK_ORDER)
-            {
-                requestWorkOrder(buildingLevel);
-            }
-            else
-            {
-                removeWorkOrder();
-            }
-
+            requestWorkOrder(buildingLevel);
             markDirty();
         }
     }
@@ -700,6 +693,7 @@ public abstract class AbstractBuilding
             if (o.getBuildingLocation().equals(getID()))
             {
                 colony.getWorkManager().removeWorkOrder(o.getID());
+                markDirty();
                 return;
             }
         }

--- a/src/main/java/com/minecolonies/coremod/colony/buildings/AbstractBuilding.java
+++ b/src/main/java/com/minecolonies/coremod/colony/buildings/AbstractBuilding.java
@@ -615,7 +615,6 @@ public abstract class AbstractBuilding
             if (o.getBuildingLocation().equals(getID()))
             {
                 return o.getUpgradeLevel();
-
             }
         }
 

--- a/src/main/java/com/minecolonies/coremod/colony/buildings/AbstractBuilding.java
+++ b/src/main/java/com/minecolonies/coremod/colony/buildings/AbstractBuilding.java
@@ -599,7 +599,6 @@ public abstract class AbstractBuilding
         if (buildingLevel < getMaxBuildingLevel())
         {
             requestWorkOrder(buildingLevel + 1);
-            markDirty();
         }
     }
 
@@ -655,6 +654,7 @@ public abstract class AbstractBuilding
 
         colony.getWorkManager().addWorkOrder(new WorkOrderBuild(this, level));
         LanguageHandler.sendPlayersMessage(colony.getMessageEntityPlayers(), "com.minecolonies.coremod.workOrderAdded");
+        markDirty();
     }
 
     /**
@@ -676,7 +676,6 @@ public abstract class AbstractBuilding
         if (buildingLevel > 0)
         {
             requestWorkOrder(buildingLevel);
-            markDirty();
         }
     }
 

--- a/src/main/java/com/minecolonies/coremod/colony/buildings/AbstractBuilding.java
+++ b/src/main/java/com/minecolonies/coremod/colony/buildings/AbstractBuilding.java
@@ -628,7 +628,7 @@ public abstract class AbstractBuilding
      */
     public boolean hasWorkOrder()
     {
-        return getCurrentWorkOrderLevel() == NO_WORK_ORDER;
+        return getCurrentWorkOrderLevel() != NO_WORK_ORDER;
     }
 
     /**

--- a/src/main/java/com/minecolonies/coremod/network/messages/BuildRequestMessage.java
+++ b/src/main/java/com/minecolonies/coremod/network/messages/BuildRequestMessage.java
@@ -99,16 +99,23 @@ public class BuildRequestMessage extends AbstractMessage<BuildRequestMessage, IM
             return;
         }
 
-        switch (message.mode)
+        if (building.hasWorkOrder())
         {
-            case BUILD:
-                building.requestUpgrade();
-                break;
-            case REPAIR:
-                building.requestRepair();
-                break;
-            default:
-                break;
+            building.removeWorkOrder();
+        }
+        else
+        {
+            switch (message.mode)
+            {
+                case BUILD:
+                    building.requestUpgrade();
+                    break;
+                case REPAIR:
+                    building.requestRepair();
+                    break;
+                default:
+                    break;
+            }
         }
     }
 }

--- a/src/main/resources/assets/minecolonies/gui/windowhutbuilder.xml
+++ b/src/main/resources/assets/minecolonies/gui/windowhutbuilder.xml
@@ -3,7 +3,7 @@
         xsi:noNamespaceSchemaLocation="file:../../../../java/com/minecolonies/blockout/blockOut.xsd">
     <switch id="pages" size="100% 200px" pos="0 7">
 
-        <view size="100% 200px" pos="0 7">
+        <view id="pageActions" size="100% 200px" pos="0 7">
             <layout source="minecolonies:gui/layoutWorkerBuildingDefault.xml"/>
         </view>
 

--- a/src/main/resources/assets/minecolonies/gui/windowhutfisherman.xml
+++ b/src/main/resources/assets/minecolonies/gui/windowhutfisherman.xml
@@ -1,7 +1,7 @@
 <window xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         inherit="minecolonies:gui/windowBase.xml"
         xsi:noNamespaceSchemaLocation="file:../../../../java/com/minecolonies/blockout/blockOut.xsd">
-    <view size="100% 200px" pos="0 7">
+    <view id="pageActions" size="100% 200px" pos="0 7">
         <layout source="minecolonies:gui/layoutWorkerBuildingDefault.xml"/>
     </view>
 

--- a/src/main/resources/assets/minecolonies/gui/windowhuthome.xml
+++ b/src/main/resources/assets/minecolonies/gui/windowhuthome.xml
@@ -1,7 +1,7 @@
 <window xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         inherit="minecolonies:gui/windowBase.xml"
         xsi:noNamespaceSchemaLocation="file:../../../../java/com/minecolonies/blockout/blockOut.xsd">
-    <view size="100% 200px" pos="0 7">
+    <view id="pageActions" size="100% 200px" pos="0 7">
         <layout source="minecolonies:gui/layoutBuildingDefault.xml"/>
     </view>
 

--- a/src/main/resources/assets/minecolonies/gui/windowhutminer.xml
+++ b/src/main/resources/assets/minecolonies/gui/windowhutminer.xml
@@ -1,6 +1,6 @@
 <window inherit="minecolonies:gui/windowBase.xml">
     <switch id="pages" size="100% 200px" pos="0 7">
-        <view id="pageActions" size="100% 100%">
+        <view id="pageActions" id="pageActions" size="100% 100%">
             <layout source="minecolonies:gui/layoutWorkerBuildingDefault.xml"/>
         </view>
 

--- a/src/main/resources/assets/minecolonies/gui/windowhutminer.xml
+++ b/src/main/resources/assets/minecolonies/gui/windowhutminer.xml
@@ -1,6 +1,6 @@
 <window inherit="minecolonies:gui/windowBase.xml">
     <switch id="pages" size="100% 200px" pos="0 7">
-        <view id="pageActions" id="pageActions" size="100% 100%">
+        <view id="pageActions" size="100% 100%">
             <layout source="minecolonies:gui/layoutWorkerBuildingDefault.xml"/>
         </view>
 

--- a/src/main/resources/assets/minecolonies/gui/windowhutworkerplaceholder.xml
+++ b/src/main/resources/assets/minecolonies/gui/windowhutworkerplaceholder.xml
@@ -1,7 +1,7 @@
 <window xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         inherit="minecolonies:gui/windowBase.xml"
         xsi:noNamespaceSchemaLocation="file:../../../../java/com/minecolonies/blockout/blockOut.xsd">
-    <view size="100% 200px" pos="0 7">
+    <view id="pageActions" size="100% 200px" pos="0 7">
         <layout source="minecolonies:gui/layoutWorkerBuildingDefault.xml"/>
     </view>
 

--- a/src/main/resources/assets/minecolonies/gui/windowworkerbuilding.xml
+++ b/src/main/resources/assets/minecolonies/gui/windowworkerbuilding.xml
@@ -1,5 +1,5 @@
 <window inherit="minecolonies:gui/windowBase.xml">
-    <view size="100% 100%" pos="0 7">
+    <view id="pageActions" size="100% 100%" pos="0 7">
         <label id="name" size="100% 11" pos="0 0"
                textalign="MIDDLE_LEFT" textcolor="red"/>
         <label id="workerName" size="100% 11" pos="0 18"

--- a/src/main/resources/assets/minecolonies/lang/en_uk.lang
+++ b/src/main/resources/assets/minecolonies/lang/en_uk.lang
@@ -215,3 +215,6 @@ tile.minecolonies.blockHutWareHouse.name=Warehouse
 com.minecolonies.coremod.gui.workerHuts.buildingWareHouse=Warehouse
 tile.minecolonies.blockHutDeliveryman.name=Deliveryman
 com.minecolonies.coremod.gui.workerHuts.Deliveryman=Deliveryman
+com.minecolonies.coremod.gui.workerHuts.cancelBuild=Cancel Build
+com.minecolonies.coremod.gui.workerHuts.cancelUpgrade=Cancel Upgrade
+com.minecolonies.coremod.gui.workerHuts.cancelRepair=Cancel Repair

--- a/src/main/resources/assets/minecolonies/lang/en_us.lang
+++ b/src/main/resources/assets/minecolonies/lang/en_us.lang
@@ -215,3 +215,6 @@ tile.minecolonies.blockHutWareHouse.name=Warehouse
 com.minecolonies.coremod.gui.workerHuts.buildingWareHouse=Warehouse
 tile.minecolonies.blockHutDeliveryman.name=Deliveryman
 com.minecolonies.coremod.gui.workerHuts.Deliveryman=Deliveryman
+com.minecolonies.coremod.gui.workerHuts.cancelBuild=Cancel Build
+com.minecolonies.coremod.gui.workerHuts.cancelUpgrade=Cancel Upgrade
+com.minecolonies.coremod.gui.workerHuts.cancelRepair=Cancel Repair

--- a/src/main/resources/assets/minecolonies/lang/fr_fr.lang
+++ b/src/main/resources/assets/minecolonies/lang/fr_fr.lang
@@ -218,3 +218,7 @@ tile.minecolonies.blockHutWareHouse.name=Entrepôt
 com.minecolonies.coremod.gui.workerHuts.buildingWareHouse=Entrepôt
 tile.minecolonies.blockHutDeliveryman.name=Facteur
 com.minecolonies.coremod.gui.workerHuts.Deliveryman=Facteur
+com.minecolonies.coremod.gui.workerHuts.cancelBuild=Annuler la Construction
+com.minecolonies.coremod.gui.workerHuts.cancelUpgrade=Annuler l'Amélioration
+com.minecolonies.coremod.gui.workerHuts.cancelRepair=Annuler la Réparation
+


### PR DESCRIPTION
# Changes proposed in this pull request:
- Allow to cancel a repair from the hut gui
- Allow to cancel an upgrade from the hut gui

Note: 
- The Town Hall Gui do no longer display the buttons as **Build Town Hall** and **Repair Town Hall** but will use the generic **Build Building** and **Repair Building** label.

![2017-02-06_22 17 33](https://cloud.githubusercontent.com/assets/2778556/22668955/8718eb12-ecba-11e6-9c4f-208a2f26c8af.png)
![2017-02-06_22 17 37](https://cloud.githubusercontent.com/assets/2778556/22668956/87194210-ecba-11e6-90e8-17031c087748.png)

Review please
