### PR TITLE
Update the CurseForge Gradle Plugin

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -13,7 +13,7 @@ buildscript {
 
 plugins {
     id "org.sonarqube" version "2.3"
-    id "com.matthewprenger.cursegradle" version "1.0.7"
+    id "com.matthewprenger.cursegradle" version "1.0.9"
 }
 
 


### PR DESCRIPTION
Updates the CurseForge Gradle plugin to fix the Upload error occuring due to changed curse API endpoints.

Closes #
Closes #
Closes #

# Changes proposed in this pull request:
-
-
-

Review please
