### PR TITLE
Prevent citizens from spawning in the void after wakeup.

### DIFF
--- a/src/main/java/com/minecolonies/coremod/entity/EntityCitizen.java
+++ b/src/main/java/com/minecolonies/coremod/entity/EntityCitizen.java
@@ -2097,21 +2097,29 @@ public class EntityCitizen extends EntityAgeable implements INpc
             homeBuilding.onWakeUp();
         }
 
-        final BlockPos spawn = Utils.scanForBlockNearPoint(
-          world,
-          getBedLocation(),
-          4,
-          2,
-          4,
-          PLAYER_HEIGHT,
-          Blocks.AIR,
-          Blocks.SNOW_LAYER,
-          Blocks.TALLGRASS,
-          Blocks.RED_FLOWER,
-          Blocks.YELLOW_FLOWER,
-          Blocks.CARPET);
+        BlockPos spawn;
+        if (getBedLocation() != BlockPos.ORIGIN)
+        {
+            spawn = Utils.scanForBlockNearPoint(
+              world,
+              getBedLocation(),
+              4,
+              2,
+              4,
+              PLAYER_HEIGHT,
+              Blocks.AIR,
+              Blocks.SNOW_LAYER,
+              Blocks.TALLGRASS,
+              Blocks.RED_FLOWER,
+              Blocks.YELLOW_FLOWER,
+              Blocks.CARPET);
+        }
+        else
+        {
+            spawn = getPosition();
+        }
 
-        if (spawn != null)
+        if (spawn != null && spawn != BlockPos.ORIGIN)
         {
             setPosition(spawn.getX(), spawn.getY(), spawn.getZ());
         }


### PR DESCRIPTION
## Primary Feature:
- Improvement of the citizen placement after waking up, by preventing them from spawning at 0,0,0 and falling into the void.
- Improve the spawn protection logic used to find the position for a citizen that is waking up by using the bed as fallback. Certain buildings might need to me modified.

### A note on Sonar.
This PR has no Sonar improvements on the changes. Namely and most notably: The constants used for the search range are literals. I have been debugging this more or less without me seeing the behaviour itself. So I have no real idea if this really helps much. Once the problems reside I will do a Sonar run over my latest PRs. Which will clean this up as well.

