### PR TITLE
Adds a recipe for the Double Fern

### DIFF
--- a/src/main/java/com/minecolonies/coremod/util/RecipeHandler.java
+++ b/src/main/java/com/minecolonies/coremod/util/RecipeHandler.java
@@ -88,7 +88,7 @@ public final class RecipeHandler
         GameRegistry.addRecipe(new ItemStack(Blocks.WEB, 1), "X X", " X ", "X X", 'X', Items.STRING);
         
         //Double Fern
-        GameRegistry.addRecipe(new ItemStack(Blocks.DOUBLE_PLANT, 1,3), "   ", " X ", " X ", 'X', Items.FERN);
+        GameRegistry.addRecipe(new ItemStack(Blocks.DOUBLE_PLANT, 1,3), "   ", " X ", " X ", 'X', Blocks.TALLGRASS, 1, 2);
         
         //enableInDevelopmentFeatures(enableInDevelopmentFeatures);
         addSupplyChestRecipes(supplyChests);

--- a/src/main/java/com/minecolonies/coremod/util/RecipeHandler.java
+++ b/src/main/java/com/minecolonies/coremod/util/RecipeHandler.java
@@ -88,7 +88,7 @@ public final class RecipeHandler
         GameRegistry.addRecipe(new ItemStack(Blocks.WEB, 1), "X X", " X ", "X X", 'X', Items.STRING);
         
         //Double Fern
-        GameRegistry.addRecipe(new ItemStack(Blocks.DOUBLE_PLANT, 1,3), "   ", " X ", " X ", 'X', Blocks.TALLGRASS, 1, 2);
+        GameRegistry.addRecipe(new ShapelessOreRecipe(new ItemStack(Blocks.DOUBLE_PLANT, 1, 3), new ItemStack(Blocks.TALLGRASS, 1, 2), new ItemStack(Blocks.TALLGRASS, 1, 2)));
         
         //enableInDevelopmentFeatures(enableInDevelopmentFeatures);
         addSupplyChestRecipes(supplyChests);

--- a/src/main/java/com/minecolonies/coremod/util/RecipeHandler.java
+++ b/src/main/java/com/minecolonies/coremod/util/RecipeHandler.java
@@ -86,7 +86,10 @@ public final class RecipeHandler
         GameRegistry.addRecipe(new ShapedOreRecipe(new ItemStack(ModBlocks.blockHutField, 1), 
                 " Y ", "X#X", " X ", 'X', WOODEN_STICK, '#', Items.LEATHER, 'Y', Blocks.HAY_BLOCK));
         GameRegistry.addRecipe(new ItemStack(Blocks.WEB, 1), "X X", " X ", "X X", 'X', Items.STRING);
-
+        
+        //Double Fern
+        GameRegistry.addRecipe(new ItemStack(Blocks.DOUBLE_PLANT, 1,3), "   ", " X ", " X ", 'X', Items.FERN);
+        
         //enableInDevelopmentFeatures(enableInDevelopmentFeatures);
         addSupplyChestRecipes(supplyChests);
     }

--- a/src/main/java/com/minecolonies/coremod/util/RecipeHandler.java
+++ b/src/main/java/com/minecolonies/coremod/util/RecipeHandler.java
@@ -88,7 +88,7 @@ public final class RecipeHandler
         GameRegistry.addRecipe(new ItemStack(Blocks.WEB, 1), "X X", " X ", "X X", 'X', Items.STRING);
         
         //Double Fern
-        GameRegistry.addRecipe(new ShapelessOreRecipe(new ItemStack(Blocks.DOUBLE_PLANT, 1, 3), new ItemStack(Blocks.TALLGRASS, 1, 2), new ItemStack(Blocks.TALLGRASS, 1, 2)));
+        GameRegistry.addShapelessRecipe(new ItemStack(Blocks.DOUBLE_PLANT, 1, 3), new ItemStack(Blocks.TALLGRASS, 1, 2), new ItemStack(Blocks.TALLGRASS, 1, 2));
         
         //enableInDevelopmentFeatures(enableInDevelopmentFeatures);
         addSupplyChestRecipes(supplyChests);


### PR DESCRIPTION
Adds the Double Fern as a craftable block - as it is requested by the builder when building some sandstone buildings.

Created by two normal ferns (Obtainable with shears on a fern/double fern) - Shapeless Recipe

Review please
