### PR TITLE
hotfix nullpointer exception

### DIFF
--- a/src/main/java/com/minecolonies/coremod/tileentities/TileEntityRack.java
+++ b/src/main/java/com/minecolonies/coremod/tileentities/TileEntityRack.java
@@ -478,7 +478,7 @@ public class TileEntityRack extends TileEntity
      */
     public TileEntityRack getOtherChest()
     {
-        if (neighbor.equals(BlockPos.ORIGIN))
+        if (neighbor.equals(BlockPos.ORIGIN) || worldObj == null)
         {
             return null;
         }


### PR DESCRIPTION
Fixes that:

java.lang.NullPointerException: Unexpected error
	at com.minecolonies.coremod.tileentities.TileEntityRack.getOtherChest(TileEntityRack.java:485)
	at com.minecolonies.coremod.blocks.BlockMinecoloniesRack.func_176221_a(BlockMinecoloniesRack.java:142)
	at com.minecolonies.structures.helpers.Structure.renderStructure(Structure.java:574)

@OrionDevelopment that shouldn't happen at all but I guess the tileentity is only partially loaded at the moment of the crash, so we should add that.
