### PR TITLE
Add abandoned colony and fix bugs with loading

### DIFF
--- a/src/main/java/com/minecolonies/coremod/colony/ColonyList.java
+++ b/src/main/java/com/minecolonies/coremod/colony/ColonyList.java
@@ -181,6 +181,15 @@ public final class ColonyList<T extends IColony> implements Iterable<T>
     }
 
     /**
+     * Get the top colony id.
+     * @return the top id.
+     */
+    public int getTopID()
+    {
+        return topID;
+    }
+
+    /**
      * Return the number of Colonies in the list.
      *
      * @return number of Colonies in the list.

--- a/src/main/java/com/minecolonies/coremod/colony/ColonyManager.java
+++ b/src/main/java/com/minecolonies/coremod/colony/ColonyManager.java
@@ -16,7 +16,6 @@ import com.minecolonies.coremod.blocks.AbstractBlockHut;
 import com.minecolonies.coremod.colony.buildings.AbstractBuilding;
 import com.minecolonies.coremod.colony.buildings.views.AbstractBuildingView;
 import com.minecolonies.coremod.colony.requestsystem.management.manager.StandardRecipeManager;
-import com.minecolonies.coremod.entity.EntityCitizen;
 import com.minecolonies.coremod.util.AchievementUtils;
 import io.netty.buffer.ByteBuf;
 import net.minecraft.client.Minecraft;
@@ -664,7 +663,7 @@ public final class ColonyManager
         final NBTTagCompound recipeCompound = new NBTTagCompound();
         recipeManager.writeToNBT(recipeCompound);
         compound.setTag(RECIPE_MANAGER_TAG, recipeCompound);
-        compound.setInteger(TAG_NEW_COLONIES, colonies.getSize());
+        compound.setInteger(TAG_NEW_COLONIES, colonies.getTopID());
     }
 
     /**
@@ -808,7 +807,7 @@ public final class ColonyManager
             @NotNull final File saveDir = new File(DimensionManager.getWorld(0).getSaveHandler().getWorldDirectory(), FILENAME_MINECOLONIES_PATH);
             final ZipOutputStream zos = new ZipOutputStream(fos);
 
-            for (int i = 0; i < colonies.getSize() + BUFFER; i++)
+            for (int i = 1; i < colonies.getTopID(); i++)
             {
                 @NotNull final File file = new File(saveDir, String.format(FILENAME_COLONY, i));
                 if (file.exists())

--- a/src/main/java/com/minecolonies/coremod/colony/buildings/BuildingLumberjack.java
+++ b/src/main/java/com/minecolonies/coremod/colony/buildings/BuildingLumberjack.java
@@ -87,34 +87,37 @@ public class BuildingLumberjack extends AbstractBuildingWorker
     {
         final Map<Predicate<ItemStack>, Integer> tempKeep = super.getRequiredItemsAndAmount();
 
-        final int invSIze = getMainWorker().getInventory().getSizeInventory();
-        int keptStacks = 0;
-        for(int i = 0; i < invSIze; i++)
+        if(getMainWorker() != null && getMainWorker().getInventory() != null)
         {
-            final ItemStack stack = getMainWorker().getInventory().getStackInSlot(i);
-
-            if(ItemStackUtils.isEmpty(stack) || stack.getItem() != SAPLING_STACK.getItem())
+            final int invSIze = getMainWorker().getInventory().getSizeInventory();
+            int keptStacks = 0;
+            for (int i = 0; i < invSIze; i++)
             {
-                continue;
-            }
+                final ItemStack stack = getMainWorker().getInventory().getStackInSlot(i);
 
-            boolean isAlreadyInList = false;
-            for(final Map.Entry<Predicate<ItemStack>, Integer> entry : tempKeep.entrySet())
-            {
-                if(entry.getKey().test(stack))
+                if (ItemStackUtils.isEmpty(stack) || stack.getItem() != SAPLING_STACK.getItem())
                 {
-                    isAlreadyInList = true;
+                    continue;
                 }
-            }
 
-            if(!isAlreadyInList)
-            {
-                tempKeep.put(stack::isItemEqual, com.minecolonies.api.util.constant.Constants.STACKSIZE);
-                keptStacks++;
-
-                if (keptStacks >= getMaxBuildingLevel() * 2)
+                boolean isAlreadyInList = false;
+                for (final Map.Entry<Predicate<ItemStack>, Integer> entry : tempKeep.entrySet())
                 {
-                    return tempKeep;
+                    if (entry.getKey().test(stack))
+                    {
+                        isAlreadyInList = true;
+                    }
+                }
+
+                if (!isAlreadyInList)
+                {
+                    tempKeep.put(stack::isItemEqual, com.minecolonies.api.util.constant.Constants.STACKSIZE);
+                    keptStacks++;
+
+                    if (keptStacks >= getMaxBuildingLevel() * 2)
+                    {
+                        return tempKeep;
+                    }
                 }
             }
         }

--- a/src/main/java/com/minecolonies/coremod/colony/buildings/BuildingLumberjack.java
+++ b/src/main/java/com/minecolonies/coremod/colony/buildings/BuildingLumberjack.java
@@ -12,8 +12,6 @@ import com.minecolonies.coremod.colony.ColonyManager;
 import com.minecolonies.coremod.colony.ColonyView;
 import com.minecolonies.coremod.colony.jobs.AbstractJob;
 import com.minecolonies.coremod.colony.jobs.JobLumberjack;
-import com.minecolonies.coremod.entity.EntityCitizen;
-import com.minecolonies.api.crafting.ItemStorage;
 import io.netty.buffer.ByteBuf;
 import net.minecraft.init.Blocks;
 import net.minecraft.item.ItemStack;

--- a/src/main/java/com/minecolonies/coremod/commands/colonycommands/ChangeColonyOwnerCommand.java
+++ b/src/main/java/com/minecolonies/coremod/commands/colonycommands/ChangeColonyOwnerCommand.java
@@ -4,6 +4,7 @@ import com.minecolonies.api.colony.IColony;
 import com.minecolonies.coremod.colony.Colony;
 import com.minecolonies.coremod.colony.ColonyManager;
 import com.minecolonies.coremod.commands.AbstractSingleCommand;
+import com.mojang.authlib.GameProfile;
 import net.minecraft.command.CommandException;
 import net.minecraft.command.ICommandSender;
 import net.minecraft.entity.Entity;
@@ -11,11 +12,13 @@ import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.server.MinecraftServer;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.text.TextComponentString;
+import net.minecraftforge.common.util.FakePlayer;
 import org.jetbrains.annotations.NotNull;
 
 import javax.annotation.Nullable;
 import java.util.Collections;
 import java.util.List;
+import java.util.UUID;
 
 /**
  * gives ability to change the colony owner.
@@ -50,7 +53,6 @@ public class ChangeColonyOwnerCommand extends AbstractSingleCommand
     @Override
     public void execute(@NotNull final MinecraftServer server, @NotNull final ICommandSender sender, @NotNull final String... args) throws CommandException
     {
-
         if (args.length < 2)
         {
             sender.sendMessage(new TextComponentString(NO_ARGUMENTS));
@@ -113,11 +115,18 @@ public class ChangeColonyOwnerCommand extends AbstractSingleCommand
             return;
         }
 
-        final EntityPlayer player = sender.getEntityWorld().getPlayerEntityByName(playerName);
+        EntityPlayer player = sender.getEntityWorld().getPlayerEntityByName(playerName);
         if (player == null)
         {
-            sender.sendMessage(new TextComponentString(NO_PLAYER));
-            return;
+            if("[abandoned]".equals(playerName))
+            {
+                player = new FakePlayer(server.getWorld(0), new GameProfile(UUID.randomUUID(), "[abandoned]"));
+            }
+            else
+            {
+                sender.sendMessage(new TextComponentString(NO_PLAYER));
+                return;
+            }
         }
 
         if (ColonyManager.getIColonyByOwner(sender.getEntityWorld(), player) != null)

--- a/src/main/java/com/minecolonies/coremod/entity/EntityCitizen.java
+++ b/src/main/java/com/minecolonies/coremod/entity/EntityCitizen.java
@@ -2094,21 +2094,24 @@ public class EntityCitizen extends EntityAgeable implements INpc
             homeBuilding.onWakeUp();
         }
 
-        final BlockPos spawn;
-        if (!getBedLocation().equals(BlockPos.ORIGIN))
+        //Only do this if he really sleeps
+        if(isAsleep())
         {
-            spawn = BlockBed.getSafeExitLocation(world, getBedLocation(), 0);
-        }
-        else
-        {
-            spawn = getPosition();
-        }
+            final BlockPos spawn;
+            if (!getBedLocation().equals(BlockPos.ORIGIN))
+            {
+                spawn = BlockBed.getSafeExitLocation(world, getBedLocation(), 0);
+            }
+            else
+            {
+                spawn = getPosition();
+            }
 
-        if (spawn != null && !spawn.equals(BlockPos.ORIGIN))
-        {
-            setPosition(spawn.getX(), spawn.getY(), spawn.getZ());
+            if (spawn != null && !spawn.equals(BlockPos.ORIGIN))
+            {
+                setPosition(spawn.getX(), spawn.getY(), spawn.getZ());
+            }
         }
-
         setIsAsleep(false);
         dataManager.set(DATA_BED_POS, new BlockPos(0, 0, 0));
     }


### PR DESCRIPTION
Closes #1299 

# Changes proposed in this pull request:
- This fixes a bug where not enough colonies get loaded after deleting more than the buffer.
- This allows to abandon your colony now. Just transfer ownership to [abandoned] and the colony will be transferred to a fake player allowing the player to create a new colony. He can also add himself as an officer via command so he might even control both.
- Fix bug where sleeping colonists die (since they're not in a bed and search a tp location)

Review please
