### PR TITLE
Fixing citizen waking up.

### DIFF
--- a/src/main/java/com/minecolonies/coremod/entity/EntityCitizen.java
+++ b/src/main/java/com/minecolonies/coremod/entity/EntityCitizen.java
@@ -2112,7 +2112,7 @@ public class EntityCitizen extends EntityAgeable implements INpc
 
         if (spawn != null && !spawn.equals(BlockPos.ORIGIN))
         {
-            setPosition(spawn.getX(), spawn.getY(), spawn.getZ());
+            setPosition(spawn.getX() + Constants.HALF_BLOCK, spawn.getY() + Constants.HALF_BLOCK, spawn.getZ() + Constants.HALF_BLOCK);
         }
 
         setIsAsleep(false);


### PR DESCRIPTION
## Primary feature / change.
Fix citizens waking up in wall due to a partial spawn in block, which disables their AI (vanilla MC behaviour)

## Closes issues:
Closes #2157 