### PR TITLE
Fix INVENTORY_FULL state for AIs without full inventory (#2179)

### DIFF
--- a/src/main/java/com/minecolonies/coremod/entity/ai/basic/AbstractEntityAIBasic.java
+++ b/src/main/java/com/minecolonies/coremod/entity/ai/basic/AbstractEntityAIBasic.java
@@ -874,6 +874,10 @@ public abstract class AbstractEntityAIBasic<J extends AbstractJob> extends Abstr
         {
             chatSpamFilter.talkWithoutSpam(COM_MINECOLONIES_COREMOD_ENTITY_WORKER_INVENTORYFULLCHEST);
         }
+        if (isBuildingChestFull())
+        {
+            chatSpamFilter.talkWithoutSpam(COM_MINECOLONIES_COREMOD_ENTITY_WORKER_INVENTORYFULLCHEST);
+        }
         //collect items that are nice to have if they are available
         this.itemsNiceToHave().forEach(this::isInHut);
         // we dumped the inventory, reset actions done
@@ -909,10 +913,19 @@ public abstract class AbstractEntityAIBasic<J extends AbstractJob> extends Abstr
      */
     private boolean isInventoryAndChestFull()
     {
+        return InventoryUtils.isProviderFull(worker) && isBuildingChestFull();
+    }
+
+    /**
+     * Checks if the worker building chest is full.
+     *
+     * @return true if full
+     */
+    private boolean isBuildingChestFull()
+    {
         @Nullable final AbstractBuildingWorker buildingWorker = getOwnBuilding();
-        return InventoryUtils.isProviderFull(worker)
-                 && (buildingWorker != null
-                       && InventoryUtils.isProviderFull(buildingWorker.getTileEntity()));
+        return buildingWorker != null
+               && InventoryUtils.isProviderFull(buildingWorker.getTileEntity());
     }
 
     /**


### PR DESCRIPTION
Closes ##2179

Changes proposed in this pull request:
- If AI wants to dump inventory into a chest, but chest is full, stay in INVENTORY_FULL state even if AI inventory is not full.  (Currently switches to IDLE)

This is a work in progress.   There's no point in checking first for chest-full & inventory-full, then checking for only chest-full.    This fix probably adversely affects other AIs who should go to an IDLE state if the chest is full and the inventory is not.

A better fix would check a method on the AI to determine whether to stay in INVENTORY_FULL or IDLE if the chest is full but the inventory is not.

The best fix would be to add a new AI state or rename this state as INVENTORY_FULL doesn't accurately describe the current state.

Review please
