### PR TITLE
Improved the upload of build outputs to the Dropbox

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -114,6 +114,7 @@ task incrementBuildNumber() {
 }
 
 jar {
+    dependsOn "deobfJar"
     appendix = 'universal'
     archiveName = "minecolonies-universal-" + project.version + ".jar"
 

--- a/travis/dropbox.sh
+++ b/travis/dropbox.sh
@@ -10,10 +10,14 @@ if [ "$TRAVIS_PULL_REQUEST" == "false" ]; then
     ~/dropbox_uploader.sh mkdir "branch"
     ~/dropbox_uploader.sh mkdir "branch/$TRAVIS_BRANCH"
     ~/dropbox_uploader.sh upload ./build/libs/*univ*.jar "branch/$TRAVIS_BRANCH"
+    ~/dropbox_uploader.sh upload ./build/libs/*deobf*.jar "branch/$TRAVIS_BRANCH"
+    ~/dropbox_uploader.sh upload ./build/libs/*sources*.jar "branch/$TRAVIS_BRANCH"
 else
     ~/dropbox_uploader.sh mkdir "pr"
     ~/dropbox_uploader.sh mkdir "pr/$TRAVIS_PULL_REQUEST"
     ~/dropbox_uploader.sh upload ./build/libs/*univ*.jar "pr/$TRAVIS_PULL_REQUEST"
+    ~/dropbox_uploader.sh upload ./build/libs/*sources*.jar "pr/$TRAVIS_PULL_REQUEST"
+    ~/dropbox_uploader.sh upload ./build/libs/*deobf*.jar "pr/$TRAVIS_PULL_REQUEST"
 fi
 
 if [ "$TRAVIS_BRANCH" = "develop" ] || [ "$TRAVIS_BRANCH" = "master" ] || [ "$TRAVIS_PULL_REQUEST" != "false" ]; then


### PR DESCRIPTION
Signed-off-by: OrionOnline <oriondevelopment@outlook.com>

# Changes proposed in this pull request:
- Create a deobf jar when a build is happening.
- Upload both the Source and the Deobfed variant of the Minecolonies jars to dropbox.

Review please
