### PR TITLE
Check if the colony center is null before checking how close we are t…

### DIFF
--- a/src/main/java/com/minecolonies/coremod/colony/ColonyManager.java
+++ b/src/main/java/com/minecolonies/coremod/colony/ColonyManager.java
@@ -426,7 +426,7 @@ public final class ColonyManager
 
         for (@NotNull final ColonyView c : colonyViews)
         {
-            if (c.getDimension() == w.provider.getDimension())
+            if (c.getDimension() == w.provider.getDimension() && c.getCenter() != null)
             {
                 final long dist = c.getDistanceSquared(pos);
                 if (dist < closestDist)


### PR DESCRIPTION
…o it

So the server is sending the player a colony which has a null center. Because that's the only way the client could have a ColonyView with a null center. Now on the server side, it looks like the only way a Colony could have a null center is in between the time the object is created and the value is read from NBT. That seems pretty unlikely given the following:
```
    @NotNull
    public static Colony loadColony(@NotNull final NBTTagCompound compound)
    {
        final int id = compound.getInteger(TAG_ID);
        final int dimensionId = compound.getInteger(TAG_DIMENSION);
        @NotNull final Colony c = new Colony(id, dimensionId);
        c.readFromNBT(compound);
        return c;
    }
```
So, I think the NBT was corrupted :/ or the user has a bad client :/ or some network packet corruption, not sure what protections are used by minecraft :(

Closes #1485 
