### PR TITLE
Resolves #1857

### DIFF
--- a/src/main/java/com/minecolonies/coremod/colony/buildings/BuildingFarmer.java
+++ b/src/main/java/com/minecolonies/coremod/colony/buildings/BuildingFarmer.java
@@ -1,5 +1,6 @@
 package com.minecolonies.coremod.colony.buildings;
 
+import com.minecolonies.api.util.BlockPosUtil;
 import com.minecolonies.api.util.ItemStackUtils;
 import com.minecolonies.api.util.LanguageHandler;
 import com.minecolonies.api.util.constant.ToolType;
@@ -14,7 +15,6 @@ import com.minecolonies.coremod.colony.jobs.AbstractJob;
 import com.minecolonies.coremod.colony.jobs.JobFarmer;
 import com.minecolonies.coremod.entity.ai.citizen.farmer.Field;
 import com.minecolonies.coremod.entity.ai.citizen.farmer.FieldView;
-import com.minecolonies.coremod.entity.ai.item.handling.ItemStorage;
 import com.minecolonies.coremod.network.messages.AssignFieldMessage;
 import com.minecolonies.coremod.network.messages.AssignmentModeMessage;
 import com.minecolonies.coremod.tileentities.ScarecrowTileEntity;
@@ -31,6 +31,7 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.*;
+import java.util.function.Predicate;
 
 import static com.minecolonies.api.util.constant.ToolLevelConstants.TOOL_LEVEL_WOOD_OR_GOLD;
 import static com.minecolonies.api.util.constant.TranslationConstants.COM_MINECOLONIES_COREMOD_GUI_SCARECROW_USER;
@@ -57,6 +58,11 @@ public class BuildingFarmer extends AbstractBuildingWorker
     private static final String TAG_FIELDS = "fields";
 
     /**
+     * NBTTag to store the field BlockPos.
+     */
+    private static final String TAG_FIELDS_BLOCKPOS = "fieldsPos";
+
+    /**
      * NBT tag to store assign manually.
      */
     private static final String TAG_ASSIGN_MANUALLY = "assign";
@@ -66,6 +72,14 @@ public class BuildingFarmer extends AbstractBuildingWorker
      */
     private static final int                       BLOCK_UPDATE_FLAG = 3;
 
+    /**
+     * The last field tag.
+     */
+    private static final String LAST_FIELD_TAG = "lastField";
+    /**
+     * Sets the amount of saplings the lumberjack should keep.
+     */
+    private static final int SEEDS_TO_KEEP = 64;
     /**
      * The list of the fields the farmer manages.
      */
@@ -77,19 +91,14 @@ public class BuildingFarmer extends AbstractBuildingWorker
     @Nullable
     private Field currentField;
     /**
+     * The field the farmer worked on the last morning (first).
+     */
+    @Nullable
+    private Field lastField;
+    /**
      * Fields should be assigned manually to the farmer.
      */
     private boolean assignManually = false;
-
-    /**
-     * Sets the amount of saplings the lumberjack should keep.
-     */
-    private static final int SEEDS_TO_KEEP = 64;
-
-    /**
-     * List of items the farmer should keep.
-     */
-    private final Map<ItemStorage, Integer> keepX = new HashMap<>();
 
     /**
      * Public constructor which instantiates the building.
@@ -105,10 +114,12 @@ public class BuildingFarmer extends AbstractBuildingWorker
         final ItemStack stackPotatoe = new ItemStack(Items.POTATO);
         final ItemStack stackReed = new ItemStack(Items.BEETROOT_SEEDS);
 
-        keepX.put(new ItemStorage(stackSeed, false), SEEDS_TO_KEEP);
-        keepX.put(new ItemStorage(stackCarrot, false), SEEDS_TO_KEEP);
-        keepX.put(new ItemStorage(stackPotatoe, false), SEEDS_TO_KEEP);
-        keepX.put(new ItemStorage(stackReed, false), SEEDS_TO_KEEP);
+        keepX.put(stackSeed::isItemEqual, SEEDS_TO_KEEP);
+        keepX.put(stackCarrot::isItemEqual, SEEDS_TO_KEEP);
+        keepX.put(stackPotatoe::isItemEqual, SEEDS_TO_KEEP);
+        keepX.put(stackReed::isItemEqual, SEEDS_TO_KEEP);
+        keepX.put(itemStack -> ItemStackUtils.hasToolLevel(itemStack, ToolType.HOE, TOOL_LEVEL_WOOD_OR_GOLD, getMaxToolLevel()), 1);
+        keepX.put(itemStack -> ItemStackUtils.hasToolLevel(itemStack, ToolType.AXE, TOOL_LEVEL_WOOD_OR_GOLD, getMaxToolLevel()), 1);
     }
 
     /**
@@ -173,6 +184,15 @@ public class BuildingFarmer extends AbstractBuildingWorker
     public Field getFieldToWorkOn()
     {
         Collections.shuffle(farmerFields);
+
+        if (!farmerFields.isEmpty())
+        {
+            if (farmerFields.get(0).equals(lastField))
+            {
+                Collections.shuffle(farmerFields);
+            }
+            lastField = farmerFields.get(0);
+        }
         for (@NotNull final Field field : farmerFields)
         {
             if (field.needsWork())
@@ -182,56 +202,6 @@ public class BuildingFarmer extends AbstractBuildingWorker
             }
         }
         return null;
-    }
-
-    /**
-     * Override this method if you want to keep an amount of items in inventory.
-     * When the inventory is full, everything get's dumped into the building chest.
-     * But you can use this method to hold some stacks back.
-     *
-     * @return a list of objects which should be kept.
-     */
-    @Override
-    public Map<ItemStorage, Integer> getRequiredItemsAndAmount()
-    {
-        final Map<ItemStorage, Integer> toKeep = new HashMap<>(keepX);
-        for (final Field field : farmerFields)
-        {
-            if (!ItemStackUtils.isEmpty(field.getSeed()))
-            {
-                final ItemStack seedStack = field.getSeed();
-                toKeep.put(new ItemStorage(seedStack, false), SEEDS_TO_KEEP);
-            }
-        }
-        return toKeep;
-    }
-
-    @NotNull
-    @Override
-    public String getSchematicName()
-    {
-        return FARMER;
-    }
-
-    @Override
-    public int getMaxBuildingLevel()
-    {
-        return MAX_BUILDING_LEVEL;
-    }
-
-    @Override
-    public void onUpgradeComplete(final int newLevel)
-    {
-        super.onUpgradeComplete(newLevel);
-
-        if (newLevel == 1)
-        {
-            getColony().triggerAchievement(ModAchievements.achievementBuildingFarmer);
-        }
-        if (newLevel >= getMaxBuildingLevel())
-        {
-            getColony().triggerAchievement(ModAchievements.achievementUpgradeFarmerMax);
-        }
     }
 
     @NotNull
@@ -253,21 +223,6 @@ public class BuildingFarmer extends AbstractBuildingWorker
         return new JobFarmer(citizen);
     }
 
-    /**
-     * Override this method if you want to keep some items in inventory.
-     * When the inventory is full, everything get's dumped into the building chest.
-     * But you can use this method to hold some stacks back.
-     *
-     * @param stack the stack to decide on
-     * @return true if the stack should remain in inventory
-     */
-    @Override
-    public boolean neededForWorker(@Nullable final ItemStack stack)
-    {
-        return !ItemStackUtils.isEmpty(stack) && (ItemStackUtils.hasToolLevel(stack, ToolType.HOE, TOOL_LEVEL_WOOD_OR_GOLD, getMaxToolLevel())
-                || ItemStackUtils.hasToolLevel(stack, ToolType.AXE, TOOL_LEVEL_WOOD_OR_GOLD, getMaxToolLevel()));
-    }
-
     //we have to update our field from the colony!
     @Override
     public void readFromNBT(@NotNull final NBTTagCompound compound)
@@ -277,13 +232,19 @@ public class BuildingFarmer extends AbstractBuildingWorker
         for (int i = 0; i < fieldTagList.tagCount(); ++i)
         {
             final NBTTagCompound fieldCompound = fieldTagList.getCompoundTagAt(i);
-            final Field f = Field.createFromNBT(getColony(), fieldCompound);
+            final BlockPos fieldLocation = BlockPosUtil.readFromNBT(fieldCompound, TAG_FIELDS_BLOCKPOS);
+            final Field f = getColony().getField(fieldLocation);
             if (f != null)
             {
                 farmerFields.add(f);
             }
         }
         assignManually = compound.getBoolean(TAG_ASSIGN_MANUALLY);
+
+        if (compound.hasKey(LAST_FIELD_TAG))
+        {
+            lastField = getColony().getField(BlockPosUtil.readFromNBT(compound, LAST_FIELD_TAG));
+        }
     }
 
     @Override
@@ -294,11 +255,16 @@ public class BuildingFarmer extends AbstractBuildingWorker
         for (@NotNull final Field f : farmerFields)
         {
             @NotNull final NBTTagCompound fieldCompound = new NBTTagCompound();
-            f.writeToNBT(fieldCompound);
+            BlockPosUtil.writeToNBT(fieldCompound, TAG_FIELDS_BLOCKPOS, f.getLocation());
             fieldTagList.appendTag(fieldCompound);
         }
         compound.setTag(TAG_FIELDS, fieldTagList);
         compound.setBoolean(TAG_ASSIGN_MANUALLY, assignManually);
+
+        if (lastField != null)
+        {
+            BlockPosUtil.writeToNBT(compound, LAST_FIELD_TAG, lastField.getLocation());
+        }
     }
 
     @Override
@@ -319,21 +285,15 @@ public class BuildingFarmer extends AbstractBuildingWorker
                     final ScarecrowTileEntity scarecrowTileEntity = (ScarecrowTileEntity) getColony().getWorld().getTileEntity(field.getID());
 
                     getColony().getWorld()
-                            .notifyBlockUpdate(scarecrowTileEntity.getPos(),
-                                    getColony().getWorld().getBlockState(scarecrowTileEntity.getPos()),
-                                    getColony().getWorld().getBlockState(scarecrowTileEntity.getPos()),
-                                    BLOCK_UPDATE_FLAG);
+                      .notifyBlockUpdate(scarecrowTileEntity.getPos(),
+                        getColony().getWorld().getBlockState(scarecrowTileEntity.getPos()),
+                        getColony().getWorld().getBlockState(scarecrowTileEntity.getPos()),
+                        BLOCK_UPDATE_FLAG);
                     scarecrowTileEntity.setName(LanguageHandler.format(COM_MINECOLONIES_COREMOD_GUI_SCARECROW_USER,
-                            LanguageHandler.format(COM_MINECOLONIES_COREMOD_GUI_SCARECROW_USER_NOONE)));
+                      LanguageHandler.format(COM_MINECOLONIES_COREMOD_GUI_SCARECROW_USER_NOONE)));
                 }
             }
         }
-    }
-
-    @Override
-    public void onWakeUp()
-    {
-        resetFields();
     }
 
     @NotNull
@@ -400,6 +360,75 @@ public class BuildingFarmer extends AbstractBuildingWorker
         }
     }
 
+    @Override
+    public void onWakeUp()
+    {
+        resetFields();
+    }
+
+    @NotNull
+    @Override
+    public String getSchematicName()
+    {
+        return FARMER;
+    }
+
+    @Override
+    public int getMaxBuildingLevel()
+    {
+        return MAX_BUILDING_LEVEL;
+    }
+
+    @Override
+    public void onUpgradeComplete(final int newLevel)
+    {
+        super.onUpgradeComplete(newLevel);
+
+        if (newLevel == 1)
+        {
+            getColony().triggerAchievement(ModAchievements.achievementBuildingFarmer);
+        }
+        if (newLevel >= getMaxBuildingLevel())
+        {
+            getColony().triggerAchievement(ModAchievements.achievementUpgradeFarmerMax);
+        }
+    }
+
+    /**
+     * Override this method if you want to keep an amount of items in inventory.
+     * When the inventory is full, everything get's dumped into the building chest.
+     * But you can use this method to hold some stacks back.
+     *
+     * @return a list of objects which should be kept.
+     */
+    @Override
+    public Map<Predicate<ItemStack>, Integer> getRequiredItemsAndAmount()
+    {
+        final Map<Predicate<ItemStack>, Integer> toKeep = new HashMap<>(keepX);
+        toKeep.putAll(keepX);
+        for (final Field field : farmerFields)
+        {
+            if (!ItemStackUtils.isEmpty(field.getSeed()))
+            {
+                final ItemStack seedStack = field.getSeed();
+                toKeep.put(seedStack::isItemEqual, SEEDS_TO_KEEP);
+            }
+        }
+        return toKeep;
+    }
+
+    /**
+     * Resets the fields to need work again.
+     */
+    public void resetFields()
+    {
+        for (@NotNull final Field field : farmerFields)
+        {
+            field.setNeedsWork(true);
+            field.calculateSize(getColony().getWorld(), field.getLocation().down());
+        }
+    }
+
     /**
      * Synchronize field list with colony.
      *
@@ -426,11 +455,11 @@ public class BuildingFarmer extends AbstractBuildingWorker
                 {
                     scarecrow.setName(LanguageHandler.format(COM_MINECOLONIES_COREMOD_GUI_SCARECROW_USER, getMainWorker().getName()));
                     getColony().getWorld()
-                            .notifyBlockUpdate(scarecrow.getPos(),
-                                    getColony().getWorld().getBlockState(scarecrow.getPos()),
-                                    getColony().getWorld().getBlockState(scarecrow
-                                            .getPos()),
-                                    BLOCK_UPDATE_FLAG);
+                      .notifyBlockUpdate(scarecrow.getPos(),
+                        getColony().getWorld().getBlockState(scarecrow.getPos()),
+                        getColony().getWorld().getBlockState(scarecrow
+                                                               .getPos()),
+                        BLOCK_UPDATE_FLAG);
                     field.setInventoryField(scarecrow.getInventoryField());
                     if (currentField != null && currentField.getID() == field.getID())
                     {
@@ -438,18 +467,6 @@ public class BuildingFarmer extends AbstractBuildingWorker
                     }
                 }
             }
-        }
-    }
-
-    /**
-     * Resets the fields to need work again.
-     */
-    public void resetFields()
-    {
-        for (@NotNull final Field field : farmerFields)
-        {
-            field.setNeedsWork(true);
-            field.calculateSize(getColony().getWorld(), field.getLocation().down());
         }
     }
 
@@ -481,12 +498,12 @@ public class BuildingFarmer extends AbstractBuildingWorker
             field.setOwner("");
             final ScarecrowTileEntity scarecrowTileEntity = (ScarecrowTileEntity) getColony().getWorld().getTileEntity(field.getID());
             getColony().getWorld()
-                    .notifyBlockUpdate(scarecrowTileEntity.getPos(),
-                            getColony().getWorld().getBlockState(scarecrowTileEntity.getPos()),
-                            getColony().getWorld().getBlockState(scarecrowTileEntity.getPos()),
-                            BLOCK_UPDATE_FLAG);
+              .notifyBlockUpdate(scarecrowTileEntity.getPos(),
+                getColony().getWorld().getBlockState(scarecrowTileEntity.getPos()),
+                getColony().getWorld().getBlockState(scarecrowTileEntity.getPos()),
+                BLOCK_UPDATE_FLAG);
             scarecrowTileEntity.setName(LanguageHandler.format(COM_MINECOLONIES_COREMOD_GUI_SCARECROW_USER,
-                    LanguageHandler.format(COM_MINECOLONIES_COREMOD_GUI_SCARECROW_USER_NOONE)));
+              LanguageHandler.format(COM_MINECOLONIES_COREMOD_GUI_SCARECROW_USER_NOONE)));
         }
     }
 
@@ -500,7 +517,7 @@ public class BuildingFarmer extends AbstractBuildingWorker
         final Field field = getColony().getField(position);
         field.setTaken(true);
 
-        if(getMainWorker() != null)
+        if (getMainWorker() != null)
         {
             field.setOwner(getMainWorker().getName());
         }


### PR DESCRIPTION
This resolves issue #1857.   Assignments are not working because the farmerFields get out of sync.  This makes sure when it tried to sync the field is assigned to this farmer.

It appears it is a sync issue with farmerFields. Once it is out of sync, it can never get back into sync.
A quick look at syncWithColony(). It doesn't do what the name indicates. It doesn't sync because when it is going through the list. It assumes everything in the farmerFields is assigned to him.

I dont' know the correct solution but this worked.

I changed:
if (scarecrow == null)
to:
if (scarecrow == null || field.getOwner().compareTo(getMainWorker().getName()) != 0)

This also put a second check in if the sync of the fields are off. It check the owner. I assume there is a better version. Like a unique IDEA??? Because a rename of citizen would cause them to lose this field. but I can't locate a variable inside of Field that would use a unique ID to point back to the farmer. I don't see one. So this seems like the best solution.

BUT THIS SOLVES the assignment issue, When someone has gone through mod with bugs, or other issues. This will make sure it is in sync correctly.
Review please
