### PR TITLE
avoid concurrent modificatione xception

### DIFF
--- a/src/main/java/com/minecolonies/coremod/colony/buildings/BuildingBaker.java
+++ b/src/main/java/com/minecolonies/coremod/colony/buildings/BuildingBaker.java
@@ -379,7 +379,8 @@ public class BuildingBaker extends AbstractBuildingWorker
             return;
         }
 
-        for(final Map.Entry<BlockPos, BakingProduct> entry: this.getFurnacesWithProduct().entrySet())
+        final List<Map.Entry<BlockPos, BakingProduct>> copyOfList = new ArrayList<>(this.getFurnacesWithProduct().entrySet());
+        for(final Map.Entry<BlockPos, BakingProduct> entry: copyOfList)
         {
             final IBlockState furnace = worldObj.getBlockState(entry.getKey());
             if(!(furnace.getBlock() instanceof BlockFurnace))


### PR DESCRIPTION
java.util.ConcurrentModificationException
	at java.util.HashMap$HashIterator.nextNode(Unknown Source)
	at java.util.HashMap$EntryIterator.next(Unknown Source)
	at java.util.HashMap$EntryIterator.next(Unknown Source)
	at java.util.Collections$UnmodifiableMap$UnmodifiableEntrySet$1.next(Unknown Source)
	at java.util.Collections$UnmodifiableMap$UnmodifiableEntrySet$1.next(Unknown Source)
	at com.minecolonies.coremod.colony.buildings.BuildingBaker.checkFurnaces(BuildingBaker.java:382)
	at com.minecolonies.coremod.colony.buildings.BuildingBaker.onWorldTick(BuildingBaker.java:366)
	at com.minecolonies.coremod.colony.Colony.onWorldTick(Colony.java:1209)
	at com.minecolonies.coremod.colony.ColonyManager.lambda$onWorldTick$1(ColonyManager.java:694)
	at java.util.ArrayList.forEach(Unknown Source)
	at com.minecolonies.coremod.colony.ColonyManager.onWorldTick(ColonyManager.java:694)
	at com.minecolonies.coremod.event.FMLEventHandler.onWorldTick(FMLEventHandler.java:51)
	at net.minecraftforge.fml.common.eventhandler.ASMEventHandler_16_FMLEventHandler_onWorldTick_WorldTickEvent.invoke(.dynamic)
	at net.minecraftforge.fml.common.eventhandler.ASMEventHandler.invoke(ASMEventHandler.java:90)
	at net.minecraftforge.fml.common.eventhandler.EventBus.post(EventBus.java:185)
	at net.minecraftforge.fml.common.FMLCommonHandler.onPreWorldTick(FMLCommonHandler.java:282)
	at net.minecraft.server.MinecraftServer.func_71190_q(MinecraftServer.java:694)
	at net.minecraft.server.MinecraftServer.func_71217_p(MinecraftServer.java:613)
	at net.minecraft.server.integrated.IntegratedServer.func_71217_p(IntegratedServer.java:149)
	at net.minecraft.server.MinecraftServer.run(MinecraftServer.java:471)


# Changes proposed in this pull request:
- Fixes the above

Review please
