### PR TITLE
Refactor/1.10 workorders

### DIFF
--- a/src/main/java/com/minecolonies/coremod/colony/WorkManager.java
+++ b/src/main/java/com/minecolonies/coremod/colony/WorkManager.java
@@ -1,9 +1,6 @@
 package com.minecolonies.coremod.colony;
 
-import com.minecolonies.coremod.colony.buildings.AbstractBuilding;
 import com.minecolonies.coremod.colony.workorders.AbstractWorkOrder;
-import com.minecolonies.coremod.colony.workorders.WorkOrderBuild;
-import com.minecolonies.coremod.entity.ai.citizen.builder.ConstructionTapeHelper;
 import com.minecolonies.coremod.util.Log;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.nbt.NBTTagList;
@@ -68,16 +65,7 @@ public class WorkManager
         final AbstractWorkOrder workOrder = workOrders.get(orderId);
         workOrders.remove(orderId);
         colony.removeWorkOrder(orderId);
-        if (workOrder instanceof WorkOrderBuild)
-        {
-            final WorkOrderBuild wob = (WorkOrderBuild)workOrder;
-            final AbstractBuilding building = colony.getBuilding(wob.getBuildingLocation());
-            ConstructionTapeHelper.removeConstructionTape(wob, colony.getWorld());
-            if(building != null)
-            {
-                building.markDirty();
-            }
-        }
+        workOrder.onRemoved(colony);
     }
 
     /**
@@ -231,11 +219,9 @@ public class WorkManager
             topWorkOrderId++;
             order.setID(topWorkOrderId);
         }
-        if (order instanceof WorkOrderBuild && colony != null && colony.getWorld() != null)
-        {
-            ConstructionTapeHelper.placeConstructionTape((WorkOrderBuild) order, colony.getWorld());
-        }
+
         workOrders.put(order.getID(), order);
+        order.onAdded(colony);
     }
 
     /**

--- a/src/main/java/com/minecolonies/coremod/colony/jobs/JobBuilder.java
+++ b/src/main/java/com/minecolonies/coremod/colony/jobs/JobBuilder.java
@@ -4,7 +4,7 @@ import com.minecolonies.coremod.client.render.RenderBipedCitizen;
 import com.minecolonies.coremod.colony.CitizenData;
 import com.minecolonies.coremod.colony.buildings.AbstractBuilding;
 import com.minecolonies.coremod.colony.buildings.BuildingBuilder;
-import com.minecolonies.coremod.colony.workorders.WorkOrderBuild;
+import com.minecolonies.coremod.colony.workorders.WorkOrderBuildDecoration;
 import com.minecolonies.coremod.entity.ai.basic.AbstractAISkeleton;
 import com.minecolonies.coremod.entity.ai.citizen.builder.EntityAIStructureBuilder;
 import net.minecraft.nbt.NBTTagCompound;
@@ -115,14 +115,7 @@ public class JobBuilder extends AbstractJobStructure
      */
     public void complete()
     {
-        final BlockPos buildingLocation = this.getWorkOrder().getBuildingLocation();
-        final AbstractBuilding building = this.getCitizen().getColony().getBuilding(buildingLocation);
-
-        if (building != null)
-        {
-            this.getCitizen().getColony().onBuildingUpgradeComplete(building, this.getWorkOrder().getUpgradeLevel());
-        }
-
+        getWorkOrder().onCompleted(getCitizen().getColony());
         getCitizen().getColony().getWorkManager().removeWorkOrder(workOrderId);
         setWorkOrder(null);
         setStructure(null);
@@ -133,11 +126,11 @@ public class JobBuilder extends AbstractJobStructure
      * Get the Work Order for the Job.
      * Warning: WorkOrder is not cached
      *
-     * @return WorkOrderBuild for the Build
+     * @return WorkOrderBuildDecoration for the Build
      */
-    public WorkOrderBuild getWorkOrder()
+    public WorkOrderBuildDecoration getWorkOrder()
     {
-        return getColony().getWorkManager().getWorkOrder(workOrderId, WorkOrderBuild.class);
+        return getColony().getWorkManager().getWorkOrder(workOrderId, WorkOrderBuildDecoration.class);
     }
 
     /**
@@ -157,7 +150,7 @@ public class JobBuilder extends AbstractJobStructure
      *
      * @param order Work Order to associate with this job, or null
      */
-    public void setWorkOrder(@Nullable final WorkOrderBuild order)
+    public void setWorkOrder(@Nullable final WorkOrderBuildDecoration order)
     {
         if (order == null)
         {

--- a/src/main/java/com/minecolonies/coremod/colony/jobs/package-info.java
+++ b/src/main/java/com/minecolonies/coremod/colony/jobs/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * Contains the Job Classes for the workers
+ */
+package com.minecolonies.coremod.colony.jobs;

--- a/src/main/java/com/minecolonies/coremod/colony/workorders/AbstractWorkOrder.java
+++ b/src/main/java/com/minecolonies/coremod/colony/workorders/AbstractWorkOrder.java
@@ -285,9 +285,13 @@ public abstract class AbstractWorkOrder
     /**
      * Is this WorkOrder still valid?  If not, it will be deleted.
      *
+     * Suppressing Sonar Rule squid:S1172
+     * This rule does " Unused method parameters should be removed"
+     * But in this case extending class may need to use the colony parameter
      * @param colony The colony that owns the Work Order
      * @return True if the WorkOrder is still valid, or False if it should be deleted
      */
+    @SuppressWarnings("squid:S1172")
     public boolean isValid(final Colony colony)
     {
         return true;
@@ -338,4 +342,35 @@ public abstract class AbstractWorkOrder
     {
         BUILD
     }
+
+    /**
+     * Executed when a work order is added.
+     *
+     * Override this when something need to be done when the work order is added
+     * @param colony in which the work order exist
+     */
+    public void onAdded(final Colony colony)
+    {
+    }
+
+    /**
+     * Executed when a work order is completed.
+     *
+     * Override this when something need to be done when the work order is completed
+     * @param colony in which the work order exist
+     */
+    public void onCompleted(final Colony colony)
+    {
+    }
+
+    /**
+     * Executed when a work order is removed.
+     *
+     * Override this when something need to be done when the work order is removed
+     * @param colony in which the work order exist
+     */
+    public void onRemoved(final Colony colony)
+    {
+    }
+
 }

--- a/src/main/java/com/minecolonies/coremod/colony/workorders/WorkOrderBuildDecoration.java
+++ b/src/main/java/com/minecolonies/coremod/colony/workorders/WorkOrderBuildDecoration.java
@@ -1,14 +1,45 @@
 package com.minecolonies.coremod.colony.workorders;
 
+import com.minecolonies.coremod.colony.CitizenData;
 import com.minecolonies.coremod.colony.Colony;
 import com.minecolonies.coremod.colony.Structures;
+import com.minecolonies.coremod.colony.jobs.JobBuilder;
+import com.minecolonies.coremod.entity.ai.citizen.builder.ConstructionTapeHelper;
+import com.minecolonies.coremod.util.BlockPosUtil;
+import com.minecolonies.coremod.util.LanguageHandler;
+import com.minecolonies.coremod.util.Log;
+import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.util.math.BlockPos;
+import net.minecraft.world.World;
+import org.jetbrains.annotations.NotNull;
+
 
 /**
  * A work order that the build can take to build decorations.
  */
-public class WorkOrderBuildDecoration extends WorkOrderBuild
+public class WorkOrderBuildDecoration extends AbstractWorkOrder
 {
+    private static final String TAG_BUILDING       = "building";
+    private static final String TAG_WORKORDER_NAME = "workOrderName";
+    private static final String TAG_IS_CLEARED     = "cleared";
+    private static final String TAG_IS_REQUESTED   = "requested";
+    private static final String TAG_IS_MIRRORED    = "mirrored";
+
+    private static final String TAG_SCHEMATIC_NAME    = "structureName";
+    private static final String TAG_SCHEMATIC_MD5     = "schematicMD5";
+    private static final String TAG_BUILDING_ROTATION = "buildingRotation";
+
+    protected boolean  isMirrored;
+    protected BlockPos buildingLocation;
+    protected int      buildingRotation;
+    protected String   structureName;
+    protected String   md5;
+    protected boolean  cleared;
+    protected String   workOrderName;
+
+    protected boolean hasSentMessageForThisWorkOrder = false;
+    private boolean requested;
+
     /**
      * Unused constructor for reflection.
      */
@@ -37,7 +68,170 @@ public class WorkOrderBuildDecoration extends WorkOrderBuild
         this.buildingLocation = location;
         this.cleared = false;
         this.isMirrored = mirror;
+        this.requested = false;
     }
+
+    /**
+     * Get the name of the work order.
+     *
+     * @return the work order name
+     */
+    public String getName()
+    {
+        return workOrderName;
+    }
+
+    /**
+     * Read the WorkOrder data from the NBTTagCompound.
+     *
+     * @param compound NBT Tag compound.
+     */
+    @Override
+    public void readFromNBT(@NotNull final NBTTagCompound compound)
+    {
+        super.readFromNBT(compound);
+        buildingLocation = BlockPosUtil.readFromNBT(compound, TAG_BUILDING);
+        final Structures.StructureName sn = new Structures.StructureName(compound.getString(TAG_SCHEMATIC_NAME));
+        structureName = sn.toString();
+        workOrderName = compound.getString(TAG_WORKORDER_NAME);
+        cleared = compound.getBoolean(TAG_IS_CLEARED);
+        md5 = compound.getString(TAG_SCHEMATIC_MD5);
+        if (!Structures.hasMD5(structureName))
+        {
+            // If the schematic move we can use the MD5 hash to find it
+            final Structures.StructureName newSN = Structures.getStructureNameByMD5(md5);
+            if (newSN == null)
+            {
+                Log.getLogger().error("WorkOrderBuildDecoration.readFromNBT: Could not find " + structureName);
+            }
+            else
+            {
+                Log.getLogger().warn("WorkOrderBuildDecoration.readFromNBT: replace " + sn + " by " + newSN);
+                structureName = newSN.toString();
+
+            }
+        }
+
+        buildingRotation = compound.getInteger(TAG_BUILDING_ROTATION);
+        requested = compound.getBoolean(TAG_IS_REQUESTED);
+        isMirrored = compound.getBoolean(TAG_IS_MIRRORED);
+    }
+
+    /**
+     * Save the Work Order to an NBTTagCompound.
+     *
+     * @param compound NBT tag compound.
+     */
+    @Override
+    public void writeToNBT(@NotNull final NBTTagCompound compound)
+    {
+        super.writeToNBT(compound);
+        BlockPosUtil.writeToNBT(compound, TAG_BUILDING, buildingLocation);
+        if (workOrderName != null)
+        {
+            compound.setString(TAG_WORKORDER_NAME, workOrderName);
+        }
+        compound.setBoolean(TAG_IS_CLEARED, cleared);
+        if (md5 != null)
+        {
+            compound.setString(TAG_SCHEMATIC_MD5, md5);
+        }
+        if (structureName == null)
+        {
+            Log.getLogger().error("WorkOrderBuild.writeToNBT: structureName should not be null!!!");
+        }
+        else
+        {
+            compound.setString(TAG_SCHEMATIC_NAME, structureName);
+        }
+        compound.setInteger(TAG_BUILDING_ROTATION, buildingRotation);
+        compound.setBoolean(TAG_IS_REQUESTED, requested);
+        compound.setBoolean(TAG_IS_MIRRORED, isMirrored);
+    }
+
+    /**
+     * Attempt to fulfill the Work Order.
+     * Override this with an implementation for the Work Order to find a Citizen to perform the job
+     * <p>
+     * finds the first suitable builder for this job.
+     *
+     * @param colony The colony that owns the Work Order.
+     */
+    @Override
+    public void attemptToFulfill(@NotNull final Colony colony)
+    {
+        boolean sendMessage = true;
+        boolean hasBuilder = false;
+
+        for (@NotNull final CitizenData citizen : colony.getCitizens().values())
+        {
+            final JobBuilder job = citizen.getJob(JobBuilder.class);
+
+            if (job == null || citizen.getWorkBuilding() == null)
+            {
+                continue;
+            }
+
+            hasBuilder = true;
+
+            // don't send a message if we have a valid worker that is busy.
+            if (canBuild(citizen))
+            {
+                sendMessage = false;
+            }
+
+            if (!job.hasWorkOrder() && canBuild(citizen))
+            {
+                job.setWorkOrder(this);
+                this.setClaimedBy(citizen);
+                return;
+            }
+        }
+
+        sendBuilderMessage(colony, hasBuilder, sendMessage);
+    }
+
+    /**
+     * send a message from the builder.
+     *
+     * Suppressing Sonar Rule squid:S1172
+     * This rule does "Unused method parameters should be removed"
+     * But in this case extending class may need to use the sendMessage parameter
+     * @param colony which the work order belong to
+     * @param hasBuilder true if we have a builder for this work order
+     * @param sendMessage true if we need to send the message
+     */
+    @SuppressWarnings("squid:S1172")
+    protected void sendBuilderMessage(@NotNull final Colony colony, final boolean hasBuilder, final boolean sendMessage)
+    {
+        if (hasSentMessageForThisWorkOrder)
+        {
+            return;
+        }
+
+        if (!hasBuilder)
+        {
+            hasSentMessageForThisWorkOrder = true;
+            LanguageHandler.sendPlayersMessage(colony.getMessageEntityPlayers(),
+              "entity.builder.messageNoBuilder");
+        }
+    }
+
+    /**
+     * Checks if a builder may accept this workOrder.
+     *
+     * Suppressing Sonar Rule squid:S1172
+     * This rule does "Unused method parameters should be removed"
+     * But in this case extending class may need to use the citizen parameter
+     * @param citizen which could build it or not
+     * @return true if he is able to.
+     */
+    @SuppressWarnings("squid:S1172")
+    protected boolean canBuild(@NotNull final CitizenData citizen)
+    {
+        return true;
+    }
+
 
     @Override
     public boolean isValid(final Colony colony)
@@ -45,9 +239,121 @@ public class WorkOrderBuildDecoration extends WorkOrderBuild
         return true;
     }
 
+    @NotNull
+    @Override
+    protected WorkOrderType getType()
+    {
+        return WorkOrderType.BUILD;
+    }
+
+
     @Override
     protected String getValue()
     {
         return workOrderName;
     }
+
+    /**
+     * Returns the ID of the building (aka ChunkCoordinates).
+     *
+     * @return ID of the building.
+     */
+    public BlockPos getBuildingLocation()
+    {
+        return buildingLocation;
+    }
+
+    /**
+     * Get the name the structure for this work order.
+     *
+     * @return the internal string for this structure.
+     */
+    public String getStructureName()
+    {
+        return structureName;
+    }
+
+    /**
+     * Gets how many times this structure should be rotated.
+     *
+     * Suppressing Sonar Rule squid:S1172
+     * This rule does "Unused method parameters should be removed"
+     * But in this case extending class may need to use the world parameter
+     * @param world where the decoration is
+     * @return building rotation.
+     */
+    @SuppressWarnings("squid:S1172")
+    public int getRotation(final World world)
+    {
+        return buildingRotation;
+    }
+
+    /**
+     * Gets whether or not the building has been cleared.
+     *
+     * @return true if the building has been cleared.
+     */
+    public boolean isCleared()
+    {
+        return cleared;
+    }
+
+    /**
+     * Set whether or not the building has been cleared.
+     *
+     * @param cleared true if the building has been cleared.
+     */
+    public void setCleared(final boolean cleared)
+    {
+        this.cleared = cleared;
+    }
+
+    /**
+     * Gets whether or not the building materials have been requested already.
+     *
+     * @return true if the materials has been requested.
+     */
+    public boolean isRequested()
+    {
+        return requested;
+    }
+
+
+    /**
+     * Set whether or not the building materials have been requested already.
+     *
+     * @param requested true if so.
+     */
+    public void setRequested(final boolean requested)
+    {
+        this.requested = requested;
+    }
+
+    /**
+     * Check if the workOrder should be built isMirrored.
+     *
+     * @return true if so.
+     */
+    public boolean isMirrored()
+    {
+        return isMirrored;
+    }
+
+    @Override
+    public void onAdded(final Colony colony)
+    {
+        super.onAdded(colony);
+        if (colony != null && colony.getWorld() != null)
+        {
+            ConstructionTapeHelper.placeConstructionTape(this, colony.getWorld());
+        }
+    }
+
+    @Override
+    public void onRemoved(final Colony colony)
+    {
+        super.onRemoved(colony);
+        ConstructionTapeHelper.removeConstructionTape(this, colony.getWorld());
+    }
+
 }

--- a/src/main/java/com/minecolonies/coremod/colony/workorders/package-info.java
+++ b/src/main/java/com/minecolonies/coremod/colony/workorders/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * Contains the classes relative to work orders
+ */
+package com.minecolonies.coremod.colony.workorders;

--- a/src/main/java/com/minecolonies/coremod/entity/ai/citizen/builder/ConstructionTapeHelper.java
+++ b/src/main/java/com/minecolonies/coremod/entity/ai/citizen/builder/ConstructionTapeHelper.java
@@ -1,12 +1,10 @@
 package com.minecolonies.coremod.entity.ai.citizen.builder;
 
-import com.minecolonies.coremod.blocks.AbstractBlockHut;
 import com.minecolonies.coremod.blocks.ModBlocks;
 import com.minecolonies.coremod.colony.buildings.AbstractBuilding;
-import com.minecolonies.coremod.colony.workorders.WorkOrderBuild;
 import com.minecolonies.coremod.colony.workorders.WorkOrderBuildDecoration;
+import com.minecolonies.coremod.colony.workorders.WorkOrderBuild;
 import com.minecolonies.coremod.configuration.Configurations;
-import com.minecolonies.coremod.util.BlockUtils;
 import com.minecolonies.coremod.util.StructureWrapper;
 import net.minecraft.block.Block;
 import net.minecraft.block.BlockHorizontal;
@@ -107,30 +105,16 @@ public final class ConstructionTapeHelper
      * @param world the world.
      */
 
-    public static void placeConstructionTape(@NotNull WorkOrderBuild workOrder, @NotNull World world)
+    public static void placeConstructionTape(@NotNull WorkOrderBuildDecoration workOrder, @NotNull World world)
     {
         if (Configurations.builderPlaceConstructionTape)
         {
             final StructureWrapper wrapper = new StructureWrapper(world, workOrder.getStructureName());
             final BlockPos pos = workOrder.getBuildingLocation();
-            int tempRotation = 0;
             final IBlockState constructionTape = ModBlocks.blockConstructionTape.getDefaultState();
             final IBlockState constructionTapeCorner = ModBlocks.blockConstructionTapeCorner.getDefaultState();
 
-            if (workOrder.getRotation() == 0 && !(workOrder instanceof WorkOrderBuildDecoration))
-            {
-                final IBlockState blockState = world.getBlockState(pos);
-                if (blockState.getBlock() instanceof AbstractBlockHut)
-                {
-                    tempRotation = BlockUtils.getRotationFromFacing(blockState.getValue(AbstractBlockHut.FACING));
-                }
-            }
-            else
-            {
-                tempRotation = workOrder.getRotation();
-            }
-
-            wrapper.rotate(tempRotation, world, workOrder.getBuildingLocation(), workOrder.isMirrored() ? Mirror.FRONT_BACK : Mirror.NONE);
+            wrapper.rotate(workOrder.getRotation(world), world, workOrder.getBuildingLocation(), workOrder.isMirrored() ? Mirror.FRONT_BACK : Mirror.NONE);
             wrapper.setPosition(pos);
 
             final int x1 = wrapper.getPosition().getX() - wrapper.getOffset().getX() - 1;
@@ -219,23 +203,11 @@ public final class ConstructionTapeHelper
      * @param world the world.
      */
 
-    public static void removeConstructionTape(@NotNull WorkOrderBuild workOrder,@NotNull World world)
+    public static void removeConstructionTape(@NotNull WorkOrderBuildDecoration workOrder, @NotNull World world)
     {
         final StructureWrapper wrapper = new StructureWrapper(world, workOrder.getStructureName());
         final BlockPos pos = workOrder.getBuildingLocation();
-        int tempRotation = 0;
-        if (workOrder.getRotation() == 0 && !(workOrder instanceof WorkOrderBuildDecoration))
-        {
-            final IBlockState blockState = world.getBlockState(pos);
-            if (blockState.getBlock() instanceof AbstractBlockHut)
-            {
-                tempRotation = BlockUtils.getRotationFromFacing(blockState.getValue(AbstractBlockHut.FACING));
-            }
-        }
-        else
-        {
-            tempRotation = workOrder.getRotation();
-        }
+        final int tempRotation =  workOrder.getRotation(world);
         wrapper.rotate(tempRotation, world, workOrder.getBuildingLocation(), workOrder.isMirrored() ? Mirror.FRONT_BACK : Mirror.NONE);
         wrapper.setPosition(pos);
         final int x1 = wrapper.getPosition().getX() - wrapper.getOffset().getX() - 1;

--- a/src/main/java/com/minecolonies/coremod/entity/ai/citizen/builder/EntityAIStructureBuilder.java
+++ b/src/main/java/com/minecolonies/coremod/entity/ai/citizen/builder/EntityAIStructureBuilder.java
@@ -7,8 +7,8 @@ import com.minecolonies.coremod.colony.buildings.AbstractBuildingWorker;
 import com.minecolonies.coremod.colony.buildings.BuildingBuilder;
 import com.minecolonies.coremod.colony.buildings.utils.BuildingBuilderResource;
 import com.minecolonies.coremod.colony.jobs.JobBuilder;
-import com.minecolonies.coremod.colony.workorders.WorkOrderBuild;
 import com.minecolonies.coremod.colony.workorders.WorkOrderBuildDecoration;
+import com.minecolonies.coremod.colony.workorders.WorkOrderBuild;
 import com.minecolonies.coremod.configuration.Configurations;
 import com.minecolonies.coremod.entity.ai.basic.AbstractEntityAIStructure;
 import com.minecolonies.coremod.entity.ai.util.AIState;
@@ -98,7 +98,7 @@ public class EntityAIStructureBuilder extends AbstractEntityAIStructure<JobBuild
      */
     private void loadStructure()
     {
-        WorkOrderBuild workOrder = null;
+        WorkOrderBuildDecoration workOrder = null;
         workOrder = job.getWorkOrder();
 
         if (workOrder == null)
@@ -107,26 +107,14 @@ public class EntityAIStructureBuilder extends AbstractEntityAIStructure<JobBuild
         }
 
         final BlockPos pos = workOrder.getBuildingLocation();
-        if (!(workOrder instanceof WorkOrderBuildDecoration) && worker.getColony().getBuilding(pos) == null)
+        if (workOrder instanceof WorkOrderBuild && worker.getColony().getBuilding(pos) == null)
         {
             Log.getLogger().warn("AbstractBuilding does not exist - removing build request");
             worker.getColony().getWorkManager().removeWorkOrder(workOrder);
             return;
         }
 
-        int tempRotation = 0;
-        if (workOrder.getRotation() == 0 && !(workOrder instanceof WorkOrderBuildDecoration))
-        {
-            final IBlockState blockState = world.getBlockState(pos);
-            if (blockState.getBlock() instanceof AbstractBlockHut)
-            {
-                tempRotation = BlockUtils.getRotationFromFacing(blockState.getValue(AbstractBlockHut.FACING));
-            }
-        }
-        else
-        {
-            tempRotation = workOrder.getRotation();
-        }
+        final int tempRotation = workOrder.getRotation(world);
 
         loadStructure(workOrder.getStructureName(), tempRotation, pos, workOrder.isMirrored());
         workOrder.setCleared(false);
@@ -151,9 +139,9 @@ public class EntityAIStructureBuilder extends AbstractEntityAIStructure<JobBuild
             return true;
         }
 
-        final WorkOrderBuild wo = job.getWorkOrder();
+        final WorkOrderBuildDecoration wo = job.getWorkOrder();
 
-        if (job.getColony().getBuilding(wo.getBuildingLocation()) == null && !(wo instanceof WorkOrderBuildDecoration))
+        if (job.getColony().getBuilding(wo.getBuildingLocation()) == null && wo instanceof WorkOrderBuild)
         {
             job.complete();
             return true;
@@ -323,7 +311,7 @@ public class EntityAIStructureBuilder extends AbstractEntityAIStructure<JobBuild
         {
             workFrom = null;
             loadStructure();
-            final WorkOrderBuild wo = job.getWorkOrder();
+            final WorkOrderBuildDecoration wo = job.getWorkOrder();
             if (wo == null)
             {
                 Log.getLogger().error(
@@ -333,11 +321,7 @@ public class EntityAIStructureBuilder extends AbstractEntityAIStructure<JobBuild
                 return;
             }
 
-            if (wo instanceof WorkOrderBuildDecoration)
-            {
-                worker.sendLocalizedChat(COM_MINECOLONIES_COREMOD_ENTITY_BUILDER_BUILDSTART, wo.getName());
-            }
-            else
+            if (wo instanceof WorkOrderBuild)
             {
                 final AbstractBuilding building = job.getColony().getBuilding(wo.getBuildingLocation());
                 if (building == null)
@@ -355,6 +339,10 @@ public class EntityAIStructureBuilder extends AbstractEntityAIStructure<JobBuild
                 {
                     wo.setCleared(true);
                 }
+            }
+            else
+            {
+                worker.sendLocalizedChat(COM_MINECOLONIES_COREMOD_ENTITY_BUILDER_BUILDSTART, wo.getName());
             }
         }
     }
@@ -467,7 +455,7 @@ public class EntityAIStructureBuilder extends AbstractEntityAIStructure<JobBuild
         final String structureName = job.getStructure().getName();
         worker.sendLocalizedChat(COM_MINECOLONIES_COREMOD_ENTITY_BUILDER_BUILDCOMPLETE, structureName);
 
-        final WorkOrderBuild wo = job.getWorkOrder();
+        final WorkOrderBuildDecoration wo = job.getWorkOrder();
         if (wo == null)
         {
             Log.getLogger().error(String.format("Builder (%d:%d) ERROR - Finished, but missing work order(%d)",
@@ -477,11 +465,12 @@ public class EntityAIStructureBuilder extends AbstractEntityAIStructure<JobBuild
         }
         else
         {
-            if (wo instanceof WorkOrderBuildDecoration && structureName.contains(WAYPOINT_STRING))
+            final WorkOrderBuild woh = (wo instanceof WorkOrderBuild)?(WorkOrderBuild) wo : null;
+            if (woh == null && structureName.contains(WAYPOINT_STRING))
             {
                 worker.getColony().addWayPoint(wo.getBuildingLocation(), world.getBlockState(wo.getBuildingLocation()));
             }
-            else
+            else if (woh != null)
             {
                 final AbstractBuilding building = job.getColony().getBuilding(wo.getBuildingLocation());
                 if (building == null)
@@ -489,11 +478,11 @@ public class EntityAIStructureBuilder extends AbstractEntityAIStructure<JobBuild
                     Log.getLogger().error(String.format("Builder (%d:%d) ERROR - Finished, but missing building(%s)",
                             worker.getColony().getID(),
                             worker.getCitizenData().getId(),
-                            wo.getBuildingLocation()));
+                            woh.getBuildingLocation()));
                 }
                 else
                 {
-                    building.setBuildingLevel(wo.getUpgradeLevel());
+                    building.setBuildingLevel(woh.getUpgradeLevel());
                 }
             }
             job.complete();


### PR DESCRIPTION
 Refactor/1.10 workorders

* Suppress some warnings

* Add worker name to the message when chest is full

* Fix warnings for PlacementHandlers

* Builder say when then start a job

* WorkOrderBuildHut extends WorkOrderBuildDecoration
instead of
WorkOrderBuildDecoration extends WorkOrderBuild

* revert WorkOrderBuildHut class to WorkOrderBuild

* Work Manager does not need to know about Construction tape and WorkOrderBuildDecoration

* JobBuilder class does not need to know about WorkOrderBuild

* remove duplicated code

* add package info

* Sonar suppress

Tested

