### PR TITLE
Fix message when building to far from the town hall

### DIFF
--- a/src/main/java/com/minecolonies/coremod/event/EventHandler.java
+++ b/src/main/java/com/minecolonies/coremod/event/EventHandler.java
@@ -231,7 +231,14 @@ public class EventHandler
         if (colony == null)
         {
             //  Not in a colony
-            LanguageHandler.sendPlayerMessage(player, "tile.blockHut.messageNoTownHall");
+            if (ColonyManager.getIColonyByOwner(world, player) == null)
+            {
+                LanguageHandler.sendPlayerMessage(player, "tile.blockHut.messageNoTownHall");
+            }
+            else
+            {
+                LanguageHandler.sendPlayerMessage(player, "tile.blockHut.messageTooFarFromTownHall");
+            }
             return false;
         }
         else if (!colony.getPermissions().hasPermission(player, Permissions.Action.PLACE_HUTS))


### PR DESCRIPTION
Closes #702

# Changes proposed in this pull request:
- When building too far, minecolonies tell the player that he need a town hall, instead of saying that he is too far.

**Note:** For some reason the translation is already here but was never used

Review please
