### PR TITLE
Fix rack messup

### DIFF
--- a/src/main/java/com/minecolonies/coremod/entity/ai/basic/AbstractEntityAIStructure.java
+++ b/src/main/java/com/minecolonies/coremod/entity/ai/basic/AbstractEntityAIStructure.java
@@ -842,6 +842,7 @@ public abstract class AbstractEntityAIStructure<J extends AbstractJob> extends A
             {
                 request.add(entity.getPickedResult(new RayTraceResult(worker)));
                 entity.getArmorInventoryList().forEach(request::add);
+                entity.getHeldEquipment().forEach(request::add);
             }
             else
             {

--- a/src/main/java/com/minecolonies/coremod/entity/ai/citizen/builder/EntityAIStructureBuilder.java
+++ b/src/main/java/com/minecolonies/coremod/entity/ai/citizen/builder/EntityAIStructureBuilder.java
@@ -290,6 +290,7 @@ public class EntityAIStructureBuilder extends AbstractEntityAIStructure<JobBuild
                 {
                     request.add(entity.getPickedResult(new RayTraceResult(worker)));
                     entity.getArmorInventoryList().forEach(request::add);
+                    entity.getHeldEquipment().forEach(request::add);
                 }
                 else if (entity instanceof EntityMob)
                 {

--- a/src/main/java/com/minecolonies/coremod/placementhandlers/PlacementHandlers.java
+++ b/src/main/java/com/minecolonies/coremod/placementhandlers/PlacementHandlers.java
@@ -590,12 +590,6 @@ public final class PlacementHandlers
                 return ActionProcessingResult.DENY;
             }
 
-            entity = world.getTileEntity(pos);
-            if(entity instanceof TileEntityRack && ((TileEntityRack) entity).isMain())
-            {
-                ((TileEntityRack) entity).softReset();
-            }
-
             return blockState;
         }
     }

--- a/src/main/java/com/minecolonies/coremod/tileentities/TileEntityRack.java
+++ b/src/main/java/com/minecolonies/coremod/tileentities/TileEntityRack.java
@@ -336,6 +336,14 @@ public class TileEntityRack extends TileEntity
     public void neighborChanged(final BlockPos newNeighbor)
     {
         final TileEntity entity = world.getTileEntity(newNeighbor);
+
+        if(!this.neighbor.equals(BlockPos.ORIGIN)
+                && this.neighbor.distanceSq(this.pos) > 1
+                && entity instanceof TileEntityRack)
+        {
+            softReset();
+        }
+
         if (this.neighbor.equals(BlockPos.ORIGIN) && world.getBlockState(newNeighbor).getBlock() instanceof BlockMinecoloniesRack
                 && !(entity instanceof TileEntityRack && ((TileEntityRack) entity).getOtherChest() != null))
         {


### PR DESCRIPTION

# Changes proposed in this pull request:
- Racks get messed up when building or pasting because they store the neighbor pos in them on scanning.
This pr refreshes them if they detect their neighbor is not a neighbor at all.


Review please
