### PR TITLE
Compatibility/1.11 itemstack count

### DIFF
--- a/src/api/java/com/minecolonies/api/colony/requestsystem/requestable/Tool.java
+++ b/src/api/java/com/minecolonies/api/colony/requestsystem/requestable/Tool.java
@@ -1,5 +1,6 @@
 package com.minecolonies.api.colony.requestsystem.requestable;
 
+import com.minecolonies.api.util.ItemStackUtils;
 import net.minecraft.item.ItemStack;
 import org.jetbrains.annotations.NotNull;
 
@@ -23,7 +24,7 @@ public class Tool
 
     public Tool(@NotNull String toolClass, @NotNull Integer minLevel, @NotNull Integer maxLevel)
     {
-        this(toolClass, minLevel, maxLevel, ItemStack.EMPTY);
+        this(toolClass, minLevel, maxLevel, ItemStackUtils.EMPTY);
     }
 
     public Tool(@NotNull String toolClass, @NotNull Integer minLevel, @NotNull Integer maxLevel, @NotNull ItemStack result)

--- a/src/api/java/com/minecolonies/api/colony/requestsystem/requestable/Weapon.java
+++ b/src/api/java/com/minecolonies/api/colony/requestsystem/requestable/Weapon.java
@@ -1,5 +1,6 @@
 package com.minecolonies.api.colony.requestsystem.requestable;
 
+import com.minecolonies.api.util.ItemStackUtils;
 import net.minecraft.item.ItemStack;
 import org.jetbrains.annotations.NotNull;
 
@@ -23,7 +24,7 @@ public class Weapon
 
     public Weapon(@NotNull final WeaponType type, @NotNull final Integer minLevel, @NotNull final Integer maxLevel)
     {
-        this(type, minLevel, maxLevel, ItemStack.EMPTY);
+        this(type, minLevel, maxLevel, ItemStackUtils.EMPTY);
     }
 
     public Weapon(@NotNull final WeaponType type, @NotNull final Integer minLevel, @NotNull final Integer maxLevel, @NotNull final ItemStack result)

--- a/src/api/java/com/minecolonies/api/util/InventoryUtils.java
+++ b/src/api/java/com/minecolonies/api/util/InventoryUtils.java
@@ -1461,7 +1461,7 @@ public class InventoryUtils
             }
             else
             {
-                ItemStackUtils.setSize(stack, ItemStackUtils.getSize(stack) - removedSize);
+                ItemStackUtils.increaseOrDecreaseSize(stack, -removedSize);
             }
             tries++;
         }

--- a/src/api/java/com/minecolonies/api/util/InventoryUtils.java
+++ b/src/api/java/com/minecolonies/api/util/InventoryUtils.java
@@ -68,7 +68,7 @@ public class InventoryUtils
         for (int slot = 0; slot < itemHandler.getSlots(); slot++)
         {
             final ItemStack stack = itemHandler.getStackInSlot(slot);
-            if (!ItemStackUtils.isItemStackEmpty(stack) && itemStackSelectionPredicate.test(stack))
+            if (!ItemStackUtils.isEmpty(stack) && itemStackSelectionPredicate.test(stack))
             {
                 filtered.add(stack);
             }
@@ -87,7 +87,7 @@ public class InventoryUtils
      */
     private static boolean compareItems(@Nullable final ItemStack itemStack, final Item targetItem, final int itemDamage)
     {
-        return !ItemStackUtils.isItemStackEmpty(itemStack) && itemStack.getItem() == targetItem && (itemStack.getItemDamage() == itemDamage || itemDamage == -1);
+        return !ItemStackUtils.isEmpty(itemStack) && itemStack.getItem() == targetItem && (itemStack.getItemDamage() == itemDamage || itemDamage == -1);
     }
 
     /**
@@ -262,7 +262,7 @@ public class InventoryUtils
     {
         //Test with two different ItemStacks to insert in simulation mode.
         return IntStream.range(0, itemHandler.getSlots())
-                .filter(slot -> ItemStackUtils.isItemStackEmpty(itemHandler.getStackInSlot(slot)))
+                .filter(slot -> ItemStackUtils.isEmpty(itemHandler.getStackInSlot(slot)))
                 .findFirst()
                 .orElse(-1);
     }
@@ -287,7 +287,7 @@ public class InventoryUtils
      */
     public static boolean addItemStackToItemHandler(@NotNull final IItemHandler itemHandler, @Nullable final ItemStack itemStack)
     {
-        if (!ItemStackUtils.isItemStackEmpty(itemStack))
+        if (!ItemStackUtils.isEmpty(itemStack))
         {
             int slot;
 
@@ -309,17 +309,17 @@ public class InventoryUtils
             {
                 ItemStack resultStack = itemStack;
                 slot = itemHandler.getSlots() == 0 ? -1 : 0;
-                while (!ItemStackUtils.isItemStackEmpty(resultStack) && slot != -1 && slot != itemHandler.getSlots())
+                while (!ItemStackUtils.isEmpty(resultStack) && slot != -1 && slot != itemHandler.getSlots())
                 {
                     resultStack = itemHandler.insertItem(slot, resultStack, false);
-                    if (!ItemStackUtils.isItemStackEmpty(resultStack))
+                    if (!ItemStackUtils.isEmpty(resultStack))
                     {
                         slot++;
                     }
                 }
 
 
-                return ItemStackUtils.isItemStackEmpty(resultStack);
+                return ItemStackUtils.isEmpty(resultStack);
             }
         }
         else
@@ -348,17 +348,17 @@ public class InventoryUtils
     {
         final ItemStack standardInsertionResult = addItemStackToItemHandlerWithResult(itemHandler, itemStack);
 
-        if (!ItemStackUtils.isItemStackEmpty(standardInsertionResult))
+        if (!ItemStackUtils.isEmpty(standardInsertionResult))
         {
-            for (int i = 0; i < itemHandler.getSlots() && !ItemStackUtils.isItemStackEmpty(standardInsertionResult); i++)
+            for (int i = 0; i < itemHandler.getSlots() && !ItemStackUtils.isEmpty(standardInsertionResult); i++)
             {
                 final ItemStack localStack = itemHandler.getStackInSlot(i);
-                if (ItemStackUtils.isItemStackEmpty(localStack) || !itemStackToKeepPredicate.test(localStack))
+                if (ItemStackUtils.isEmpty(localStack) || !itemStackToKeepPredicate.test(localStack))
                 {
                     final ItemStack removedStack = itemHandler.extractItem(i, Integer.MAX_VALUE, false);
                     final ItemStack localInsertionResult = itemHandler.insertItem(i, standardInsertionResult, false);
 
-                    if (ItemStackUtils.isItemStackEmpty(localInsertionResult))
+                    if (ItemStackUtils.isEmpty(localInsertionResult))
                     {
                         //Insertion successful. Returning the extracted stack.
                         return removedStack.copy();
@@ -750,7 +750,7 @@ public class InventoryUtils
     {
         ItemStack activeStack = itemStack;
 
-        if (ItemStackUtils.isItemStackEmpty(activeStack))
+        if (ItemStackUtils.isEmpty(activeStack))
         {
             return ItemStackUtils.EMPTY;
         }
@@ -772,7 +772,7 @@ public class InventoryUtils
      */
     public static ItemStack addItemStackToItemHandlerWithResult(@NotNull final IItemHandler itemHandler, @Nullable final ItemStack itemStack)
     {
-        if (!ItemStackUtils.isItemStackEmpty(itemStack))
+        if (!ItemStackUtils.isEmpty(itemStack))
         {
             int slot;
 
@@ -794,10 +794,10 @@ public class InventoryUtils
             {
                 ItemStack resultStack = itemStack;
                 slot = itemHandler.getSlots() == 0 ? -1 : 0;
-                while (!ItemStackUtils.isItemStackEmpty(resultStack) && slot != -1 && slot != itemHandler.getSlots())
+                while (!ItemStackUtils.isEmpty(resultStack) && slot != -1 && slot != itemHandler.getSlots())
                 {
                     resultStack = itemHandler.insertItem(slot, resultStack, false);
-                    if (!ItemStackUtils.isItemStackEmpty(resultStack))
+                    if (!ItemStackUtils.isEmpty(resultStack))
                     {
                         slot++;
                     }
@@ -831,11 +831,11 @@ public class InventoryUtils
     {
         final ItemStack standardInsertionResult = addItemStackToProviderWithResult(provider, itemStack);
 
-        if (!ItemStackUtils.isItemStackEmpty(standardInsertionResult))
+        if (!ItemStackUtils.isEmpty(standardInsertionResult))
         {
             ItemStack resultStack = standardInsertionResult.copy();
             final Iterator<IItemHandler> iterator = getItemHandlersFromProvider(provider).iterator();
-            while (iterator.hasNext() && !ItemStackUtils.isItemStackEmpty(resultStack))
+            while (iterator.hasNext() && !ItemStackUtils.isEmpty(resultStack))
             {
                 resultStack = forceItemStackToItemHandler(iterator.next(), resultStack, itemStackToKeepPredicate);
             }
@@ -1272,7 +1272,7 @@ public class InventoryUtils
     public static boolean hasItemHandlerToolWithLevel(@NotNull final IItemHandler itemHandler, final IToolType toolType, final int requiredLevel, final int maximumLevel)
     {
         return findFirstSlotInItemHandlerWith(itemHandler,
-          (ItemStack stack) -> (!ItemStackUtils.isItemStackEmpty(stack) && (ItemStackUtils.isTool(stack, toolType) && ItemStackUtils.verifyToolLevel(stack,
+          (ItemStack stack) -> (!ItemStackUtils.isEmpty(stack) && (ItemStackUtils.isTool(stack, toolType) && ItemStackUtils.verifyToolLevel(stack,
             ItemStackUtils.getMiningLevel(stack, toolType),
             requiredLevel, maximumLevel)))) > -1;
     }
@@ -1316,7 +1316,7 @@ public class InventoryUtils
             return false;
         }
         final ItemStack returnStack = sourceHandler.extractItem(desiredItemSlot, amount, false);
-        if(ItemStackUtils.isItemStackEmpty(returnStack))
+        if(ItemStackUtils.isEmpty(returnStack))
         {
             return false;
         }
@@ -1340,7 +1340,7 @@ public class InventoryUtils
         for (int i = 0; i < targetHandler.getSlots(); i++)
         {
             sourceStack = targetHandler.insertItem(i, sourceStack, false);
-            if (ItemStackUtils.isItemStackEmpty(sourceStack))
+            if (ItemStackUtils.isEmpty(sourceStack))
             {
                 sourceHandler.extractItem(sourceIndex, Integer.MAX_VALUE, false);
                 return true;
@@ -1406,7 +1406,7 @@ public class InventoryUtils
         final ItemStack sourceStack = sourceHandler.extractItem(sourceIndex, Integer.MAX_VALUE, true);
 
         final ItemStack resultSourceSimulationInsertion = targetHandler.insertItem(targetIndex, sourceStack, true);
-        if (ItemStackUtils.isItemStackEmpty(resultSourceSimulationInsertion) || ItemStackUtils.isItemStackEmpty(targetStack))
+        if (ItemStackUtils.isEmpty(resultSourceSimulationInsertion) || ItemStackUtils.isEmpty(targetStack))
         {
             targetHandler.insertItem(targetIndex, sourceStack, false);
             sourceHandler.extractItem(sourceIndex, Integer.MAX_VALUE, false);

--- a/src/api/java/com/minecolonies/api/util/InventoryUtils.java
+++ b/src/api/java/com/minecolonies/api/util/InventoryUtils.java
@@ -1434,7 +1434,7 @@ public class InventoryUtils
         int maxTries = 0;
         for(final ItemStack stack: input)
         {
-            maxTries+= stack.getCount();
+            maxTries+= ItemStackUtils.getItemStackSize(stack);
             list.add(stack.copy());
         }
 
@@ -1453,15 +1453,15 @@ public class InventoryUtils
                 continue;
             }
 
-            final int removedSize = handler.extractItem(slot, stack.getCount(), false).getCount();
+            final int removedSize = ItemStackUtils.getItemStackSize(handler.extractItem(slot, ItemStackUtils.getItemStackSize(stack), false));
 
-            if(removedSize == stack.getCount())
+            if(removedSize == ItemStackUtils.getItemStackSize(stack))
             {
                 i++;
             }
             else
             {
-                stack.setCount(stack.getCount() - removedSize);
+                stack.setCount(ItemStackUtils.getItemStackSize(stack) - removedSize);
             }
             tries++;
         }

--- a/src/api/java/com/minecolonies/api/util/InventoryUtils.java
+++ b/src/api/java/com/minecolonies/api/util/InventoryUtils.java
@@ -1461,7 +1461,7 @@ public class InventoryUtils
             }
             else
             {
-                ItemStackUtils.increaseOrDecreaseSize(stack, -removedSize);
+                ItemStackUtils.changeSize(stack, -removedSize);
             }
             tries++;
         }

--- a/src/api/java/com/minecolonies/api/util/InventoryUtils.java
+++ b/src/api/java/com/minecolonies/api/util/InventoryUtils.java
@@ -206,7 +206,7 @@ public class InventoryUtils
      */
     public static int getItemCountInItemHandler(@NotNull final IItemHandler itemHandler, @NotNull final Predicate<ItemStack> itemStackSelectionPredicate)
     {
-        return filterItemHandler(itemHandler, itemStackSelectionPredicate).stream().mapToInt(ItemStackUtils::getItemStackSize).sum();
+        return filterItemHandler(itemHandler, itemStackSelectionPredicate).stream().mapToInt(ItemStackUtils::getSize).sum();
     }
 
     /**
@@ -636,7 +636,7 @@ public class InventoryUtils
     public static int getItemCountInProvider(@NotNull final ICapabilityProvider provider, @NotNull final Predicate<ItemStack> itemStackSelectionPredicate)
     {
         return getItemHandlersFromProvider(provider).stream()
-                 .mapToInt(handler -> filterItemHandler(handler, itemStackSelectionPredicate).stream().mapToInt(ItemStackUtils::getItemStackSize).sum())
+                 .mapToInt(handler -> filterItemHandler(handler, itemStackSelectionPredicate).stream().mapToInt(ItemStackUtils::getSize).sum())
                  .sum();
     }
 
@@ -1099,7 +1099,7 @@ public class InventoryUtils
             return 0;
         }
 
-        return filterItemHandler(provider.getCapability(ITEM_HANDLER_CAPABILITY, facing), itemStackSelectionPredicate).stream().mapToInt(ItemStackUtils::getItemStackSize).sum();
+        return filterItemHandler(provider.getCapability(ITEM_HANDLER_CAPABILITY, facing), itemStackSelectionPredicate).stream().mapToInt(ItemStackUtils::getSize).sum();
     }
 
     /**
@@ -1349,7 +1349,7 @@ public class InventoryUtils
 
         if (!ItemStack.areItemStacksEqual(sourceStack, originalStack) && ItemStackUtils.compareItemStacksIgnoreStackSize(sourceStack, originalStack))
         {
-            final int usedAmount = ItemStackUtils.getItemStackSize(sourceStack) - ItemStackUtils.getItemStackSize(originalStack);
+            final int usedAmount = ItemStackUtils.getSize(sourceStack) - ItemStackUtils.getSize(originalStack);
             sourceHandler.extractItem(sourceIndex, usedAmount, false);
             return true;
         }
@@ -1434,7 +1434,7 @@ public class InventoryUtils
         int maxTries = 0;
         for(final ItemStack stack: input)
         {
-            maxTries+= ItemStackUtils.getItemStackSize(stack);
+            maxTries+= ItemStackUtils.getSize(stack);
             list.add(stack.copy());
         }
 
@@ -1453,15 +1453,15 @@ public class InventoryUtils
                 continue;
             }
 
-            final int removedSize = ItemStackUtils.getItemStackSize(handler.extractItem(slot, ItemStackUtils.getItemStackSize(stack), false));
+            final int removedSize = ItemStackUtils.getSize(handler.extractItem(slot, ItemStackUtils.getSize(stack), false));
 
-            if(removedSize == ItemStackUtils.getItemStackSize(stack))
+            if(removedSize == ItemStackUtils.getSize(stack))
             {
                 i++;
             }
             else
             {
-                stack.setCount(ItemStackUtils.getItemStackSize(stack) - removedSize);
+                stack.setCount(ItemStackUtils.getSize(stack) - removedSize);
             }
             tries++;
         }

--- a/src/api/java/com/minecolonies/api/util/InventoryUtils.java
+++ b/src/api/java/com/minecolonies/api/util/InventoryUtils.java
@@ -1461,7 +1461,7 @@ public class InventoryUtils
             }
             else
             {
-                stack.setCount(ItemStackUtils.getSize(stack) - removedSize);
+                ItemStackUtils.setSize(stack, ItemStackUtils.getSize(stack) - removedSize);
             }
             tries++;
         }

--- a/src/api/java/com/minecolonies/api/util/ItemStackUtils.java
+++ b/src/api/java/com/minecolonies/api/util/ItemStackUtils.java
@@ -375,6 +375,17 @@ public final class ItemStackUtils
         stack.setCount(size);
     }
 
+    /**
+     * Increase or decrease the stack size.
+     *
+     * @param stack to set the size to
+     * @param amount to increase the stack's size of (negative value to decrease)
+     */
+    public static void increaseOrDecreaseSize(@NotNull final ItemStack stack, final int amount)
+    {
+        stack.setCount(stack.getCount() + amount);
+    }
+
 
     /**
      * Method to compare to stacks, ignoring their stacksize.

--- a/src/api/java/com/minecolonies/api/util/ItemStackUtils.java
+++ b/src/api/java/com/minecolonies/api/util/ItemStackUtils.java
@@ -370,7 +370,7 @@ public final class ItemStackUtils
      * @param size of the stack
      */
     @NotNull
-    public static int getSize(@NotNull final ItemStack stack, final int size)
+    public static void setSize(@NotNull final ItemStack stack, final int size)
     {
         stack.setCount(size);
     }

--- a/src/api/java/com/minecolonies/api/util/ItemStackUtils.java
+++ b/src/api/java/com/minecolonies/api/util/ItemStackUtils.java
@@ -32,7 +32,7 @@ public final class ItemStackUtils
      * Predicate to check if an itemStack is empty.
      */
     @NotNull
-    public static final Predicate<ItemStack> EMPTY_PREDICATE = ItemStackUtils::isItemStackEmpty;
+    public static final Predicate<ItemStack> EMPTY_PREDICATE = ItemStackUtils::isEmpty;
 
     /**
      * Negation of the itemStack empty predicate (not empty).
@@ -77,7 +77,7 @@ public final class ItemStackUtils
      */
     public static boolean hasToolLevel(@Nullable final ItemStack stack, final IToolType toolType, final int minimalLevel, final int maximumLevel)
     {
-        if (isItemStackEmpty(stack))
+        if (isEmpty(stack))
         {
             return false;
         }
@@ -94,7 +94,7 @@ public final class ItemStackUtils
      * @return True when the stack is empty, false when not.
      */
     @NotNull
-    public static Boolean isItemStackEmpty(@Nullable final ItemStack stack)
+    public static Boolean isEmpty(@Nullable final ItemStack stack)
     {
         return stack == null || stack == EMPTY || stack.getCount() <= 0;
     }
@@ -108,7 +108,7 @@ public final class ItemStackUtils
      */
     public static boolean isTool(@Nullable final ItemStack itemStack, final IToolType toolType)
     {
-        if (isItemStackEmpty(itemStack))
+        if (isEmpty(itemStack))
         {
             return false;
         }
@@ -341,25 +341,40 @@ public final class ItemStackUtils
             return false;
         }
 
-        return existingStack.getMaxStackSize() >= (getItemStackSize(existingStack) + getItemStackSize(mergingStack));
+        return existingStack.getMaxStackSize() >= (getSize(existingStack) + getSize(mergingStack));
     }
 
     /**
      * get the size of the stack.
+     * This is for compatibility between 1.10 and 1.11
      *
      * @param stack to get the size from
      * @return the size of the stack
      */
     @NotNull
-    public static int getItemStackSize(final ItemStack stack)
+    public static int getSize(final ItemStack stack)
     {
-        if (ItemStackUtils.isItemStackEmpty(stack))
+        if (ItemStackUtils.isEmpty(stack))
         {
             return 0;
         }
 
         return stack.getCount();
     }
+
+    /**
+     * set the size of the stack.
+     * This is for compatibility between 1.10 and 1.11
+     *
+     * @param stack to set the size to
+     * @param size of the stack
+     */
+    @NotNull
+    public static int getSize(@NotNull final ItemStack stack, final int size)
+    {
+        stack.setCount(size);
+    }
+
 
     /**
      * Method to compare to stacks, ignoring their stacksize.
@@ -371,8 +386,8 @@ public final class ItemStackUtils
     @NotNull
     public static Boolean compareItemStacksIgnoreStackSize(final ItemStack itemStack1, final ItemStack itemStack2)
     {
-        if (!ItemStackUtils.isItemStackEmpty(itemStack1) &&
-            !ItemStackUtils.isItemStackEmpty(itemStack2) &&
+        if (!isEmpty(itemStack1) &&
+            !isEmpty(itemStack2) &&
             itemStack1.getItem() == itemStack2.getItem() &&
             itemStack1.getItemDamage() == itemStack2.getItemDamage())
         {

--- a/src/api/java/com/minecolonies/api/util/ItemStackUtils.java
+++ b/src/api/java/com/minecolonies/api/util/ItemStackUtils.java
@@ -381,7 +381,7 @@ public final class ItemStackUtils
      * @param stack to set the size to
      * @param amount to increase the stack's size of (negative value to decrease)
      */
-    public static void increaseOrDecreaseSize(@NotNull final ItemStack stack, final int amount)
+    public static void changeSize(@NotNull final ItemStack stack, final int amount)
     {
         stack.setCount(stack.getCount() + amount);
     }

--- a/src/main/java/com/minecolonies/coremod/blocks/BlockBarrel.java
+++ b/src/main/java/com/minecolonies/coremod/blocks/BlockBarrel.java
@@ -100,7 +100,7 @@ public class BlockBarrel extends Block
             return true;
         }
 
-        if (itemstack == null)
+        if (ItemStackUtils.isEmpty(itemstack))
         {
             return true;
         }

--- a/src/main/java/com/minecolonies/coremod/blocks/BlockBarrel.java
+++ b/src/main/java/com/minecolonies/coremod/blocks/BlockBarrel.java
@@ -2,6 +2,7 @@ package com.minecolonies.coremod.blocks;
 
 import com.minecolonies.api.util.Log;
 import com.minecolonies.api.util.constant.Constants;
+import com.minecolonies.api.util.ItemStackUtils;
 import com.minecolonies.coremod.creativetab.ModCreativeTabs;
 import net.minecraft.block.Block;
 import net.minecraft.block.material.Material;
@@ -110,7 +111,7 @@ public class BlockBarrel extends Block
         {
             Log.getLogger().info("item Consumed");
 
-            itemstack.setCount(itemstack.getCount() - 1);
+            itemstack.setCount(ItemStackUtils.getItemStackSize(itemstack) - 1);
 
             fullness += 1;
             if (fullness >= MAX_FULLNESS)

--- a/src/main/java/com/minecolonies/coremod/blocks/BlockBarrel.java
+++ b/src/main/java/com/minecolonies/coremod/blocks/BlockBarrel.java
@@ -111,7 +111,7 @@ public class BlockBarrel extends Block
         {
             Log.getLogger().info("item Consumed");
 
-            ItemStackUtils.increaseOrDecreaseSize(itemstack, -1);
+            ItemStackUtils.changeSize(itemstack, -1);
 
             fullness += 1;
             if (fullness >= MAX_FULLNESS)

--- a/src/main/java/com/minecolonies/coremod/blocks/BlockBarrel.java
+++ b/src/main/java/com/minecolonies/coremod/blocks/BlockBarrel.java
@@ -111,7 +111,7 @@ public class BlockBarrel extends Block
         {
             Log.getLogger().info("item Consumed");
 
-            itemstack.setCount(ItemStackUtils.getItemStackSize(itemstack) - 1);
+            itemstack.setCount(ItemStackUtils.getSize(itemstack) - 1);
 
             fullness += 1;
             if (fullness >= MAX_FULLNESS)

--- a/src/main/java/com/minecolonies/coremod/blocks/BlockBarrel.java
+++ b/src/main/java/com/minecolonies/coremod/blocks/BlockBarrel.java
@@ -111,7 +111,7 @@ public class BlockBarrel extends Block
         {
             Log.getLogger().info("item Consumed");
 
-            ItemStackUtils.setSize(itemstack, ItemStackUtils.getSize(itemstack) - 1);
+            ItemStackUtils.increaseOrDecreaseSize(itemstack, -1);
 
             fullness += 1;
             if (fullness >= MAX_FULLNESS)

--- a/src/main/java/com/minecolonies/coremod/blocks/BlockBarrel.java
+++ b/src/main/java/com/minecolonies/coremod/blocks/BlockBarrel.java
@@ -111,7 +111,7 @@ public class BlockBarrel extends Block
         {
             Log.getLogger().info("item Consumed");
 
-            itemstack.setCount(ItemStackUtils.getSize(itemstack) - 1);
+            ItemStackUtils.setSize(itemstack, ItemStackUtils.getSize(itemstack) - 1);
 
             fullness += 1;
             if (fullness >= MAX_FULLNESS)

--- a/src/main/java/com/minecolonies/coremod/colony/buildings/AbstractBuilding.java
+++ b/src/main/java/com/minecolonies/coremod/colony/buildings/AbstractBuilding.java
@@ -1052,7 +1052,7 @@ public abstract class AbstractBuilding
             final Iterator<BlockPos> posIterator = containerList.iterator();
             @NotNull ItemStack resultStack = stack.copy();
 
-            while (posIterator.hasNext() && !ItemStackUtils.isItemStackEmpty(resultStack))
+            while (posIterator.hasNext() && !ItemStackUtils.isEmpty(resultStack))
             {
                 final BlockPos pos = posIterator.next();
                 final TileEntity tempTileEntity = world.getTileEntity(pos);

--- a/src/main/java/com/minecolonies/coremod/colony/buildings/BuildingBuilder.java
+++ b/src/main/java/com/minecolonies/coremod/colony/buildings/BuildingBuilder.java
@@ -145,7 +145,7 @@ public class BuildingBuilder extends AbstractBuildingWorker
         {
             final NBTTagCompound neededRes = neededResTagList.getCompoundTagAt(i);
             final ItemStack stack = new ItemStack(neededRes);
-            final BuildingBuilderResource resource = new BuildingBuilderResource(stack.getItem(), stack.getItemDamage(), stack.getCount());
+            final BuildingBuilderResource resource = new BuildingBuilderResource(stack.getItem(), stack.getItemDamage(), ItemStackUtils.getItemStackSize(stack));
             neededResources.put(stack.getUnlocalizedName(), resource);
         }
     }

--- a/src/main/java/com/minecolonies/coremod/colony/buildings/BuildingBuilder.java
+++ b/src/main/java/com/minecolonies/coremod/colony/buildings/BuildingBuilder.java
@@ -145,7 +145,7 @@ public class BuildingBuilder extends AbstractBuildingWorker
         {
             final NBTTagCompound neededRes = neededResTagList.getCompoundTagAt(i);
             final ItemStack stack = new ItemStack(neededRes);
-            final BuildingBuilderResource resource = new BuildingBuilderResource(stack.getItem(), stack.getItemDamage(), ItemStackUtils.getItemStackSize(stack));
+            final BuildingBuilderResource resource = new BuildingBuilderResource(stack.getItem(), stack.getItemDamage(), ItemStackUtils.getSize(stack));
             neededResources.put(stack.getUnlocalizedName(), resource);
         }
     }

--- a/src/main/java/com/minecolonies/coremod/colony/buildings/BuildingBuilder.java
+++ b/src/main/java/com/minecolonies/coremod/colony/buildings/BuildingBuilder.java
@@ -325,7 +325,7 @@ public class BuildingBuilder extends AbstractBuildingWorker
     {
         @NotNull final ItemStack resultStack = super.transferStack(stack, world);
 
-        if (ItemStackUtils.isItemStackEmpty(resultStack))
+        if (ItemStackUtils.isEmpty(resultStack))
         {
             this.markDirty();
         }
@@ -337,7 +337,7 @@ public class BuildingBuilder extends AbstractBuildingWorker
     public ItemStack forceTransferStack(final ItemStack stack, final World world)
     {
         final ItemStack itemStack = super.forceTransferStack(stack, world);
-        if (ItemStackUtils.isItemStackEmpty(itemStack))
+        if (ItemStackUtils.isEmpty(itemStack))
         {
             this.markDirty();
         }

--- a/src/main/java/com/minecolonies/coremod/colony/buildings/BuildingFarmer.java
+++ b/src/main/java/com/minecolonies/coremod/colony/buildings/BuildingFarmer.java
@@ -264,7 +264,7 @@ public class BuildingFarmer extends AbstractBuildingWorker
     @Override
     public boolean neededForWorker(@Nullable final ItemStack stack)
     {
-        return stack != null &&  ItemStackUtils.hasToolLevel(stack, ToolType.HOE, TOOL_LEVEL_WOOD_OR_GOLD, getMaxToolLevel());
+        return !ItemStackUtils.isEmpty(stack) &&  ItemStackUtils.hasToolLevel(stack, ToolType.HOE, TOOL_LEVEL_WOOD_OR_GOLD, getMaxToolLevel());
     }
 
     //we have to update our field from the colony!

--- a/src/main/java/com/minecolonies/coremod/colony/buildings/BuildingFarmer.java
+++ b/src/main/java/com/minecolonies/coremod/colony/buildings/BuildingFarmer.java
@@ -197,7 +197,7 @@ public class BuildingFarmer extends AbstractBuildingWorker
         final Map<ItemStorage, Integer> toKeep = new HashMap<>(keepX);
         for(final Field field: farmerFields)
         {
-            if(!ItemStackUtils.isItemStackEmpty(field.getSeed()))
+            if(!ItemStackUtils.isEmpty(field.getSeed()))
             {
                 final ItemStack seedStack = field.getSeed();
                 toKeep.put(new ItemStorage(seedStack.getItem(), seedStack.getItemDamage(), 0, false), SEEDS_TO_KEEP);

--- a/src/main/java/com/minecolonies/coremod/colony/jobs/AbstractJob.java
+++ b/src/main/java/com/minecolonies/coremod/colony/jobs/AbstractJob.java
@@ -283,7 +283,7 @@ public abstract class AbstractJob
         {
             if (stack.isItemEqualIgnoreDurability(neededItem))
             {
-                ItemStackUtils.increaseOrDecreaseSize(neededItem, ItemStackUtils.getSize(stack));
+                ItemStackUtils.changeSize(neededItem, ItemStackUtils.getSize(stack));
                 return;
             }
         }
@@ -314,8 +314,8 @@ public abstract class AbstractJob
             {
                 //todo make this sofisticated as soon as material handling has been implemented.
                 //final int itemsToRemove = Math.min(ItemStackUtils.getSize(neededItem), ItemStackUtils.getSize(stackCopy));
-                //ItemStackUtils.increaseOrDecreaseSize(neededItem, -itemsToRemove);
-                //ItemStackUtils.increaseOrDecreaseSize(stackCopy, -itemsToRemove);
+                //ItemStackUtils.changeSize(neededItem, -itemsToRemove);
+                //ItemStackUtils.changeSize(stackCopy, -itemsToRemove);
 
                 //Deativate this if for now in order to keep working even if not all items are given. previously checked if stackSize is 0 and only removed then.
                 itemsNeeded.remove(neededItem);

--- a/src/main/java/com/minecolonies/coremod/colony/jobs/AbstractJob.java
+++ b/src/main/java/com/minecolonies/coremod/colony/jobs/AbstractJob.java
@@ -283,7 +283,7 @@ public abstract class AbstractJob
         {
             if (stack.isItemEqualIgnoreDurability(neededItem))
             {
-                neededItem.setCount(ItemStackUtils.getSize(neededItem) + ItemStackUtils.getSize(stack));
+                ItemStackUtils.setSize(neededItem, ItemStackUtils.getSize(neededItem) + ItemStackUtils.getSize(stack));
                 return;
             }
         }
@@ -314,8 +314,8 @@ public abstract class AbstractJob
             {
                 //todo make this sofisticated as soon as material handling has been implemented.
                 //final int itemsToRemove = Math.min(ItemStackUtils.getSize(neededItem), ItemStackUtils.getSize(stackCopy));
-                //neededItem.setCount(ItemStackUtils.getSize(stackCopy) - itemsToRemove);
-                //stackCopy.setCount(ItemStackUtils.getSize(stackCopy) - itemsToRemove);
+                //ItemStackUtils.setSize(neededItem, ItemStackUtils.getSize(stackCopy) - itemsToRemove);
+                //ItemStackUtils.setSize(stackCopy, ItemStackUtils.getSize(stackCopy) - itemsToRemove);
 
                 //Deativate this if for now in order to keep working even if not all items are given. previously checked if stackSize is 0 and only removed then.
                 itemsNeeded.remove(neededItem);

--- a/src/main/java/com/minecolonies/coremod/colony/jobs/AbstractJob.java
+++ b/src/main/java/com/minecolonies/coremod/colony/jobs/AbstractJob.java
@@ -324,7 +324,7 @@ public abstract class AbstractJob
             }
         }
 
-        return ItemStackUtils.isItemStackEmpty(stackCopy) ? ItemStackUtils.EMPTY : stackCopy;
+        return ItemStackUtils.isEmpty(stackCopy) ? ItemStackUtils.EMPTY : stackCopy;
     }
 
     /**

--- a/src/main/java/com/minecolonies/coremod/colony/jobs/AbstractJob.java
+++ b/src/main/java/com/minecolonies/coremod/colony/jobs/AbstractJob.java
@@ -283,7 +283,7 @@ public abstract class AbstractJob
         {
             if (stack.isItemEqualIgnoreDurability(neededItem))
             {
-                ItemStackUtils.setSize(neededItem, ItemStackUtils.getSize(neededItem) + ItemStackUtils.getSize(stack));
+                ItemStackUtils.increaseOrDecreaseSize(neededItem, ItemStackUtils.getSize(stack));
                 return;
             }
         }
@@ -314,8 +314,8 @@ public abstract class AbstractJob
             {
                 //todo make this sofisticated as soon as material handling has been implemented.
                 //final int itemsToRemove = Math.min(ItemStackUtils.getSize(neededItem), ItemStackUtils.getSize(stackCopy));
-                //ItemStackUtils.setSize(neededItem, ItemStackUtils.getSize(stackCopy) - itemsToRemove);
-                //ItemStackUtils.setSize(stackCopy, ItemStackUtils.getSize(stackCopy) - itemsToRemove);
+                //ItemStackUtils.increaseOrDecreaseSize(neededItem, -itemsToRemove);
+                //ItemStackUtils.increaseOrDecreaseSize(stackCopy, -itemsToRemove);
 
                 //Deativate this if for now in order to keep working even if not all items are given. previously checked if stackSize is 0 and only removed then.
                 itemsNeeded.remove(neededItem);

--- a/src/main/java/com/minecolonies/coremod/colony/jobs/AbstractJob.java
+++ b/src/main/java/com/minecolonies/coremod/colony/jobs/AbstractJob.java
@@ -1,6 +1,7 @@
 package com.minecolonies.coremod.colony.jobs;
 
 import com.minecolonies.api.util.Log;
+import com.minecolonies.api.util.ItemStackUtils;
 import com.minecolonies.coremod.client.render.RenderBipedCitizen;
 import com.minecolonies.coremod.colony.CitizenData;
 import com.minecolonies.coremod.colony.Colony;
@@ -282,7 +283,7 @@ public abstract class AbstractJob
         {
             if (stack.isItemEqualIgnoreDurability(neededItem))
             {
-                neededItem.setCount(neededItem.getCount() + stack.getCount());
+                neededItem.setCount(ItemStackUtils.getItemStackSize(neededItem) + ItemStackUtils.getItemStackSize(stack));
                 return;
             }
         }
@@ -312,9 +313,9 @@ public abstract class AbstractJob
             if (stack.isItemEqualIgnoreDurability(neededItem))
             {
                 //todo make this sofisticated as soon as material handling has been implemented.
-                //final int itemsToRemove = Math.min(neededItem.getCount(), stackCopy.getCount());
-                //neededItem.setCount(stackCopy.getCount() - itemsToRemove);
-                //stackCopy.setCount(stackCopy.getCount() - itemsToRemove);
+                //final int itemsToRemove = Math.min(ItemStackUtils.getItemStackSize(neededItem), ItemStackUtils.getItemStackSize(stackCopy));
+                //neededItem.setCount(ItemStackUtils.getItemStackSize(stackCopy) - itemsToRemove);
+                //stackCopy.setCount(ItemStackUtils.getItemStackSize(stackCopy) - itemsToRemove);
 
                 //Deativate this if for now in order to keep working even if not all items are given. previously checked if stackSize is 0 and only removed then.
                 itemsNeeded.remove(neededItem);
@@ -323,7 +324,7 @@ public abstract class AbstractJob
             }
         }
 
-        return stackCopy.getCount() == 0 ? ItemStack.EMPTY : stackCopy;
+        return ItemStackUtils.isItemStackEmpty(stackCopy) ? ItemStackUtils.EMPTY : stackCopy;
     }
 
     /**

--- a/src/main/java/com/minecolonies/coremod/colony/jobs/AbstractJob.java
+++ b/src/main/java/com/minecolonies/coremod/colony/jobs/AbstractJob.java
@@ -283,7 +283,7 @@ public abstract class AbstractJob
         {
             if (stack.isItemEqualIgnoreDurability(neededItem))
             {
-                neededItem.setCount(ItemStackUtils.getItemStackSize(neededItem) + ItemStackUtils.getItemStackSize(stack));
+                neededItem.setCount(ItemStackUtils.getSize(neededItem) + ItemStackUtils.getSize(stack));
                 return;
             }
         }
@@ -313,9 +313,9 @@ public abstract class AbstractJob
             if (stack.isItemEqualIgnoreDurability(neededItem))
             {
                 //todo make this sofisticated as soon as material handling has been implemented.
-                //final int itemsToRemove = Math.min(ItemStackUtils.getItemStackSize(neededItem), ItemStackUtils.getItemStackSize(stackCopy));
-                //neededItem.setCount(ItemStackUtils.getItemStackSize(stackCopy) - itemsToRemove);
-                //stackCopy.setCount(ItemStackUtils.getItemStackSize(stackCopy) - itemsToRemove);
+                //final int itemsToRemove = Math.min(ItemStackUtils.getSize(neededItem), ItemStackUtils.getSize(stackCopy));
+                //neededItem.setCount(ItemStackUtils.getSize(stackCopy) - itemsToRemove);
+                //stackCopy.setCount(ItemStackUtils.getSize(stackCopy) - itemsToRemove);
 
                 //Deativate this if for now in order to keep working even if not all items are given. previously checked if stackSize is 0 and only removed then.
                 itemsNeeded.remove(neededItem);

--- a/src/main/java/com/minecolonies/coremod/entity/EntityCitizen.java
+++ b/src/main/java/com/minecolonies/coremod/entity/EntityCitizen.java
@@ -1509,7 +1509,7 @@ public class EntityCitizen extends EntityAgeable implements INpc
     public void tryToEat()
     {
         final int slot = InventoryUtils.findFirstSlotInProviderWith(this,
-                itemStack -> !ItemStackUtils.isItemStackEmpty(itemStack) && itemStack.getItem() instanceof ItemFood);
+                itemStack -> !ItemStackUtils.isEmpty(itemStack) && itemStack.getItem() instanceof ItemFood);
 
         if(slot == -1)
         {
@@ -1517,7 +1517,7 @@ public class EntityCitizen extends EntityAgeable implements INpc
         }
 
         final ItemStack stack = inventory.getStackInSlot(slot);
-        if(!ItemStackUtils.isItemStackEmpty(stack) && stack.getItem() instanceof ItemFood && citizenData != null)
+        if(!ItemStackUtils.isEmpty(stack) && stack.getItem() instanceof ItemFood && citizenData != null)
         {
             final int heal = ((ItemFood) stack.getItem()).getHealAmount(stack);
             citizenData.increaseSaturation(heal);
@@ -1683,8 +1683,8 @@ public class EntityCitizen extends EntityAgeable implements INpc
             final ItemStack itemStack = entityItem.getEntityItem();
 
             final ItemStack resultStack = InventoryUtils.addItemStackToItemHandlerWithResult(new InvWrapper(getInventoryCitizen()), itemStack.copy());
-            final int resultingStackSize = ItemStackUtils.isItemStackEmpty(resultStack) ? 0 : ItemStackUtils.getItemStackSize(resultStack);
-            if (ItemStackUtils.isItemStackEmpty(resultStack) || ItemStackUtils.compareItemStacksIgnoreStackSize(itemStack, resultStack))
+            final int resultingStackSize = ItemStackUtils.isEmpty(resultStack) ? 0 : ItemStackUtils.getItemStackSize(resultStack);
+            if (ItemStackUtils.isEmpty(resultStack) || ItemStackUtils.compareItemStacksIgnoreStackSize(itemStack, resultStack))
             {
                 this.world.playSound((EntityPlayer) null,
                         this.getPosition(),
@@ -1694,7 +1694,7 @@ public class EntityCitizen extends EntityAgeable implements INpc
                         (float) ((this.rand.nextGaussian() * 0.7D + 1.0D) * 2.0D));
                 this.onItemPickup(entityItem, ItemStackUtils.getItemStackSize(itemStack) - resultingStackSize);
 
-                if (ItemStackUtils.isItemStackEmpty(resultStack))
+                if (ItemStackUtils.isEmpty(resultStack))
                 {
                     entityItem.setDead();
                 }

--- a/src/main/java/com/minecolonies/coremod/entity/EntityCitizen.java
+++ b/src/main/java/com/minecolonies/coremod/entity/EntityCitizen.java
@@ -894,7 +894,7 @@ public class EntityCitizen extends EntityAgeable implements INpc
 
             if (ItemStackUtils.getSize(stack) < 1)
             {
-                setItemStackToSlot(getSlotForItemStack(stack), ItemStack.EMPTY);
+                setItemStackToSlot(getSlotForItemStack(stack), ItemStackUtils.EMPTY);
             }
             setItemStackToSlot(getSlotForItemStack(stack), stack);
         }
@@ -1707,7 +1707,7 @@ public class EntityCitizen extends EntityAgeable implements INpc
      */
     public void removeHeldItem()
     {
-        setItemStackToSlot(EntityEquipmentSlot.MAINHAND, ItemStack.EMPTY);
+        setItemStackToSlot(EntityEquipmentSlot.MAINHAND, ItemStackUtils.EMPTY);
     }
 
     /**
@@ -1816,8 +1816,8 @@ public class EntityCitizen extends EntityAgeable implements INpc
         //check if tool breaks
         if (ItemStackUtils.getSize(heldItem) < 1)
         {
-            getInventoryCitizen().setInventorySlotContents(getInventoryCitizen().getHeldItemSlot(), ItemStack.EMPTY);
-            this.setItemStackToSlot(EntityEquipmentSlot.MAINHAND, ItemStack.EMPTY);
+            getInventoryCitizen().setInventorySlotContents(getInventoryCitizen().getHeldItemSlot(), ItemStackUtils.EMPTY);
+            this.setItemStackToSlot(EntityEquipmentSlot.MAINHAND, ItemStackUtils.EMPTY);
         }
     }
 

--- a/src/main/java/com/minecolonies/coremod/entity/EntityCitizen.java
+++ b/src/main/java/com/minecolonies/coremod/entity/EntityCitizen.java
@@ -886,7 +886,7 @@ public class EntityCitizen extends EntityAgeable implements INpc
     {
         for (final ItemStack stack : this.getArmorInventoryList())
         {
-            if (stack == null || stack.getItem() == null || !(stack.getItem() instanceof ItemArmor))
+            if (ItemStackUtils.isEmpty(stack) || !(stack.getItem() instanceof ItemArmor))
             {
                 continue;
             }

--- a/src/main/java/com/minecolonies/coremod/entity/EntityCitizen.java
+++ b/src/main/java/com/minecolonies/coremod/entity/EntityCitizen.java
@@ -892,7 +892,7 @@ public class EntityCitizen extends EntityAgeable implements INpc
             }
             stack.damageItem((int) (damage / 2), this);
 
-            if (ItemStackUtils.getItemStackSize(stack) < 1)
+            if (ItemStackUtils.getSize(stack) < 1)
             {
                 setItemStackToSlot(getSlotForItemStack(stack), ItemStack.EMPTY);
             }
@@ -1404,7 +1404,7 @@ public class EntityCitizen extends EntityAgeable implements INpc
         for (int i = 0; i < new InvWrapper(getInventoryCitizen()).getSlots(); i++)
         {
             final ItemStack itemstack = inventory.getStackInSlot(i);
-            if (ItemStackUtils.getItemStackSize(itemstack) > 0)
+            if (ItemStackUtils.getSize(itemstack) > 0)
             {
                 entityDropItem(itemstack);
             }
@@ -1683,7 +1683,7 @@ public class EntityCitizen extends EntityAgeable implements INpc
             final ItemStack itemStack = entityItem.getEntityItem();
 
             final ItemStack resultStack = InventoryUtils.addItemStackToItemHandlerWithResult(new InvWrapper(getInventoryCitizen()), itemStack.copy());
-            final int resultingStackSize = ItemStackUtils.isEmpty(resultStack) ? 0 : ItemStackUtils.getItemStackSize(resultStack);
+            final int resultingStackSize = ItemStackUtils.isEmpty(resultStack) ? 0 : ItemStackUtils.getSize(resultStack);
             if (ItemStackUtils.isEmpty(resultStack) || ItemStackUtils.compareItemStacksIgnoreStackSize(itemStack, resultStack))
             {
                 this.world.playSound((EntityPlayer) null,
@@ -1692,7 +1692,7 @@ public class EntityCitizen extends EntityAgeable implements INpc
                         SoundCategory.AMBIENT,
                         0.2F,
                         (float) ((this.rand.nextGaussian() * 0.7D + 1.0D) * 2.0D));
-                this.onItemPickup(entityItem, ItemStackUtils.getItemStackSize(itemStack) - resultingStackSize);
+                this.onItemPickup(entityItem, ItemStackUtils.getSize(itemStack) - resultingStackSize);
 
                 if (ItemStackUtils.isEmpty(resultStack))
                 {
@@ -1814,7 +1814,7 @@ public class EntityCitizen extends EntityAgeable implements INpc
         heldItem.damageItem(damage, this);
 
         //check if tool breaks
-        if (ItemStackUtils.getItemStackSize(heldItem) < 1)
+        if (ItemStackUtils.getSize(heldItem) < 1)
         {
             getInventoryCitizen().setInventorySlotContents(getInventoryCitizen().getHeldItemSlot(), ItemStack.EMPTY);
             this.setItemStackToSlot(EntityEquipmentSlot.MAINHAND, ItemStack.EMPTY);

--- a/src/main/java/com/minecolonies/coremod/entity/EntityCitizen.java
+++ b/src/main/java/com/minecolonies/coremod/entity/EntityCitizen.java
@@ -892,7 +892,7 @@ public class EntityCitizen extends EntityAgeable implements INpc
             }
             stack.damageItem((int) (damage / 2), this);
 
-            if (stack.getCount() < 1)
+            if (ItemStackUtils.getItemStackSize(stack) < 1)
             {
                 setItemStackToSlot(getSlotForItemStack(stack), ItemStack.EMPTY);
             }
@@ -1404,7 +1404,7 @@ public class EntityCitizen extends EntityAgeable implements INpc
         for (int i = 0; i < new InvWrapper(getInventoryCitizen()).getSlots(); i++)
         {
             final ItemStack itemstack = inventory.getStackInSlot(i);
-            if (itemstack != null && itemstack.getCount() > 0)
+            if (ItemStackUtils.getItemStackSize(itemstack) > 0)
             {
                 entityDropItem(itemstack);
             }
@@ -1683,7 +1683,7 @@ public class EntityCitizen extends EntityAgeable implements INpc
             final ItemStack itemStack = entityItem.getEntityItem();
 
             final ItemStack resultStack = InventoryUtils.addItemStackToItemHandlerWithResult(new InvWrapper(getInventoryCitizen()), itemStack.copy());
-            final int resultingStackSize = ItemStackUtils.isItemStackEmpty(resultStack) ? 0 : resultStack.getCount();
+            final int resultingStackSize = ItemStackUtils.isItemStackEmpty(resultStack) ? 0 : ItemStackUtils.getItemStackSize(resultStack);
             if (ItemStackUtils.isItemStackEmpty(resultStack) || ItemStackUtils.compareItemStacksIgnoreStackSize(itemStack, resultStack))
             {
                 this.world.playSound((EntityPlayer) null,
@@ -1692,7 +1692,7 @@ public class EntityCitizen extends EntityAgeable implements INpc
                         SoundCategory.AMBIENT,
                         0.2F,
                         (float) ((this.rand.nextGaussian() * 0.7D + 1.0D) * 2.0D));
-                this.onItemPickup(entityItem, itemStack.getCount() - resultingStackSize);
+                this.onItemPickup(entityItem, ItemStackUtils.getItemStackSize(itemStack) - resultingStackSize);
 
                 if (ItemStackUtils.isItemStackEmpty(resultStack))
                 {
@@ -1814,7 +1814,7 @@ public class EntityCitizen extends EntityAgeable implements INpc
         heldItem.damageItem(damage, this);
 
         //check if tool breaks
-        if (heldItem.getCount() < 1)
+        if (ItemStackUtils.getItemStackSize(heldItem) < 1)
         {
             getInventoryCitizen().setInventorySlotContents(getInventoryCitizen().getHeldItemSlot(), ItemStack.EMPTY);
             this.setItemStackToSlot(EntityEquipmentSlot.MAINHAND, ItemStack.EMPTY);

--- a/src/main/java/com/minecolonies/coremod/entity/ai/basic/AbstractEntityAIBasic.java
+++ b/src/main/java/com/minecolonies/coremod/entity/ai/basic/AbstractEntityAIBasic.java
@@ -394,7 +394,7 @@ public abstract class AbstractEntityAIBasic<J extends AbstractJob> extends Abstr
 
             if (!getOwnBuilding().hasOnGoingDelivery())
             {
-                requestWithoutSpam(first.getCount() + " " + first.getDisplayName());
+                requestWithoutSpam(ItemStackUtils.getItemStackSize(first) + " " + first.getDisplayName());
             }
         }
         return NEEDS_ITEM;
@@ -878,25 +878,25 @@ public abstract class AbstractEntityAIBasic<J extends AbstractJob> extends Abstr
         }
         else
         {
-            final ItemStorage tempStorage = new ItemStorage(stack.getItem(), stack.getItemDamage(), stack.getCount(), false);
+            final ItemStorage tempStorage = new ItemStorage(stack.getItem(), stack.getItemDamage(), ItemStackUtils.getItemStackSize(stack), false);
             final ItemStack tempStack = handleKeepX(alreadyKept, shouldKeep, tempStorage);
             if (ItemStackUtils.isItemStackEmpty(tempStack))
             {
                 return false;
             }
-            amountToKeep = stack.getCount() - tempStorage.getAmount();
+            amountToKeep = ItemStackUtils.getItemStackSize(stack) - tempStorage.getAmount();
             returnStack = InventoryUtils.addItemStackToProviderWithResult(buildingWorker.getTileEntity(), tempStack);
         }
         if (ItemStackUtils.isItemStackEmpty(returnStack))
         {
-            new InvWrapper(worker.getInventoryCitizen()).extractItem(slot, stack.getCount() - amountToKeep, false);
+            new InvWrapper(worker.getInventoryCitizen()).extractItem(slot, ItemStackUtils.getItemStackSize(stack) - amountToKeep, false);
             return amountToKeep == 0;
         }
 
-        new InvWrapper(worker.getInventoryCitizen()).extractItem(slot, stack.getCount() - returnStack.getCount() - amountToKeep, false);
+        new InvWrapper(worker.getInventoryCitizen()).extractItem(slot, ItemStackUtils.getItemStackSize(stack) - ItemStackUtils.getItemStackSize(returnStack) - amountToKeep, false);
 
         //Check that we are not inserting into a full inventory.
-        return stack.getCount() != returnStack.getCount();
+        return ItemStackUtils.getItemStackSize(stack) != ItemStackUtils.getItemStackSize(returnStack);
     }
 
     /**
@@ -1000,7 +1000,7 @@ public abstract class AbstractEntityAIBasic<J extends AbstractJob> extends Abstr
 
             if (countOfItem < 1)
             {
-                final int itemsLeft = stack.getCount() - countOfItem;
+                final int itemsLeft = ItemStackUtils.getItemStackSize(stack) - countOfItem;
                 @NotNull final ItemStack requiredStack = new ItemStack(stack.getItem(), itemsLeft, itemDamage);
                 getOwnBuilding().addNeededItems(requiredStack);
                 allClear = false;
@@ -1045,9 +1045,9 @@ public abstract class AbstractEntityAIBasic<J extends AbstractJob> extends Abstr
             }
             final int itemDamage = useItemDamage ? stack.getItemDamage() : -1;
             final int countOfItem = worker.getItemCountInInventory(stack.getItem(), itemDamage);
-            if (countOfItem < tempStack.getCount())
+            if (countOfItem < ItemStackUtils.getItemStackSize(tempStack))
             {
-                final int itemsLeft = stack.getCount() - countOfItem;
+                final int itemsLeft = ItemStackUtils.getItemStackSize(stack) - countOfItem;
                 @NotNull final ItemStack requiredStack = new ItemStack(stack.getItem(), itemsLeft, -1);
                 if(!isInNeededItems(tempStack))
                 {

--- a/src/main/java/com/minecolonies/coremod/entity/ai/basic/AbstractEntityAIBasic.java
+++ b/src/main/java/com/minecolonies/coremod/entity/ai/basic/AbstractEntityAIBasic.java
@@ -394,7 +394,7 @@ public abstract class AbstractEntityAIBasic<J extends AbstractJob> extends Abstr
 
             if (!getOwnBuilding().hasOnGoingDelivery())
             {
-                requestWithoutSpam(ItemStackUtils.getItemStackSize(first) + " " + first.getDisplayName());
+                requestWithoutSpam(ItemStackUtils.getSize(first) + " " + first.getDisplayName());
             }
         }
         return NEEDS_ITEM;
@@ -878,25 +878,25 @@ public abstract class AbstractEntityAIBasic<J extends AbstractJob> extends Abstr
         }
         else
         {
-            final ItemStorage tempStorage = new ItemStorage(stack.getItem(), stack.getItemDamage(), ItemStackUtils.getItemStackSize(stack), false);
+            final ItemStorage tempStorage = new ItemStorage(stack.getItem(), stack.getItemDamage(), ItemStackUtils.getSize(stack), false);
             final ItemStack tempStack = handleKeepX(alreadyKept, shouldKeep, tempStorage);
             if (ItemStackUtils.isEmpty(tempStack))
             {
                 return false;
             }
-            amountToKeep = ItemStackUtils.getItemStackSize(stack) - tempStorage.getAmount();
+            amountToKeep = ItemStackUtils.getSize(stack) - tempStorage.getAmount();
             returnStack = InventoryUtils.addItemStackToProviderWithResult(buildingWorker.getTileEntity(), tempStack);
         }
         if (ItemStackUtils.isEmpty(returnStack))
         {
-            new InvWrapper(worker.getInventoryCitizen()).extractItem(slot, ItemStackUtils.getItemStackSize(stack) - amountToKeep, false);
+            new InvWrapper(worker.getInventoryCitizen()).extractItem(slot, ItemStackUtils.getSize(stack) - amountToKeep, false);
             return amountToKeep == 0;
         }
 
-        new InvWrapper(worker.getInventoryCitizen()).extractItem(slot, ItemStackUtils.getItemStackSize(stack) - ItemStackUtils.getItemStackSize(returnStack) - amountToKeep, false);
+        new InvWrapper(worker.getInventoryCitizen()).extractItem(slot, ItemStackUtils.getSize(stack) - ItemStackUtils.getSize(returnStack) - amountToKeep, false);
 
         //Check that we are not inserting into a full inventory.
-        return ItemStackUtils.getItemStackSize(stack) != ItemStackUtils.getItemStackSize(returnStack);
+        return ItemStackUtils.getSize(stack) != ItemStackUtils.getSize(returnStack);
     }
 
     /**
@@ -1000,7 +1000,7 @@ public abstract class AbstractEntityAIBasic<J extends AbstractJob> extends Abstr
 
             if (countOfItem < 1)
             {
-                final int itemsLeft = ItemStackUtils.getItemStackSize(stack) - countOfItem;
+                final int itemsLeft = ItemStackUtils.getSize(stack) - countOfItem;
                 @NotNull final ItemStack requiredStack = new ItemStack(stack.getItem(), itemsLeft, itemDamage);
                 getOwnBuilding().addNeededItems(requiredStack);
                 allClear = false;
@@ -1045,9 +1045,9 @@ public abstract class AbstractEntityAIBasic<J extends AbstractJob> extends Abstr
             }
             final int itemDamage = useItemDamage ? stack.getItemDamage() : -1;
             final int countOfItem = worker.getItemCountInInventory(stack.getItem(), itemDamage);
-            if (countOfItem < ItemStackUtils.getItemStackSize(tempStack))
+            if (countOfItem < ItemStackUtils.getSize(tempStack))
             {
-                final int itemsLeft = ItemStackUtils.getItemStackSize(stack) - countOfItem;
+                final int itemsLeft = ItemStackUtils.getSize(stack) - countOfItem;
                 @NotNull final ItemStack requiredStack = new ItemStack(stack.getItem(), itemsLeft, -1);
                 if(!isInNeededItems(tempStack))
                 {

--- a/src/main/java/com/minecolonies/coremod/entity/ai/basic/AbstractEntityAIBasic.java
+++ b/src/main/java/com/minecolonies/coremod/entity/ai/basic/AbstractEntityAIBasic.java
@@ -853,7 +853,7 @@ public abstract class AbstractEntityAIBasic<J extends AbstractJob> extends Abstr
         return buildingWorker != null
                 && (walkToBuilding()
                 || InventoryFunctions.matchFirstInProvider(worker,
-                (slot, stack) -> !(ItemStackUtils.isItemStackEmpty(stack) || keepIt.test(stack)) && shouldDumpItem(alreadyKept, shouldKeep, buildingWorker, stack, slot)));
+                (slot, stack) -> !(ItemStackUtils.isEmpty(stack) || keepIt.test(stack)) && shouldDumpItem(alreadyKept, shouldKeep, buildingWorker, stack, slot)));
     }
 
     /**
@@ -880,14 +880,14 @@ public abstract class AbstractEntityAIBasic<J extends AbstractJob> extends Abstr
         {
             final ItemStorage tempStorage = new ItemStorage(stack.getItem(), stack.getItemDamage(), ItemStackUtils.getItemStackSize(stack), false);
             final ItemStack tempStack = handleKeepX(alreadyKept, shouldKeep, tempStorage);
-            if (ItemStackUtils.isItemStackEmpty(tempStack))
+            if (ItemStackUtils.isEmpty(tempStack))
             {
                 return false;
             }
             amountToKeep = ItemStackUtils.getItemStackSize(stack) - tempStorage.getAmount();
             returnStack = InventoryUtils.addItemStackToProviderWithResult(buildingWorker.getTileEntity(), tempStack);
         }
-        if (ItemStackUtils.isItemStackEmpty(returnStack))
+        if (ItemStackUtils.isEmpty(returnStack))
         {
             new InvWrapper(worker.getInventoryCitizen()).extractItem(slot, ItemStackUtils.getItemStackSize(stack) - amountToKeep, false);
             return amountToKeep == 0;
@@ -990,7 +990,7 @@ public abstract class AbstractEntityAIBasic<J extends AbstractJob> extends Abstr
         for (final @Nullable ItemStack tempStack : items)
         {
             final ItemStack stack = tempStack.copy();
-            if (ItemStackUtils.isItemStackEmpty(stack))
+            if (ItemStackUtils.isEmpty(stack))
             {
                 continue;
             }

--- a/src/main/java/com/minecolonies/coremod/entity/ai/basic/AbstractEntityAIBasic.java
+++ b/src/main/java/com/minecolonies/coremod/entity/ai/basic/AbstractEntityAIBasic.java
@@ -1039,7 +1039,7 @@ public abstract class AbstractEntityAIBasic<J extends AbstractJob> extends Abstr
         for (final @Nullable ItemStack tempStack : items)
         {
             final ItemStack stack = tempStack.copy();
-            if (stack == null || stack.getItem() == null)
+            if (ItemStackUtils.isEmpty(stack))
             {
                 continue;
             }

--- a/src/main/java/com/minecolonies/coremod/entity/ai/basic/AbstractEntityAIStructure.java
+++ b/src/main/java/com/minecolonies/coremod/entity/ai/basic/AbstractEntityAIStructure.java
@@ -783,7 +783,7 @@ public abstract class AbstractEntityAIStructure<J extends AbstractJob> extends A
                 final ItemStack stack = ((EntityItemFrame) entity).getDisplayedItem();
                 if (stack != null)
                 {
-                    stack.setCount(ItemStackUtils.getItemStackSize(stack) + 1);
+                    stack.setCount(ItemStackUtils.getSize(stack) + 1);
                     request.add(stack);
                 }
                 request.add(new ItemStack(Items.ITEM_FRAME, 1));

--- a/src/main/java/com/minecolonies/coremod/entity/ai/basic/AbstractEntityAIStructure.java
+++ b/src/main/java/com/minecolonies/coremod/entity/ai/basic/AbstractEntityAIStructure.java
@@ -781,9 +781,9 @@ public abstract class AbstractEntityAIStructure<J extends AbstractJob> extends A
             if (entity instanceof EntityItemFrame)
             {
                 final ItemStack stack = ((EntityItemFrame) entity).getDisplayedItem();
-                if (stack != null)
+                if (!ItemStackUtils.isEmpty(stack))
                 {
-                    ItemStackUtils.setSize(stack, ItemStackUtils.getSize(stack) + 1);
+                    ItemStackUtils.increaseOrDecreaseSize(stack, 1);
                     request.add(stack);
                 }
                 request.add(new ItemStack(Items.ITEM_FRAME, 1));

--- a/src/main/java/com/minecolonies/coremod/entity/ai/basic/AbstractEntityAIStructure.java
+++ b/src/main/java/com/minecolonies/coremod/entity/ai/basic/AbstractEntityAIStructure.java
@@ -783,7 +783,7 @@ public abstract class AbstractEntityAIStructure<J extends AbstractJob> extends A
                 final ItemStack stack = ((EntityItemFrame) entity).getDisplayedItem();
                 if (stack != null)
                 {
-                    stack.setCount(stack.getCount() + 1);
+                    stack.setCount(ItemStackUtils.getItemStackSize(stack) + 1);
                     request.add(stack);
                 }
                 request.add(new ItemStack(Items.ITEM_FRAME, 1));

--- a/src/main/java/com/minecolonies/coremod/entity/ai/basic/AbstractEntityAIStructure.java
+++ b/src/main/java/com/minecolonies/coremod/entity/ai/basic/AbstractEntityAIStructure.java
@@ -653,7 +653,7 @@ public abstract class AbstractEntityAIStructure<J extends AbstractJob> extends A
         }
 
         @Nullable final ItemStack stack = BlockUtils.getItemStackFromBlockState(stateToPlace);
-        if (ItemStackUtils.isItemStackEmpty(stack))
+        if (ItemStackUtils.isEmpty(stack))
         {
             Log.getLogger().error("Block causes NPE: " + stateToPlace.getBlock());
             return false;
@@ -665,7 +665,7 @@ public abstract class AbstractEntityAIStructure<J extends AbstractJob> extends A
 
         for (final ItemStack tempStack : itemList)
         {
-            if (!ItemStackUtils.isItemStackEmpty(tempStack))
+            if (!ItemStackUtils.isEmpty(tempStack))
             {
                 final int slot = worker.findFirstSlotInInventoryWith(tempStack.getItem(), tempStack.getItemDamage());
                 if (slot != -1)

--- a/src/main/java/com/minecolonies/coremod/entity/ai/basic/AbstractEntityAIStructure.java
+++ b/src/main/java/com/minecolonies/coremod/entity/ai/basic/AbstractEntityAIStructure.java
@@ -783,7 +783,7 @@ public abstract class AbstractEntityAIStructure<J extends AbstractJob> extends A
                 final ItemStack stack = ((EntityItemFrame) entity).getDisplayedItem();
                 if (!ItemStackUtils.isEmpty(stack))
                 {
-                    ItemStackUtils.increaseOrDecreaseSize(stack, 1);
+                    ItemStackUtils.changeSize(stack, 1);
                     request.add(stack);
                 }
                 request.add(new ItemStack(Items.ITEM_FRAME, 1));

--- a/src/main/java/com/minecolonies/coremod/entity/ai/basic/AbstractEntityAIStructure.java
+++ b/src/main/java/com/minecolonies/coremod/entity/ai/basic/AbstractEntityAIStructure.java
@@ -783,7 +783,7 @@ public abstract class AbstractEntityAIStructure<J extends AbstractJob> extends A
                 final ItemStack stack = ((EntityItemFrame) entity).getDisplayedItem();
                 if (stack != null)
                 {
-                    stack.setCount(ItemStackUtils.getSize(stack) + 1);
+                    ItemStackUtils.setSize(stack, ItemStackUtils.getSize(stack) + 1);
                     request.add(stack);
                 }
                 request.add(new ItemStack(Items.ITEM_FRAME, 1));

--- a/src/main/java/com/minecolonies/coremod/entity/ai/basic/AbstractEntityAIStructure.java
+++ b/src/main/java/com/minecolonies/coremod/entity/ai/basic/AbstractEntityAIStructure.java
@@ -811,7 +811,7 @@ public abstract class AbstractEntityAIStructure<J extends AbstractJob> extends A
                 //Surpress
                 for (final ItemStack stack : request)
                 {
-                    if (stack == null)
+                    if (ItemStackUtils.isEmpty(stack))
                     {
                         continue;
                     }

--- a/src/main/java/com/minecolonies/coremod/entity/ai/citizen/baker/EntityAIWorkBaker.java
+++ b/src/main/java/com/minecolonies/coremod/entity/ai/citizen/baker/EntityAIWorkBaker.java
@@ -279,7 +279,7 @@ public class EntityAIWorkBaker extends AbstractEntityAISkill<JobBaker>
             {
                 req = form < 0 ? -worker.getRandom().nextInt(Math.abs(form)) : worker.getRandom().nextInt(form);
             }
-            ItemStackUtils.increaseOrDecreaseSize(copy, req);
+            ItemStackUtils.changeSize(copy, req);
             list.add(copy);
         }
 

--- a/src/main/java/com/minecolonies/coremod/entity/ai/citizen/baker/EntityAIWorkBaker.java
+++ b/src/main/java/com/minecolonies/coremod/entity/ai/citizen/baker/EntityAIWorkBaker.java
@@ -279,7 +279,7 @@ public class EntityAIWorkBaker extends AbstractEntityAISkill<JobBaker>
             {
                 req = form < 0 ? -worker.getRandom().nextInt(Math.abs(form)) : worker.getRandom().nextInt(form);
             }
-            ItemStackUtils.setSize(copy,ItemStackUtils.getSize(copy) + req);
+            ItemStackUtils.increaseOrDecreaseSize(copy, req);
             list.add(copy);
         }
 

--- a/src/main/java/com/minecolonies/coremod/entity/ai/citizen/baker/EntityAIWorkBaker.java
+++ b/src/main/java/com/minecolonies/coremod/entity/ai/citizen/baker/EntityAIWorkBaker.java
@@ -279,7 +279,7 @@ public class EntityAIWorkBaker extends AbstractEntityAISkill<JobBaker>
             {
                 req = form < 0 ? -worker.getRandom().nextInt(Math.abs(form)) : worker.getRandom().nextInt(form);
             }
-            copy.setCount(ItemStackUtils.getSize(copy) + req);
+            ItemStackUtils.setSize(copy,ItemStackUtils.getSize(copy) + req);
             list.add(copy);
         }
 

--- a/src/main/java/com/minecolonies/coremod/entity/ai/citizen/baker/EntityAIWorkBaker.java
+++ b/src/main/java/com/minecolonies/coremod/entity/ai/citizen/baker/EntityAIWorkBaker.java
@@ -273,13 +273,13 @@ public class EntityAIWorkBaker extends AbstractEntityAISkill<JobBaker>
         if (copy != null)
         {
             //Wheat will be reduced by chance only (Between 3 and 6- getBuildingLevel, meaning 3-5, 3-4, 3-3, 3-2, 3-1)
-            final int form = (getOwnBuilding().getMaxBuildingLevel() + 1) - (getOwnBuilding().getBuildingLevel() + ItemStackUtils.getItemStackSize(copy));
+            final int form = (getOwnBuilding().getMaxBuildingLevel() + 1) - (getOwnBuilding().getBuildingLevel() + ItemStackUtils.getSize(copy));
             int req = 0;
             if (form != 0)
             {
                 req = form < 0 ? -worker.getRandom().nextInt(Math.abs(form)) : worker.getRandom().nextInt(form);
             }
-            copy.setCount(ItemStackUtils.getItemStackSize(copy) + req);
+            copy.setCount(ItemStackUtils.getSize(copy) + req);
             list.add(copy);
         }
 
@@ -306,7 +306,7 @@ public class EntityAIWorkBaker extends AbstractEntityAISkill<JobBaker>
     {
         for (final @Nullable ItemStack tempStack : list)
         {
-            if (InventoryUtils.getItemCountInItemHandler(new InvWrapper(worker.getInventoryCitizen()), tempStack::isItemEqual) < ItemStackUtils.getItemStackSize(tempStack)
+            if (InventoryUtils.getItemCountInItemHandler(new InvWrapper(worker.getInventoryCitizen()), tempStack::isItemEqual) < ItemStackUtils.getSize(tempStack)
                     && !isInHut(tempStack) && shouldRequest())
             {
                 chatSpamFilter.requestTextStringWithoutSpam(tempStack.getDisplayName());

--- a/src/main/java/com/minecolonies/coremod/entity/ai/citizen/baker/EntityAIWorkBaker.java
+++ b/src/main/java/com/minecolonies/coremod/entity/ai/citizen/baker/EntityAIWorkBaker.java
@@ -273,13 +273,13 @@ public class EntityAIWorkBaker extends AbstractEntityAISkill<JobBaker>
         if (copy != null)
         {
             //Wheat will be reduced by chance only (Between 3 and 6- getBuildingLevel, meaning 3-5, 3-4, 3-3, 3-2, 3-1)
-            final int form = (getOwnBuilding().getMaxBuildingLevel() + 1) - (getOwnBuilding().getBuildingLevel() + copy.getCount());
+            final int form = (getOwnBuilding().getMaxBuildingLevel() + 1) - (getOwnBuilding().getBuildingLevel() + ItemStackUtils.getItemStackSize(copy));
             int req = 0;
             if (form != 0)
             {
                 req = form < 0 ? -worker.getRandom().nextInt(Math.abs(form)) : worker.getRandom().nextInt(form);
             }
-            copy.setCount(copy.getCount() + req);
+            copy.setCount(ItemStackUtils.getItemStackSize(copy) + req);
             list.add(copy);
         }
 
@@ -306,7 +306,7 @@ public class EntityAIWorkBaker extends AbstractEntityAISkill<JobBaker>
     {
         for (final @Nullable ItemStack tempStack : list)
         {
-            if (InventoryUtils.getItemCountInItemHandler(new InvWrapper(worker.getInventoryCitizen()), tempStack::isItemEqual) < tempStack.getCount()
+            if (InventoryUtils.getItemCountInItemHandler(new InvWrapper(worker.getInventoryCitizen()), tempStack::isItemEqual) < ItemStackUtils.getItemStackSize(tempStack)
                     && !isInHut(tempStack) && shouldRequest())
             {
                 chatSpamFilter.requestTextStringWithoutSpam(tempStack.getDisplayName());

--- a/src/main/java/com/minecolonies/coremod/entity/ai/citizen/builder/EntityAIStructureBuilder.java
+++ b/src/main/java/com/minecolonies/coremod/entity/ai/citizen/builder/EntityAIStructureBuilder.java
@@ -271,7 +271,7 @@ public class EntityAIStructureBuilder extends AbstractEntityAIStructure<JobBuild
                     final ItemStack stack = ((EntityItemFrame) entity).getDisplayedItem();
                     if (!ItemStackUtils.isEmpty(stack))
                     {
-                        stack.setCount(1);
+                        ItemStackUtils.setSize(stack, 1);
                         request.add(stack);
                     }
                     request.add(new ItemStack(Items.ITEM_FRAME, 1));

--- a/src/main/java/com/minecolonies/coremod/entity/ai/citizen/builder/EntityAIStructureBuilder.java
+++ b/src/main/java/com/minecolonies/coremod/entity/ai/citizen/builder/EntityAIStructureBuilder.java
@@ -269,7 +269,7 @@ public class EntityAIStructureBuilder extends AbstractEntityAIStructure<JobBuild
                 if (entity instanceof EntityItemFrame)
                 {
                     final ItemStack stack = ((EntityItemFrame) entity).getDisplayedItem();
-                    if (!ItemStackUtils.isItemStackEmpty(stack))
+                    if (!ItemStackUtils.isEmpty(stack))
                     {
                         stack.setCount(1);
                         request.add(stack);

--- a/src/main/java/com/minecolonies/coremod/entity/ai/citizen/builder/EntityAIStructureBuilder.java
+++ b/src/main/java/com/minecolonies/coremod/entity/ai/citizen/builder/EntityAIStructureBuilder.java
@@ -433,7 +433,7 @@ public class EntityAIStructureBuilder extends AbstractEntityAIStructure<JobBuild
     {
         final AbstractBuildingWorker buildingWorker = getOwnBuilding();
 
-        if(stack == null || stack.getItem() == null)
+        if(ItemStackUtils.isEmpty(stack))
         {
             return null;
         }

--- a/src/main/java/com/minecolonies/coremod/entity/ai/citizen/deliveryman/EntityAIWorkDeliveryman.java
+++ b/src/main/java/com/minecolonies/coremod/entity/ai/citizen/deliveryman/EntityAIWorkDeliveryman.java
@@ -318,13 +318,13 @@ public class EntityAIWorkDeliveryman extends AbstractEntityAIInteract<JobDeliver
         for (int i = 0; i < new InvWrapper(worker.getInventoryCitizen()).getSlots(); i++)
         {
             final ItemStack stack = workerInventory.extractItem(i, Integer.MAX_VALUE, false);
-            if (ItemStackUtils.isItemStackEmpty(stack))
+            if (ItemStackUtils.isEmpty(stack))
             {
                 continue;
             }
 
             final ItemStack insertionResultStack = buildingToDeliver.forceTransferStack(stack, world);
-            if (!ItemStackUtils.isItemStackEmpty(insertionResultStack))
+            if (!ItemStackUtils.isEmpty(insertionResultStack))
             {
                 if (ItemStack.areItemStacksEqual(insertionResultStack, stack))
                 {
@@ -446,7 +446,7 @@ public class EntityAIWorkDeliveryman extends AbstractEntityAIInteract<JobDeliver
     private boolean hasFood(final AbstractBuilding buildingToDeliver)
     {
         return InventoryUtils.getItemCountInItemHandler(new InvWrapper(worker.getInventoryCitizen()),
-                stack -> !ItemStackUtils.isItemStackEmpty(stack) && stack.getItem() instanceof ItemFood) > buildingToDeliver.getBuildingLevel();
+                stack -> !ItemStackUtils.isEmpty(stack) && stack.getItem() instanceof ItemFood) > buildingToDeliver.getBuildingLevel();
     }
 
     /**
@@ -462,7 +462,7 @@ public class EntityAIWorkDeliveryman extends AbstractEntityAIInteract<JobDeliver
         if (buildingToDeliver instanceof BuildingHome)
         {
             position = wareHouse.getTileEntity().getPositionOfChestWithItemStack(
-                    itemStack -> !ItemStackUtils.isItemStackEmpty(itemStack) && itemStack.getItem() instanceof ItemFood);
+                    itemStack -> !ItemStackUtils.isEmpty(itemStack) && itemStack.getItem() instanceof ItemFood);
         }
         else if (itemsToDeliver.isEmpty())
         {
@@ -527,7 +527,7 @@ public class EntityAIWorkDeliveryman extends AbstractEntityAIInteract<JobDeliver
                 //Tries to extract a certain amount of the item of the chest.
                 if (InventoryUtils.transferXOfFirstSlotInProviderWithIntoNextFreeSlotInItemHandler(
                         tileEntity.getCapability(CapabilityItemHandler.ITEM_HANDLER_CAPABILITY, null),
-                        itemStack -> !ItemStackUtils.isItemStackEmpty(itemStack) && itemStack.getItem() instanceof ItemFood,
+                        itemStack -> !ItemStackUtils.isEmpty(itemStack) && itemStack.getItem() instanceof ItemFood,
                         buildingToDeliver.getBuildingLevel() + extraFood,
                         new InvWrapper(worker.getInventoryCitizen())))
                 {

--- a/src/main/java/com/minecolonies/coremod/entity/ai/citizen/farmer/Field.java
+++ b/src/main/java/com/minecolonies/coremod/entity/ai/citizen/farmer/Field.java
@@ -261,12 +261,12 @@ public class Field extends Container
         if (slotIndex == 0)
         {
             playerIn.inventory.addItemStackToInventory(inventory.getStackInSlot(0));
-            inventory.setStackInSlot(0, ItemStack.EMPTY);
+            inventory.setStackInSlot(0, ItemStackUtils.EMPTY);
         }
-        else if (inventory.getStackInSlot(0) == ItemStack.EMPTY || ItemStackUtils.getSize(inventory.getStackInSlot(0)) == 0)
+        else if (inventory.getStackInSlot(0) == ItemStackUtils.EMPTY || ItemStackUtils.getSize(inventory.getStackInSlot(0)) == 0)
         {
             final int playerIndex = slotIndex < MAX_INVENTORY_INDEX ? (slotIndex + INVENTORY_BAR_SIZE) : (slotIndex - MAX_INVENTORY_INDEX);
-            if (playerIn.inventory.getStackInSlot(playerIndex) != ItemStack.EMPTY)
+            if (playerIn.inventory.getStackInSlot(playerIndex) != ItemStackUtils.EMPTY)
             {
                 @NotNull final ItemStack stack = playerIn.inventory.getStackInSlot(playerIndex).splitStack(1);
                 inventory.setStackInSlot(0, stack);
@@ -277,7 +277,7 @@ public class Field extends Container
             }
         }
 
-        return ItemStack.EMPTY;
+        return ItemStackUtils.EMPTY;
     }
 
     @Override
@@ -509,7 +509,7 @@ public class Field extends Container
     @Nullable
     public ItemStack getSeed()
     {
-        if (inventory.getStackInSlot(0) != ItemStack.EMPTY && inventory.getStackInSlot(0).getItem() instanceof IPlantable)
+        if (inventory.getStackInSlot(0) != ItemStackUtils.EMPTY && inventory.getStackInSlot(0).getItem() instanceof IPlantable)
         {
             return inventory.getStackInSlot(0);
         }

--- a/src/main/java/com/minecolonies/coremod/entity/ai/citizen/farmer/Field.java
+++ b/src/main/java/com/minecolonies/coremod/entity/ai/citizen/farmer/Field.java
@@ -3,6 +3,7 @@ package com.minecolonies.coremod.entity.ai.citizen.farmer;
 import com.minecolonies.api.colony.permissions.Action;
 import com.minecolonies.api.util.BlockPosUtil;
 import com.minecolonies.api.util.constant.Constants;
+import com.minecolonies.api.util.ItemStackUtils;
 import com.minecolonies.coremod.colony.Colony;
 import com.minecolonies.coremod.colony.ColonyManager;
 import com.minecolonies.coremod.inventory.InventoryField;
@@ -262,14 +263,14 @@ public class Field extends Container
             playerIn.inventory.addItemStackToInventory(inventory.getStackInSlot(0));
             inventory.setStackInSlot(0, ItemStack.EMPTY);
         }
-        else if (inventory.getStackInSlot(0) == ItemStack.EMPTY || inventory.getStackInSlot(0).getCount() == 0)
+        else if (inventory.getStackInSlot(0) == ItemStack.EMPTY || ItemStackUtils.getItemStackSize(inventory.getStackInSlot(0)) == 0)
         {
             final int playerIndex = slotIndex < MAX_INVENTORY_INDEX ? (slotIndex + INVENTORY_BAR_SIZE) : (slotIndex - MAX_INVENTORY_INDEX);
             if (playerIn.inventory.getStackInSlot(playerIndex) != ItemStack.EMPTY)
             {
                 @NotNull final ItemStack stack = playerIn.inventory.getStackInSlot(playerIndex).splitStack(1);
                 inventory.setStackInSlot(0, stack);
-                if (playerIn.inventory.getStackInSlot(playerIndex).getCount() == 0)
+                if (ItemStackUtils.getItemStackSize(playerIn.inventory.getStackInSlot(playerIndex)) == 0)
                 {
                     playerIn.inventory.removeStackFromSlot(playerIndex);
                 }

--- a/src/main/java/com/minecolonies/coremod/entity/ai/citizen/farmer/Field.java
+++ b/src/main/java/com/minecolonies/coremod/entity/ai/citizen/farmer/Field.java
@@ -263,14 +263,14 @@ public class Field extends Container
             playerIn.inventory.addItemStackToInventory(inventory.getStackInSlot(0));
             inventory.setStackInSlot(0, ItemStack.EMPTY);
         }
-        else if (inventory.getStackInSlot(0) == ItemStack.EMPTY || ItemStackUtils.getItemStackSize(inventory.getStackInSlot(0)) == 0)
+        else if (inventory.getStackInSlot(0) == ItemStack.EMPTY || ItemStackUtils.getSize(inventory.getStackInSlot(0)) == 0)
         {
             final int playerIndex = slotIndex < MAX_INVENTORY_INDEX ? (slotIndex + INVENTORY_BAR_SIZE) : (slotIndex - MAX_INVENTORY_INDEX);
             if (playerIn.inventory.getStackInSlot(playerIndex) != ItemStack.EMPTY)
             {
                 @NotNull final ItemStack stack = playerIn.inventory.getStackInSlot(playerIndex).splitStack(1);
                 inventory.setStackInSlot(0, stack);
-                if (ItemStackUtils.getItemStackSize(playerIn.inventory.getStackInSlot(playerIndex)) == 0)
+                if (ItemStackUtils.getSize(playerIn.inventory.getStackInSlot(playerIndex)) == 0)
                 {
                     playerIn.inventory.removeStackFromSlot(playerIndex);
                 }

--- a/src/main/java/com/minecolonies/coremod/entity/ai/citizen/guard/AbstractEntityAIGuard.java
+++ b/src/main/java/com/minecolonies/coremod/entity/ai/citizen/guard/AbstractEntityAIGuard.java
@@ -165,7 +165,7 @@ public abstract class AbstractEntityAIGuard extends AbstractEntityAIInteract<Job
             {
                 final ItemStack stack = chest.getStackInSlot(i);
 
-                if (ItemStackUtils.isItemStackEmpty(stack))
+                if (ItemStackUtils.isEmpty(stack))
                 {
                     continue;
                 }
@@ -173,7 +173,7 @@ public abstract class AbstractEntityAIGuard extends AbstractEntityAIInteract<Job
                 if (stack.getItem() instanceof ItemArmor && worker.getItemStackFromSlot(((ItemArmor) stack.getItem()).armorType) == null)
                 {
                     final int emptySlot = InventoryUtils.findFirstSlotInItemHandlerWith(new InvWrapper(worker.getInventoryCitizen()),
-                      ItemStackUtils::isItemStackEmpty);
+                      ItemStackUtils::isEmpty);
 
                     if (emptySlot != -1)
                     {
@@ -219,7 +219,7 @@ public abstract class AbstractEntityAIGuard extends AbstractEntityAIInteract<Job
         {
             final ItemStack stack = worker.getInventoryCitizen().getStackInSlot(i);
 
-            if (ItemStackUtils.isItemStackEmpty(stack))
+            if (ItemStackUtils.isEmpty(stack))
             {
                 new InvWrapper(worker.getInventoryCitizen()).extractItem(i, Integer.MAX_VALUE, false);
                 continue;

--- a/src/main/java/com/minecolonies/coremod/entity/ai/citizen/guard/AbstractEntityAIGuard.java
+++ b/src/main/java/com/minecolonies/coremod/entity/ai/citizen/guard/AbstractEntityAIGuard.java
@@ -178,7 +178,7 @@ public abstract class AbstractEntityAIGuard extends AbstractEntityAIInteract<Job
                     if (emptySlot != -1)
                     {
                         new InvWrapper(worker.getInventoryCitizen()).insertItem(emptySlot, stack, false);
-                        chest.setInventorySlotContents(i, ItemStack.EMPTY);
+                        chest.setInventorySlotContents(i, ItemStackUtils.EMPTY);
                     }
                 }
                 dumpAfterActions = DUMP_BASE * workBuilding.getBuildingLevel();
@@ -210,10 +210,10 @@ public abstract class AbstractEntityAIGuard extends AbstractEntityAIInteract<Job
      */
     protected void updateArmor()
     {
-        worker.setItemStackToSlot(EntityEquipmentSlot.CHEST, ItemStack.EMPTY);
-        worker.setItemStackToSlot(EntityEquipmentSlot.FEET, ItemStack.EMPTY);
-        worker.setItemStackToSlot(EntityEquipmentSlot.HEAD, ItemStack.EMPTY);
-        worker.setItemStackToSlot(EntityEquipmentSlot.LEGS, ItemStack.EMPTY);
+        worker.setItemStackToSlot(EntityEquipmentSlot.CHEST, ItemStackUtils.EMPTY);
+        worker.setItemStackToSlot(EntityEquipmentSlot.FEET, ItemStackUtils.EMPTY);
+        worker.setItemStackToSlot(EntityEquipmentSlot.HEAD, ItemStackUtils.EMPTY);
+        worker.setItemStackToSlot(EntityEquipmentSlot.LEGS, ItemStackUtils.EMPTY);
 
         for (int i = 0; i < new InvWrapper(worker.getInventoryCitizen()).getSlots(); i++)
         {
@@ -225,7 +225,7 @@ public abstract class AbstractEntityAIGuard extends AbstractEntityAIInteract<Job
                 continue;
             }
 
-            if (stack.getItem() instanceof ItemArmor && worker.getItemStackFromSlot(((ItemArmor) stack.getItem()).armorType) == ItemStack.EMPTY)
+            if (stack.getItem() instanceof ItemArmor && worker.getItemStackFromSlot(((ItemArmor) stack.getItem()).armorType) == ItemStackUtils.EMPTY)
             {
                 worker.setItemStackToSlot(((ItemArmor) stack.getItem()).armorType, stack);
             }

--- a/src/main/java/com/minecolonies/coremod/entity/ai/minimal/EntityAIGoHome.java
+++ b/src/main/java/com/minecolonies/coremod/entity/ai/minimal/EntityAIGoHome.java
@@ -157,7 +157,7 @@ public class EntityAIGoHome extends EntityAIBase
                             citizen.getInventoryCitizen().setInventorySlotContents(slotToSet, new ItemStack(stack.getItem(), 1));
                         }
                         tookFood = true;
-                        ItemStackUtils.increaseOrDecreaseSize(stack, -1);
+                        ItemStackUtils.changeSize(stack, -1);
                     }
                     ((BuildingHome) home).setFoodNeeded(false);
                 }

--- a/src/main/java/com/minecolonies/coremod/entity/ai/minimal/EntityAIGoHome.java
+++ b/src/main/java/com/minecolonies/coremod/entity/ai/minimal/EntityAIGoHome.java
@@ -157,7 +157,7 @@ public class EntityAIGoHome extends EntityAIBase
                             citizen.getInventoryCitizen().setInventorySlotContents(slotToSet, new ItemStack(stack.getItem(), 1));
                         }
                         tookFood = true;
-                        stack.setCount(stack.getCount() - 1);
+                        stack.setCount(ItemStackUtils.getItemStackSize(stack) - 1);
                     }
                     ((BuildingHome) home).setFoodNeeded(false);
                 }

--- a/src/main/java/com/minecolonies/coremod/entity/ai/minimal/EntityAIGoHome.java
+++ b/src/main/java/com/minecolonies/coremod/entity/ai/minimal/EntityAIGoHome.java
@@ -141,7 +141,7 @@ public class EntityAIGoHome extends EntityAIBase
                 if (slot != -1)
                 {
                     final ItemStack stack = home.getTileEntity().getStackInSlot(slot);
-                    if (!ItemStackUtils.isItemStackEmpty(stack))
+                    if (!ItemStackUtils.isEmpty(stack))
                     {
                         final int slotToSet = InventoryUtils.getFirstOpenSlotFromItemHandler(new InvWrapper(citizen.getInventoryCitizen()));
 

--- a/src/main/java/com/minecolonies/coremod/entity/ai/minimal/EntityAIGoHome.java
+++ b/src/main/java/com/minecolonies/coremod/entity/ai/minimal/EntityAIGoHome.java
@@ -157,7 +157,7 @@ public class EntityAIGoHome extends EntityAIBase
                             citizen.getInventoryCitizen().setInventorySlotContents(slotToSet, new ItemStack(stack.getItem(), 1));
                         }
                         tookFood = true;
-                        stack.setCount(ItemStackUtils.getSize(stack) - 1);
+                        ItemStackUtils.setSize(stack, ItemStackUtils.getSize(stack) - 1);
                     }
                     ((BuildingHome) home).setFoodNeeded(false);
                 }

--- a/src/main/java/com/minecolonies/coremod/entity/ai/minimal/EntityAIGoHome.java
+++ b/src/main/java/com/minecolonies/coremod/entity/ai/minimal/EntityAIGoHome.java
@@ -157,7 +157,7 @@ public class EntityAIGoHome extends EntityAIBase
                             citizen.getInventoryCitizen().setInventorySlotContents(slotToSet, new ItemStack(stack.getItem(), 1));
                         }
                         tookFood = true;
-                        ItemStackUtils.setSize(stack, ItemStackUtils.getSize(stack) - 1);
+                        ItemStackUtils.increaseOrDecreaseSize(stack, -1);
                     }
                     ((BuildingHome) home).setFoodNeeded(false);
                 }

--- a/src/main/java/com/minecolonies/coremod/entity/ai/minimal/EntityAIGoHome.java
+++ b/src/main/java/com/minecolonies/coremod/entity/ai/minimal/EntityAIGoHome.java
@@ -157,7 +157,7 @@ public class EntityAIGoHome extends EntityAIBase
                             citizen.getInventoryCitizen().setInventorySlotContents(slotToSet, new ItemStack(stack.getItem(), 1));
                         }
                         tookFood = true;
-                        stack.setCount(ItemStackUtils.getItemStackSize(stack) - 1);
+                        stack.setCount(ItemStackUtils.getSize(stack) - 1);
                     }
                     ((BuildingHome) home).setFoodNeeded(false);
                 }

--- a/src/main/java/com/minecolonies/coremod/entity/ai/util/RecipeStorage.java
+++ b/src/main/java/com/minecolonies/coremod/entity/ai/util/RecipeStorage.java
@@ -99,7 +99,7 @@ public class RecipeStorage
     {
         for(final ItemStack stack: input)
         {
-            int amountNeeded = stack.getCount();
+            int amountNeeded = ItemStackUtils.getItemStackSize(stack);
             boolean hasStack = false;
             for(final IItemHandler handler: inventories)
             {

--- a/src/main/java/com/minecolonies/coremod/entity/ai/util/RecipeStorage.java
+++ b/src/main/java/com/minecolonies/coremod/entity/ai/util/RecipeStorage.java
@@ -99,7 +99,7 @@ public class RecipeStorage
     {
         for(final ItemStack stack: input)
         {
-            int amountNeeded = ItemStackUtils.getItemStackSize(stack);
+            int amountNeeded = ItemStackUtils.getSize(stack);
             boolean hasStack = false;
             for(final IItemHandler handler: inventories)
             {

--- a/src/main/java/com/minecolonies/coremod/entity/ai/util/RecipeStorage.java
+++ b/src/main/java/com/minecolonies/coremod/entity/ai/util/RecipeStorage.java
@@ -103,11 +103,11 @@ public class RecipeStorage
             boolean hasStack = false;
             for(final IItemHandler handler: inventories)
             {
-                hasStack = InventoryUtils.hasItemInItemHandler(handler, itemStack -> !ItemStackUtils.isItemStackEmpty(itemStack) && itemStack.isItemEqual(stack));
+                hasStack = InventoryUtils.hasItemInItemHandler(handler, itemStack -> !ItemStackUtils.isEmpty(itemStack) && itemStack.isItemEqual(stack));
 
                 if(hasStack)
                 {
-                    final int count = InventoryUtils.getItemCountInItemHandler(handler, itemStack -> !ItemStackUtils.isItemStackEmpty(itemStack) && itemStack.isItemEqual(stack));
+                    final int count = InventoryUtils.getItemCountInItemHandler(handler, itemStack -> !ItemStackUtils.isEmpty(itemStack) && itemStack.isItemEqual(stack));
                     if(count >= amountNeeded)
                     {
                         break;

--- a/src/main/java/com/minecolonies/coremod/inventory/InventoryCitizen.java
+++ b/src/main/java/com/minecolonies/coremod/inventory/InventoryCitizen.java
@@ -687,7 +687,7 @@ public class InventoryCitizen implements IInventory
                     {
                         this.mainInventory.set(j, itemStackIn.copy());
                         (this.mainInventory.get(j)).setAnimationsToGo(5);
-                        itemStackIn.setCount(0);
+                        ItemStackUtils.setSize(itemStackIn, 0);
                         return true;
                     }
                     else
@@ -702,7 +702,7 @@ public class InventoryCitizen implements IInventory
                     while (true)
                     {
                         i = ItemStackUtils.getSize(itemStackIn);
-                        itemStackIn.setCount(this.storePartialItemStack(itemStackIn));
+                        ItemStackUtils.setSize(itemStackIn, this.storePartialItemStack(itemStackIn));
 
                         if (ItemStackUtils.getSize(itemStackIn) >= i)
                         {
@@ -772,7 +772,7 @@ public class InventoryCitizen implements IInventory
             {
                 // Forge: Replace Item clone above to preserve item capabilities when picking the item up.
                 itemstack = itemStackIn.copy();
-                itemstack.setCount(0);
+                ItemStackUtils.setSize(itemstack, 0);
 
                 if (itemStackIn.hasTagCompound())
                 {

--- a/src/main/java/com/minecolonies/coremod/inventory/InventoryCitizen.java
+++ b/src/main/java/com/minecolonies/coremod/inventory/InventoryCitizen.java
@@ -1,6 +1,7 @@
 package com.minecolonies.coremod.inventory;
 
 import com.minecolonies.api.colony.permissions.Action;
+import com.minecolonies.api.util.ItemStackUtils;
 import com.minecolonies.coremod.entity.EntityCitizen;
 import net.minecraft.block.state.IBlockState;
 import net.minecraft.crash.CrashReport;
@@ -291,7 +292,7 @@ public class InventoryCitizen implements IInventory
                   && (metadataIn <= NO_SLOT || itemstack.getMetadata() == metadataIn) && (itemNBT == null || NBTUtil
                                                                                                                .areNBTEquals(itemNBT, itemstack.getTagCompound(), true)))
             {
-                final int k = removeCount <= 0 ? itemstack.getCount() : Math.min(removeCount - i, itemstack.getCount());
+                final int k = removeCount <= 0 ? ItemStackUtils.getItemStackSize(itemstack) : Math.min(removeCount - i, ItemStackUtils.getItemStackSize(itemstack));
                 i += k;
 
                 if (removeCount != 0)
@@ -328,7 +329,7 @@ public class InventoryCitizen implements IInventory
                 return i;
             }
 
-            final int l = removeCount <= 0 ? this.itemStack.getCount() : Math.min(removeCount - i, this.itemStack.getCount());
+            final int l = removeCount <= 0 ? ItemStackUtils.getItemStackSize(this.itemStack) : Math.min(removeCount - i, ItemStackUtils.getItemStackSize(this.itemStack));
             i += l;
 
             if (removeCount != 0)
@@ -700,16 +701,16 @@ public class InventoryCitizen implements IInventory
 
                     while (true)
                     {
-                        i = itemStackIn.getCount();
+                        i = ItemStackUtils.getItemStackSize(itemStackIn);
                         itemStackIn.setCount(this.storePartialItemStack(itemStackIn));
 
-                        if (itemStackIn.isEmpty() || itemStackIn.getCount() >= i)
+                        if (ItemStackUtils.getItemStackSize(itemStackIn) >= i)
                         {
                             break;
                         }
                     }
 
-                    return itemStackIn.getCount() < i;
+                    return ItemStackUtils.getItemStackSize(itemStackIn) < i;
                 }
             }
             catch (final RuntimeException exception)
@@ -751,7 +752,7 @@ public class InventoryCitizen implements IInventory
      */
     private int storePartialItemStack(final ItemStack itemStackIn)
     {
-        int i = itemStackIn.getCount();
+        int i = ItemStackUtils.getItemStackSize(itemStackIn);
         int j = this.storeItemStack(itemStackIn);
 
         if (j == NO_SLOT)
@@ -783,14 +784,14 @@ public class InventoryCitizen implements IInventory
 
             int k = i;
 
-            if (i > itemstack.getMaxStackSize() - itemstack.getCount())
+            if (i > itemstack.getMaxStackSize() - ItemStackUtils.getItemStackSize(itemstack))
             {
-                k = itemstack.getMaxStackSize() - itemstack.getCount();
+                k = itemstack.getMaxStackSize() - ItemStackUtils.getItemStackSize(itemstack);
             }
 
-            if (k > this.getInventoryStackLimit() - itemstack.getCount())
+            if (k > this.getInventoryStackLimit() - ItemStackUtils.getItemStackSize(itemstack))
             {
-                k = this.getInventoryStackLimit() - itemstack.getCount();
+                k = this.getInventoryStackLimit() - ItemStackUtils.getItemStackSize(itemstack);
             }
 
             if (k == 0)
@@ -837,7 +838,7 @@ public class InventoryCitizen implements IInventory
     private boolean canMergeStacks(final ItemStack stack1, final ItemStack stack2)
     {
         return !stack1.isEmpty() && InventoryCitizen.stackEqualExact(stack1, stack2) && stack1.isStackable()
-                 && stack1.getCount() < stack1.getMaxStackSize() && stack1.getCount() < this.getInventoryStackLimit();
+                 && ItemStackUtils.getItemStackSize(stack1) < stack1.getMaxStackSize() && ItemStackUtils.getItemStackSize(stack1) < this.getInventoryStackLimit();
     }
 
     /**
@@ -1001,7 +1002,7 @@ public class InventoryCitizen implements IInventory
 
                 if (!itemstack.isEmpty())
                 {
-                    this.citizen.dropItem(itemstack.getItem(), itemstack.getCount());
+                    this.citizen.dropItem(itemstack.getItem(), ItemStackUtils.getItemStackSize(itemstack));
                     list.set(i, ItemStack.EMPTY);
                 }
             }

--- a/src/main/java/com/minecolonies/coremod/inventory/InventoryCitizen.java
+++ b/src/main/java/com/minecolonies/coremod/inventory/InventoryCitizen.java
@@ -445,7 +445,7 @@ public class InventoryCitizen implements IInventory
             tempIndex -= nonnulllist.size();
         }
 
-        return list != null && !(list.get(tempIndex)).isEmpty() ? ItemStackHelper.getAndSplit(list, tempIndex, count) : ItemStackUtils.EMPTY;
+        return list != null && !ItemStackUtils.isEmpty(list.get(tempIndex)) ? ItemStackHelper.getAndSplit(list, tempIndex, count) : ItemStackUtils.EMPTY;
     }
 
     /**
@@ -470,7 +470,7 @@ public class InventoryCitizen implements IInventory
             tempIndex -= nonnulllist1.size();
         }
 
-        if (nonnulllist != null && !(nonnulllist.get(tempIndex)).isEmpty())
+        if (nonnulllist != null && !ItemStackUtils.isEmpty(nonnulllist.get(tempIndex)))
         {
             final ItemStack itemstack = nonnulllist.get(tempIndex);
             nonnulllist.set(tempIndex, ItemStackUtils.EMPTY);
@@ -837,7 +837,7 @@ public class InventoryCitizen implements IInventory
 
     private boolean canMergeStacks(final ItemStack stack1, final ItemStack stack2)
     {
-        return !stack1.isEmpty() && InventoryCitizen.stackEqualExact(stack1, stack2) && stack1.isStackable()
+        return !ItemStackUtils.isEmpty(stack1) && InventoryCitizen.stackEqualExact(stack1, stack2) && stack1.isStackable()
                  && ItemStackUtils.getSize(stack1) < stack1.getMaxStackSize() && ItemStackUtils.getSize(stack1) < this.getInventoryStackLimit();
     }
 
@@ -1000,7 +1000,7 @@ public class InventoryCitizen implements IInventory
             {
                 final ItemStack itemstack = list.get(i);
 
-                if (!itemstack.isEmpty())
+                if (!ItemStackUtils.isEmpty(itemstack))
                 {
                     this.citizen.dropItem(itemstack.getItem(), ItemStackUtils.getSize(itemstack));
                     list.set(i, ItemStackUtils.EMPTY);

--- a/src/main/java/com/minecolonies/coremod/inventory/InventoryCitizen.java
+++ b/src/main/java/com/minecolonies/coremod/inventory/InventoryCitizen.java
@@ -292,7 +292,7 @@ public class InventoryCitizen implements IInventory
                   && (metadataIn <= NO_SLOT || itemstack.getMetadata() == metadataIn) && (itemNBT == null || NBTUtil
                                                                                                                .areNBTEquals(itemNBT, itemstack.getTagCompound(), true)))
             {
-                final int k = removeCount <= 0 ? ItemStackUtils.getItemStackSize(itemstack) : Math.min(removeCount - i, ItemStackUtils.getItemStackSize(itemstack));
+                final int k = removeCount <= 0 ? ItemStackUtils.getSize(itemstack) : Math.min(removeCount - i, ItemStackUtils.getSize(itemstack));
                 i += k;
 
                 if (removeCount != 0)
@@ -329,7 +329,7 @@ public class InventoryCitizen implements IInventory
                 return i;
             }
 
-            final int l = removeCount <= 0 ? ItemStackUtils.getItemStackSize(this.itemStack) : Math.min(removeCount - i, ItemStackUtils.getItemStackSize(this.itemStack));
+            final int l = removeCount <= 0 ? ItemStackUtils.getSize(this.itemStack) : Math.min(removeCount - i, ItemStackUtils.getSize(this.itemStack));
             i += l;
 
             if (removeCount != 0)
@@ -701,16 +701,16 @@ public class InventoryCitizen implements IInventory
 
                     while (true)
                     {
-                        i = ItemStackUtils.getItemStackSize(itemStackIn);
+                        i = ItemStackUtils.getSize(itemStackIn);
                         itemStackIn.setCount(this.storePartialItemStack(itemStackIn));
 
-                        if (ItemStackUtils.getItemStackSize(itemStackIn) >= i)
+                        if (ItemStackUtils.getSize(itemStackIn) >= i)
                         {
                             break;
                         }
                     }
 
-                    return ItemStackUtils.getItemStackSize(itemStackIn) < i;
+                    return ItemStackUtils.getSize(itemStackIn) < i;
                 }
             }
             catch (final RuntimeException exception)
@@ -752,7 +752,7 @@ public class InventoryCitizen implements IInventory
      */
     private int storePartialItemStack(final ItemStack itemStackIn)
     {
-        int i = ItemStackUtils.getItemStackSize(itemStackIn);
+        int i = ItemStackUtils.getSize(itemStackIn);
         int j = this.storeItemStack(itemStackIn);
 
         if (j == NO_SLOT)
@@ -784,14 +784,14 @@ public class InventoryCitizen implements IInventory
 
             int k = i;
 
-            if (i > itemstack.getMaxStackSize() - ItemStackUtils.getItemStackSize(itemstack))
+            if (i > itemstack.getMaxStackSize() - ItemStackUtils.getSize(itemstack))
             {
-                k = itemstack.getMaxStackSize() - ItemStackUtils.getItemStackSize(itemstack);
+                k = itemstack.getMaxStackSize() - ItemStackUtils.getSize(itemstack);
             }
 
-            if (k > this.getInventoryStackLimit() - ItemStackUtils.getItemStackSize(itemstack))
+            if (k > this.getInventoryStackLimit() - ItemStackUtils.getSize(itemstack))
             {
-                k = this.getInventoryStackLimit() - ItemStackUtils.getItemStackSize(itemstack);
+                k = this.getInventoryStackLimit() - ItemStackUtils.getSize(itemstack);
             }
 
             if (k == 0)
@@ -838,7 +838,7 @@ public class InventoryCitizen implements IInventory
     private boolean canMergeStacks(final ItemStack stack1, final ItemStack stack2)
     {
         return !stack1.isEmpty() && InventoryCitizen.stackEqualExact(stack1, stack2) && stack1.isStackable()
-                 && ItemStackUtils.getItemStackSize(stack1) < stack1.getMaxStackSize() && ItemStackUtils.getItemStackSize(stack1) < this.getInventoryStackLimit();
+                 && ItemStackUtils.getSize(stack1) < stack1.getMaxStackSize() && ItemStackUtils.getSize(stack1) < this.getInventoryStackLimit();
     }
 
     /**
@@ -1002,7 +1002,7 @@ public class InventoryCitizen implements IInventory
 
                 if (!itemstack.isEmpty())
                 {
-                    this.citizen.dropItem(itemstack.getItem(), ItemStackUtils.getItemStackSize(itemstack));
+                    this.citizen.dropItem(itemstack.getItem(), ItemStackUtils.getSize(itemstack));
                     list.set(i, ItemStack.EMPTY);
                 }
             }

--- a/src/main/java/com/minecolonies/coremod/inventory/InventoryCitizen.java
+++ b/src/main/java/com/minecolonies/coremod/inventory/InventoryCitizen.java
@@ -48,22 +48,22 @@ public class InventoryCitizen implements IInventory
     /**
      * The main inventory.
      */
-    private final        NonNullList<ItemStack> mainInventory    = NonNullList.<ItemStack>withSize(36, ItemStack.EMPTY);
+    private final        NonNullList<ItemStack> mainInventory    = NonNullList.<ItemStack>withSize(36, ItemStackUtils.EMPTY);
     /**
      * The armour inventory.
      */
-    private final        NonNullList<ItemStack> armorInventory   = NonNullList.<ItemStack>withSize(4, ItemStack.EMPTY);
+    private final        NonNullList<ItemStack> armorInventory   = NonNullList.<ItemStack>withSize(4, ItemStackUtils.EMPTY);
     /**
      * The off-hand inventory.
      */
-    private final        NonNullList<ItemStack> offHandInventory = NonNullList.<ItemStack>withSize(1, ItemStack.EMPTY);
+    private final        NonNullList<ItemStack> offHandInventory = NonNullList.<ItemStack>withSize(1, ItemStackUtils.EMPTY);
     private final List<NonNullList<ItemStack>> allInventories;
     /**
      * The index of the currently held item (0-8).
      */
     public        int                          currentItem;
 
-    private ItemStack itemStack = ItemStack.EMPTY;
+    private ItemStack itemStack = ItemStackUtils.EMPTY;
 
     /**
      * The inventories custom name. In our case the citizens name.
@@ -97,7 +97,7 @@ public class InventoryCitizen implements IInventory
         this.allInventories.add(this.armorInventory);
         this.allInventories.add(this.offHandInventory);
 
-        this.itemStack = ItemStack.EMPTY;
+        this.itemStack = ItemStackUtils.EMPTY;
     }
 
     /**
@@ -116,7 +116,7 @@ public class InventoryCitizen implements IInventory
         this.allInventories.add(this.mainInventory);
         this.allInventories.add(this.armorInventory);
         this.allInventories.add(this.offHandInventory);
-        this.itemStack = ItemStack.EMPTY;
+        this.itemStack = ItemStackUtils.EMPTY;
     }
 
     /**
@@ -193,7 +193,7 @@ public class InventoryCitizen implements IInventory
      */
     public boolean isSlotEmpty(final int index)
     {
-        return getStackInSlot(index) == null || getStackInSlot(index) == ItemStack.EMPTY;
+        return getStackInSlot(index) == null || getStackInSlot(index) == ItemStackUtils.EMPTY;
     }
 
     /**
@@ -301,7 +301,7 @@ public class InventoryCitizen implements IInventory
 
                     if (itemstack.isEmpty())
                     {
-                        this.setInventorySlotContents(j, ItemStack.EMPTY);
+                        this.setInventorySlotContents(j, ItemStackUtils.EMPTY);
                     }
 
                     if (removeCount > 0 && i >= removeCount)
@@ -338,7 +338,7 @@ public class InventoryCitizen implements IInventory
 
                 if (this.itemStack.isEmpty())
                 {
-                    this.itemStack = ItemStack.EMPTY;
+                    this.itemStack = ItemStackUtils.EMPTY;
                 }
 
                 if (removeCount > 0 && i >= removeCount)
@@ -419,7 +419,7 @@ public class InventoryCitizen implements IInventory
             tempIndex -= nonnulllist.size();
         }
 
-        return list == null ? ItemStack.EMPTY : list.get(tempIndex);
+        return list == null ? ItemStackUtils.EMPTY : list.get(tempIndex);
     }
 
     /**
@@ -445,7 +445,7 @@ public class InventoryCitizen implements IInventory
             tempIndex -= nonnulllist.size();
         }
 
-        return list != null && !(list.get(tempIndex)).isEmpty() ? ItemStackHelper.getAndSplit(list, tempIndex, count) : ItemStack.EMPTY;
+        return list != null && !(list.get(tempIndex)).isEmpty() ? ItemStackHelper.getAndSplit(list, tempIndex, count) : ItemStackUtils.EMPTY;
     }
 
     /**
@@ -473,12 +473,12 @@ public class InventoryCitizen implements IInventory
         if (nonnulllist != null && !(nonnulllist.get(tempIndex)).isEmpty())
         {
             final ItemStack itemstack = nonnulllist.get(tempIndex);
-            nonnulllist.set(tempIndex, ItemStack.EMPTY);
+            nonnulllist.set(tempIndex, ItemStackUtils.EMPTY);
             return itemstack;
         }
         else
         {
-            return ItemStack.EMPTY;
+            return ItemStackUtils.EMPTY;
         }
     }
 
@@ -854,7 +854,7 @@ public class InventoryCitizen implements IInventory
             {
                 if (nonnulllist.get(i) == stack)
                 {
-                    nonnulllist.set(i, ItemStack.EMPTY);
+                    nonnulllist.set(i, ItemStackUtils.EMPTY);
                     break;
                 }
             }
@@ -1003,7 +1003,7 @@ public class InventoryCitizen implements IInventory
                 if (!itemstack.isEmpty())
                 {
                     this.citizen.dropItem(itemstack.getItem(), ItemStackUtils.getSize(itemstack));
-                    list.set(i, ItemStack.EMPTY);
+                    list.set(i, ItemStackUtils.EMPTY);
                 }
             }
         }

--- a/src/main/java/com/minecolonies/coremod/items/ItemCompost.java
+++ b/src/main/java/com/minecolonies/coremod/items/ItemCompost.java
@@ -1,5 +1,6 @@
 package com.minecolonies.coremod.items;
 
+import com.minecolonies.api.util.ItemStackUtils;
 import com.minecolonies.coremod.creativetab.ModCreativeTabs;
 import net.minecraft.block.IGrowable;
 import net.minecraft.block.state.IBlockState;
@@ -70,7 +71,7 @@ public class ItemCompost extends AbstractItemMinecolonies
                         igrowable.grow(worldIn, worldIn.rand, pos, iblockstate);
                     }
 
-                    stack.setCount(stack.getCount() - 1);
+                    ItemStackUtils.setSize(stack, ItemStackUtils.getSize(stack) - 1);
                 }
             }
         }

--- a/src/main/java/com/minecolonies/coremod/items/ItemSupplyCampDeployer.java
+++ b/src/main/java/com/minecolonies/coremod/items/ItemSupplyCampDeployer.java
@@ -100,7 +100,7 @@ public class ItemSupplyCampDeployer extends AbstractItemMinecolonies
 
             fillChest((TileEntityChest) worldIn.getTileEntity(pos.up()));
 
-            stack.setCount(ItemStackUtils.getItemStackSize(stack)-1);
+            stack.setCount(ItemStackUtils.getSize(stack)-1);
             player.addStat(ModAchievements.achievementGetSupply);
 
             return EnumActionResult.SUCCESS;

--- a/src/main/java/com/minecolonies/coremod/items/ItemSupplyCampDeployer.java
+++ b/src/main/java/com/minecolonies/coremod/items/ItemSupplyCampDeployer.java
@@ -4,6 +4,7 @@ import com.minecolonies.api.configuration.Configurations;
 import com.minecolonies.api.util.LanguageHandler;
 import com.minecolonies.api.util.Log;
 import com.minecolonies.api.util.constant.Constants;
+import com.minecolonies.api.util.ItemStackUtils;
 import com.minecolonies.coremod.achievements.ModAchievements;
 import com.minecolonies.coremod.blocks.ModBlocks;
 import com.minecolonies.coremod.colony.ColonyManager;
@@ -87,7 +88,7 @@ public class ItemSupplyCampDeployer extends AbstractItemMinecolonies
         }
 
         final ItemStack stack = player.getHeldItem(hand);
-        if (worldIn.isRemote || stack.getCount() == 0 || !isFirstPlacing(player))
+        if (worldIn.isRemote || ItemStackUtils.isItemStackEmpty(stack) || !isFirstPlacing(player))
         {
             return EnumActionResult.FAIL;
         }
@@ -99,7 +100,7 @@ public class ItemSupplyCampDeployer extends AbstractItemMinecolonies
 
             fillChest((TileEntityChest) worldIn.getTileEntity(pos.up()));
 
-            stack.setCount(stack.getCount()-1);
+            stack.setCount(ItemStackUtils.getItemStackSize(stack)-1);
             player.addStat(ModAchievements.achievementGetSupply);
 
             return EnumActionResult.SUCCESS;

--- a/src/main/java/com/minecolonies/coremod/items/ItemSupplyCampDeployer.java
+++ b/src/main/java/com/minecolonies/coremod/items/ItemSupplyCampDeployer.java
@@ -88,7 +88,7 @@ public class ItemSupplyCampDeployer extends AbstractItemMinecolonies
         }
 
         final ItemStack stack = player.getHeldItem(hand);
-        if (worldIn.isRemote || ItemStackUtils.isItemStackEmpty(stack) || !isFirstPlacing(player))
+        if (worldIn.isRemote || ItemStackUtils.isEmpty(stack) || !isFirstPlacing(player))
         {
             return EnumActionResult.FAIL;
         }

--- a/src/main/java/com/minecolonies/coremod/items/ItemSupplyCampDeployer.java
+++ b/src/main/java/com/minecolonies/coremod/items/ItemSupplyCampDeployer.java
@@ -100,7 +100,7 @@ public class ItemSupplyCampDeployer extends AbstractItemMinecolonies
 
             fillChest((TileEntityChest) worldIn.getTileEntity(pos.up()));
 
-            ItemStackUtils.setSize(stack, ItemStackUtils.getSize(stack)-1);
+            ItemStackUtils.increaseOrDecreaseSize(stack, -1);
             player.addStat(ModAchievements.achievementGetSupply);
 
             return EnumActionResult.SUCCESS;

--- a/src/main/java/com/minecolonies/coremod/items/ItemSupplyCampDeployer.java
+++ b/src/main/java/com/minecolonies/coremod/items/ItemSupplyCampDeployer.java
@@ -100,7 +100,7 @@ public class ItemSupplyCampDeployer extends AbstractItemMinecolonies
 
             fillChest((TileEntityChest) worldIn.getTileEntity(pos.up()));
 
-            stack.setCount(ItemStackUtils.getSize(stack)-1);
+            ItemStackUtils.setSize(stack, ItemStackUtils.getSize(stack)-1);
             player.addStat(ModAchievements.achievementGetSupply);
 
             return EnumActionResult.SUCCESS;

--- a/src/main/java/com/minecolonies/coremod/items/ItemSupplyCampDeployer.java
+++ b/src/main/java/com/minecolonies/coremod/items/ItemSupplyCampDeployer.java
@@ -100,7 +100,7 @@ public class ItemSupplyCampDeployer extends AbstractItemMinecolonies
 
             fillChest((TileEntityChest) worldIn.getTileEntity(pos.up()));
 
-            ItemStackUtils.increaseOrDecreaseSize(stack, -1);
+            ItemStackUtils.changeSize(stack, -1);
             player.addStat(ModAchievements.achievementGetSupply);
 
             return EnumActionResult.SUCCESS;

--- a/src/main/java/com/minecolonies/coremod/items/ItemSupplyChestDeployer.java
+++ b/src/main/java/com/minecolonies/coremod/items/ItemSupplyChestDeployer.java
@@ -112,7 +112,7 @@ public class ItemSupplyChestDeployer extends AbstractItemMinecolonies
         if (enumfacing != EnumFacing.DOWN)
         {
             spawnShip(worldIn, pos, enumfacing);
-            stack.setCount(ItemStackUtils.getSize(stack) - 1);
+            ItemStackUtils.setSize(stack, ItemStackUtils.getSize(stack) - 1);
 
             playerIn.addStat(ModAchievements.achievementGetSupply);
 

--- a/src/main/java/com/minecolonies/coremod/items/ItemSupplyChestDeployer.java
+++ b/src/main/java/com/minecolonies/coremod/items/ItemSupplyChestDeployer.java
@@ -112,7 +112,7 @@ public class ItemSupplyChestDeployer extends AbstractItemMinecolonies
         if (enumfacing != EnumFacing.DOWN)
         {
             spawnShip(worldIn, pos, enumfacing);
-            ItemStackUtils.setSize(stack, ItemStackUtils.getSize(stack) - 1);
+            ItemStackUtils.increaseOrDecreaseSize(stack, -1);
 
             playerIn.addStat(ModAchievements.achievementGetSupply);
 

--- a/src/main/java/com/minecolonies/coremod/items/ItemSupplyChestDeployer.java
+++ b/src/main/java/com/minecolonies/coremod/items/ItemSupplyChestDeployer.java
@@ -103,7 +103,7 @@ public class ItemSupplyChestDeployer extends AbstractItemMinecolonies
                                        final float hitZ)
     {
         final ItemStack stack = playerIn.getHeldItem(hand);
-        if (worldIn.isRemote || ItemStackUtils.isItemStackEmpty(stack) || !isFirstPlacing(playerIn))
+        if (worldIn.isRemote || ItemStackUtils.isEmpty(stack) || !isFirstPlacing(playerIn))
         {
             return EnumActionResult.FAIL;
         }

--- a/src/main/java/com/minecolonies/coremod/items/ItemSupplyChestDeployer.java
+++ b/src/main/java/com/minecolonies/coremod/items/ItemSupplyChestDeployer.java
@@ -112,7 +112,7 @@ public class ItemSupplyChestDeployer extends AbstractItemMinecolonies
         if (enumfacing != EnumFacing.DOWN)
         {
             spawnShip(worldIn, pos, enumfacing);
-            ItemStackUtils.increaseOrDecreaseSize(stack, -1);
+            ItemStackUtils.changeSize(stack, -1);
 
             playerIn.addStat(ModAchievements.achievementGetSupply);
 

--- a/src/main/java/com/minecolonies/coremod/items/ItemSupplyChestDeployer.java
+++ b/src/main/java/com/minecolonies/coremod/items/ItemSupplyChestDeployer.java
@@ -112,7 +112,7 @@ public class ItemSupplyChestDeployer extends AbstractItemMinecolonies
         if (enumfacing != EnumFacing.DOWN)
         {
             spawnShip(worldIn, pos, enumfacing);
-            stack.setCount(ItemStackUtils.getItemStackSize(stack) - 1);
+            stack.setCount(ItemStackUtils.getSize(stack) - 1);
 
             playerIn.addStat(ModAchievements.achievementGetSupply);
 

--- a/src/main/java/com/minecolonies/coremod/items/ItemSupplyChestDeployer.java
+++ b/src/main/java/com/minecolonies/coremod/items/ItemSupplyChestDeployer.java
@@ -5,6 +5,7 @@ import com.minecolonies.api.util.BlockUtils;
 import com.minecolonies.api.util.LanguageHandler;
 import com.minecolonies.api.util.Log;
 import com.minecolonies.api.util.constant.Constants;
+import com.minecolonies.api.util.ItemStackUtils;
 import com.minecolonies.coremod.achievements.ModAchievements;
 import com.minecolonies.coremod.blocks.ModBlocks;
 import com.minecolonies.coremod.colony.ColonyManager;
@@ -102,7 +103,7 @@ public class ItemSupplyChestDeployer extends AbstractItemMinecolonies
                                        final float hitZ)
     {
         final ItemStack stack = playerIn.getHeldItem(hand);
-        if (worldIn.isRemote || stack.getCount() == 0 || !isFirstPlacing(playerIn))
+        if (worldIn.isRemote || ItemStackUtils.isItemStackEmpty(stack) || !isFirstPlacing(playerIn))
         {
             return EnumActionResult.FAIL;
         }
@@ -111,7 +112,7 @@ public class ItemSupplyChestDeployer extends AbstractItemMinecolonies
         if (enumfacing != EnumFacing.DOWN)
         {
             spawnShip(worldIn, pos, enumfacing);
-            stack.setCount(stack.getCount() - 1);
+            stack.setCount(ItemStackUtils.getItemStackSize(stack) - 1);
 
             playerIn.addStat(ModAchievements.achievementGetSupply);
 

--- a/src/main/java/com/minecolonies/coremod/network/messages/TransferItemsRequestMessage.java
+++ b/src/main/java/com/minecolonies/coremod/network/messages/TransferItemsRequestMessage.java
@@ -119,7 +119,7 @@ public class TransferItemsRequestMessage  extends AbstractMessage<TransferItemsR
 
         ItemStack remainingItemStack = InventoryUtils.addItemStackToProviderWithResult(building.getTileEntity(), itemStackToTake);
 
-        if (!ItemStackUtils.isItemStackEmpty(remainingItemStack))
+        if (!ItemStackUtils.isEmpty(remainingItemStack))
         {
             //If we still have some to drop, let's try the additional chests now
             final World world = colony.getWorld();
@@ -128,14 +128,14 @@ public class TransferItemsRequestMessage  extends AbstractMessage<TransferItemsR
                 final TileEntity entity = world.getTileEntity(pos);
                 remainingItemStack = InventoryUtils.addItemStackToProviderWithResult(entity, remainingItemStack);
 
-                if (ItemStackUtils.isItemStackEmpty(remainingItemStack))
+                if (ItemStackUtils.isEmpty(remainingItemStack))
                 {
                     break;
                 }
             }
         }
 
-        if (ItemStackUtils.isItemStackEmpty(remainingItemStack) || ItemStackUtils.getItemStackSize(remainingItemStack) != ItemStackUtils.getItemStackSize(itemStackToTake))
+        if (ItemStackUtils.isEmpty(remainingItemStack) || ItemStackUtils.getItemStackSize(remainingItemStack) != ItemStackUtils.getItemStackSize(itemStackToTake))
         {
             //Only doing this at the moment as the additional chest do not detect new content
             building.getTileEntity().markDirty();

--- a/src/main/java/com/minecolonies/coremod/network/messages/TransferItemsRequestMessage.java
+++ b/src/main/java/com/minecolonies/coremod/network/messages/TransferItemsRequestMessage.java
@@ -135,19 +135,19 @@ public class TransferItemsRequestMessage  extends AbstractMessage<TransferItemsR
             }
         }
 
-        if (ItemStackUtils.isEmpty(remainingItemStack) || ItemStackUtils.getItemStackSize(remainingItemStack) != ItemStackUtils.getItemStackSize(itemStackToTake))
+        if (ItemStackUtils.isEmpty(remainingItemStack) || ItemStackUtils.getSize(remainingItemStack) != ItemStackUtils.getSize(itemStackToTake))
         {
             //Only doing this at the moment as the additional chest do not detect new content
             building.getTileEntity().markDirty();
         }
 
-        int amountToRemoveFromPlayer = amountToTake - ItemStackUtils.getItemStackSize(remainingItemStack);
+        int amountToRemoveFromPlayer = amountToTake - ItemStackUtils.getSize(remainingItemStack);
 
         while (amountToRemoveFromPlayer > 0)
         {
             final int slot = InventoryUtils.findFirstSlotInItemHandlerWith(new InvWrapper(player.inventory), item, message.itemStack.getItemDamage());
             final ItemStack itemsTaken = player.inventory.decrStackSize(slot, amountToRemoveFromPlayer);
-            amountToRemoveFromPlayer-=ItemStackUtils.getItemStackSize(itemsTaken);
+            amountToRemoveFromPlayer-=ItemStackUtils.getSize(itemsTaken);
         }
 
     }

--- a/src/main/java/com/minecolonies/coremod/placementhandlers/PlacementHandlers.java
+++ b/src/main/java/com/minecolonies/coremod/placementhandlers/PlacementHandlers.java
@@ -77,7 +77,7 @@ public final class PlacementHandlers
                 final int slot = InventoryUtils.findFirstSlotInItemHandlerNotEmptyWith(new InvWrapper(citizen.getInventoryCitizen()), s ->
                         s.getItem() == Items.FLINT_AND_STEEL);
                 final ItemStack item = slot == -1 ? ItemStackUtils.EMPTY : citizen.getInventoryCitizen().getStackInSlot(slot);
-                if (ItemStackUtils.isItemStackEmpty(item) || !(item.getItem() instanceof ItemFlintAndSteel))
+                if (ItemStackUtils.isEmpty(item) || !(item.getItem() instanceof ItemFlintAndSteel))
                 {
                     return ActionProcessingResult.DENY;
                 }

--- a/src/main/java/com/minecolonies/coremod/tileentities/TileEntityWareHouse.java
+++ b/src/main/java/com/minecolonies/coremod/tileentities/TileEntityWareHouse.java
@@ -115,7 +115,7 @@ public class TileEntityWareHouse extends TileEntityColonyBuilding
     {
         if (buildingEntry.isFoodNeeded())
         {
-            if (isInHut(itemStack -> !ItemStackUtils.isItemStackEmpty(itemStack) && itemStack.getItem() instanceof ItemFood))
+            if (isInHut(itemStack -> !ItemStackUtils.isEmpty(itemStack) && itemStack.getItem() instanceof ItemFood))
             {
                 if (addToList)
                 {
@@ -411,7 +411,7 @@ public class TileEntityWareHouse extends TileEntityColonyBuilding
         for (int i = 0; i < new InvWrapper(inventoryCitizen).getSlots(); i++)
         {
             final ItemStack stack = inventoryCitizen.getStackInSlot(i);
-            if(ItemStackUtils.isItemStackEmpty(stack))
+            if(ItemStackUtils.isEmpty(stack))
             {
                 continue;
             }

--- a/src/main/java/com/minecolonies/coremod/tileentities/TileEntityWareHouse.java
+++ b/src/main/java/com/minecolonies/coremod/tileentities/TileEntityWareHouse.java
@@ -165,7 +165,7 @@ public class TileEntityWareHouse extends TileEntityColonyBuilding
         {
             for(final ItemStack stack : buildingEntry.getCopyOfNeededItems())
             {
-                if(stack == null
+                if(ItemStackUtils.isEmpty(stack)
                      || (deliveryManHasBuildingAsTask(buildingEntry)
                            && addToList))
                 {


### PR DESCRIPTION
replace ItemStack.setCount,  ItemStack.getCount by ItemStackUtils methods
replace ItemStack.EMPTY by ItemStackUtils.EMPTY 

This is to make it easier to port to 1.10 and 1.11

A similar pr will be done for 1.10

It would be very nice if we could configure *sonar* so that we don't use:
- ItemStack.EMPTY
- ItemStack.setCount
- ItemStack.getCount
- ItemStack.stackSize

Review please
