### PR TITLE
[RS 1.12] - Bughunting finished. Fixes several problems introduced with the private crafting update.

### DIFF
--- a/src/api/java/com/minecolonies/api/colony/requestsystem/location/ILocation.java
+++ b/src/api/java/com/minecolonies/api/colony/requestsystem/location/ILocation.java
@@ -32,4 +32,6 @@ public interface ILocation
      * @return True when reachable, false when not.
      */
     boolean isReachableFromLocation(@NotNull ILocation location);
+
+
 }

--- a/src/main/java/com/minecolonies/blockout/views/View.java
+++ b/src/main/java/com/minecolonies/blockout/views/View.java
@@ -73,7 +73,7 @@ public class View extends Pane
         final int drawX = mx - paddedX;
         final int drawY = my - paddedY;
 
-        new ArrayList<>(children).stream().filter(this::childIsVisible).forEach(child -> child.draw(drawX, drawY));
+        children.stream().filter(this::childIsVisible).forEach(child -> child.draw(drawX, drawY));
 
         GlStateManager.popMatrix();
     }

--- a/src/main/java/com/minecolonies/blockout/views/View.java
+++ b/src/main/java/com/minecolonies/blockout/views/View.java
@@ -73,7 +73,7 @@ public class View extends Pane
         final int drawX = mx - paddedX;
         final int drawY = my - paddedY;
 
-        children.stream().filter(this::childIsVisible).forEach(child -> child.draw(drawX, drawY));
+        new ArrayList<>(children).stream().filter(this::childIsVisible).forEach(child -> child.draw(drawX, drawY));
 
         GlStateManager.popMatrix();
     }
@@ -81,7 +81,7 @@ public class View extends Pane
     @Override
     public void scrollInput(final int wheel)
     {
-        for (final Pane child : children)
+        for (final Pane child : new ArrayList<>(children))
         {
             if (child != null)
             {

--- a/src/main/java/com/minecolonies/coremod/client/gui/WindowCitizen.java
+++ b/src/main/java/com/minecolonies/coremod/client/gui/WindowCitizen.java
@@ -370,7 +370,8 @@ public class WindowCitizen extends AbstractWindowSkeleton
         createXpBar();
         createSkillContent();
 
-        resourceList.setDataProvider(new ScrollingList.DataProvider() {
+        resourceList.setDataProvider(new ScrollingList.DataProvider()
+        {
 
             private List<RequestWrapper> requestWrappers = null;
 
@@ -412,7 +413,7 @@ public class WindowCitizen extends AbstractWindowSkeleton
                     logo.setImage(request.getDisplayIcon());
                 }
 
-                ColonyView view = ColonyManager.getColonyView(citizen.getColonyId());
+                final ColonyView view = ColonyManager.getColonyView(citizen.getColonyId());
                 rowPane.findPaneOfTypeByID(REQUESTER, Label.class)
                         .setLabelText(request.getRequester().getDisplayName(view.getRequestManager(), request.getToken()).getFormattedText());
                 rowPane.findPaneOfTypeByID(REQUEST_SHORT_DETAIL, Label.class)
@@ -434,7 +435,8 @@ public class WindowCitizen extends AbstractWindowSkeleton
 
                     rowPane.findPaneOfTypeByID(REQUEST_CANCEL, ButtonImage.class).hide();
                 }
-                else {
+                else
+                {
                     request.getRequestOfType(IDeliverable.class).ifPresent((IDeliverable requestRequest) -> {
                         if (!isCreative && !InventoryUtils.hasItemInItemHandler(new InvWrapper(inventory), requestRequest::matches))
                         {

--- a/src/main/java/com/minecolonies/coremod/client/gui/WindowClipBoard.java
+++ b/src/main/java/com/minecolonies/coremod/client/gui/WindowClipBoard.java
@@ -115,7 +115,7 @@ public class WindowClipBoard extends AbstractWindowSkeleton
             final ItemIcon exampleStackDisplay = rowPane.findPaneOfTypeByID(LIST_ELEMENT_ID_REQUEST_STACK, ItemIcon.class);
             final List<ItemStack> displayStacks = request.getDisplayStacks();
 
-            if (!displayStacks.isEmpty())
+            if (!displayStacks.isEmpty() && exampleStackDisplay != null)
             {
                 exampleStackDisplay.setItem(displayStacks.get((lifeCount / LIFE_COUNT_DIVIDER) % displayStacks.size()));
             }
@@ -126,7 +126,7 @@ public class WindowClipBoard extends AbstractWindowSkeleton
                 logo.setImage(request.getDisplayIcon());
             }
 
-            ColonyView view = ColonyManager.getColonyView(colonyId);
+            final ColonyView view = ColonyManager.getColonyView(colonyId);
             rowPane.findPaneOfTypeByID(REQUESTER, Label.class).setLabelText(request.getRequester().getDisplayName(view.getRequestManager(), request.getToken()).getFormattedText());
 
             rowPane.findPaneOfTypeByID(REQUEST_SHORT_DETAIL, Label.class)

--- a/src/main/java/com/minecolonies/coremod/client/gui/WindowClipBoard.java
+++ b/src/main/java/com/minecolonies/coremod/client/gui/WindowClipBoard.java
@@ -115,9 +115,12 @@ public class WindowClipBoard extends AbstractWindowSkeleton
             final ItemIcon exampleStackDisplay = rowPane.findPaneOfTypeByID(LIST_ELEMENT_ID_REQUEST_STACK, ItemIcon.class);
             final List<ItemStack> displayStacks = request.getDisplayStacks();
 
-            if (!displayStacks.isEmpty() && exampleStackDisplay != null)
+            if (!displayStacks.isEmpty())
             {
-                exampleStackDisplay.setItem(displayStacks.get((lifeCount / LIFE_COUNT_DIVIDER) % displayStacks.size()));
+                if(exampleStackDisplay != null)
+                {
+                    exampleStackDisplay.setItem(displayStacks.get((lifeCount / LIFE_COUNT_DIVIDER) % displayStacks.size()));
+                }
             }
             else
             {

--- a/src/main/java/com/minecolonies/coremod/client/gui/WindowTownHall.java
+++ b/src/main/java/com/minecolonies/coremod/client/gui/WindowTownHall.java
@@ -688,6 +688,10 @@ public class WindowTownHall extends AbstractWindowBuilding<BuildingTownHall.View
         findPaneOfTypeByID(TOTAL_CITIZENS_LABEL, Label.class).setLabelText(numberOfCitizens);
 
         final Group group = findPaneOfTypeByID("citizen-stats", Group.class);
+        if (group == null)
+        {
+            return;
+        }
         final Integer unemployed = jobCountMap.get("") == null ? 0 : jobCountMap.get("");
         jobCountMap.remove("");
 

--- a/src/main/java/com/minecolonies/coremod/colony/buildings/views/AbstractBuildingView.java
+++ b/src/main/java/com/minecolonies/coremod/colony/buildings/views/AbstractBuildingView.java
@@ -319,12 +319,19 @@ public abstract class AbstractBuildingView implements IRequester
             return  ImmutableList.of();
         }
 
-        if (!getOpenRequestsByCitizen().containsKey(data.getId()) || getOpenRequestsByCitizen().get(data.getId()) == null || getOpenRequestsByCitizen().get(data.getId()).isEmpty())
+        if (!getOpenRequestsByCitizen().containsKey(data.getId()))
         {
             return ImmutableList.of();
         }
 
-        return ImmutableList.copyOf(getOpenRequestsByCitizen().get(data.getId())
+        final Collection<IToken<?>> list = getOpenRequestsByCitizen().get(data.getId());
+
+        if(list == null || list.isEmpty())
+        {
+            return ImmutableList.of();
+        }
+
+        return ImmutableList.copyOf(list
                 .stream().filter(Objects::nonNull)
                 .map(getColony().getRequestManager()::getRequestForToken)
                 .filter(Objects::nonNull).iterator());

--- a/src/main/java/com/minecolonies/coremod/colony/buildings/views/AbstractBuildingView.java
+++ b/src/main/java/com/minecolonies/coremod/colony/buildings/views/AbstractBuildingView.java
@@ -319,7 +319,7 @@ public abstract class AbstractBuildingView implements IRequester
             return  ImmutableList.of();
         }
 
-        if (!getOpenRequestsByCitizen().containsKey(data.getId()) || getOpenRequestsByCitizen().get(data.getId()) == null)
+        if (!getOpenRequestsByCitizen().containsKey(data.getId()) || getOpenRequestsByCitizen().get(data.getId()) == null || getOpenRequestsByCitizen().get(data.getId()).isEmpty())
         {
             return ImmutableList.of();
         }

--- a/src/main/java/com/minecolonies/coremod/colony/requestsystem/locations/StaticLocation.java
+++ b/src/main/java/com/minecolonies/coremod/colony/requestsystem/locations/StaticLocation.java
@@ -63,6 +63,35 @@ public class StaticLocation implements ILocation
     }
 
     @Override
+    public boolean equals(final Object o)
+    {
+        if (this == o)
+        {
+            return true;
+        }
+        if (!(o instanceof StaticLocation))
+        {
+            return false;
+        }
+
+        final StaticLocation that = (StaticLocation) o;
+
+        if (getDimension() != that.getDimension())
+        {
+            return false;
+        }
+        return pos.equals(that.pos);
+    }
+
+    @Override
+    public int hashCode()
+    {
+        int result = pos.hashCode();
+        result = 31 * result + getDimension();
+        return result;
+    }
+
+    @Override
     public String toString()
     {
         return "Dim: " + dimension + " " + pos.getX() + "." + pos.getY() + "." + pos.getZ() + " ";

--- a/src/main/java/com/minecolonies/coremod/colony/requestsystem/management/handlers/RequestHandler.java
+++ b/src/main/java/com/minecolonies/coremod/colony/requestsystem/management/handlers/RequestHandler.java
@@ -357,6 +357,8 @@ public final class RequestHandler
             return;
         }
 
+        request.setState(new WrappedStaticStateRequestManager(manager), RequestState.CANCELLED);
+
         processInternalCancellation(manager, token);
 
         //Notify the requester.
@@ -377,7 +379,7 @@ public final class RequestHandler
     {
         @SuppressWarnings(RAWTYPES) final IRequest request = getRequest(manager, token);
 
-        if (manager.getRequestResolverRequestAssignmentDataStore().getAssignmentForValue(token) != null)
+        if (manager.getRequestResolverRequestAssignmentDataStore().getAssignmentForValue(token) == null)
         {
             return;
         }

--- a/src/main/java/com/minecolonies/coremod/colony/requestsystem/management/handlers/RequestHandler.java
+++ b/src/main/java/com/minecolonies/coremod/colony/requestsystem/management/handlers/RequestHandler.java
@@ -133,7 +133,7 @@ public final class RequestHandler
                 continue;
             }
 
-            Collection<IRequestResolver<?>> resolversForRequestType = manager.getRequestableTypeRequestResolverAssignmentDataStore()
+            List<IRequestResolver<?>> resolversForRequestType = manager.getRequestableTypeRequestResolverAssignmentDataStore()
                                                                         .getAssignments()
                                                                         .get(requestType)
                                                                         .stream()
@@ -143,8 +143,8 @@ public final class RequestHandler
             resolversForRequestType = resolversForRequestType.stream()
                                         .filter(r -> r.getRequestType().isSupertypeOf(request.getRequestType()))
                                         .filter(r -> !failedResolvers.contains(r.getRequesterId()))
-                                        .sorted(Comparator.comparing(r -> -1 * r.getPriority()))
-                                        .collect(Collectors.toCollection(LinkedHashSet::new));
+                                        .sorted(Comparator.comparingInt(r -> -1 * r.getPriority()))
+                                        .collect(Collectors.toList());
 
             for (final IRequestResolver<?> resolver : resolversForRequestType)
             {

--- a/src/main/java/com/minecolonies/coremod/colony/requestsystem/management/handlers/RequestHandler.java
+++ b/src/main/java/com/minecolonies/coremod/colony/requestsystem/management/handlers/RequestHandler.java
@@ -1,6 +1,7 @@
 package com.minecolonies.coremod.colony.requestsystem.management.handlers;
 
 import com.google.common.collect.ImmutableCollection;
+import com.google.common.collect.ImmutableList;
 import com.google.common.reflect.TypeToken;
 import com.minecolonies.api.colony.requestsystem.manager.AssigningStrategy;
 import com.minecolonies.api.colony.requestsystem.manager.RequestMappingHandler;
@@ -111,7 +112,7 @@ public final class RequestHandler
      *
      * @throws IllegalArgumentException is thrown when the request is unknown to this manager.
      */
-    @SuppressWarnings({UNCHECKED,RAWTYPES})
+    @SuppressWarnings({UNCHECKED, RAWTYPES})
     public static IToken<?> assignRequestDefault(final IStandardRequestManager manager, final IRequest request, final Collection<IToken<?>> resolverTokenBlackList)
     {
         //Check if the request is registered
@@ -121,86 +122,75 @@ public final class RequestHandler
 
         request.setState(new WrappedStaticStateRequestManager(manager), RequestState.ASSIGNING);
 
-        @SuppressWarnings(RAWTYPES) final Set<TypeToken> requestTypes = ReflectionUtils.getSuperClasses(request.getRequestType());
+        final Set<TypeToken> requestTypes = ReflectionUtils.getSuperClasses(request.getRequestType());
         requestTypes.remove(TypeConstants.OBJECT);
 
-        final Set<IToken<?>> failedResolvers = new HashSet<>();
+        final List<TypeToken> typeIndexList = new LinkedList<>(requestTypes);
 
-        for (@SuppressWarnings(RAWTYPES) final TypeToken requestType : requestTypes)
+        final Set<IRequestResolver<?>> resolvers = requestTypes.stream()
+                                                     .filter(typeToken -> manager.getRequestableTypeRequestResolverAssignmentDataStore().getAssignments().containsKey(typeToken))
+                                                     .flatMap(type -> manager.getRequestableTypeRequestResolverAssignmentDataStore()
+                                                                        .getAssignments()
+                                                                        .get(type)
+                                                                        .stream()
+                                                                        .map(iToken -> ResolverHandler.getResolver(manager, iToken)))
+                                                     .filter(iRequestResolver -> typeIndexList.contains(iRequestResolver.getRequestType()))
+                                                     .sorted(Comparator.comparingInt((IRequestResolver<?> r) -> -1 * r.getPriority())
+                                                               .thenComparingInt((IRequestResolver<?> r) -> typeIndexList.indexOf(r.getRequestType())))
+                                                     .collect(Collectors.toCollection(LinkedHashSet::new));
+
+
+        for (final IRequestResolver<?> resolver : resolvers)
         {
-            if (!manager.getRequestableTypeRequestResolverAssignmentDataStore().getAssignments().containsKey(requestType))
+            //Skip when the resolver is in the blacklist.
+            if (resolverTokenBlackList.contains(resolver.getRequesterId()))
             {
                 continue;
             }
 
-            List<IRequestResolver<?>> resolversForRequestType = manager.getRequestableTypeRequestResolverAssignmentDataStore()
-                                                                        .getAssignments()
-                                                                        .get(requestType)
-                                                                        .stream()
-                                                                        .map(iToken -> ResolverHandler.getResolver(manager, iToken))
-                                                                        .collect(Collectors.toList());
-
-            resolversForRequestType = resolversForRequestType.stream()
-                                        .filter(r -> r.getRequestType().isSupertypeOf(request.getRequestType()))
-                                        .filter(r -> !failedResolvers.contains(r.getRequesterId()))
-                                        .sorted(Comparator.comparingInt(r -> -1 * r.getPriority()))
-                                        .collect(Collectors.toList());
-
-            for (final IRequestResolver<?> resolver : resolversForRequestType)
+            //Skip if preliminary check fails
+            if (!resolver.canResolve(manager, request))
             {
-                //Skip when the resolver is in the blacklist.
-                if (resolverTokenBlackList.contains(resolver.getRequesterId()))
-                {
-                    failedResolvers.add(resolver.getRequesterId());
-                    continue;
-                }
-
-                //Skip if preliminary check fails
-                if (!resolver.canResolve(manager, request))
-                {
-                    failedResolvers.add(resolver.getRequesterId());
-                    continue;
-                }
-
-                @Nullable final List<IToken<?>> attemptResult = resolver.attemptResolve(new WrappedBlacklistAssignmentRequestManager(manager, resolverTokenBlackList), request);
-
-                //Skip if attempt failed (aka attemptResult == null)
-                if (attemptResult == null)
-                {
-                    failedResolvers.add(resolver.getRequesterId());
-                    continue;
-                }
-
-                //Successfully found a resolver. Registering
-                LogHandler.log("Finished resolver assignment search for request: " + request + " successfully");
-
-                ResolverHandler.addRequestToResolver(manager, resolver, request);
-
-                for (final IToken<?> childRequestToken :
-                  attemptResult)
-                {
-                    @SuppressWarnings(RAWTYPES) final IRequest childRequest = RequestHandler.getRequest(manager, childRequestToken);
-
-                    childRequest.setParent(request.getToken());
-                    request.addChild(childRequest.getToken());
-
-                    if (!isAssigned(manager, childRequestToken))
-                    {
-                        assignRequest(manager, childRequest, resolverTokenBlackList);
-                    }
-                }
-
-                if (request.getState().ordinal() < RequestState.IN_PROGRESS.ordinal())
-                {
-                    request.setState(new WrappedStaticStateRequestManager(manager), RequestState.IN_PROGRESS);
-                    if (!request.hasChildren())
-                    {
-                        resolveRequest(manager, request);
-                    }
-                }
-
-                return resolver.getRequesterId();
+                continue;
             }
+
+            @Nullable final List<IToken<?>> attemptResult = resolver.attemptResolve(new WrappedBlacklistAssignmentRequestManager(manager, resolverTokenBlackList), request);
+
+            //Skip if attempt failed (aka attemptResult == null)
+            if (attemptResult == null)
+            {
+                continue;
+            }
+
+            //Successfully found a resolver. Registering
+            LogHandler.log("Finished resolver assignment search for request: " + request + " successfully");
+
+            ResolverHandler.addRequestToResolver(manager, resolver, request);
+
+            for (final IToken<?> childRequestToken :
+              attemptResult)
+            {
+                @SuppressWarnings(RAWTYPES) final IRequest childRequest = RequestHandler.getRequest(manager, childRequestToken);
+
+                childRequest.setParent(request.getToken());
+                request.addChild(childRequest.getToken());
+
+                if (!isAssigned(manager, childRequestToken))
+                {
+                    assignRequest(manager, childRequest, resolverTokenBlackList);
+                }
+            }
+
+            if (request.getState().ordinal() < RequestState.IN_PROGRESS.ordinal())
+            {
+                request.setState(new WrappedStaticStateRequestManager(manager), RequestState.IN_PROGRESS);
+                if (!request.hasChildren())
+                {
+                    resolveRequest(manager, request);
+                }
+            }
+
+            return resolver.getRequesterId();
         }
 
         return null;
@@ -447,7 +437,7 @@ public final class RequestHandler
      * @param request The request about to be resolved.
      * @throws IllegalArgumentException when the request is unknown, not resolved, or cannot be resolved.
      */
-    @SuppressWarnings({UNCHECKED,RAWTYPES})
+    @SuppressWarnings({UNCHECKED, RAWTYPES})
     public static void resolveRequest(final IStandardRequestManager manager, final IRequest request)
     {
         getRequest(manager, request.getToken());
@@ -535,7 +525,8 @@ public final class RequestHandler
      */
     private static final class AssigningResult<T> implements Comparable<AssigningResult<T>>
     {
-        @SuppressWarnings(RAWTYPES) private final IRequestResolver resolver;
+        @SuppressWarnings(RAWTYPES)
+        private final IRequestResolver resolver;
         private final List<IToken<T>>  children;
 
         @SuppressWarnings(RAWTYPES)

--- a/src/main/java/com/minecolonies/coremod/colony/requestsystem/management/handlers/UpdateHandler.java
+++ b/src/main/java/com/minecolonies/coremod/colony/requestsystem/management/handlers/UpdateHandler.java
@@ -36,4 +36,9 @@ public class UpdateHandler
               manager.setCurrentVersion(s.updatesToVersion());
           });
     }
+
+    public static int getCurrentVersion()
+    {
+        return steps.stream().max(Comparator.comparing(IUpdateStep::updatesToVersion)).get().updatesToVersion();
+    }
 }

--- a/src/main/java/com/minecolonies/coremod/colony/requestsystem/management/handlers/update/implementation/InitialUpdate.java
+++ b/src/main/java/com/minecolonies/coremod/colony/requestsystem/management/handlers/update/implementation/InitialUpdate.java
@@ -15,6 +15,6 @@ public class InitialUpdate implements IUpdateStep
     @Override
     public void update(@NotNull final IStandardRequestManager manager)
     {
-        //Noop the update handler will set this on his own.
+        //Noop
     }
 }

--- a/src/main/java/com/minecolonies/coremod/colony/requestsystem/management/manager/StandardRequestManager.java
+++ b/src/main/java/com/minecolonies/coremod/colony/requestsystem/management/manager/StandardRequestManager.java
@@ -406,6 +406,25 @@ public class StandardRequestManager implements IStandardRequestManager
     @Override
     public void deserializeNBT(final NBTTagCompound nbt)
     {
+        if (nbt.hasKey(NBT_VERSION))
+        {
+            version = nbt.getInteger(NBT_VERSION);
+        }
+
+        if (nbt.hasKey(NBT_DATASTORE))
+        {
+            dataStoreManager = getFactoryController().deserialize(nbt.getCompoundTag(NBT_DATASTORE));
+            requestIdentitiesDataStoreId = getFactoryController().deserialize(nbt.getCompoundTag(NBT_ID_REQUEST_IDENTITIES));
+            requestResolverIdentitiesDataStoreId = getFactoryController().deserialize(nbt.getCompoundTag(NBT_ID_REQUEST_RESOLVER_IDENTITIES));
+            providerRequestResolverAssignmentDataStoreId = getFactoryController().deserialize(nbt.getCompoundTag(NBT_ID_PROVIDER_ASSIGNMENTS));
+            requestResolverRequestAssignmentDataStoreId = getFactoryController().deserialize(nbt.getCompoundTag(NBT_ID_REQUEST_RESOLVER_ASSIGNMENTS));
+            requestableTypeRequestResolverAssignmentDataStoreId = getFactoryController().deserialize(nbt.getCompoundTag(NBT_ID_REQUESTABLE_TYPE_ASSIGNMENTS));
+        }
+        else
+        {
+            setup();
+        }
+
         if (playerResolver != null)
         {
             ResolverHandler.removeResolverInternal(this, this.playerResolver);
@@ -443,25 +462,6 @@ public class StandardRequestManager implements IStandardRequestManager
         if (this.retryingResolver != null)
         {
             ResolverHandler.registerResolver(this, this.retryingResolver);
-        }
-
-        if (nbt.hasKey(NBT_VERSION))
-        {
-            version = nbt.getInteger(NBT_VERSION);
-        }
-
-        if (nbt.hasKey(NBT_DATASTORE))
-        {
-            dataStoreManager = getFactoryController().deserialize(nbt.getCompoundTag(NBT_DATASTORE));
-            requestIdentitiesDataStoreId = getFactoryController().deserialize(nbt.getCompoundTag(NBT_ID_REQUEST_IDENTITIES));
-            requestResolverIdentitiesDataStoreId = getFactoryController().deserialize(nbt.getCompoundTag(NBT_ID_REQUEST_RESOLVER_IDENTITIES));
-            providerRequestResolverAssignmentDataStoreId = getFactoryController().deserialize(nbt.getCompoundTag(NBT_ID_PROVIDER_ASSIGNMENTS));
-            requestResolverRequestAssignmentDataStoreId = getFactoryController().deserialize(nbt.getCompoundTag(NBT_ID_REQUEST_RESOLVER_ASSIGNMENTS));
-            requestableTypeRequestResolverAssignmentDataStoreId = getFactoryController().deserialize(nbt.getCompoundTag(NBT_ID_REQUESTABLE_TYPE_ASSIGNMENTS));
-        }
-        else
-        {
-            setup();
         }
 
         UpdateHandler.handleUpdate(this );

--- a/src/main/java/com/minecolonies/coremod/colony/requestsystem/management/manager/StandardRequestManager.java
+++ b/src/main/java/com/minecolonies/coremod/colony/requestsystem/management/manager/StandardRequestManager.java
@@ -359,6 +359,9 @@ public class StandardRequestManager implements IStandardRequestManager
         this.playerResolver.onSystemReset();
         this.retryingResolver.onSystemReset();
 
+        ResolverHandler.registerResolver(this, this.playerResolver);
+        ResolverHandler.registerResolver(this, this.retryingResolver);
+
         version = -1;
         UpdateHandler.handleUpdate(this);
     }

--- a/src/main/java/com/minecolonies/coremod/colony/requestsystem/management/manager/StandardRequestManager.java
+++ b/src/main/java/com/minecolonies/coremod/colony/requestsystem/management/manager/StandardRequestManager.java
@@ -359,9 +359,6 @@ public class StandardRequestManager implements IStandardRequestManager
         this.playerResolver.onSystemReset();
         this.retryingResolver.onSystemReset();
 
-        ResolverHandler.registerResolver(this, this.playerResolver);
-        ResolverHandler.registerResolver(this, this.retryingResolver);
-
         version = -1;
         UpdateHandler.handleUpdate(this);
     }

--- a/src/main/java/com/minecolonies/coremod/colony/requestsystem/management/manager/StandardRequestManager.java
+++ b/src/main/java/com/minecolonies/coremod/colony/requestsystem/management/manager/StandardRequestManager.java
@@ -463,7 +463,6 @@ public class StandardRequestManager implements IStandardRequestManager
     public void update()
     {
         this.getRetryingRequestResolver().update();
-        this.colony.markDirty();
     }
 
     @NotNull

--- a/src/main/java/com/minecolonies/coremod/colony/requestsystem/resolvers/DeliveryRequestResolver.java
+++ b/src/main/java/com/minecolonies/coremod/colony/requestsystem/resolvers/DeliveryRequestResolver.java
@@ -8,6 +8,7 @@ import com.minecolonies.api.colony.requestsystem.request.IRequest;
 import com.minecolonies.api.colony.requestsystem.requestable.Delivery;
 import com.minecolonies.api.colony.requestsystem.token.IToken;
 import com.minecolonies.api.util.BlockPosUtil;
+import com.minecolonies.blockout.Log;
 import com.minecolonies.coremod.MineColonies;
 import com.minecolonies.coremod.colony.CitizenData;
 import com.minecolonies.coremod.colony.Colony;
@@ -157,6 +158,6 @@ public class DeliveryRequestResolver extends AbstractRequestResolver<Delivery>
     @Override
     public void onRequestCancelled(@NotNull final IRequestManager manager, @NotNull final IToken<?> token)
     {
-        //Noop
+        Log.getLogger().error("cancelled");
     }
 }

--- a/src/main/java/com/minecolonies/coremod/colony/requestsystem/resolvers/WarehouseRequestResolver.java
+++ b/src/main/java/com/minecolonies/coremod/colony/requestsystem/resolvers/WarehouseRequestResolver.java
@@ -13,6 +13,7 @@ import com.minecolonies.api.colony.requestsystem.token.IToken;
 import com.minecolonies.api.util.ItemStackUtils;
 import com.minecolonies.api.util.constant.TranslationConstants;
 import com.minecolonies.api.util.constant.TypeConstants;
+import com.minecolonies.blockout.Log;
 import com.minecolonies.coremod.colony.Colony;
 import com.minecolonies.coremod.colony.buildings.BuildingWareHouse;
 import com.minecolonies.coremod.colony.requestsystem.resolvers.core.AbstractRequestResolver;
@@ -57,8 +58,15 @@ public class WarehouseRequestResolver extends AbstractRequestResolver<IDeliverab
             final Colony colony = (Colony) manager.getColony();
             final Set<TileEntityWareHouse> wareHouses = getWareHousesInColony(colony);
             wareHouses.removeIf(Objects::isNull);
-            
-            return wareHouses.stream().anyMatch(wareHouse -> wareHouse.hasMatchinItemStackInWarehouse(itemStack -> requestToCheck.getRequest().matches(itemStack)));
+
+            try
+            {
+                return wareHouses.stream().anyMatch(wareHouse -> wareHouse.hasMatchinItemStackInWarehouse(itemStack -> requestToCheck.getRequest().matches(itemStack)));
+            } catch (Exception e)
+            {
+                Log.getLogger().error(e);
+            }
+
         }
 
         return false;

--- a/src/main/java/com/minecolonies/coremod/colony/requestsystem/resolvers/WarehouseRequestResolver.java
+++ b/src/main/java/com/minecolonies/coremod/colony/requestsystem/resolvers/WarehouseRequestResolver.java
@@ -168,7 +168,9 @@ public class WarehouseRequestResolver extends AbstractRequestResolver<IDeliverab
         if (request.hasParent())
         {
             final IRequest parent = manager.getRequestForToken(token);
-            manager.reassignRequest(parent.getToken(), ImmutableList.of());
+
+            if (parent.getState() != RequestState.CANCELLED && parent.getState() != RequestState.OVERRULED)
+                manager.reassignRequest(parent.getToken(), ImmutableList.of());
         }
     }
 

--- a/src/test/java/com/minecolonies/coremod/colony/requestsystem/management/manager/StandardRequestManagerTest.java
+++ b/src/test/java/com/minecolonies/coremod/colony/requestsystem/management/manager/StandardRequestManagerTest.java
@@ -28,7 +28,6 @@ import com.minecolonies.coremod.colony.Colony;
 import com.minecolonies.coremod.colony.requestsystem.init.StandardFactoryControllerInitializer;
 import com.minecolonies.coremod.colony.requestsystem.requests.AbstractRequest;
 import com.minecolonies.coremod.colony.requestsystem.requests.StandardRequestFactories;
-import com.minecolonies.coremod.test.AbstractTest;
 import com.minecolonies.coremod.test.ReflectionUtil;
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
@@ -47,11 +46,17 @@ import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
 
 import java.util.List;
+import java.util.stream.IntStream;
 
 import static com.minecolonies.api.util.constant.Suppression.RAWTYPES;
 import static com.minecolonies.api.util.constant.Suppression.UNCHECKED;
 import static org.junit.Assert.*;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyObject;
 import static org.mockito.Mockito.when;
+import static org.powermock.api.mockito.PowerMockito.doThrow;
+import static org.powermock.api.mockito.PowerMockito.spy;
+import static org.powermock.api.support.membermodification.MemberMatcher.method;
 
 @RunWith(MockitoJUnitRunner.class)
 public class StandardRequestManagerTest
@@ -76,6 +81,9 @@ public class StandardRequestManagerTest
     private StandardRequestManager   requestManager;
     private IRequestResolverProvider provider;
 
+    private StringResolver resolverLowPrio;
+    private StringResolver resolverHighPrio;
+
     @Before
     public void setUp() throws Exception
     {
@@ -95,7 +103,13 @@ public class StandardRequestManagerTest
         requestManager = new StandardRequestManager(colony);
 
         RequestMappingHandler.registerRequestableTypeMapping(StringRequestable.class, StringRequest.class);
-        provider = new TestResolvingProvider();
+
+        resolverLowPrio = spy(new StringResolver(0));
+        resolverHighPrio = spy(new StringResolver(1));
+
+        doThrow(new AssertionError("Lower priority resolver got called!")).when(resolverLowPrio).resolve(anyObject(), anyObject());
+
+        provider = new TestResolvingProvider(resolverLowPrio, resolverHighPrio);
     }
 
     @After
@@ -146,6 +160,15 @@ public class StandardRequestManagerTest
     }
 
     @Test
+    public void multiTestCreateAndAssignRequest() throws Exception
+    {
+        for (int i = 0; i < 100; i++)
+        {
+            testCreateAndAssignRequest();
+        }
+    }
+
+    @Test
     public void testUpdateRequestState() throws Exception
     {
         requestManager.onProviderAddedToColony(provider);
@@ -181,10 +204,12 @@ public class StandardRequestManagerTest
         private final IToken<?>                                token;
         private final ImmutableCollection<IRequestResolver<?>> resolvers;
 
-        private TestResolvingProvider()
+        private TestResolvingProvider(
+          final StringResolver resolverLowPrio,
+          final StringResolver resolverHighPrio)
         {
             token = StandardFactoryController.getInstance().getNewInstance(TypeConstants.ITOKEN);
-            resolvers = ImmutableList.of(new StringResolver());
+            resolvers = ImmutableList.of(resolverLowPrio, resolverHighPrio);
         }
 
         @SuppressWarnings(RAWTYPES)
@@ -354,6 +379,10 @@ public class StandardRequestManagerTest
 
     private static class StringResolver implements IRequestResolver<StringRequestable>
     {
+        private final IToken token = StandardFactoryController.getInstance().getNewInstance(TypeConstants.ITOKEN);
+        private final Integer prio;
+
+        private StringResolver(final Integer prio) {this.prio = prio;}
 
         @Override
         public TypeToken<? extends StringRequestable> getRequestType()
@@ -382,7 +411,7 @@ public class StandardRequestManagerTest
         }
 
         @Override
-        public void resolve(@NotNull final IRequestManager manager, @NotNull final IRequest<? extends StringRequestable> request) throws RuntimeException
+        public void resolve(final IRequestManager manager, final IRequest<? extends StringRequestable> request) throws RuntimeException
         {
             System.out.println(request.getRequest().content);
             manager.updateRequestState(request.getToken(), RequestState.COMPLETED);
@@ -415,14 +444,14 @@ public class StandardRequestManagerTest
         @Override
         public int getPriority()
         {
-            return 0;
+            return prio;
         }
 
         @SuppressWarnings(RAWTYPES)
         @Override
         public IToken getRequesterId()
         {
-            return TestRequester.INSTANCE.token;
+            return token;
         }
 
         @NotNull
@@ -475,21 +504,23 @@ public class StandardRequestManagerTest
         public StringResolver getNewInstance(@NotNull final IFactoryController factoryController, @NotNull final ILocation iLocation, @NotNull final Object... context)
           throws IllegalArgumentException
         {
-            return new StringResolver();
+            return new StringResolver((Integer) context[0]);
         }
 
         @NotNull
         @Override
         public NBTTagCompound serialize(@NotNull final IFactoryController controller, @NotNull final StringResolver stackResolver)
         {
-            return new NBTTagCompound();
+            final NBTTagCompound compound = new NBTTagCompound();
+            compound.setInteger("prio", stackResolver.getPriority());
+            return compound;
         }
 
         @NotNull
         @Override
         public StringResolver deserialize(@NotNull final IFactoryController controller, @NotNull final NBTTagCompound nbt)
         {
-            return new StringResolver();
+            return new StringResolver(nbt.getInteger("prio"));
         }
     }
 

--- a/src/test/java/com/minecolonies/coremod/colony/requestsystem/management/manager/StandardRequestManagerTest.java
+++ b/src/test/java/com/minecolonies/coremod/colony/requestsystem/management/manager/StandardRequestManagerTest.java
@@ -120,22 +120,6 @@ public class StandardRequestManagerTest
     }
 
     @Test
-    public void testSerializeNBT() throws Exception
-    {
-        requestManager.onProviderAddedToColony(provider);
-
-
-        final StringRequestable hello = new StringRequestable(LOG);
-        final StringRequestable Test2 = new StringRequestable("Test 2");
-        requestManager.createRequest(TestRequester.INSTANCE, hello);
-        requestManager.createRequest(TestRequester.INSTANCE, Test2);
-
-        final NBTTagCompound compound = requestManager.serializeNBT();
-
-        assertNotNull(compound);
-    }
-
-    @Test
     public void testGetFactoryController() throws Exception
     {
         assertEquals(StandardFactoryController.getInstance(), requestManager.getFactoryController());

--- a/src/test/java/com/minecolonies/coremod/colony/requestsystem/management/manager/StandardRequestManagerTest.java
+++ b/src/test/java/com/minecolonies/coremod/colony/requestsystem/management/manager/StandardRequestManagerTest.java
@@ -25,6 +25,7 @@ import com.minecolonies.api.configuration.Configurations;
 import com.minecolonies.api.util.constant.Suppression;
 import com.minecolonies.api.util.constant.TypeConstants;
 import com.minecolonies.coremod.colony.Colony;
+import com.minecolonies.coremod.colony.managers.IBuildingManager;
 import com.minecolonies.coremod.colony.requestsystem.init.StandardFactoryControllerInitializer;
 import com.minecolonies.coremod.colony.requestsystem.requests.AbstractRequest;
 import com.minecolonies.coremod.colony.requestsystem.requests.StandardRequestFactories;
@@ -45,6 +46,7 @@ import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
 
+import java.util.HashMap;
 import java.util.List;
 import java.util.stream.IntStream;
 
@@ -78,6 +80,9 @@ public class StandardRequestManagerTest
     @Mock
     private BlockPos center;
 
+    @Mock
+    private IBuildingManager manager;
+
     private StandardRequestManager   requestManager;
     private IRequestResolverProvider provider;
 
@@ -96,6 +101,8 @@ public class StandardRequestManagerTest
 
         when(colony.getWorld()).thenReturn(world);
         when(colony.getID()).thenReturn(1);
+        when(colony.getBuildingManager()).thenReturn(manager);
+        when(manager.getBuildings()).thenReturn(new HashMap<>());
         when(worldProvider.getDimension()).thenReturn(1);
         ReflectionUtil.setFinalField(world, "provider", worldProvider);
         when(colony.getCenter()).thenReturn(center);


### PR DESCRIPTION
# Purpose:
- Fixes several problems with the current resolving implementation of the RS.
- Ensures that Priority is now the dominant factor instead of Specificity.
- Moves al RS related data into the DataStore.
- Ensures that when an update of the RS's NBT Data structure is made, an automatic Whipe is triggered. (Missing or not matching NBT Type found -> Reset)
- Prevents the RS from creating duplicate SRRR and SPRR.
- Makes the RS notifiy Requesters and Requestresolvers of cancellations.
- Ensures that when a cancellation happens the Request state is update to cancelled before any action is undertaken. Ensures that Requesters and Resolvers can handle child request cancellations properly (aka rerequests a delivery etc).

# Issues closed
Closes #2109 
Closes #2105 
Closes #2104 
Closes #2101 
Closes #2100 

