### PR TITLE
[HOTFIX] - Permission$View NPE when entering colony.

### DIFF
--- a/src/main/java/com/minecolonies/coremod/colony/permissions/Permissions.java
+++ b/src/main/java/com/minecolonies/coremod/colony/permissions/Permissions.java
@@ -938,7 +938,7 @@ public class Permissions implements IPermissions
         public boolean hasPermission(final Rank rank, @NotNull final Action action)
         {
             return (rank == Rank.OWNER && action != Action.GUARDS_ATTACK)
-                     || (permissions != null && action != null && Utils.testFlag(permissions.get(rank), action.getFlag()));
+                     || (permissions != null && action != null && permissions.containsKey(rank) && Utils.testFlag(permissions.get(rank), action.getFlag()));
         }
 
         /**


### PR DESCRIPTION
Finally fixes the NPE caused by having an empty View.
Reproduceable:

Create colony far away from spawn on a dedicated server.
Go back to spawn.
Stop the client.
Start the client.
TP Into the colony. Experience that the client ticks before the View package has arrived which causes the NPE, since no permissions for any rank have been loaded.