### PR TITLE
Updating build script to use HTTPS instead of HTTP

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -303,7 +303,7 @@ task signJar(type: SignJar, dependsOn: reobfJar) {
 build.dependsOn signJar
 
 curseforge {
-    if (System.getenv().CURSEAPIKEY != null && System.getenv().CURSERELEASETYPE != null)    
+    if (System.getenv().CURSEAPIKEY != null && System.getenv().CURSERELEASETYPE != null)
     {
         apiKey = System.getenv().CURSEAPIKEY
 

--- a/build.gradle
+++ b/build.gradle
@@ -327,7 +327,7 @@ task("createChangelog") {
     group = 'upload'
 
     doLast {
-        def teamCityURL = "http://teamcity.minecolonies.com/"
+        def teamCityURL = "shttp://teamcity.minecolonies.com/"
         def file = new FileOutputStream("build/changelog.md")
         def out = new BufferedOutputStream(file)
         def changesXML = new XmlSlurper().parse(teamCityURL + "guestAuth/app/rest/changes?locator=build:(id:" + teamcity["teamcity.build.id"] + ")")

--- a/build.gradle
+++ b/build.gradle
@@ -303,8 +303,7 @@ task signJar(type: SignJar, dependsOn: reobfJar) {
 build.dependsOn signJar
 
 curseforge {
-    if (System.getenv().CURSEAPIKEY != null && System.getenv().CURSERELEASETYPE != null)
-    {
+    if (System.getenv().CURSEAPIKEY != null && System.getenv().CURSERELEASETYPE != null)    {
         apiKey = System.getenv().CURSEAPIKEY
 
         project {
@@ -327,7 +326,7 @@ task("createChangelog") {
     group = 'upload'
 
     doLast {
-        def teamCityURL = "shttp://teamcity.minecolonies.com/"
+        def teamCityURL = "https://teamcity.minecolonies.com/"
         def file = new FileOutputStream("build/changelog.md")
         def out = new BufferedOutputStream(file)
         def changesXML = new XmlSlurper().parse(teamCityURL + "guestAuth/app/rest/changes?locator=build:(id:" + teamcity["teamcity.build.id"] + ")")

--- a/build.gradle
+++ b/build.gradle
@@ -303,7 +303,8 @@ task signJar(type: SignJar, dependsOn: reobfJar) {
 build.dependsOn signJar
 
 curseforge {
-    if (System.getenv().CURSEAPIKEY != null && System.getenv().CURSERELEASETYPE != null)    {
+    if (System.getenv().CURSEAPIKEY != null && System.getenv().CURSERELEASETYPE != null)    
+    {
         apiKey = System.getenv().CURSEAPIKEY
 
         project {


### PR DESCRIPTION
The new buildserver autoredirects all http requests to http.
This causes issues in releasing builds since the XML Parser can not parse the Redirect requests.
