### PR TITLE
Adding new construction tape models.

### DIFF
--- a/src/main/java/com/minecolonies/coremod/entity/ai/citizen/builder/ConstructionTapeHelper.java
+++ b/src/main/java/com/minecolonies/coremod/entity/ai/citizen/builder/ConstructionTapeHelper.java
@@ -14,6 +14,7 @@ import net.minecraft.util.EnumFacing;
 import net.minecraft.util.Tuple;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.World;
+import net.minecraft.world.chunk.Chunk;
 import org.jetbrains.annotations.NotNull;
 
 /**
@@ -144,29 +145,18 @@ public final class ConstructionTapeHelper
 
     public static int checkIfPlaceable(@NotNull final int x, @NotNull final int y, @NotNull final int z, @NotNull final World world)
     {
-        int newY = y;
-        boolean working = true;
-        while (working)
+        BlockPos target = new BlockPos(x,y,z);
+        final Chunk chunk = world.getChunkFromBlockCoords(target);
+
+        target = new BlockPos(x, chunk.getTopFilledSegment() + 16, z);
+        while(world.getBlockState(target).getMaterial().isReplaceable())
         {
-            final BlockPos block = new BlockPos(x, newY, z);
-            final BlockPos blockMin1 = new BlockPos(x, newY - 1, z);
-            if (world.getBlockState(block).getMaterial().isReplaceable())
-            {
-                if (world.getBlockState(blockMin1).getMaterial().isReplaceable() && newY >= 1)
-                {
-                    newY = newY - 1;
-                }
-                else
-                {
-                    working = false;
-                }
-            }
-            else
-            {
-                newY = newY + 1;
-            }
+            target = target.down();
+            if (target.getY() == 0)
+                break;
         }
-        return newY > 0 ? newY : y;
+
+        return target.getY() + 1;
     }
 
     /**

--- a/src/main/java/com/minecolonies/coremod/entity/ai/citizen/builder/ConstructionTapeHelper.java
+++ b/src/main/java/com/minecolonies/coremod/entity/ai/citizen/builder/ConstructionTapeHelper.java
@@ -153,7 +153,9 @@ public final class ConstructionTapeHelper
         {
             target = target.down();
             if (target.getY() == 0)
+            {
                 break;
+            }
         }
 
         return target.getY() + 1;

--- a/src/main/java/com/minecolonies/coremod/network/messages/BuildToolPasteMessage.java
+++ b/src/main/java/com/minecolonies/coremod/network/messages/BuildToolPasteMessage.java
@@ -12,6 +12,8 @@ import com.minecolonies.coremod.colony.ColonyManager;
 import com.minecolonies.coremod.colony.StructureName;
 import com.minecolonies.coremod.colony.Structures;
 import com.minecolonies.coremod.colony.buildings.AbstractBuilding;
+import com.minecolonies.coremod.colony.workorders.WorkOrderBuild;
+import com.minecolonies.coremod.entity.ai.citizen.builder.ConstructionTapeHelper;
 import com.minecolonies.coremod.event.EventHandler;
 import com.minecolonies.coremod.items.ModItems;
 import com.minecolonies.coremod.util.StructureWrapper;
@@ -177,8 +179,20 @@ public class BuildToolPasteMessage extends AbstractMessage<BuildToolPasteMessage
             {
                 handleHut(CompatibilityUtils.getWorld(player), player, sn, message.rotation, message.pos, message.mirror);
             }
+
+
             StructureWrapper.loadAndPlaceStructureWithRotation(player.world, message.structureName,
               message.pos, message.rotation, message.mirror ? Mirror.FRONT_BACK : Mirror.NONE, message.complete);
+
+            if (message.isHut)
+            {
+                @Nullable final AbstractBuilding building = ColonyManager.getBuilding(CompatibilityUtils.getWorld(player), message.pos);
+                if (building != null)
+                {
+                    final WorkOrderBuild workOrder = new WorkOrderBuild(building, 1);
+                    ConstructionTapeHelper.removeConstructionTape(workOrder, CompatibilityUtils.getWorld(player));
+                }
+            }
         }
         else if(message.freeMode !=  null )
         {

--- a/src/main/resources/assets/minecolonies/models/block/blockconstructiontape.json
+++ b/src/main/resources/assets/minecolonies/models/block/blockconstructiontape.json
@@ -1,219 +1,74 @@
 {
-  "__comment": "Model generated using MrCrayfish's Model Creator (http://mrcrayfish.com/modelcreator/)",
+  "__comment": "Minecolonies normal construction tape.",
   "textures": {
-    "particle": "minecolonies:blocks/constructionTape/constructionTape_south",
-    "0": "minecolonies:blocks/constructionTape/constructionTape_north",
-    "1": "minecolonies:blocks/constructionTape/constructionTape_east-west",
-    "2": "minecolonies:blocks/constructionTape/constructionTape_south",
-    "3": "minecolonies:blocks/constructionTape/constructionTape_up-down"
-
+    "particle": "blocks/planks_oak",
+    "0": "blocks/door_iron_lower",
+    "1": "blocks/planks_oak"
   },
   "elements": [
     {
-      "name": "Cube",
-      "from": [
-        0.0,
-        0.0,
-        7.0
-      ],
-      "to": [
-        1.0,
-        16.0,
-        9.0
-      ],
+      "__comment": "PostLeft",
+      "from": [ 0, 0, 6 ],
+      "to": [ 1, 16, 10 ],
       "faces": {
-        "north": {
-          "texture": "#0",
-          "uv": [
-            0.0,
-            0.0,
-            1.0,
-            16.0
-          ]
-        },
-        "east": {
-          "texture": "#1",
-          "uv": [
-            0.0,
-            0.0,
-            2.0,
-            16.0
-          ]
-        },
-        "south": {
-          "texture": "#2",
-          "uv": [
-            0.0,
-            0.0,
-            1.0,
-            16.0
-          ]
-        },
-        "west": {
-          "texture": "#1",
-          "uv": [
-            0.0,
-            0.0,
-            2.0,
-            16.0
-          ]
-        },
-        "up": {
-          "texture": "#3",
-          "uv": [
-            0.0,
-            0.0,
-            1.0,
-            2.0
-          ]
-        },
-        "down": {
-          "texture": "#3",
-          "uv": [
-            0.0,
-            0.0,
-            1.0,
-            2.0
-          ]
-        }
+        "down": { "uv": [ 0, 0, 3.5, 1 ], "texture": "#1" },
+        "up": { "uv": [ 0, 0, 4, 1 ], "texture": "#1", "rotation": 90 },
+        "north": { "uv": [ 4, 0, 5, 16 ], "texture": "#1" },
+        "south": { "uv": [ 12, 0, 13, 16 ], "texture": "#1" },
+        "west": { "uv": [ 5, 0, 9, 16 ], "texture": "#1", "rotation": 180 },
+        "east": { "uv": [ 9, 0, 13, 16 ], "texture": "#1" }
       }
     },
     {
-      "name": "Cube",
-      "from": [
-        15.0,
-        0.0,
-        7.0
-      ],
-      "to": [
-        16.0,
-        16.0,
-        9.0
-      ],
+      "__comment": "PostRight",
+      "from": [ 15, 0, 6 ],
+      "to": [ 16, 16, 10 ],
       "faces": {
-        "north": {
-          "texture": "#0",
-          "uv": [
-            1.0,
-            0.0,
-            0.0,
-            16.0
-          ]
-        },
-        "east": {
-          "texture": "#1",
-          "uv": [
-            0.0,
-            0.0,
-            2.0,
-            16.0
-          ]
-        },
-        "south": {
-          "texture": "#2",
-          "uv": [
-            15.0,
-            0.0,
-            16.0,
-            16.0
-          ]
-        },
-        "west": {
-          "texture": "#1",
-          "uv": [
-            0.0,
-            0.0,
-            2.0,
-            16.0
-          ]
-        },
-        "up": {
-          "texture": "#3",
-          "uv": [
-            0.0,
-            0.0,
-            1.0,
-            2.0
-          ]
-        },
-        "down": {
-          "texture": "#3",
-          "uv": [
-            0.0,
-            0.0,
-            1.0,
-            2.0
-          ]
-        }
+        "down": { "uv": [ 0, 0, 3.5, 1 ], "texture": "#1" },
+        "up": { "uv": [ 0, 0, 4, 1 ], "texture": "#1", "rotation": 90 },
+        "north": { "uv": [ 4, 0, 5, 16 ], "texture": "#1" },
+        "south": { "uv": [ 12, 0, 13, 16 ], "texture": "#1" },
+        "west": { "uv": [ 5, 0, 9, 16 ], "texture": "#1", "rotation": 180 },
+        "east": { "uv": [ 9, 0, 13, 16 ], "texture": "#1" }
       }
     },
     {
-      "name": "Cube",
-      "from": [
-        1.0,
-        12.0,
-        9.0
-      ],
-      "to": [
-        15.0,
-        15.0,
-        9.0
-      ],
+      "__comment": "Chain2",
+      "from": [ 13, 14, 7 ],
+      "to": [ 15, 15, 9 ],
       "faces": {
-        "north": {
-          "texture": "#0",
-          "uv": [
-            1.0,
-            1.0,
-            15.0,
-            4.0
-          ]
-        },
-        "east": {
-          "texture": "#-1",
-          "uv": [
-            0.0,
-            0.0,
-            0.0,
-            3.0
-          ]
-        },
-        "south": {
-          "texture": "#2",
-          "uv": [
-            1.0,
-            1.0,
-            15.0,
-            4.0
-          ]
-        },
-        "west": {
-          "texture": "#-1",
-          "uv": [
-            0.0,
-            0.0,
-            0.0,
-            3.0
-          ]
-        },
-        "up": {
-          "texture": "#-1",
-          "uv": [
-            0.0,
-            0.0,
-            14.0,
-            0.0
-          ]
-        },
-        "down": {
-          "texture": "#-1",
-          "uv": [
-            0.0,
-            0.0,
-            14.0,
-            0.0
-          ]
-        }
+        "down": { "uv": [ 0, 13, 2, 15 ], "texture": "#0" },
+        "up": { "uv": [ 0, 13, 2, 15 ], "texture": "#0" },
+        "north": { "uv": [ 1, 13, 3, 15 ], "texture": "#0" },
+        "south": { "uv": [ 1, 13, 3, 15 ], "texture": "#0" },
+        "west": { "uv": [ 1, 13, 2, 15 ], "texture": "#0" },
+        "east": { "uv": [ 0, 13, 1, 15 ], "texture": "#0" }
+      }
+    },
+    {
+      "__comment": "Chain1",
+      "from": [ 3, 13, 7 ],
+      "to": [ 13, 14, 9 ],
+      "faces": {
+        "down": { "uv": [ 2.5, 14, 12.5, 16 ], "texture": "#0" },
+        "up": { "uv": [ 3, 14, 13, 16 ], "texture": "#0" },
+        "north": { "uv": [ 3, 14, 13, 15 ], "texture": "#0" },
+        "south": { "uv": [ 3, 15, 13, 16 ], "texture": "#0" },
+        "west": { "uv": [ 15, 14, 16, 16 ], "texture": "#0" },
+        "east": { "uv": [ 15, 14, 16, 16 ], "texture": "#0" }
+      }
+    },
+    {
+      "__comment": "Chain0",
+      "from": [ 1, 14, 7 ],
+      "to": [ 3, 15, 9 ],
+      "faces": {
+        "down": { "uv": [ 0, 13, 2, 15 ], "texture": "#0" },
+        "up": { "uv": [ 0, 13, 2, 15 ], "texture": "#0" },
+        "north": { "uv": [ 1, 13, 3, 15 ], "texture": "#0" },
+        "south": { "uv": [ 1, 13, 3, 15 ], "texture": "#0" },
+        "west": { "uv": [ 1, 13, 2, 15 ], "texture": "#0" },
+        "east": { "uv": [ 0, 13, 1, 15 ], "texture": "#0" }
       }
     }
   ]

--- a/src/main/resources/assets/minecolonies/models/block/blockconstructiontapecorner.json
+++ b/src/main/resources/assets/minecolonies/models/block/blockconstructiontapecorner.json
@@ -1,360 +1,74 @@
 {
-  "__comment": "Model generated using MrCrayfish's Model Creator (http://mrcrayfish.com/modelcreator/)",
+  "__comment": "MineColonies Construction Tape Corner",
   "textures": {
-    "particle": "minecolonies:blocks/constructionTape/constructionTape_south",
-    "0": "minecolonies:blocks/constructionTape/constructionTape_north",
-    "1": "minecolonies:blocks/constructionTape/constructionTape_east-west",
-    "2": "minecolonies:blocks/constructionTape/constructionTape_south",
-    "3": "minecolonies:blocks/constructionTape/constructionTape_up-down",
-    "4": "minecolonies:blocks/constructionTape/constructionTape_corner",
-    "5": "minecolonies:blocks/constructionTape/constructionTape_corner2",
-    "6": "minecolonies:blocks/constructionTape/constructionTapeStudMiddle",
-    "7": "minecolonies:blocks/constructionTape/constructionTapeStudMiddle2"
+    "particle": "blocks/planks_oak",
+    "0": "blocks/door_iron_lower",
+    "1": "blocks/planks_oak"
   },
   "elements": [
     {
-      "name": "StudU",
-      "from": [
-        0.0,
-        0.0,
-        7.0
-      ],
-      "to": [
-        1.0,
-        16.0,
-        9.0
-      ],
+      "__comment": "PostLeft",
+      "from": [ 0, 0, 6 ],
+      "to": [ 2, 16, 10 ],
       "faces": {
-        "north": {
-          "texture": "#0",
-          "uv": [
-            0.0,
-            0.0,
-            1.0,
-            16.0
-          ]
-        },
-        "east": {
-          "texture": "#1",
-          "uv": [
-            0.0,
-            0.0,
-            2.0,
-            16.0
-          ]
-        },
-        "south": {
-          "texture": "#4",
-          "uv": [
-            0.0,
-            0.0,
-            0.0,
-            16.0
-          ]
-        },
-        "west": {
-          "texture": "#1",
-          "uv": [
-            0.0,
-            0.0,
-            2.0,
-            16.0
-          ]
-        },
-        "up": {
-          "texture": "#3",
-          "uv": [
-            0.0,
-            0.0,
-            1.0,
-            2.0
-          ]
-        },
-        "down": {
-          "texture": "#3",
-          "uv": [
-            0.0,
-            0.0,
-            1.0,
-            2.0
-          ]
-        }
+        "down": { "uv": [ 0, 0, 2, 4 ], "texture": "#1" },
+        "up": { "uv": [ 7, 3, 9, 7 ], "texture": "#1" },
+        "north": { "uv": [ 0, 0, 2, 16 ], "texture": "#1", "rotation": 180 },
+        "south": { "uv": [ 6, 0, 8, 16 ], "texture": "#1", "rotation": 180 },
+        "west": { "uv": [ 2, 0, 6, 16 ], "texture": "#1", "rotation": 180 },
+        "east": { "uv": [ 10, 0, 14, 16 ], "texture": "#1", "rotation": 180 }
       }
     },
     {
-      "name": "StudMiddle",
-      "from": [
-        7.0,
-        0.0,
-        7.0
-      ],
-      "to": [
-        9.0,
-        16.0,
-        9.0
-      ],
+      "__comment": "PostCenter",
+      "from": [ 6, 0, 6 ],
+      "to": [ 10, 16, 10 ],
       "faces": {
-        "north": {
-          "texture": "#0",
-          "uv": [
-            0.0,
-            0.0,
-            1.0,
-            16.0
-          ]
-        },
-        "east": {
-          "texture": "#7",
-          "uv": [
-            8.0,
-            0.0,
-            10.0,
-            16.0
-          ]
-        },
-        "south": {
-          "texture": "#6",
-          "uv": [
-            7.0,
-            0.0,
-            9.0,
-            16.0
-          ]
-        },
-        "west": {
-          "texture": "#1",
-          "uv": [
-            0.0,
-            0.0,
-            2.0,
-            16.0
-          ]
-        },
-        "up": {
-          "texture": "#3",
-          "uv": [
-            0.0,
-            0.0,
-            1.0,
-            2.0
-          ]
-        },
-        "down": {
-          "texture": "#3",
-          "uv": [
-            0.0,
-            0.0,
-            1.0,
-            2.0
-          ]
-        }
+        "down": { "uv": [ 0, 0, 4, 4 ], "texture": "#1" },
+        "up": { "uv": [ 0, 0, 4, 4 ], "texture": "#1" },
+        "north": { "uv": [ 0, 0, 4, 16 ], "texture": "#1", "rotation": 180 },
+        "south": { "uv": [ 4, 0, 8, 16 ], "texture": "#1", "rotation": 180 },
+        "west": { "uv": [ 8, 0, 12, 16 ], "texture": "#1", "rotation": 180 },
+        "east": { "uv": [ 12, 0, 16, 16 ], "texture": "#1", "rotation": 180 }
       }
     },
     {
-      "name": "StudN",
-      "from": [
-        7.0,
-        0.0,
-        0.0
-      ],
-      "to": [
-        9.0,
-        16.0,
-        1.0
-      ],
+      "__comment": "PostTop",
+      "from": [ 6, 0, 0 ],
+      "to": [ 10, 16, 2 ],
       "faces": {
-        "north": {
-          "texture": "#0",
-          "uv": [
-            1.0,
-            0.0,
-            0.0,
-            16.0
-          ]
-        },
-        "east": {
-          "texture": "#2",
-          "uv": [
-            15.7,
-            0.0,
-            16.0,
-            16.0
-          ]
-        },
-        "south": {
-          "texture": "#1",
-          "uv": [
-            0.0,
-            0.0,
-            2.0,
-            16.0
-          ]
-        },
-        "west": {
-          "texture": "#1",
-          "uv": [
-            0.0,
-            0.0,
-            0.0,
-            16.0
-          ]
-        },
-        "up": {
-          "texture": "#3",
-          "uv": [
-            0.0,
-            0.0,
-            1.0,
-            2.0
-          ]
-        },
-        "down": {
-          "texture": "#3",
-          "uv": [
-            0.0,
-            0.0,
-            1.0,
-            2.0
-          ]
-        }
+        "down": { "uv": [ 0, 0, 2, 4 ], "texture": "#1", "rotation": 90 },
+        "up": { "uv": [ 7, 3, 9, 7 ], "texture": "#1", "rotation": 90 },
+        "north": { "uv": [ 0, 0, 4, 16 ], "texture": "#1", "rotation": 180 },
+        "south": { "uv": [ 6, 0, 10, 16 ], "texture": "#1", "rotation": 180 },
+        "west": { "uv": [ 12, 0, 14, 16 ], "texture": "#1", "rotation": 180 },
+        "east": { "uv": [ 10, 0, 14, 16 ], "texture": "#1", "rotation": 180 }
       }
     },
     {
-      "name": "BandUnderC",
-      "from": [
-        1.0,
-        12.0,
-        9.0
-      ],
-      "to": [
-        7.0,
-        15.0,
-        9.0
-      ],
+      "__comment": "ChainBottom",
+      "from": [ 1, 14, 7 ],
+      "to": [ 7, 15, 9 ],
       "faces": {
-        "north": {
-          "texture": "#0",
-          "uv": [
-            1.0,
-            1.0,
-            15.0,
-            4.0
-          ]
-        },
-        "east": {
-          "texture": "#1",
-          "uv": [
-            0.0,
-            0.0,
-            0.0,
-            3.0
-          ]
-        },
-        "south": {
-          "texture": "#5",
-          "uv": [
-            1.0,
-            1.0,
-            7.0,
-            4.0
-          ]
-        },
-        "west": {
-          "texture": "#1",
-          "uv": [
-            0.0,
-            0.0,
-            0.0,
-            3.0
-          ]
-        },
-        "up": {
-          "texture": "#1",
-          "uv": [
-            0.0,
-            0.0,
-            14.0,
-            0.0
-          ]
-        },
-        "down": {
-          "texture": "#1",
-          "uv": [
-            0.0,
-            0.0,
-            14.0,
-            0.0
-          ]
-        }
+        "down": { "uv": [ 1, 7, 7, 9 ], "texture": "#0" },
+        "up": { "uv": [ 1, 7, 7, 9 ], "texture": "#0" },
+        "north": { "uv": [ 9, 1, 15, 2 ], "texture": "#0" },
+        "south": { "uv": [ 1, 1, 7, 2 ], "texture": "#0" },
+        "west": { "uv": [ 7, 1, 9, 2 ], "texture": "#0" },
+        "east": { "uv": [ 7, 1, 9, 2 ], "texture": "#0" }
       }
     },
     {
-      "name": "Band-struction",
-      "from": [
-        9.0,
-        12.0,
-        1.0
-      ],
-      "to": [
-        9.0,
-        15.0,
-        7.0
-      ],
+      "__comment": "ChainRight",
+      "from": [ 7, 14, 1 ],
+      "to": [ 9, 15, 7 ],
       "faces": {
-        "north": {
-          "texture": "#0",
-          "uv": [
-            1.0,
-            1.0,
-            15.0,
-            4.0
-          ]
-        },
-        "east": {
-          "texture": "#5",
-          "uv": [
-            -6.0,
-            1.0,
-            0.0,
-            4.0
-          ]
-        },
-        "south": {
-          "texture": "#4",
-          "uv": [
-            7.0,
-            1.0,
-            9.0,
-            4.0
-          ]
-        },
-        "west": {
-          "texture": "#0",
-          "uv": [
-            1.0,
-            1.0,
-            15.0,
-            4.0
-          ]
-        },
-        "up": {
-          "texture": "#1",
-          "uv": [
-            0.0,
-            0.0,
-            14.0,
-            0.0
-          ]
-        },
-        "down": {
-          "texture": "#1",
-          "uv": [
-            0.0,
-            0.0,
-            14.0,
-            0.0
-          ]
-        }
+        "down": { "uv": [ 7, 9, 9, 15 ], "texture": "#0" },
+        "up": { "uv": [ 7, 1, 9, 7 ], "texture": "#0" },
+        "north": { "uv": [ 7, 1, 9, 2 ], "texture": "#0" },
+        "south": { "uv": [ 7, 1, 9, 2 ], "texture": "#0" },
+        "west": { "uv": [ 1, 1, 7, 2 ], "texture": "#0" },
+        "east": { "uv": [ 9, 1, 15, 2 ], "texture": "#0" }
       }
     }
   ]


### PR DESCRIPTION
## Primary Change / Feature:
Updated the construction tape Model.
Model created by: @Imrielle

## Secondary Change / Feature:
Improve the placement of the construction tape by the build tool:
- Construction tape now gets place over all replaceable blocks. (Like tall grass and flowers)
- Creatively pasted buildings now get their construction tape removed since they get build properly in creative mode due to changes in: #2130 (Secondary Feature)

## Images
#### New design of the tape
![2018-02-06_07 49 54](https://user-images.githubusercontent.com/5585406/35845441-b8004122-0b12-11e8-9402-ee3473562b53.png)
#### Tape placement over replaceable blocks
![2018-02-07_09 28 18](https://user-images.githubusercontent.com/5585406/35906492-07cef1b6-0beb-11e8-80da-f212d520b297.png)
#### Creatively build buildings do not have construction tape around them anymore
![2018-02-07_09 36 47](https://user-images.githubusercontent.com/5585406/35906512-1a3627ac-0beb-11e8-85fc-3ccb6be7fac4.png)


