### PR TITLE
Using the BlockBed spawn code to wakeup Citizens

### DIFF
--- a/src/main/java/com/minecolonies/coremod/entity/EntityCitizen.java
+++ b/src/main/java/com/minecolonies/coremod/entity/EntityCitizen.java
@@ -28,6 +28,7 @@ import com.minecolonies.coremod.network.messages.BlockParticleEffectMessage;
 import com.minecolonies.coremod.network.messages.OpenInventoryMessage;
 import com.minecolonies.coremod.util.*;
 import net.minecraft.block.Block;
+import net.minecraft.block.BlockBed;
 import net.minecraft.block.BlockHorizontal;
 import net.minecraft.block.material.Material;
 import net.minecraft.block.state.IBlockState;
@@ -2096,19 +2097,7 @@ public class EntityCitizen extends EntityAgeable implements INpc
         final BlockPos spawn;
         if (!getBedLocation().equals(BlockPos.ORIGIN))
         {
-            spawn = Utils.scanForBlockNearPoint(
-              world,
-              getBedLocation(),
-              4,
-              2,
-              4,
-              PLAYER_HEIGHT,
-              Blocks.AIR,
-              Blocks.SNOW_LAYER,
-              Blocks.TALLGRASS,
-              Blocks.RED_FLOWER,
-              Blocks.YELLOW_FLOWER,
-              Blocks.CARPET);
+            spawn = BlockBed.getSafeExitLocation(world, getBedLocation(), 0);
         }
         else
         {


### PR DESCRIPTION
## Primary Change / Feature:
Updates the wake up `setPosition(x,y,z)` logic to use the code provided by the `BlockBed` class.
This should now behave like the Player standing up.

## Issues Involved:
Closes #2137 
Closes #2132 
