### PR TITLE
1.11 d-man delivery fix

### DIFF
--- a/src/main/java/com/minecolonies/coremod/colony/Colony.java
+++ b/src/main/java/com/minecolonies/coremod/colony/Colony.java
@@ -1057,13 +1057,13 @@ public class Colony implements IColony
             final BuildingHome home = citizen.getHomeBuilding();
             if(home != null)
             {
-                housing = home.getBuildingLevel();
+                housing += home.getBuildingLevel();
             }
 
             saturation += citizen.getSaturation();
         }
 
-        final int averageHousing = housing/citizens.size();
+        final int averageHousing = housing/Math.max(1, citizens.size());
 
         if(averageHousing > 1)
         {

--- a/src/main/java/com/minecolonies/coremod/colony/buildings/AbstractBuilding.java
+++ b/src/main/java/com/minecolonies/coremod/colony/buildings/AbstractBuilding.java
@@ -1178,7 +1178,7 @@ public abstract class AbstractBuilding
      *
      * @param stack the stack to transfer.
      * @param world the world to do it in.
-     * @return the itemStack which has been replaced
+     * @return the itemStack which has been replaced or the itemStack which could not be transfered
      */
     @Nullable
     public ItemStack forceTransferStack(final ItemStack stack, final World world)
@@ -1198,7 +1198,7 @@ public abstract class AbstractBuilding
         {
             return forceItemStackToProvider(tileEntity, stack);
         }
-        return null;
+        return stack;
     }
 
     @Nullable

--- a/src/main/java/com/minecolonies/coremod/util/InventoryUtils.java
+++ b/src/main/java/com/minecolonies/coremod/util/InventoryUtils.java
@@ -473,7 +473,7 @@ public class InventoryUtils
                 if (isItemStackEmpty(localStack) || !itemStackToKeepPredicate.test(localStack))
                 {
                     final ItemStack removedStack = itemHandler.extractItem(i, Integer.MAX_VALUE, false);
-                    ItemStack localInsertionResult = itemHandler.insertItem(i, standardInsertionResult, true);
+                    ItemStack localInsertionResult = itemHandler.insertItem(i, standardInsertionResult, false);
 
                     if (isItemStackEmpty(localInsertionResult))
                     {

--- a/src/main/java/com/minecolonies/coremod/util/InventoryUtils.java
+++ b/src/main/java/com/minecolonies/coremod/util/InventoryUtils.java
@@ -887,7 +887,7 @@ public class InventoryUtils
      *
      * @param provider  {@link ICapabilityProvider} to add itemstack to.
      * @param itemStack ItemStack to add.
-     * @return Empty when successful, otherwise return the itemStack which was supposed to be added.
+     * @return Empty when fully transfered without swapping, otherwise return the remain of a partial transfer or the itemStack it has been swapped with.
      */
     public static ItemStack addItemStackToProviderWithResult(@NotNull final ICapabilityProvider provider, @Nullable ItemStack itemStack)
     {
@@ -911,7 +911,7 @@ public class InventoryUtils
      *
      * @param itemHandler {@link IItemHandler} to add itemstack to.
      * @param itemStack   ItemStack to add.
-     * @return Empty if successfull, otherwise the itemStask which was supposed to be added.
+     * @return Empty when fully transfered without swapping, otherwise return the remain of a partial transfer or the itemStack it has been swapped with.
      */
     public static ItemStack addItemStackToItemHandlerWithResult(@NotNull final IItemHandler itemHandler, @Nullable ItemStack itemStack)
     {

--- a/src/main/java/com/minecolonies/coremod/util/InventoryUtils.java
+++ b/src/main/java/com/minecolonies/coremod/util/InventoryUtils.java
@@ -887,7 +887,7 @@ public class InventoryUtils
      *
      * @param provider  {@link ICapabilityProvider} to add itemstack to.
      * @param itemStack ItemStack to add.
-     * @return True if successful, otherwise false.
+     * @return Empty when successful, otherwise return the itemStack which was supposed to be added.
      */
     public static ItemStack addItemStackToProviderWithResult(@NotNull final ICapabilityProvider provider, @Nullable ItemStack itemStack)
     {
@@ -911,7 +911,7 @@ public class InventoryUtils
      *
      * @param itemHandler {@link IItemHandler} to add itemstack to.
      * @param itemStack   ItemStack to add.
-     * @return True if successful, otherwise false.
+     * @return Empty if successfull, otherwise the itemStask which was supposed to be added.
      */
     public static ItemStack addItemStackToItemHandlerWithResult(@NotNull final IItemHandler itemHandler, @Nullable ItemStack itemStack)
     {


### PR DESCRIPTION

Close  #982


When the worker chest is full, the dman take on stack but the item he deliver disappear.
 
# Changes proposed in this pull request:
- Fix incorrect javadoc
- AbstractBuilding.forceTransferStack return the stack when it can not transfer
- InventoryUtils.forceItemStackToItemHandler

Please review