### PR TITLE
Fix builder and miner problems when chunks are unloaded + more

### DIFF
--- a/src/main/java/com/minecolonies/coremod/entity/EntityCitizen.java
+++ b/src/main/java/com/minecolonies/coremod/entity/EntityCitizen.java
@@ -116,7 +116,7 @@ public class EntityCitizen extends EntityAgeable implements INpc
     /**
      * Quantity to be moved to rotate without actually moving.
      */
-    private static final double MOVE_MINIMAL = 0.01D;
+    private static final double MOVE_MINIMAL = 0.001D;
 
     /**
      * Base max health of the citizen.

--- a/src/main/java/com/minecolonies/coremod/entity/ai/basic/AbstractEntityAIStructure.java
+++ b/src/main/java/com/minecolonies/coremod/entity/ai/basic/AbstractEntityAIStructure.java
@@ -516,32 +516,11 @@ public abstract class AbstractEntityAIStructure<J extends AbstractJob> extends A
         }
     }
 
-    private boolean checkIfCanceled()
-    {
-        if (job instanceof JobBuilder && ((JobBuilder) job).getWorkOrder() == null)
-        {
-            super.resetTask();
-            workFrom = null;
-            ((JobBuilder) job).setStructure(null);
-            ((JobBuilder) job).setWorkOrder(null);
-            currentStructure = null;
-            return true;
-        }
-        else if(job instanceof JobMiner && currentStructure == null)
-        {
-            switch (getState())
-            {
-                case CLEAR_STEP:
-                case BUILDING_STEP:
-                case DECORATION_STEP:
-                case SPAWN_STEP:
-                    return true;
-                default:
-                    return false;
-            }
-        }
-        return false;
-    }
+    /**
+     * Check if the structure tusk has been canceled.
+     * @return true if reset to idle.
+     */
+    protected abstract boolean checkIfCanceled();
 
     /**
      * Iterates through all the required resources and stores them in the building.
@@ -763,7 +742,7 @@ public abstract class AbstractEntityAIStructure<J extends AbstractJob> extends A
      *
      * @return true if we should start building.
      */
-    private boolean isThereAStructureToBuild()
+    protected boolean isThereAStructureToBuild()
     {
         return currentStructure != null;
     }
@@ -852,10 +831,7 @@ public abstract class AbstractEntityAIStructure<J extends AbstractJob> extends A
     {
         if (currentStructure == null)
         {
-            if(job instanceof JobBuilder && ((JobBuilder) job).getWorkOrder() != null)
-            {
-                loadStructure();
-            }
+            onStartWithoutStructure();
             return AIState.IDLE;
         }
         switch (currentStructure.getStage())
@@ -872,6 +848,8 @@ public abstract class AbstractEntityAIStructure<J extends AbstractJob> extends A
                 return AIState.COMPLETE_BUILD;
         }
     }
+
+    protected abstract void onStartWithoutStructure();
 
     private boolean handleMaterials(@NotNull final Block block, @NotNull final IBlockState blockState)
     {
@@ -1154,6 +1132,14 @@ public abstract class AbstractEntityAIStructure<J extends AbstractJob> extends A
             Log.getLogger().info("Couldn't restore entitiy", e);
             return null;
         }
+    }
+
+    /**
+     * Set the currentStructure to null.
+     */
+    public void resetCurrentStructure()
+    {
+        currentStructure = null;
     }
 
     private Boolean spawnEntity(@NotNull final Structure.StructureBlock currentBlock)

--- a/src/main/java/com/minecolonies/coremod/entity/ai/basic/AbstractEntityAIStructure.java
+++ b/src/main/java/com/minecolonies/coremod/entity/ai/basic/AbstractEntityAIStructure.java
@@ -1250,9 +1250,9 @@ public abstract class AbstractEntityAIStructure<J extends AbstractJob> extends A
             {
                 final BlockPos ladderPos = buildingMiner.getLadderLocation();
                 return new BlockPos(
-                        ladderPos.getX() + buildingMiner.getVectorX() * OTHER_SIDE_OF_SHAFT
-                        , buildingMiner.getCurrentLevel().getDepth()
-                        , ladderPos.getZ() + buildingMiner.getVectorZ() * OTHER_SIDE_OF_SHAFT);
+                        ladderPos.getX() + buildingMiner.getVectorX() * OTHER_SIDE_OF_SHAFT,
+                        buildingMiner.getCurrentLevel().getDepth(),
+                        ladderPos.getZ() + buildingMiner.getVectorZ() * OTHER_SIDE_OF_SHAFT);
             }
             final Point2D pos = buildingMiner.getCurrentLevel().getRandomNode().getParent();
             return new BlockPos(pos.getX(), buildingMiner.getCurrentLevel().getDepth(), pos.getY());

--- a/src/main/java/com/minecolonies/coremod/entity/ai/citizen/builder/EntityAIStructureBuilder.java
+++ b/src/main/java/com/minecolonies/coremod/entity/ai/citizen/builder/EntityAIStructureBuilder.java
@@ -146,6 +146,30 @@ public class EntityAIStructureBuilder extends AbstractEntityAIStructure<JobBuild
         }
     }
 
+    @Override
+    protected boolean checkIfCanceled()
+    {
+        if (job.getWorkOrder() == null)
+        {
+            super.resetTask();
+            workFrom = null;
+            ((JobBuilder) job).setStructure(null);
+            ((JobBuilder) job).setWorkOrder(null);
+            resetCurrentStructure();
+            return true;
+        }
+        return false;
+    }
+
+    @Override
+    protected void onStartWithoutStructure()
+    {
+        if(job.getWorkOrder() != null)
+        {
+            loadStructure();
+        }
+    }
+
     private AIState startWorkingAtOwnBuilding()
     {
         if (walkToBuilding())

--- a/src/main/java/com/minecolonies/coremod/entity/ai/citizen/miner/EntityAIStructureMiner.java
+++ b/src/main/java/com/minecolonies/coremod/entity/ai/citizen/miner/EntityAIStructureMiner.java
@@ -24,9 +24,8 @@ import static com.minecolonies.coremod.entity.ai.util.AIState.*;
  */
 public class EntityAIStructureMiner extends AbstractEntityAIStructure<JobMiner>
 {
-
-    private static final String     RENDER_META_TORCH         = "Torch";
-    private static final int        NODE_DISTANCE       = 7;
+    private static final String RENDER_META_TORCH   = "Torch";
+    private static final int    NODE_DISTANCE       = 7;
     /**
      * Return to chest after 3 stacks.
      */
@@ -485,6 +484,33 @@ public class EntityAIStructureMiner extends AbstractEntityAIStructure<JobMiner>
         initStructure(null, 0, new BlockPos(ladderPos.getX() + xOffset, lastLadder, ladderPos.getZ() + zOffset));
 
         return CLEAR_STEP;
+    }
+
+    @Override
+    protected boolean checkIfCanceled()
+    {
+       if(!isThereAStructureToBuild())
+        {
+            switch (getState())
+            {
+                case CLEAR_STEP:
+                case BUILDING_STEP:
+                case DECORATION_STEP:
+                case SPAWN_STEP:
+                    return true;
+                default:
+                    return false;
+            }
+        }
+        return false;
+    }
+
+    @Override
+    protected void onStartWithoutStructure()
+    {
+        /**
+         * Nothing to do here.
+         */
     }
 
     @NotNull

--- a/src/main/java/com/minecolonies/coremod/entity/ai/citizen/miner/Node.java
+++ b/src/main/java/com/minecolonies/coremod/entity/ai/citizen/miner/Node.java
@@ -269,7 +269,7 @@ public class Node
     /**
      * Sets the node style used.
      */
-    enum NodeType
+    public enum NodeType
     {
         //Main shaft
         SHAFT,

--- a/src/main/java/com/minecolonies/coremod/entity/pathfinding/WalkToProxy.java
+++ b/src/main/java/com/minecolonies/coremod/entity/pathfinding/WalkToProxy.java
@@ -245,9 +245,9 @@ public class WalkToProxy
 
                 proxyList.add(
                         new BlockPos(
-                                ladderPos.getX() + building.getVectorX() * OTHER_SIDE_OF_SHAFT
-                                , level.getDepth()
-                                , ladderPos.getZ() + building.getVectorZ() * OTHER_SIDE_OF_SHAFT));
+                                ladderPos.getX() + building.getVectorX() * OTHER_SIDE_OF_SHAFT,
+                                level.getDepth(),
+                                ladderPos.getZ() + building.getVectorZ() * OTHER_SIDE_OF_SHAFT));
                 return getProxy(target, worker.getPosition(), distanceToPath);
 
                 //If he already is at ladder location, the closest node automatically will be his hut block.
@@ -264,10 +264,10 @@ public class WalkToProxy
 
                 //Then add the ladder position as the latest node.
                 proxyList.add(
-                        new BlockPos(
-                                ladderPos.getX() + building.getVectorX() * OTHER_SIDE_OF_SHAFT
-                                , level.getDepth()
-                                , ladderPos.getZ() + building.getVectorZ() * OTHER_SIDE_OF_SHAFT));
+                  new BlockPos(
+                                ladderPos.getX() + building.getVectorX() * OTHER_SIDE_OF_SHAFT,
+                          level.getDepth(),
+                          ladderPos.getZ() + building.getVectorZ() * OTHER_SIDE_OF_SHAFT));
 
                 if(level.getRandomNode() != null && level.getRandomNode().getParent() != null)
                 {

--- a/src/main/java/com/minecolonies/coremod/entity/pathfinding/WalkToProxy.java
+++ b/src/main/java/com/minecolonies/coremod/entity/pathfinding/WalkToProxy.java
@@ -220,8 +220,6 @@ public class WalkToProxy
     @NotNull
     private BlockPos getMinerProxy(final BlockPos target, final double distanceToPath, @NotNull final BuildingMiner building)
     {
-        building.getLadderLocation();
-
         final Level level = building.getCurrentLevel();
         final BlockPos ladderPos = building.getLadderLocation();
 
@@ -245,7 +243,11 @@ public class WalkToProxy
                     }
                 }
 
-                proxyList.add(new BlockPos(ladderPos.getX(), level.getDepth(), ladderPos.getZ()));
+                proxyList.add(
+                        new BlockPos(
+                                ladderPos.getX() + building.getVectorX() * OTHER_SIDE_OF_SHAFT
+                                , level.getDepth()
+                                , ladderPos.getZ() + building.getVectorZ() * OTHER_SIDE_OF_SHAFT));
                 return getProxy(target, worker.getPosition(), distanceToPath);
 
                 //If he already is at ladder location, the closest node automatically will be his hut block.


### PR DESCRIPTION
Fix error in the proxy. Make worker not move while turning

Closes #518 and maybe a view more

# Changes proposed in this pull request:
- correctly Reset state after unload
- Correctly path to miner level
- Remove unnecessary retrieve

Review please
