### PR TITLE
Bugfix/#758 concurrency issue (#1025)

### DIFF
--- a/src/main/java/com/minecolonies/coremod/colony/buildings/AbstractBuilding.java
+++ b/src/main/java/com/minecolonies/coremod/colony/buildings/AbstractBuilding.java
@@ -1053,12 +1053,16 @@ public abstract class AbstractBuilding
     }
 
     /**
-     * Getter for the neededItems.
-     * @return an unmodifiable list.
+     * This method makes a copy of the itemsCurrentlyNeeded.
+     * Currently every call to this method needs a copy, if for some reason an outside
+     * class needs this list and a copy isn't desired, a new method should be created,
+     * and this doc should be changed to point to that new method.
+     *
+     * @return a copy of the itemsCurrentlyNeeded list.
      */
-    public List<ItemStack> getNeededItems()
+    public List<ItemStack> getCopyOfNeededItems()
     {
-        return Collections.unmodifiableList(itemsCurrentlyNeeded);
+        return new ArrayList<>(itemsCurrentlyNeeded);
     }
 
     /**

--- a/src/main/java/com/minecolonies/coremod/entity/ai/citizen/deliveryman/EntityAIWorkDeliveryman.java
+++ b/src/main/java/com/minecolonies/coremod/entity/ai/citizen/deliveryman/EntityAIWorkDeliveryman.java
@@ -382,7 +382,7 @@ public class EntityAIWorkDeliveryman extends AbstractEntityAIInteract<JobDeliver
                     buildingToDeliver.setOnGoingDelivery(false);
                     return START_WORKING;
                 }
-                itemsToDeliver = new ArrayList<>(buildingToDeliver.getNeededItems());
+                itemsToDeliver = buildingToDeliver.getCopyOfNeededItems();
                 return GATHER_IN_WAREHOUSE;
             }
         }


### PR DESCRIPTION
Port #1025 to version/1.10

* Centralize the copying of the needed items list, and make it explicitly clear a copy is happening

* Remove duplicated methods, and unnecessary casts

* Change CopyOnWriteArrayList to ConcurrentLinkedQueue for current warehouse tasks.

The list is being modified often, and being treated like a queue. The ConcurrentLinkedQueue should be a better data structure for the situation and be more performant.