### PR TITLE
Preventing none sleeping citizens from waking up.

### DIFF
--- a/src/main/java/com/minecolonies/coremod/entity/EntityCitizen.java
+++ b/src/main/java/com/minecolonies/coremod/entity/EntityCitizen.java
@@ -2094,6 +2094,11 @@ public class EntityCitizen extends EntityAgeable implements INpc
             homeBuilding.onWakeUp();
         }
 
+        if (!isAsleep())
+        {
+            return;
+        }
+
         final BlockPos spawn;
         if (!getBedLocation().equals(BlockPos.ORIGIN))
         {


### PR DESCRIPTION
## Primary Change / Feature
This prevents citizens that are not asleep (due to there not being enough beds) from being teleported once and for all.

