### PR TITLE
Update the build script to HTTPS instead of HTTP

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -313,7 +313,7 @@ task("createChangelog") {
     group = 'upload'
 
     doLast {
-        def teamCityURL = "http://teamcity.minecolonies.com/"
+        def teamCityURL = "https://teamcity.minecolonies.com/"
         def file = new FileOutputStream("build/changelog.md")
         def out = new BufferedOutputStream(file)
         def changesXML = new XmlSlurper().parse(teamCityURL + "guestAuth/app/rest/changes?locator=build:(id:" + teamcity["teamcity.build.id"] + ")")


### PR DESCRIPTION
Makes sure that releasing builds can acces the Buildservers API for direct parsing.