### PR TITLE
Fix the ColonyView.getWorld() crashing 1.11.2

### DIFF
--- a/src/main/java/com/minecolonies/coremod/colony/ColonyView.java
+++ b/src/main/java/com/minecolonies/coremod/colony/ColonyView.java
@@ -695,7 +695,7 @@ public final class ColonyView implements IColony
     @Override
     public World getWorld()
     {
-        return Minecraft.getMinecraft().player.getEntityWorld();
+        return null;
     }
 
     @Nullable


### PR DESCRIPTION
same as title