### PR TITLE
Show specific reasons why a supply-camp cannot be placed

### DIFF
--- a/src/api/java/com/minecolonies/api/util/constant/TranslationConstants.java
+++ b/src/api/java/com/minecolonies/api/util/constant/TranslationConstants.java
@@ -183,6 +183,14 @@ public final class TranslationConstants
     public static final String TH_TOO_LOW                                                          = "com.minecolonies.coremod.gui.townHall.tooLow";
     @NonNls
     public static final String HUNGRY_INV_FULL                                                     = "com.minecolonies.coremod.cook.full";
+    @NonNls
+    public static final String SUPPLY_CAMP_INVALID_NOT_SOLID_MESSAGE_KEY                           = "item.supplyCampDeployer.invalid.solid_block_needed";
+    @NonNls
+    public static final String SUPPLY_CAMP_INVALID_NEEDS_AIR_ABOVE_MESSAGE_KEY                     = "item.supplyCampDeployer.invalid.air_block_needed";
+    @NonNls
+    public static final String SUPPLY_CAMP_INVALID_INSIDE_COLONY_MESSAGE_KEY                       = "item.supplyCampDeployer.invalid.inside_existing_colony";
+    @NonNls
+    public static final String SUPPLY_CAMP_INVALID                                                 = "item.supplyCampDeployer.invalid";
 
     private TranslationConstants()
     {

--- a/src/main/java/com/minecolonies/coremod/client/gui/WindowBuildTool.java
+++ b/src/main/java/com/minecolonies/coremod/client/gui/WindowBuildTool.java
@@ -920,7 +920,7 @@ public class WindowBuildTool extends AbstractWindowSkeleton
         }
         else if (FreeMode.SUPPLYCAMP == Settings.instance.getFreeMode())
         {
-            final List<PlacementError> placementErrorList = new ArrayList<PlacementError>();
+            final List<PlacementError> placementErrorList = new ArrayList<>();
             if (ItemSupplyCampDeployer.canCampBePlaced(Minecraft.getMinecraft().world, Settings.instance.getPosition(),
                     Settings.instance.getActiveStructure().getSize(BlockUtils.getRotation(Settings.instance.getRotation())), placementErrorList))
             {
@@ -930,18 +930,21 @@ public class WindowBuildTool extends AbstractWindowSkeleton
             {
                 final Map<PlacementErrorType, List<BlockPos>> blockPosListByErrorTypeMap = PlacementError.partitionPlacementErrorsByErrorType(
                         placementErrorList);
-                for (final Map.Entry<PlacementErrorType, List<BlockPos>> entry : blockPosListByErrorTypeMap.entrySet()) {
+                for (final Map.Entry<PlacementErrorType, List<BlockPos>> entry : blockPosListByErrorTypeMap.entrySet())
+                {
                     final PlacementErrorType placementErrorType = entry.getKey();
                     final List<BlockPos> blockPosList = entry.getValue();
 
                     final int numberOfBlocksTOReport = blockPosList.size() > 5 ? 5 : blockPosList.size();
                     final List<BlockPos> blocksToReportList = blockPosList.subList(0, numberOfBlocksTOReport);
                     String outputList = PlacementError.blockListToCommaSeparatedString(blocksToReportList);
-                    if (blockPosList.size() > numberOfBlocksTOReport) {
+                    if (blockPosList.size() > numberOfBlocksTOReport)
+                    {
                         outputList += "...";
                     }
                     String errorMessage;
-                    switch(placementErrorType) {
+                    switch(placementErrorType)
+                    {
                         case NOT_SOLID:
                             errorMessage = String.format(SUPPLY_CAMP_INVALID_NOT_SOLID_MESSAGE_KEY, outputList);
                             LanguageHandler.sendPlayerMessage(Minecraft.getMinecraft().player, errorMessage, outputList);

--- a/src/main/java/com/minecolonies/coremod/client/gui/WindowBuildTool.java
+++ b/src/main/java/com/minecolonies/coremod/client/gui/WindowBuildTool.java
@@ -4,6 +4,7 @@ import com.minecolonies.api.util.BlockUtils;
 import com.minecolonies.api.util.LanguageHandler;
 import com.minecolonies.api.util.Log;
 import com.minecolonies.api.util.constant.Constants;
+import com.minecolonies.api.util.constant.TranslationConstants;
 import com.minecolonies.blockout.controls.Button;
 import com.minecolonies.blockout.views.DropDownList;
 import com.minecolonies.coremod.MineColonies;
@@ -52,11 +53,6 @@ public class WindowBuildTool extends AbstractWindowSkeleton
         SUPPLYSHIP,
         SUPPLYCAMP
     }
-
-    private static final String SUPPLY_CAMP_INVALID_NOT_SOLID_MESSAGE_KEY = "item.supplyCampDeployer.invalid.solid_block_needed";
-    private static final String SUPPLY_CAMP_INVALID_NEEDS_AIR_ABOVE_MESSAGE_KEY = "item.supplyCampDeployer.invalid.air_block_needed";
-    private static final String SUPPLY_CAMP_INVALID_INSIDE_COLONY_MESSAGE_KEY = "item.supplyCampDeployer.invalid.inside_existing_colony";
-    private static final String SUPPLY_CAMP_INVALID = "item.supplyCampDeployer.invalid";
 
     /**
      * All possible rotations.
@@ -946,19 +942,19 @@ public class WindowBuildTool extends AbstractWindowSkeleton
                     switch(placementErrorType)
                     {
                         case NOT_SOLID:
-                            errorMessage = String.format(SUPPLY_CAMP_INVALID_NOT_SOLID_MESSAGE_KEY, outputList);
+                            errorMessage = String.format(TranslationConstants.SUPPLY_CAMP_INVALID_NOT_SOLID_MESSAGE_KEY, outputList);
                             LanguageHandler.sendPlayerMessage(Minecraft.getMinecraft().player, errorMessage, outputList);
                             break;
                         case NEEDS_AIR_ABOVE:
-                            errorMessage = String.format(SUPPLY_CAMP_INVALID_NEEDS_AIR_ABOVE_MESSAGE_KEY, outputList);
+                            errorMessage = String.format(TranslationConstants.SUPPLY_CAMP_INVALID_NEEDS_AIR_ABOVE_MESSAGE_KEY, outputList);
                             LanguageHandler.sendPlayerMessage(Minecraft.getMinecraft().player, errorMessage, outputList);
                             break;
                         case INSIDE_COLONY:
-                            errorMessage = SUPPLY_CAMP_INVALID_INSIDE_COLONY_MESSAGE_KEY;
+                            errorMessage = TranslationConstants.SUPPLY_CAMP_INVALID_INSIDE_COLONY_MESSAGE_KEY;
                             LanguageHandler.sendPlayerMessage(Minecraft.getMinecraft().player, errorMessage);
                             break;
                         default:
-                            errorMessage = SUPPLY_CAMP_INVALID;
+                            errorMessage = TranslationConstants.SUPPLY_CAMP_INVALID;
                             LanguageHandler.sendPlayerMessage(Minecraft.getMinecraft().player, errorMessage);
                             break;
                     }

--- a/src/main/java/com/minecolonies/coremod/items/ItemSupplyCampDeployer.java
+++ b/src/main/java/com/minecolonies/coremod/items/ItemSupplyCampDeployer.java
@@ -130,7 +130,7 @@ public class ItemSupplyCampDeployer extends AbstractItemMinecolonies
      * @return true if so.
      */
     @NotNull
-    public static boolean canCampBePlaced(@NotNull final World world, @NotNull final BlockPos pos, final BlockPos size, @NotNull List<PlacementError> placementErrorList)
+    public static boolean canCampBePlaced(@NotNull final World world, @NotNull final BlockPos pos, final BlockPos size, @NotNull final List<PlacementError> placementErrorList)
     {
         for(int z = pos.getZ() - size.getZ() / 2 + 1; z < pos.getZ() + size.getZ() / 2 + 1; z++)
         {
@@ -162,7 +162,7 @@ public class ItemSupplyCampDeployer extends AbstractItemMinecolonies
      * @param pos  the position.
      * @return true if is water
      */
-    private static boolean checkIfSolidAndNotInColony(final World world, final BlockPos pos, @NotNull List<PlacementError> placementErrorList)
+    private static boolean checkIfSolidAndNotInColony(final World world, final BlockPos pos, @NotNull final List<PlacementError> placementErrorList)
     {
         final boolean isSolid = world.getBlockState(pos).getMaterial().isSolid();
         final boolean notInAnyColony = notInAnyColony(world, pos);

--- a/src/main/java/com/minecolonies/coremod/items/ItemSupplyCampDeployer.java
+++ b/src/main/java/com/minecolonies/coremod/items/ItemSupplyCampDeployer.java
@@ -5,6 +5,9 @@ import com.minecolonies.coremod.client.gui.WindowBuildTool;
 import com.minecolonies.coremod.colony.ColonyManager;
 import com.minecolonies.coremod.colony.Structures;
 import com.minecolonies.coremod.creativetab.ModCreativeTabs;
+import com.minecolonies.coremod.placementhandlers.PlacementError;
+import com.minecolonies.coremod.placementhandlers.PlacementError.PlacementErrorType;
+
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.*;
@@ -14,6 +17,8 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import static com.minecolonies.api.util.constant.Constants.*;
+
+import java.util.List;
 
 /**
  * Class to handle the placement of the supplychest and with it the supplycamp.
@@ -125,16 +130,13 @@ public class ItemSupplyCampDeployer extends AbstractItemMinecolonies
      * @return true if so.
      */
     @NotNull
-    public static boolean canCampBePlaced(@NotNull final World world, @NotNull final BlockPos pos, final BlockPos size)
+    public static boolean canCampBePlaced(@NotNull final World world, @NotNull final BlockPos pos, final BlockPos size, @NotNull List<PlacementError> placementErrorList)
     {
         for(int z = pos.getZ() - size.getZ() / 2 + 1; z < pos.getZ() + size.getZ() / 2 + 1; z++)
         {
             for(int x = pos.getX() - size.getX() / 2 + 1; x < pos.getX() + size.getX() / 2 + 1; x++)
             {
-                if(!checkIfSolidAndNotInColony(world, new BlockPos(x, pos.getY(), z)))
-                {
-                    return false;
-                }
+                checkIfSolidAndNotInColony(world, new BlockPos(x, pos.getY(), z), placementErrorList);
             }
         }
 
@@ -144,11 +146,13 @@ public class ItemSupplyCampDeployer extends AbstractItemMinecolonies
             {
                 if(!world.isAirBlock(new BlockPos(x, pos.getY()+1, z)))
                 {
-                    return false;
+                    final PlacementError placementError = new PlacementError(PlacementErrorType.NEEDS_AIR_ABOVE, pos);
+                    placementErrorList.add(placementError);
                 }
             }
         }
-        return true;
+
+        return placementErrorList.isEmpty();
     }
 
     /**
@@ -158,9 +162,21 @@ public class ItemSupplyCampDeployer extends AbstractItemMinecolonies
      * @param pos  the position.
      * @return true if is water
      */
-    private static boolean checkIfSolidAndNotInColony(final World world, final BlockPos pos)
+    private static boolean checkIfSolidAndNotInColony(final World world, final BlockPos pos, @NotNull List<PlacementError> placementErrorList)
     {
-        return world.getBlockState(pos).getMaterial().isSolid() && notInAnyColony(world, pos);
+        final boolean isSolid = world.getBlockState(pos).getMaterial().isSolid();
+        final boolean notInAnyColony = notInAnyColony(world, pos);
+        if (!isSolid)
+        {
+            final PlacementError placementError = new PlacementError(PlacementErrorType.NOT_SOLID, pos);
+            placementErrorList.add(placementError);
+        }
+        if (!notInAnyColony)
+        {
+            final PlacementError placementError = new PlacementError(PlacementErrorType.INSIDE_COLONY, pos);
+            placementErrorList.add(placementError);
+        }
+        return isSolid && notInAnyColony;
     }
 
     /**

--- a/src/main/java/com/minecolonies/coremod/placementhandlers/PlacementError.java
+++ b/src/main/java/com/minecolonies/coremod/placementhandlers/PlacementError.java
@@ -1,9 +1,11 @@
 package com.minecolonies.coremod.placementhandlers;
 
 import java.util.ArrayList;
-import java.util.HashMap;
+import java.util.EnumMap;
 import java.util.List;
 import java.util.Map;
+
+import com.google.common.collect.Lists;
 
 import net.minecraft.util.math.BlockPos;
 
@@ -73,15 +75,16 @@ public class PlacementError {
     public static Map<PlacementErrorType, List<BlockPos>> partitionPlacementErrorsByErrorType(
             List<PlacementError> placementErrorList)
     {
-        final Map<PlacementErrorType, List<BlockPos>> blockPosListByErrorTypeMap = new HashMap<PlacementErrorType, List<BlockPos>>();
+        final Map<PlacementErrorType, List<BlockPos>> blockPosListByErrorTypeMap = new EnumMap<>(PlacementErrorType.class);
         for (final PlacementError placementError : placementErrorList)
         {
             final PlacementErrorType key = placementError.getType();
             final BlockPos blockPos = placementError.getPos();
-            List<BlockPos> blockPosList = blockPosListByErrorTypeMap.get(key);
+            List<BlockPos> blockPosList = blockPosListByErrorTypeMap.computeIfAbsent(key, k -> Lists.newArrayList());
+
             if (null == blockPosList)
             {
-                blockPosList = new ArrayList<BlockPos>();
+                blockPosList = new ArrayList<>();
                 blockPosListByErrorTypeMap.put(key, blockPosList);
             }
             blockPosList.add(blockPos);

--- a/src/main/java/com/minecolonies/coremod/placementhandlers/PlacementError.java
+++ b/src/main/java/com/minecolonies/coremod/placementhandlers/PlacementError.java
@@ -18,7 +18,7 @@ public class PlacementError {
     private PlacementErrorType type;
     private BlockPos pos;
     
-    public PlacementError(PlacementErrorType type, BlockPos pos)
+    public PlacementError(final PlacementErrorType type, final BlockPos pos)
     {
         super();
         this.type = type;
@@ -30,7 +30,7 @@ public class PlacementError {
         return type;
     }
 
-    public void setType(PlacementErrorType type)
+    public void setType(final PlacementErrorType type)
     {
         this.type = type;
     }
@@ -40,12 +40,12 @@ public class PlacementError {
         return pos;
     }
 
-    public void setPos(BlockPos pos)
+    public void setPos(final BlockPos pos)
     {
         this.pos = pos;
     }
 
-    public static String blockListToCommaSeparatedString(List<BlockPos> blocksToReportList)
+    public static String blockListToCommaSeparatedString(final List<BlockPos> blocksToReportList)
     {
         final StringBuilder outputListStringBuilder = new StringBuilder();
         boolean firstItem = true;
@@ -57,8 +57,7 @@ public class PlacementError {
             }
             else
             {
-                outputListStringBuilder.append(',');
-                outputListStringBuilder.append(' ');
+                outputListStringBuilder.append(", ");
             }
             outputListStringBuilder.append('(');
             outputListStringBuilder.append(blockPos.getX());

--- a/src/main/java/com/minecolonies/coremod/placementhandlers/PlacementError.java
+++ b/src/main/java/com/minecolonies/coremod/placementhandlers/PlacementError.java
@@ -9,9 +9,11 @@ import com.google.common.collect.Lists;
 
 import net.minecraft.util.math.BlockPos;
 
-public class PlacementError {
+public class PlacementError
+{
 
-    public enum PlacementErrorType {
+    public enum PlacementErrorType
+    {
         NOT_SOLID,
         INSIDE_COLONY,
         NEEDS_AIR_ABOVE

--- a/src/main/java/com/minecolonies/coremod/placementhandlers/PlacementError.java
+++ b/src/main/java/com/minecolonies/coremod/placementhandlers/PlacementError.java
@@ -1,0 +1,93 @@
+package com.minecolonies.coremod.placementhandlers;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import net.minecraft.util.math.BlockPos;
+
+public class PlacementError {
+
+    public enum PlacementErrorType {
+        NOT_SOLID,
+        INSIDE_COLONY,
+        NEEDS_AIR_ABOVE
+    }
+
+    private PlacementErrorType type;
+    private BlockPos pos;
+    
+    public PlacementError(PlacementErrorType type, BlockPos pos)
+    {
+        super();
+        this.type = type;
+        this.pos = pos;
+    }
+
+    public PlacementErrorType getType()
+    {
+        return type;
+    }
+
+    public void setType(PlacementErrorType type)
+    {
+        this.type = type;
+    }
+
+    public BlockPos getPos()
+    {
+        return pos;
+    }
+
+    public void setPos(BlockPos pos)
+    {
+        this.pos = pos;
+    }
+
+    public static String blockListToCommaSeparatedString(List<BlockPos> blocksToReportList)
+    {
+        final StringBuilder outputListStringBuilder = new StringBuilder();
+        boolean firstItem = true;
+        for (final BlockPos blockPos : blocksToReportList)
+        {
+            if (firstItem)
+            {
+                firstItem = false;
+            }
+            else
+            {
+                outputListStringBuilder.append(',');
+                outputListStringBuilder.append(' ');
+            }
+            outputListStringBuilder.append('(');
+            outputListStringBuilder.append(blockPos.getX());
+            outputListStringBuilder.append(' ');
+            outputListStringBuilder.append(blockPos.getY());
+            outputListStringBuilder.append(' ');
+            outputListStringBuilder.append(blockPos.getZ());
+            outputListStringBuilder.append(')');
+        }
+        return outputListStringBuilder.toString();
+    }
+
+    public static Map<PlacementErrorType, List<BlockPos>> partitionPlacementErrorsByErrorType(
+            List<PlacementError> placementErrorList)
+    {
+        final Map<PlacementErrorType, List<BlockPos>> blockPosListByErrorTypeMap = new HashMap<PlacementErrorType, List<BlockPos>>();
+        for (final PlacementError placementError : placementErrorList)
+        {
+            final PlacementErrorType key = placementError.getType();
+            final BlockPos blockPos = placementError.getPos();
+            List<BlockPos> blockPosList = blockPosListByErrorTypeMap.get(key);
+            if (null == blockPosList)
+            {
+                blockPosList = new ArrayList<BlockPos>();
+                blockPosListByErrorTypeMap.put(key, blockPosList);
+            }
+            blockPosList.add(blockPos);
+        }
+        return blockPosListByErrorTypeMap;
+    }
+
+}

--- a/src/main/resources/assets/minecolonies/lang/en_us.lang
+++ b/src/main/resources/assets/minecolonies/lang/en_us.lang
@@ -426,6 +426,9 @@ com.minecolonies.coremod.permission.access_free_blocks=Access free-blocks
 com.minecolonies.coremod.permission.explode=Explode
 
 item.supplyCampDeployer.invalid=Requiring a flat ground of at least 16*17.
+item.supplyCampDeployer.invalid.solid_block_needed=Placing a supply camp requires flat ground of at least 16*17.  These blocks must be solid: %s.
+item.supplyCampDeployer.invalid.air_block_needed=Placing a supply camp requires flat ground of at least 16*17.  These blocks must be air: %s.
+item.supplyCampDeployer.invalid.inside_existing_colony=You cannot place your supply camp near an existing colony.
 item.minecolonies.supplyChestDeployer.name=SupplyShip Chest
 item.minecolonies.supplyCampDeployer.name=SupplyCamp Chest
 com.minecolonies.coremod.error.supplyChestAlreadyPlaced=You have already placed a supply ship or supply camp!


### PR DESCRIPTION
2 Changes proposed in this pull request:
- Show "needs solid block", "needs air block", and "too close to existing colony" warnings along with a list of specific problem blocks (no more than 5 each) when you are unable to place a supply camp.
- Provide infrastructure for improving other placement messages (supply ship, for instance)

Review please
