### PR TITLE
Sleeping Citizens.

### DIFF
--- a/src/api/java/com/minecolonies/api/colony/requestsystem/StandardFactoryController.java
+++ b/src/api/java/com/minecolonies/api/colony/requestsystem/StandardFactoryController.java
@@ -125,8 +125,6 @@ public final class StandardFactoryController implements IFactoryController
             //Request from cache or search.
             return secondaryMappingsCache.get(new Tuple<>(input, output), () ->
             {
-                Log.getLogger().debug("Attempting to find a Factory with Primary: " + input.toString() + " -> " + output.toString());
-
                 final Set<TypeToken> secondaryInputSet = ReflectionUtils.getSuperClasses(input);
 
                 for (final TypeToken secondaryInputClass : secondaryInputSet)
@@ -137,13 +135,11 @@ public final class StandardFactoryController implements IFactoryController
                         continue;
                     }
 
-                    Log.getLogger().debug("Found matching Factory for Primary input type.");
                     for (final IFactory factory : factories)
                     {
                         final Set<TypeToken> secondaryOutputSet = ReflectionUtils.getSuperClasses(factory.getFactoryOutputType());
                         if (secondaryOutputSet.contains(output))
                         {
-                            Log.getLogger().debug("Found input factory with matching super OUTPUT type. Search complete with: " + factory);
                             return factory;
                         }
                     }
@@ -204,9 +200,6 @@ public final class StandardFactoryController implements IFactoryController
     @Override
     public <INPUT, OUTPUT> void registerNewFactory(@NotNull final IFactory<INPUT, OUTPUT> factory) throws IllegalArgumentException
     {
-        Log.getLogger()
-          .debug(
-            "Registering factory: " + factory.toString() + " with input: " + factory.getFactoryInputType().toString() + " and output: " + factory.getFactoryOutputType() + ".");
         primaryInputMappings.putIfAbsent(factory.getFactoryInputType(), new HashSet<>());
         primaryOutputMappings.putIfAbsent(factory.getFactoryOutputType(), new HashSet<>());
 
@@ -221,16 +214,12 @@ public final class StandardFactoryController implements IFactoryController
         primaryInputFactories.add(factory);
         primaryOutputFactories.add(factory);
 
-        Log.getLogger()
-          .debug("Retrieving super types of output: " + factory.getFactoryOutputType().toString());
-
         final Set<TypeToken> outputSuperTypes = ReflectionUtils.getSuperClasses(factory.getFactoryOutputType());
 
         outputSuperTypes.remove(factory.getFactoryOutputType());
 
         if (!outputSuperTypes.isEmpty())
         {
-            Log.getLogger().debug("OUTPUT type is not Object or Interface. Introducing secondary OUTPUT-Types");
             outputSuperTypes.forEach(t ->
             {
                 if (!secondaryOutputMappings.containsKey(t))

--- a/src/main/java/com/minecolonies/coremod/client/render/RenderBipedCitizen.java
+++ b/src/main/java/com/minecolonies/coremod/client/render/RenderBipedCitizen.java
@@ -3,6 +3,7 @@ package com.minecolonies.coremod.client.render;
 import com.minecolonies.coremod.client.model.*;
 import com.minecolonies.coremod.entity.EntityCitizen;
 import net.minecraft.client.model.ModelBiped;
+import net.minecraft.client.renderer.GlStateManager;
 import net.minecraft.client.renderer.entity.RenderBiped;
 import net.minecraft.client.renderer.entity.RenderManager;
 import net.minecraft.client.renderer.entity.layers.LayerBipedArmor;
@@ -67,6 +68,34 @@ public class RenderBipedCitizen extends RenderBiped<EntityCitizen>
         }
 
         super.doRender(citizen, d, d1, d2, f, f1);
+    }
+
+    @Override
+    protected void renderLivingAt(final EntityCitizen entityLivingBaseIn, final double x, final double y, final double z)
+    {
+        if (entityLivingBaseIn.isEntityAlive() && entityLivingBaseIn.isAsleep())
+        {
+            super.renderLivingAt(entityLivingBaseIn, x + (double)entityLivingBaseIn.renderOffsetX, y, z + (double)entityLivingBaseIn.renderOffsetZ);
+        }
+        else
+        {
+            super.renderLivingAt(entityLivingBaseIn, x, y, z);
+        }
+    }
+
+    @Override
+    protected void applyRotations(final EntityCitizen entityLiving, final float p_77043_2_, final float rotationYaw, final float partialTicks)
+    {
+        if (entityLiving.isEntityAlive() && entityLiving.isAsleep())
+        {
+            GlStateManager.rotate(entityLiving.getBedOrientationInDegrees(), 0.0F, 1.0F, 0.0F);
+            GlStateManager.rotate(this.getDeathMaxRotation(entityLiving), 0.0F, 0.0F, 1.0F);
+            GlStateManager.rotate(270.0F, 0.0F, 1.0F, 0.0F);
+        }
+        else
+        {
+            super.applyRotations(entityLiving, p_77043_2_, rotationYaw, partialTicks);
+        }
     }
 
     @Override

--- a/src/main/java/com/minecolonies/coremod/client/render/RenderBipedCitizen.java
+++ b/src/main/java/com/minecolonies/coremod/client/render/RenderBipedCitizen.java
@@ -75,7 +75,7 @@ public class RenderBipedCitizen extends RenderBiped<EntityCitizen>
     {
         if (entityLivingBaseIn.isEntityAlive() && entityLivingBaseIn.isAsleep())
         {
-            super.renderLivingAt(entityLivingBaseIn, x + (double)entityLivingBaseIn.renderOffsetX, y, z + (double)entityLivingBaseIn.renderOffsetZ);
+            super.renderLivingAt(entityLivingBaseIn, x + (double)entityLivingBaseIn.getRenderOffsetX(), y, z + (double)entityLivingBaseIn.getRenderOffsetZ());
         }
         else
         {

--- a/src/main/java/com/minecolonies/coremod/client/render/RenderBipedCitizen.java
+++ b/src/main/java/com/minecolonies/coremod/client/render/RenderBipedCitizen.java
@@ -23,6 +23,8 @@ public class RenderBipedCitizen extends RenderBiped<EntityCitizen>
     private static final Map<Model, ModelBiped> idToMaleModelMap   = new EnumMap<>(Model.class);
     private static final Map<Model, ModelBiped> idToFemaleModelMap = new EnumMap<>(Model.class);
     private static final double                 SHADOW_SIZE        = 0.5F;
+    private static final int THREE_QUARTERS = 270;
+
     static
     {
         idToMaleModelMap.put(Model.DELIVERYMAN, new ModelEntityDeliverymanMale());
@@ -90,7 +92,7 @@ public class RenderBipedCitizen extends RenderBiped<EntityCitizen>
         {
             GlStateManager.rotate(entityLiving.getBedOrientationInDegrees(), 0.0F, 1.0F, 0.0F);
             GlStateManager.rotate(this.getDeathMaxRotation(entityLiving), 0.0F, 0.0F, 1.0F);
-            GlStateManager.rotate(270.0F, 0.0F, 1.0F, 0.0F);
+            GlStateManager.rotate(THREE_QUARTERS, 0.0F, 1.0F, 0.0F);
         }
         else
         {

--- a/src/main/java/com/minecolonies/coremod/colony/buildings/AbstractBuilding.java
+++ b/src/main/java/com/minecolonies/coremod/colony/buildings/AbstractBuilding.java
@@ -37,6 +37,7 @@ import com.minecolonies.coremod.util.StructureWrapper;
 import io.netty.buffer.ByteBuf;
 import net.minecraft.block.Block;
 import net.minecraft.block.BlockContainer;
+import net.minecraft.block.state.IBlockState;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.inventory.IInventory;
 import net.minecraft.inventory.InventoryHelper;
@@ -1076,6 +1077,19 @@ public abstract class AbstractBuilding implements IRequestResolverProvider, IReq
     public boolean isMirrored()
     {
         return isBuildingMirrored;
+    }
+
+    /**
+     * Register a blockState and position.
+     * We suppress this warning since this parameter will be used in child classes which override this method.
+     *
+     * @param blockState to be registered
+     * @param pos   of the blockState
+     */
+    @SuppressWarnings("squid:S1172")
+    public void registerBlockPosition(@NotNull final IBlockState blockState, @NotNull final BlockPos pos, @NotNull final World world)
+    {
+        registerBlockPosition(blockState.getBlock(), pos, world);
     }
 
     /**

--- a/src/main/java/com/minecolonies/coremod/colony/buildings/AbstractBuilding.java
+++ b/src/main/java/com/minecolonies/coremod/colony/buildings/AbstractBuilding.java
@@ -1086,7 +1086,6 @@ public abstract class AbstractBuilding implements IRequestResolverProvider, IReq
      * @param blockState to be registered
      * @param pos   of the blockState
      */
-    @SuppressWarnings("squid:S1172")
     public void registerBlockPosition(@NotNull final IBlockState blockState, @NotNull final BlockPos pos, @NotNull final World world)
     {
         registerBlockPosition(blockState.getBlock(), pos, world);

--- a/src/main/java/com/minecolonies/coremod/colony/buildings/BuildingHome.java
+++ b/src/main/java/com/minecolonies/coremod/colony/buildings/BuildingHome.java
@@ -156,11 +156,22 @@ public class BuildingHome extends AbstractBuildingHut
     }
 
     @Override
-    public void registerBlockPosition(@NotNull final Block block, @NotNull final BlockPos pos, @NotNull final World world)
+    public void registerBlockPosition(@NotNull final IBlockState blockState, @NotNull final BlockPos pos, @NotNull final World world)
     {
-        if (block == Blocks.BED && !bedList.contains(pos))
+        super.registerBlockPosition(blockState, pos, world);
+
+        BlockPos registrationPosition = pos;
+        if (blockState.getBlock() instanceof BlockBed)
         {
-            bedList.add(pos);
+            if (blockState.getValue(BlockBed.PART) == BlockBed.EnumPartType.FOOT)
+            {
+                registrationPosition = registrationPosition.offset(blockState.getValue(BlockBed.FACING));
+            }
+
+            if (!bedList.contains(registrationPosition))
+            {
+                bedList.add(registrationPosition);
+            }
         }
     }
 

--- a/src/main/java/com/minecolonies/coremod/colony/buildings/BuildingTownHall.java
+++ b/src/main/java/com/minecolonies/coremod/colony/buildings/BuildingTownHall.java
@@ -13,7 +13,7 @@ import static com.minecolonies.api.util.constant.ColonyConstants.NUM_ACHIEVEMENT
 /**
  * Class used to manage the townHall building block.
  */
-public class BuildingTownHall extends AbstractBuildingHut
+public class BuildingTownHall extends BuildingHome
 {
     /**
      * Description of the block used to set this block.
@@ -67,7 +67,7 @@ public class BuildingTownHall extends AbstractBuildingHut
     /**
      * ClientSide representation of the building.
      */
-    public static class View extends AbstractBuildingHut.View
+    public static class View extends BuildingHome.View
     {
         /**
          * Instantiates the view of the building.

--- a/src/main/java/com/minecolonies/coremod/entity/EntityCitizen.java
+++ b/src/main/java/com/minecolonies/coremod/entity/EntityCitizen.java
@@ -83,8 +83,10 @@ import static com.minecolonies.api.util.constant.TranslationConstants.CITIZEN_RE
  */
 public class EntityCitizen extends EntityAgeable implements INpc
 {
-    private static final Float CONST_BED_HEIGHT = 0.6875f;
-    private static final Float CONST_HALF_BLOCK = 0.5f;
+    private static final float CONST_BED_HEIGHT = 0.6875f;
+    private static final float CONST_HALF_BLOCK = 0.5f;
+    private static final float CONST_SLEEPING_RENDER_OFFSET = -1.5f;
+
 
     private static final DataParameter<Integer> DATA_TEXTURE         = EntityDataManager.<Integer>createKey(EntityCitizen.class, DataSerializers.VARINT);
     private static final DataParameter<Integer> DATA_LEVEL           = EntityDataManager.<Integer>createKey(EntityCitizen.class, DataSerializers.VARINT);
@@ -1484,13 +1486,19 @@ public class EntityCitizen extends EntityAgeable implements INpc
         }
     }
 
-    public void trySleep(BlockPos bedLocation)
+    /**
+     * Attempts a sleep interaction with the citizen and the given bed.
+     * @param bedLocation The possible location to sleep.
+     */
+    public void trySleep(final BlockPos bedLocation)
     {
         final IBlockState state = this.world.isBlockLoaded(bedLocation) ? this.world.getBlockState(bedLocation) : null;
         final boolean isBed = state != null && state.getBlock().isBed(state, this.world, bedLocation, this);
 
         if (!isBed)
+        {
             return;
+        }
 
         this.setPosition((double)((float)bedLocation.getX() + CONST_HALF_BLOCK), (double)((float)bedLocation.getY() + CONST_BED_HEIGHT), (double)((float)bedLocation.getZ() + CONST_HALF_BLOCK));
 
@@ -1512,7 +1520,7 @@ public class EntityCitizen extends EntityAgeable implements INpc
     {
         if (!isAsleep())
         {
-            return 0f;
+            return 0;
         }
 
         final IBlockState state = this.world.isBlockLoaded(getBedLocation()) ? this.world.getBlockState(getBedLocation()) : null;
@@ -1521,17 +1529,17 @@ public class EntityCitizen extends EntityAgeable implements INpc
 
         if (enumfacing == null)
         {
-            return 0f;
+            return 0;
         }
 
-        return -1.5F * (float)enumfacing.getFrontOffsetX();
+        return CONST_SLEEPING_RENDER_OFFSET * (float)enumfacing.getFrontOffsetX();
     }
 
     public float getRenderOffsetZ()
     {
         if (!isAsleep())
         {
-            return 0f;
+            return 0;
         }
 
         final IBlockState state = this.world.isBlockLoaded(getBedLocation()) ? this.world.getBlockState(getBedLocation()) : null;
@@ -1540,10 +1548,10 @@ public class EntityCitizen extends EntityAgeable implements INpc
 
         if (enumfacing == null)
         {
-            return 0f;
+            return 0;
         }
 
-        return -1.5F * (float)enumfacing.getFrontOffsetZ();
+        return CONST_SLEEPING_RENDER_OFFSET * (float)enumfacing.getFrontOffsetZ();
     }
 
     /**
@@ -2084,12 +2092,23 @@ public class EntityCitizen extends EntityAgeable implements INpc
         dataManager.set(DATA_BED_POS, new BlockPos(0,0,0));
     }
 
+    /**
+     * Is the citizen a sleep?
+     *
+     * @return true when a sleep.
+     */
     public boolean isAsleep()
     {
         return dataManager.get(DATA_IS_ASLEEP);
     }
 
-    public void setIsAsleep(boolean isAsleep)
+    /**
+     * Sets if the citizen is a sleep.
+     * Caution: Use trySleep(BlockPos) for better control
+     *
+     * @param isAsleep True to make the citizen sleep.
+     */
+    public void setIsAsleep(final boolean isAsleep)
     {
         dataManager.set(DATA_IS_ASLEEP, isAsleep);
     }
@@ -2100,21 +2119,23 @@ public class EntityCitizen extends EntityAgeable implements INpc
     @SideOnly(Side.CLIENT)
     public float getBedOrientationInDegrees()
     {
-        IBlockState state = this.getBedLocation() == null ? null : this.world.getBlockState(getBedLocation());
+        final IBlockState state = this.getBedLocation() == null ? null : this.world.getBlockState(getBedLocation());
         if (state != null && state.getBlock().isBed(state, world, getBedLocation(), this))
         {
-            EnumFacing enumfacing = state.getBlock().getBedDirection(state, world, getBedLocation());
+            final EnumFacing enumfacing = state.getBlock().getBedDirection(state, world, getBedLocation());
 
             switch (enumfacing)
             {
                 case SOUTH:
-                    return 90.0F;
+                    return 90.0f;
                 case WEST:
-                    return 0.0F;
+                    return 0.0f;
                 case NORTH:
-                    return 270.0F;
+                    return 270.0f;
                 case EAST:
-                    return 180.0F;
+                    return 180.0f;
+                default:
+                    return 0f;
             }
         }
 

--- a/src/main/java/com/minecolonies/coremod/entity/EntityCitizen.java
+++ b/src/main/java/com/minecolonies/coremod/entity/EntityCitizen.java
@@ -87,6 +87,9 @@ public class EntityCitizen extends EntityAgeable implements INpc
     private static final float CONST_HALF_BLOCK = 0.5f;
     private static final float CONST_SLEEPING_RENDER_OFFSET = -1.5f;
 
+    private static final int NINETY_DEGREE = 90;
+    private static final int HALF_ROTATION = 180;
+    private static final int THREE_QUARTERS = 270;
 
     private static final DataParameter<Integer> DATA_TEXTURE         = EntityDataManager.<Integer>createKey(EntityCitizen.class, DataSerializers.VARINT);
     private static final DataParameter<Integer> DATA_LEVEL           = EntityDataManager.<Integer>createKey(EntityCitizen.class, DataSerializers.VARINT);
@@ -2127,13 +2130,13 @@ public class EntityCitizen extends EntityAgeable implements INpc
             switch (enumfacing)
             {
                 case SOUTH:
-                    return 90.0f;
+                    return NINETY_DEGREE;
                 case WEST:
                     return 0.0f;
                 case NORTH:
-                    return 270.0f;
+                    return THREE_QUARTERS;
                 case EAST:
-                    return 180.0f;
+                    return HALF_ROTATION;
                 default:
                     return 0f;
             }

--- a/src/main/java/com/minecolonies/coremod/entity/ai/basic/AbstractEntityAIStructure.java
+++ b/src/main/java/com/minecolonies/coremod/entity/ai/basic/AbstractEntityAIStructure.java
@@ -365,6 +365,7 @@ public abstract class AbstractEntityAIStructure<J extends AbstractJob> extends A
             {
                 decrease = (IBlockState) result;
                 decreaseInventory(coords, decrease.getBlock(), decrease);
+                connectBlockToBuildingIfNecessary(decrease, coords);
                 worker.swingArm(worker.getActiveHand());
                 worker.addExperience(XP_EACH_BLOCK);
 
@@ -411,7 +412,6 @@ public abstract class AbstractEntityAIStructure<J extends AbstractJob> extends A
         }
 
         @NotNull final Block blockToPlace = block;
-        connectBlockToBuildingIfNecessary(blockToPlace, pos);
 
         //It will crash at blocks like water which is actually free, we don't have to decrease the stacks we have.
         if (isBlockFree(blockToPlace, blockToPlace.getMetaFromState(stateToPlace)))
@@ -454,10 +454,10 @@ public abstract class AbstractEntityAIStructure<J extends AbstractJob> extends A
     /**
      * On placement of a Block execute this to store the location in the regarding building when needed.
      *
-     * @param block itself
+     * @param blockState itself
      * @param pos   the position of the block.
      */
-    public void connectBlockToBuildingIfNecessary(@NotNull final Block block, @NotNull final BlockPos pos)
+    public void connectBlockToBuildingIfNecessary(@NotNull final IBlockState blockState, @NotNull final BlockPos pos)
     {
         /**
          * Classes can overwrite this if necessary.
@@ -524,7 +524,7 @@ public abstract class AbstractEntityAIStructure<J extends AbstractJob> extends A
 
             if (structureBlock.doesStructureBlockEqualWorldBlock())
             {
-                connectBlockToBuildingIfNecessary(structureBlock.block, structureBlock.blockPosition);
+                connectBlockToBuildingIfNecessary(structureBlock.metadata, structureBlock.blockPosition);
                 //findNextBlock count was reached and we can ignore this block
                 return true;
             }

--- a/src/main/java/com/minecolonies/coremod/entity/ai/citizen/builder/EntityAIStructureBuilder.java
+++ b/src/main/java/com/minecolonies/coremod/entity/ai/citizen/builder/EntityAIStructureBuilder.java
@@ -377,17 +377,17 @@ public class EntityAIStructureBuilder extends AbstractEntityAIStructure<JobBuild
     }
 
     @Override
-    public void connectBlockToBuildingIfNecessary(@NotNull final Block block, @NotNull final BlockPos pos)
+    public void connectBlockToBuildingIfNecessary(@NotNull final IBlockState blockState, @NotNull final BlockPos pos)
     {
         final BlockPos buildingLocation = job.getWorkOrder().getBuildingLocation();
         final AbstractBuilding building = this.getOwnBuilding().getColony().getBuildingManager().getBuilding(buildingLocation);
 
         if (building != null)
         {
-            building.registerBlockPosition(block, pos, world);
+            building.registerBlockPosition(blockState, pos, world);
         }
 
-        if (block == ModBlocks.blockWayPoint)
+        if (blockState.getBlock() == ModBlocks.blockWayPoint)
         {
             worker.getColony().addWayPoint(pos, world.getBlockState(pos));
         }

--- a/src/main/java/com/minecolonies/coremod/entity/ai/minimal/EntityAISleep.java
+++ b/src/main/java/com/minecolonies/coremod/entity/ai/minimal/EntityAISleep.java
@@ -109,6 +109,7 @@ public class EntityAISleep extends EntityAIBase
 
                 if (citizen.isWorkerAtSiteWithMove(usedBed, 1))
                 {
+                    citizen.trySleep(usedBed);
                     return true;
                 }
             }

--- a/src/main/java/com/minecolonies/coremod/entity/ai/minimal/EntityAISleep.java
+++ b/src/main/java/com/minecolonies/coremod/entity/ai/minimal/EntityAISleep.java
@@ -92,6 +92,11 @@ public class EntityAISleep extends EntityAIBase
                         {
                             usedBed = pos;
                             citizen.world.setBlockState(pos, state.withProperty(BlockBed.OCCUPIED, true), 0x03);
+
+                            final BlockPos feetPos = pos.offset(state.getValue(BlockBed.FACING).getOpposite());
+                            final IBlockState feetState = citizen.world.getBlockState(feetPos);
+                            citizen.world.setBlockState(feetPos, feetState.withProperty(BlockBed.OCCUPIED, true), 0x03);
+
                             return true;
                         }
                     }
@@ -101,12 +106,6 @@ public class EntityAISleep extends EntityAIBase
             }
             else
             {
-                if(new BlockPos(usedBed.getX(), citizen.posY, usedBed.getZ()).distanceSq(citizen.getHomePosition()) > RANGE_TO_BE_HOME * 2)
-                {
-                    usedBed = null;
-                    return true;
-                }
-
                 if (citizen.isWorkerAtSiteWithMove(usedBed, 1))
                 {
                     citizen.trySleep(usedBed);
@@ -122,7 +121,12 @@ public class EntityAISleep extends EntityAIBase
             final IBlockState state = citizen.world.getBlockState(usedBed);
             if (state.getBlock() instanceof BlockBed)
             {
-                citizen.world.setBlockState(usedBed, state.withProperty(BlockBed.OCCUPIED, false), 0x03);
+                final IBlockState headState = citizen.world.getBlockState(usedBed);
+                citizen.world.setBlockState(usedBed, headState.withProperty(BlockBed.OCCUPIED, false), 0x03);
+
+                final BlockPos feetPos = usedBed.offset(headState.getValue(BlockBed.FACING).getOpposite());
+                final IBlockState feetState = citizen.world.getBlockState(feetPos);
+                citizen.world.setBlockState(feetPos, feetState.withProperty(BlockBed.OCCUPIED, true), 0x03);
             }
             usedBed = null;
 

--- a/src/main/java/com/minecolonies/coremod/placementhandlers/PlacementHandlers.java
+++ b/src/main/java/com/minecolonies/coremod/placementhandlers/PlacementHandlers.java
@@ -271,15 +271,15 @@ public final class PlacementHandlers
             final EnumFacing facing = blockState.getValue(BlockBed.FACING);
 
             //Set other part of the bed, to the opposite PartType
-            if (blockState.getValue(BlockBed.PART) == BlockBed.EnumPartType.FOOT)
+            if (blockState.getValue(BlockBed.PART) == BlockBed.EnumPartType.HEAD)
             {
                 if (placer != null)
                 {
                     placer.handleBuildingOverBlock(pos);
                 }
                 //pos.offset(facing) will get the other part of the bed
-                world.setBlockState(pos.offset(facing), blockState.withProperty(BlockBed.PART, BlockBed.EnumPartType.HEAD), UPDATE_FLAG);
-                world.setBlockState(pos, blockState.withProperty(BlockBed.PART, BlockBed.EnumPartType.FOOT), UPDATE_FLAG);
+                world.setBlockState(pos.offset(facing.getOpposite()), blockState.withProperty(BlockBed.PART, BlockBed.EnumPartType.FOOT), UPDATE_FLAG);
+                world.setBlockState(pos, blockState.withProperty(BlockBed.PART, BlockBed.EnumPartType.HEAD), UPDATE_FLAG);
                 return blockState;
             }
             return ActionProcessingResult.ACCEPT;

--- a/src/main/java/com/minecolonies/coremod/util/StructureWrapper.java
+++ b/src/main/java/com/minecolonies/coremod/util/StructureWrapper.java
@@ -9,6 +9,9 @@ import com.minecolonies.coremod.blocks.AbstractBlockHut;
 import com.minecolonies.coremod.blocks.BlockMinecoloniesRack;
 import com.minecolonies.coremod.blocks.BlockWaypoint;
 import com.minecolonies.coremod.blocks.ModBlocks;
+import com.minecolonies.coremod.colony.Colony;
+import com.minecolonies.coremod.colony.ColonyManager;
+import com.minecolonies.coremod.colony.buildings.AbstractBuilding;
 import com.minecolonies.coremod.placementhandlers.IPlacementHandler;
 import com.minecolonies.coremod.placementhandlers.PlacementHandlers;
 import com.minecolonies.structures.helpers.StructureProxy;
@@ -112,6 +115,7 @@ public final class StructureWrapper
         try
         {
             @NotNull final StructureWrapper structureWrapper = new StructureWrapper(worldObj, name);
+            structureWrapper.position = pos;
             structureWrapper.rotate(rotations, worldObj, pos, mirror);
             structureWrapper.placeStructure(pos.subtract(structureWrapper.getOffset()), complete);
         }
@@ -241,7 +245,21 @@ public final class StructureWrapper
         for (final IPlacementHandler handlers : PlacementHandlers.handlers)
         {
             final Object result = handlers.handle(world, pos, localState, null, true, complete);
-            if (!(result instanceof IPlacementHandler.ActionProcessingResult) || result != IGNORE)
+            if (result instanceof  IBlockState)
+            {
+                final IBlockState blockState = (IBlockState) result;
+
+                final Colony colony = ColonyManager.getClosestColony(world, pos);
+                final AbstractBuilding building = colony.getBuildingManager().getBuilding(position);
+
+                if (building != null)
+                {
+                    building.registerBlockPosition(blockState, pos, world);
+                }
+
+                return;
+            }
+            else if (!(result instanceof IPlacementHandler.ActionProcessingResult) || result != IGNORE)
             {
                 return;
             }

--- a/src/main/java/com/minecolonies/coremod/util/StructureWrapper.java
+++ b/src/main/java/com/minecolonies/coremod/util/StructureWrapper.java
@@ -249,12 +249,15 @@ public final class StructureWrapper
             {
                 final IBlockState blockState = (IBlockState) result;
 
-                final Colony colony = ColonyManager.getClosestColony(world, pos);
-                final AbstractBuilding building = colony.getBuildingManager().getBuilding(position);
-
-                if (building != null)
+                final Colony colony = ColonyManager.getColony(world, pos);
+                if (colony != null)
                 {
-                    building.registerBlockPosition(blockState, pos, world);
+                    final AbstractBuilding building = colony.getBuildingManager().getBuilding(position);
+
+                    if (building != null)
+                    {
+                        building.registerBlockPosition(blockState, pos, world);
+                    }
                 }
 
                 return;


### PR DESCRIPTION
### Primary Feature
This makes citizens actually sleep in their respective beds. Or collect them at their respective home buildings block. To achieve this several changes have been made. Most notably:
- The TownHall is now a BuildingHome. This ensures that its beds are actually used.
- Block registration to a building is now done using a BlockState, the current implementation extracts the Block and passes it to the old methods.
- Bed positions are now always saved with the head of the block
- The placementhandler for the Bed now only performs his operations on the Head part of the Bed, and just noop accepts on the foot part instead of the other way around.
- The EntityAISleep finds a proper bed and marks it occupied on the first tick
- Once the citizen arrives at his bed his `trySleep(BlockPos)` method is called.
- `trySleep(BlockPos)` will check if the given position is a bed (incase we do not have enough beds and the building block is passed). Store the data in the DataManager and teleport the citizen to the top of the bed.
- During rendering the DataManager is queried if the citizen is sleeping. He is then rotated and translated properly to render him in bed.

### Secondary Feature
This PR makes so that blocks get properly registered to their respective building when it gets placed using the creative paste option.

### Images:
#### Two citizens next to each works just fine:
![image](https://user-images.githubusercontent.com/5585406/35682749-16300840-0762-11e8-92f9-68495bba7fc4.png)
#### Higher levels if Citizen huts get used properly:
![image](https://user-images.githubusercontent.com/5585406/35682830-58ccbc02-0762-11e8-895a-9e6251af33e5.png)
