### PR TITLE
lumberjack saplings update & farmer fields sync issue

### DIFF
--- a/src/main/java/com/minecolonies/coremod/colony/buildings/BuildingFarmer.java
+++ b/src/main/java/com/minecolonies/coremod/colony/buildings/BuildingFarmer.java
@@ -443,7 +443,7 @@ public class BuildingFarmer extends AbstractBuildingWorker
             for (@NotNull final Field field : tempFields)
             {
                 final ScarecrowTileEntity scarecrow = (ScarecrowTileEntity) world.getTileEntity(field.getID());
-                if (scarecrow == null)
+                if (scarecrow == null && field.getOwner().compareTo(getMainWorker().getName()) != 0)
                 {
                     farmerFields.remove(field);
                     if (currentField != null && currentField.getID() == field.getID())

--- a/src/main/java/com/minecolonies/coremod/colony/buildings/BuildingLumberjack.java
+++ b/src/main/java/com/minecolonies/coremod/colony/buildings/BuildingLumberjack.java
@@ -216,6 +216,19 @@ public class BuildingLumberjack extends AbstractBuildingWorker
                 treesToFell.put(new ItemStorage(stack), cut);
             }
         }
+		        // Not all trees can show up.  Just trees at the time of hut placement
+        // Lets check to see if there are more trees and if so add them to the list
+        //  that way is a mod is added after.  It can still use the trees from it
+        // if it has some. 
+        Map<ItemStorage, Boolean> tempTreesToFell = new LinkedHashMap<>();
+        tempTreesToFell.putAll(View.calcSaplings(OreDictionary.getOres("treeSapling")));
+        
+        for (@NotNull final Map.Entry<ItemStorage, Boolean> entry : tempTreesToFell.entrySet())
+        {
+        	ItemStorage stack = entry.getKey();
+        	treesToFell.putIfAbsent(stack, false);
+        }
+        
     }
 
     @Override


### PR DESCRIPTION
This does 2 things.

1...
Fields out of sync to gui settings

There were some bugs introduced that allow the gui assignment to get out of sync with the data from the NBT.  But there is no way to solve this issue.

I add a check to see if the owner of the field is the current citizen and if not then remove it from the list.

2.....
Lumberjack saplings - cosmetic possible

If you add a mod or update a mod after the lumberjack hut is placed there is no way to get a full list of saplings.  It was only done when you place the hut.   So this means you had to break your hut and redo it.
This allows the player to get updated list of saplings.