### PR TITLE
Hotfix for Lumberjack

### DIFF
--- a/src/main/java/com/minecolonies/coremod/colony/buildings/BuildingLumberjack.java
+++ b/src/main/java/com/minecolonies/coremod/colony/buildings/BuildingLumberjack.java
@@ -94,7 +94,7 @@ public class BuildingLumberjack extends AbstractBuildingWorker
         {
             final ItemStack stack = mainWorker.getInventoryCitizen().getStackInSlot(i);
 
-            if(ItemStackUtils.isEmpty(stack) && stack.getItem() != SAPLING_STACK.getItem())
+            if(ItemStackUtils.isEmpty(stack) || stack.getItem() != SAPLING_STACK.getItem())
             {
                 continue;
             }


### PR DESCRIPTION
Fixes a crash when the itemstack is empty.