### PR TITLE
Clean up ai cook v2

### DIFF
--- a/src/api/java/com/minecolonies/api/util/constant/TranslationConstants.java
+++ b/src/api/java/com/minecolonies/api/util/constant/TranslationConstants.java
@@ -156,6 +156,16 @@ public final class TranslationConstants
     @NonNls
     public static final String COM_MINECOLONIES_PRIVATE_CRAFTING_RESOLVER_NAME                     = "com.minecolonies.coremod.resolvers.crafter.private";
     @NonNls
+    public static final String COM_MINECOLONIES_COREMOD_STATUS_COOKING                             = "com.minecolonies.coremod.status.cooking";
+    @NonNls
+    public static final String COM_MINECOLONIES_COREMOD_STATUS_GATHERING                           = "com.minecolonies.coremod.status.gathering";
+    @NonNls
+    public static final String COM_MINECOLONIES_COREMOD_STATUS_IDLING                             = "com.minecolonies.coremod.status.idling";
+    @NonNls
+    public static final String COM_MINECOLONIES_COREMOD_STATUS_RETRIEVING                          = "com.minecolonies.coremod.status.retrieving";
+    @NonNls
+    public static final String COM_MINECOLONIES_COREMOD_STATUS_SERVING                             = "com.minecolonies.coremod.status.serving";
+    @NonNls
     public static final String COM_MINECOLONIES_COREMOD_STATUS_HERDER_DECIDING                     = "com.minecolonies.coremod.status.herder.deciding";
     @NonNls
     public static final String COM_MINECOLONIES_COREMOD_STATUS_HERDER_GOINGTOHUT                   = "com.minecolonies.coremod.status.herder.goingToHut";

--- a/src/api/java/com/minecolonies/api/util/constant/TranslationConstants.java
+++ b/src/api/java/com/minecolonies/api/util/constant/TranslationConstants.java
@@ -110,6 +110,8 @@ public final class TranslationConstants
     @NonNls
     public static final String COM_MINECOLONIES_REQUESTS_DELIVERY                                  = "com.minecolonies.coremod.request.delivery";
     @NonNls
+    public static final String COM_MINECOLONIES_REQUESTS_COOKED_FOOD                               = "com.minecolonies.coremod.request.cookedFood";
+    @NonNls
     public static final String COM_MINECOLONIES_REQUESTS_FOOD                                      = "com.minecolonies.coremod.request.food";
     @NonNls
     public static final String COM_MINECOLONIES_REQUESTS_BURNABLE                                  = "com.minecolonies.coremod.request.burnable";
@@ -158,15 +160,17 @@ public final class TranslationConstants
     @NonNls
     public static final String COM_MINECOLONIES_COREMOD_STATUS_COOKING                             = "com.minecolonies.coremod.status.cooking";
     @NonNls
+    public static final String COM_MINECOLONIES_COREMOD_STATUS_DECIDING                            = "com.minecolonies.coremod.status.deciding";
+    @NonNls
     public static final String COM_MINECOLONIES_COREMOD_STATUS_GATHERING                           = "com.minecolonies.coremod.status.gathering";
     @NonNls
-    public static final String COM_MINECOLONIES_COREMOD_STATUS_IDLING                             = "com.minecolonies.coremod.status.idling";
+    public static final String COM_MINECOLONIES_COREMOD_STATUS_IDLING                              = "com.minecolonies.coremod.status.idling";
     @NonNls
     public static final String COM_MINECOLONIES_COREMOD_STATUS_RETRIEVING                          = "com.minecolonies.coremod.status.retrieving";
     @NonNls
     public static final String COM_MINECOLONIES_COREMOD_STATUS_SERVING                             = "com.minecolonies.coremod.status.serving";
     @NonNls
-    public static final String COM_MINECOLONIES_COREMOD_STATUS_HERDER_DECIDING                     = "com.minecolonies.coremod.status.herder.deciding";
+    public static final String COM_MINECOLONIES_COREMOD_STATUS_WAITING_FOR                         = "com.minecolonies.coremod.status.waiting";
     @NonNls
     public static final String COM_MINECOLONIES_COREMOD_STATUS_HERDER_GOINGTOHUT                   = "com.minecolonies.coremod.status.herder.goingToHut";
     @NonNls

--- a/src/main/java/com/minecolonies/coremod/colony/buildings/BuildingCook.java
+++ b/src/main/java/com/minecolonies/coremod/colony/buildings/BuildingCook.java
@@ -65,6 +65,7 @@ public class BuildingCook extends AbstractBuildingWorker
     /**
      * Is true when the Cook put something in the oven.
      */
+    // TODO: this field is never used outside of load/save.  Should be removed.
     private boolean isOvenFull = true;
 
     /**
@@ -157,10 +158,12 @@ public class BuildingCook extends AbstractBuildingWorker
     }
 
     /**
-     * Check if something is in the oven of th ecook.
+     * Check if something is waiting to be cooked in at least one oven.
      *
+     * @param world needed for finding tile entities
      * @return true if so.
      */
+    // TODO: doesn't seem to be consistent to have this, and only this, AI-called method in the building.
     public boolean isSomethingInOven(final World world)
     {
         for (final BlockPos pos : getFurnaces())

--- a/src/main/java/com/minecolonies/coremod/colony/buildings/BuildingCook.java
+++ b/src/main/java/com/minecolonies/coremod/colony/buildings/BuildingCook.java
@@ -13,7 +13,6 @@ import net.minecraft.block.BlockFurnace;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.nbt.NBTTagList;
 import net.minecraft.nbt.NBTUtil;
-import net.minecraft.tileentity.TileEntity;
 import net.minecraft.tileentity.TileEntityFurnace;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.World;
@@ -24,7 +23,6 @@ import java.util.ArrayList;
 import java.util.List;
 
 import static com.minecolonies.api.util.constant.Suppression.OVERRIDE_EQUALS;
-import static com.minecolonies.coremod.entity.ai.citizen.cook.EntityAIWorkCook.COOK_SLOT;
 
 /**
  * Class of the cook building.
@@ -155,27 +153,6 @@ public class BuildingCook extends AbstractBuildingWorker
             furnaces.add(pos);
         }
         markDirty();
-    }
-
-    /**
-     * Check if something is waiting to be cooked in at least one oven.
-     *
-     * @param world needed for finding tile entities
-     * @return true if so.
-     */
-    // TODO: doesn't seem to be consistent to have this, and only this, AI-called method in the building.
-    public boolean isSomethingInOven(final World world)
-    {
-        for (final BlockPos pos : getFurnaces())
-        {
-            final TileEntity entity = world.getTileEntity(pos);
-            if (entity instanceof TileEntityFurnace && !((TileEntityFurnace) entity).isBurning()
-                && !ItemStackUtils.isEmpty(((TileEntityFurnace) entity).getStackInSlot(COOK_SLOT)))
-            {
-                return true;
-            }
-        }
-        return false;
     }
 
     /**

--- a/src/main/java/com/minecolonies/coremod/colony/buildings/BuildingCook.java
+++ b/src/main/java/com/minecolonies/coremod/colony/buildings/BuildingCook.java
@@ -51,20 +51,9 @@ public class BuildingCook extends AbstractBuildingWorker
     private static final String TAG_FURNACES = "furnaces";
 
     /**
-     * Tag to store status of ovens to NBT.
-     */
-    private static final String TAG_COOKING = "cooking";
-
-    /**
      * List of registered furnaces.
      */
     private final List<BlockPos> furnaces = new ArrayList<>();
-
-    /**
-     * Is true when the Cook put something in the oven.
-     */
-    // TODO: this field is never used outside of load/save.  Should be removed.
-    private boolean isOvenFull = true;
 
     /**
      * Instantiates a new cook building.
@@ -129,7 +118,6 @@ public class BuildingCook extends AbstractBuildingWorker
             furnacesTagList.appendTag(furnaceCompound);
         }
         compound.setTag(TAG_FURNACES, furnacesTagList);
-        compound.setBoolean(TAG_COOKING, isOvenFull);
     }
 
     @Override
@@ -141,7 +129,6 @@ public class BuildingCook extends AbstractBuildingWorker
         {
             furnaces.add(NBTUtil.getPosFromTag(furnaceTagList.getCompoundTagAt(i).getCompoundTag(TAG_POS)));
         }
-        isOvenFull = compound.getBoolean(TAG_COOKING);
     }
 
     @Override

--- a/src/main/java/com/minecolonies/coremod/entity/ai/citizen/cook/EntityAIWorkCook.java
+++ b/src/main/java/com/minecolonies/coremod/entity/ai/citizen/cook/EntityAIWorkCook.java
@@ -6,6 +6,7 @@ import com.minecolonies.api.colony.requestsystem.requestable.Food;
 import com.minecolonies.api.util.InventoryUtils;
 import com.minecolonies.api.util.ItemStackUtils;
 import com.minecolonies.api.util.constant.Constants;
+import com.minecolonies.api.util.constant.TranslationConstants;
 import com.minecolonies.coremod.colony.buildings.BuildingCook;
 import com.minecolonies.coremod.colony.jobs.JobCook;
 import com.minecolonies.coremod.entity.EntityCitizen;
@@ -28,7 +29,13 @@ import java.util.function.Predicate;
 
 import static com.minecolonies.api.util.constant.TranslationConstants.COM_MINECOLONIES_COREMOD_ENTITY_BAKER_NO_FURNACES;
 import static com.minecolonies.api.util.constant.TranslationConstants.HUNGRY_INV_FULL;
-import static com.minecolonies.coremod.entity.ai.util.AIState.*;
+import static com.minecolonies.coremod.entity.ai.util.AIState.COOK_COOK_FOOD;
+import static com.minecolonies.coremod.entity.ai.util.AIState.COOK_GATHER_FOOD_FROM_BUILDING;
+import static com.minecolonies.coremod.entity.ai.util.AIState.COOK_GATHER_FUEL;
+import static com.minecolonies.coremod.entity.ai.util.AIState.COOK_GATHER_COOKED_FOOD_FROM_FURNACE;
+import static com.minecolonies.coremod.entity.ai.util.AIState.COOK_SERVE_FOOD_TO_CITIZEN;
+import static com.minecolonies.coremod.entity.ai.util.AIState.IDLE;
+import static com.minecolonies.coremod.entity.ai.util.AIState.START_WORKING;
 
 /**
  * Cook AI class.
@@ -117,27 +124,44 @@ public class EntityAIWorkCook extends AbstractEntityAISkill<JobCook>
         super.registerTargets(
                 new AITarget(IDLE, START_WORKING),
                 new AITarget(START_WORKING, this::startWorking),
-                new AITarget(COOK_GATHERING, this::gatherFoodFromBuilding),
+                new AITarget(COOK_GATHER_FOOD_FROM_BUILDING, this::gatherFoodFromBuilding),
                 new AITarget(COOK_COOK_FOOD, this::cookFood),
-                new AITarget(COOK_SERVE, this::serveFood),
-                new AITarget(COOK_RETRIEVE_FOOD, this::retrieve),
-                new AITarget(COOK_GET_FIREWOOD, this::getBurnableMaterial)
+                new AITarget(COOK_SERVE_FOOD_TO_CITIZEN, this::serveFoodToCitizen),
+                new AITarget(COOK_GATHER_COOKED_FOOD_FROM_FURNACE, this::gatherCookedFoodFromFurnace),
+                new AITarget(COOK_GATHER_FUEL, this::gatherFuel)
         );
         worker.setSkillModifier(CHARISMA_MULTIPLIER * worker.getCitizenData().getCharisma()
                 + INTELLIGENCE_MULTIPLIER * worker.getCitizenData().getIntelligence());
         worker.setCanPickUpLoot(true);
     }
 
-    private AIState getBurnableMaterial()
+    /**
+     * Find Fuel.
+     *
+     * If not walking and we need to walk to building, repeat this state.
+     * If building has fuel or is requesting fuel, wait a while, then COOK_COOK_FOOD
+     * If no fuel in building, transition to START_WORKING.
+     * If fuel in building but not nearby, walk toward it and repeat this state.
+     * If near fuel in building, pick up fuel.
+     * If fuel was no longer available, transition to START_WORKING.
+     * If we have fuel, then COOK_COOK_FOOD
+     *
+     * @return next AIState
+     */
+    private AIState gatherFuel()
     {
-        if(walkTo == null && walkToBuilding())
+        // TODO: set status to getting fuel
+
+        // TODO: check if we already have the fuel in our inventory. If so, transition to COOK_FOOD immediately.
+
+        if (walkTo == null && walkToBuilding())
         {
             return getState();
         }
 
         if (!InventoryUtils.hasItemInProvider(getOwnBuilding(), TileEntityFurnace::isItemFuel))
         {
-            if(!getOwnBuilding().hasWorkerOpenRequestsOfType(worker.getCitizenData(), TypeToken.of(Burnable.class)))
+            if (!getOwnBuilding().hasWorkerOpenRequestsOfType(worker.getCitizenData(), TypeToken.of(Burnable.class)))
             {
                 worker.getCitizenData().createRequestAsync(new Burnable(Constants.STACKSIZE));
             }
@@ -145,7 +169,7 @@ public class EntityAIWorkCook extends AbstractEntityAISkill<JobCook>
         }
         else
         {
-            if(walkTo == null)
+            if (walkTo == null)
             {
                 final BlockPos pos = getOwnBuilding().getTileEntity().getPositionOfChestWithItemStack(TileEntityFurnace::isItemFuel);
                 if (pos == null)
@@ -172,8 +196,23 @@ public class EntityAIWorkCook extends AbstractEntityAISkill<JobCook>
         return COOK_COOK_FOOD;
     }
 
-    private AIState retrieve()
+    /**
+     * Retrieve cooked food from furnace and put more fuel in if needed.
+     *
+     * If not going anywhere, transition to START_WORKING.
+     * If we need to walk to building, repeat this state.
+     * If not a furnace target or furnace cooking or furnace is missing both uncooked and cooked food, transition to START_WORKING.
+     * If cooked food in furnace, transfer to inventory.
+     * If no fuel in furnace, and no fuel in inventory, then COOK_RETRIEVE_FUEL.
+     * If no fuel in furnace, and fuel in inventory, transfer fuel to furnace, and delay and transition to START_WORKING
+     * If fuel in furnace, delay and transition to START_WORKING
+     *
+     * @return next AIState
+     */
+    private AIState gatherCookedFoodFromFurnace()
     {
+        // TODO: set status to retrieve food from furnace
+
         if (walkTo == null)
         {
             return START_WORKING;
@@ -204,7 +243,7 @@ public class EntityAIWorkCook extends AbstractEntityAISkill<JobCook>
             if (!InventoryUtils.hasItemInItemHandler(new InvWrapper(worker.getInventoryCitizen()), TileEntityFurnace::isItemFuel))
             {
                 walkTo = null;
-                return COOK_GET_FIREWOOD;
+                return COOK_GATHER_FUEL;
             }
 
             InventoryUtils.transferItemStackIntoNextFreeSlotInItemHandlers(
@@ -218,16 +257,29 @@ public class EntityAIWorkCook extends AbstractEntityAISkill<JobCook>
         return START_WORKING;
     }
 
+    /**
+     * Retrieve food from building in order to serve it
+     *
+     * If we have food, then COOK_SERVE.
+     * If no food in the building, transition to START_WORKING.
+     * If we need to walk to the food's location, repeat this state.
+     * If we were able to get the stored food, then COOK_SERVE.
+     * If food is no longer available, delay and transition to START_WORKING.
+     *
+     * @return next AIState
+     */
     private AIState gatherFoodFromBuilding()
     {
-        if(needsCurrently == null)
+        // TODO: set status to retrieve food from storage to serve it
+
+        if (needsCurrently == null)
         {
             needsCurrently = ItemStackUtils.ISFOOD;
         }
 
-        if(InventoryUtils.hasItemInItemHandler(new InvWrapper(worker.getInventoryCitizen()), needsCurrently))
+        if (InventoryUtils.hasItemInItemHandler(new InvWrapper(worker.getInventoryCitizen()), needsCurrently))
         {
-            return COOK_SERVE;
+            return COOK_SERVE_FOOD_TO_CITIZEN;
         }
 
         final BlockPos pos = getOwnBuilding().getTileEntity().getPositionOfChestWithItemStack(needsCurrently);
@@ -244,14 +296,30 @@ public class EntityAIWorkCook extends AbstractEntityAISkill<JobCook>
         final boolean transfered = tryTransferFromPosToWorker(pos, needsCurrently);
         if (transfered)
         {
-            return COOK_SERVE;
+            return COOK_SERVE_FOOD_TO_CITIZEN;
         }
         setDelay(STANDARD_DELAY);
         return START_WORKING;
     }
 
-    private AIState serveFood()
+    /**
+     * Serve food to customer
+     *
+     * If no customer, transition to START_WORKING.
+     * If we need to walk to the customer, repeat this state with tiny delay.
+     * If the customer has a full inventory, report and remove customer, delay and repeat this state.
+     * If we have food, then COOK_SERVE.
+     * If no food in the building, transition to START_WORKING.
+     * If we were able to get the stored food, then COOK_SERVE.
+     * If food is no longer available, delay and transition to START_WORKING.
+     * Otherwise, give the customer some food, then delay and repeat this state.
+     *
+     * @return next AIState
+     */
+    private AIState serveFoodToCitizen()
     {
+        // TODO: set status to server food
+
         if (citizenToServe.isEmpty())
         {
             return START_WORKING;
@@ -281,8 +349,25 @@ public class EntityAIWorkCook extends AbstractEntityAISkill<JobCook>
         return getState();
     }
 
+    /**
+     * Find a furnace and cook raw food in it.
+     *
+     * If no furnaces, report and transition to START_WORKING.
+     * If we have no cookable food and either we are going nowhere || where we are going is not a furnace, COOK_GATHERING some kind of cookable food
+     * if we are going nowhere, find an empty furnace and walk to it, then repeat this state.
+     * If there are no empty furnaces, transition to START_WORKING.
+     * If we are at a furnace, attempt to put our uncooked food in it.
+     * If the furnace has no fuel and we have no fuel, then COOK_RETRIEVE_FUEL
+     * If the furnace has no fuel and we have fuel, then put fuel in and transition to START_WORKING.
+     * If the furnace has fuel, transition to START_WORKING.
+     * If we walked to the furnace and it's not there, then COOK_COOK_FOOD.
+     *
+     * @return next AIState
+     */
     private AIState cookFood()
     {
+        // TODO: set status to cook food
+
         if (((BuildingCook) getOwnBuilding()).getFurnaces().isEmpty())
         {
             chatSpamFilter.talkWithoutSpam(COM_MINECOLONIES_COREMOD_ENTITY_BAKER_NO_FURNACES);
@@ -295,8 +380,10 @@ public class EntityAIWorkCook extends AbstractEntityAISkill<JobCook>
         {
             walkTo = null;
             needsCurrently = ItemStackUtils.ISCOOKABLE;
-            return COOK_GATHERING;
+            return COOK_GATHER_FOOD_FROM_BUILDING;
         }
+
+        // TODO: this could leave us walking to a full furnace
 
         if (walkTo == null)
         {
@@ -310,7 +397,7 @@ public class EntityAIWorkCook extends AbstractEntityAISkill<JobCook>
             }
         }
 
-        if(walkTo == null)
+        if (walkTo == null)
         {
             return START_WORKING;
         }
@@ -324,6 +411,11 @@ public class EntityAIWorkCook extends AbstractEntityAISkill<JobCook>
         final TileEntity entity = world.getTileEntity(walkTo);
         if (entity instanceof TileEntityFurnace)
         {
+            // TODO: if the furnace isn't cooking food, we should complain about that
+
+            // TODO: if the furnace is no longer able to accept our uncooked food, should we keep feeding it fuel?
+            // TODO: we should probably empty out a furnace that isn't cooking food.
+
             InventoryUtils.transferXOfFirstSlotInItemHandlerWithIntoInItemHandler(
                     new InvWrapper(worker.getInventoryCitizen()), ItemStackUtils.ISCOOKABLE, Constants.STACKSIZE,
                     new InvWrapper((TileEntityFurnace) entity), COOK_SLOT);
@@ -333,7 +425,7 @@ public class EntityAIWorkCook extends AbstractEntityAISkill<JobCook>
                 if (!InventoryUtils.hasItemInItemHandler(new InvWrapper(worker.getInventoryCitizen()), TileEntityFurnace::isItemFuel))
                 {
                     walkTo = null;
-                    return COOK_GET_FIREWOOD;
+                    return COOK_GATHER_FUEL;
                 }
 
                 InventoryUtils.transferXOfFirstSlotInItemHandlerWithIntoInItemHandler(
@@ -346,46 +438,90 @@ public class EntityAIWorkCook extends AbstractEntityAISkill<JobCook>
         }
         walkTo = null;
         setDelay(STANDARD_DELAY);
+        // TODO: why COOK_COOK_FOOD instead of getState()?
         return COOK_COOK_FOOD;
     }
 
+    /**
+     * getPositionOfOvenToRetrieveFrom
+     *
+     * Find the first furnace in the building which is not cooking and either has a cooked result or has an uncooked input
+     * and set the worker's status to "Retrieving" and return that furnace's position.
+     *
+     * @return location of a matching furnace or null if no furnace found
+     */
     private BlockPos getPositionOfOvenToRetrieveFrom()
     {
         for (final BlockPos pos : ((BuildingCook) getOwnBuilding()).getFurnaces())
         {
+            // TODO: why do we care if the furnace is not burning?  burning && food to cook, maybe, but not burning in general.
+            // TODO: Why do we care about food in the cook slot but not fuel? both are required.
+            // TODO: It makes more sense to find ovens which have cooked food (no matter what else is going on), or will have cooked food (either because it is in the process of
+            // being cooked or because there is uncooked food plus fuel)
             final TileEntity entity = world.getTileEntity(pos);
             if (entity instanceof TileEntityFurnace && !((TileEntityFurnace) entity).isBurning()
                     && (!ItemStackUtils.isEmpty(((TileEntityFurnace) entity)
                     .getStackInSlot(RESULT_SLOT))
                     || !ItemStackUtils.isEmpty(((TileEntityFurnace) entity).getStackInSlot(COOK_SLOT))))
             {
-                worker.setLatestStatus(new TextComponentTranslation("com.minecolonies.coremod.status.retrieving"));
+                // TODO: side effect: worker status should be set in caller, not here.
+                worker.setLatestStatus(new TextComponentTranslation(TranslationConstants.COM_MINECOLONIES_COREMOD_STATUS_RETRIEVING));
                 return pos;
             }
         }
         return null;
     }
 
+    /**
+     * Specify that we dump inventory after every action.
+     * @see com.minecolonies.coremod.entity.ai.basic.AbstractEntityAIBasic#getActionsDoneUntilDumping()
+     * @return 1 to indicate that we dump inventory after every action
+     */
     @Override
     protected int getActionsDoneUntilDumping()
     {
         return 1;
     }
 
+    /**
+     * Execute tasks in this order: Retrieve food or cook food in furnaces, request food, serve food, cook food, other tasks.
+     *
+     * If any furnace has food waiting to be cooked, Find the first furnace in the building which is not cooking and either has a cooked result or has an uncooked input
+     * and set the worker's status to "Retrieving" and walk to that furnace's position by transitioning to COOK_RETRIEVE_FOOD.
+     * If any furnace has food waiting to be cooked, and if no such furnace, then COOK_COOK_FOOD.
+     * If no food in the building nor inventory, set status to "Gathering" and request food if we haven't already done so. In any case, repeat this state.
+     * If we have food in building or inventory, find all citizens nearby that are not cooks and have a zero or negative saturation.
+     * If there is a hungry citizen, then set status to "Serving"
+     * If there is a hungry citizen and we have food in inventory, then COOK_SERVE
+     * If there is a hungry citizen and we have no food in inventory, then COOK_GATHER_FOOD_FROM_BUILDING
+     * if no hungry citizens and we have less than 64 * building-level food stores, request food if we haven't already done so.
+     * If there is uncooked food in building or inventory, then set status to "Cooking", then COOK_COOK_FOOD.
+     * If any furnace is idle and has cooked food, set status to "Retrieving" then COOK_RETRIEVE_FOOD.
+     * If any furnace is idle and has uncooked food, set status to "Cooking" then COOK_COOK_FOOD.
+     * Otherwise, set status to "Idling", then delay and START_WORKING
+     *
+     * @return next AIState
+     */
     private AIState startWorking()
     {
+        // TODO: Doesn't seem like checking the ovens should be our first order of business.
+        // TODO: seems like we should try to serve food if we can, then cook if we can, then request food if no other options.
+        // TODO: If we have hungry customers, we might want to request food even if we could possibly cook it as well.
+
+        // TODO: set statuses at top of other Ai states since START_WORKING will not be the only caller.
+
         if (((BuildingCook) getOwnBuilding()).isSomethingInOven(world))
         {
             final BlockPos posOfOven = getPositionOfOvenToRetrieveFrom();
             final AIState nextState;
-            if(posOfOven == null)
+            if (posOfOven == null)
             {
                 nextState = COOK_COOK_FOOD;
             }
             else
             {
                 walkTo = posOfOven;
-                nextState = COOK_RETRIEVE_FOOD;
+                nextState = COOK_GATHER_COOKED_FOOD_FROM_FURNACE;
             }
             return nextState;
         }
@@ -395,9 +531,10 @@ public class EntityAIWorkCook extends AbstractEntityAISkill<JobCook>
 
         if (amountOfFood <= 0)
         {
-            worker.setLatestStatus(new TextComponentTranslation("com.minecolonies.coremod.status.gathering"));
-            if(!getOwnBuilding().hasWorkerOpenRequestsOfType(worker.getCitizenData(), TypeToken.of(Food.class)))
+            worker.setLatestStatus(new TextComponentTranslation(TranslationConstants.COM_MINECOLONIES_COREMOD_STATUS_GATHERING));
+            if (!getOwnBuilding().hasWorkerOpenRequestsOfType(worker.getCitizenData(), TypeToken.of(Food.class)))
             {
+                // TODO: in my play-throughs, why doesn't the cook ask for food from the warehouse, but only from the player?
                 worker.getCitizenData().createRequestAsync(new Food(Constants.STACKSIZE));
             }
             return getState();
@@ -414,13 +551,13 @@ public class EntityAIWorkCook extends AbstractEntityAISkill<JobCook>
         if (!citizenList.isEmpty())
         {
             citizenToServe.addAll(citizenList);
-            worker.setLatestStatus(new TextComponentTranslation("com.minecolonies.coremod.status.serving"));
-            if(InventoryUtils.hasItemInItemHandler(
+            worker.setLatestStatus(new TextComponentTranslation(TranslationConstants.COM_MINECOLONIES_COREMOD_STATUS_SERVING));
+            if (InventoryUtils.hasItemInItemHandler(
                     new InvWrapper(worker.getInventoryCitizen()), ItemStackUtils.ISFOOD))
             {
-                return COOK_SERVE;
+                return COOK_SERVE_FOOD_TO_CITIZEN;
             }
-            return COOK_GATHERING;
+            return COOK_GATHER_FOOD_FROM_BUILDING;
         }
 
         if (amountOfFood < getOwnBuilding().getBuildingLevel() * LEAST_KEEP_FOOD_MULTIPLIER
@@ -432,38 +569,32 @@ public class EntityAIWorkCook extends AbstractEntityAISkill<JobCook>
         if (InventoryUtils.hasItemInProvider(getOwnBuilding(), ItemStackUtils.ISCOOKABLE)
                 || InventoryUtils.getItemCountInItemHandler(new InvWrapper(worker.getInventoryCitizen()), ItemStackUtils.ISCOOKABLE) >= 1)
         {
-            worker.setLatestStatus(new TextComponentTranslation("com.minecolonies.coremod.status.cooking"));
+            worker.setLatestStatus(new TextComponentTranslation(TranslationConstants.COM_MINECOLONIES_COREMOD_STATUS_COOKING));
             return COOK_COOK_FOOD;
         }
-        return checkForAdditionalJobs();
-    }
 
-    /**
-     * If no clear tasks are given, check if something else is to do.
-     * @return the next AIState to traverse to.
-     */
-    private AIState checkForAdditionalJobs()
-    {
+        // If no clear tasks are given, check for something else to do.
+
         for (final BlockPos pos : ((BuildingCook) getOwnBuilding()).getFurnaces())
         {
             final TileEntity entity = world.getTileEntity(pos);
             if (entity instanceof TileEntityFurnace && !((TileEntityFurnace) entity).isBurning())
             {
                 walkTo = pos;
-                if(!ItemStackUtils.isEmpty(((TileEntityFurnace) entity).getStackInSlot(RESULT_SLOT)))
+                if (!ItemStackUtils.isEmpty(((TileEntityFurnace) entity).getStackInSlot(RESULT_SLOT)))
                 {
-                    worker.setLatestStatus(new TextComponentTranslation("com.minecolonies.coremod.status.retrieving"));
-                    return COOK_RETRIEVE_FOOD;
+                    worker.setLatestStatus(new TextComponentTranslation(TranslationConstants.COM_MINECOLONIES_COREMOD_STATUS_RETRIEVING));
+                    return COOK_GATHER_COOKED_FOOD_FROM_FURNACE;
                 }
-                else if(!ItemStackUtils.isEmpty(((TileEntityFurnace) entity).getStackInSlot(COOK_SLOT)))
+                else if (!ItemStackUtils.isEmpty(((TileEntityFurnace) entity).getStackInSlot(COOK_SLOT)))
                 {
-                    worker.setLatestStatus(new TextComponentTranslation("com.minecolonies.coremod.status.cooking"));
+                    worker.setLatestStatus(new TextComponentTranslation(TranslationConstants.COM_MINECOLONIES_COREMOD_STATUS_COOKING));
                     return COOK_COOK_FOOD;
                 }
             }
         }
 
-        worker.setLatestStatus(new TextComponentTranslation("com.minecolonies.coremod.status.idling"));
+        worker.setLatestStatus(new TextComponentTranslation(TranslationConstants.COM_MINECOLONIES_COREMOD_STATUS_IDLING));
         setDelay(STANDARD_DELAY);
         return START_WORKING;
     }

--- a/src/main/java/com/minecolonies/coremod/entity/ai/citizen/cook/EntityAIWorkCook.java
+++ b/src/main/java/com/minecolonies/coremod/entity/ai/citizen/cook/EntityAIWorkCook.java
@@ -457,7 +457,6 @@ public class EntityAIWorkCook extends AbstractEntityAISkill<JobCook>
      *
      * @return true if so.
      */
-    // TODO: doesn't seem to be consistent to have this, and only this, AI-called method in the building.
     private boolean isSomethingInOven()
     {
         for (final BlockPos pos : ((BuildingCook) getOwnBuilding()).getFurnaces())

--- a/src/main/java/com/minecolonies/coremod/entity/ai/citizen/cook/EntityAIWorkCook.java
+++ b/src/main/java/com/minecolonies/coremod/entity/ai/citizen/cook/EntityAIWorkCook.java
@@ -443,6 +443,25 @@ public class EntityAIWorkCook extends AbstractEntityAISkill<JobCook>
     }
 
     /**
+     * Check if something is waiting to be cooked in at least one oven.
+     *
+     * @return true if so.
+     */
+    // TODO: doesn't seem to be consistent to have this, and only this, AI-called method in the building.
+    private boolean isSomethingInOven()
+    {
+        for (final BlockPos pos : ((BuildingCook) getOwnBuilding()).getFurnaces())
+        {
+            final TileEntity entity = world.getTileEntity(pos);
+            if (entity instanceof TileEntityFurnace && !((TileEntityFurnace) entity).isBurning()
+                && !ItemStackUtils.isEmpty(((TileEntityFurnace) entity).getStackInSlot(COOK_SLOT)))
+            {
+                return true;
+            }
+        }
+        return false;
+    }
+    /**
      * getPositionOfOvenToRetrieveFrom
      *
      * Find the first furnace in the building which is not cooking and either has a cooked result or has an uncooked input
@@ -510,7 +529,7 @@ public class EntityAIWorkCook extends AbstractEntityAISkill<JobCook>
 
         // TODO: set statuses at top of other Ai states since START_WORKING will not be the only caller.
 
-        if (((BuildingCook) getOwnBuilding()).isSomethingInOven(world))
+        if (isSomethingInOven())
         {
             final BlockPos posOfOven = getPositionOfOvenToRetrieveFrom();
             final AIState nextState;

--- a/src/main/java/com/minecolonies/coremod/entity/ai/citizen/herders/AbstractEntityAIHerder.java
+++ b/src/main/java/com/minecolonies/coremod/entity/ai/citizen/herders/AbstractEntityAIHerder.java
@@ -128,7 +128,7 @@ public abstract class AbstractEntityAIHerder<J extends AbstractJob, T extends En
             return HERDER_DECIDE;
         }
 
-        worker.setLatestStatus(new TextComponentTranslation(TranslationConstants.COM_MINECOLONIES_COREMOD_STATUS_HERDER_DECIDING));
+        worker.setLatestStatus(new TextComponentTranslation(TranslationConstants.COM_MINECOLONIES_COREMOD_STATUS_DECIDING));
 
         final int numOfBreedableAnimals = (int) animals.stream().filter(animal -> animal.getGrowingAge() == 0).count();
 

--- a/src/main/java/com/minecolonies/coremod/entity/ai/util/AIState.java
+++ b/src/main/java/com/minecolonies/coremod/entity/ai/util/AIState.java
@@ -288,7 +288,7 @@ public enum AIState
     /**
      * Get some burnable material for the furnace.
      */
-    COOK_GET_FIREWOOD,
+    COOK_GATHER_FUEL,
 
     /**
      * Cook cooks food until its cooked.
@@ -298,17 +298,17 @@ public enum AIState
     /**
      * Gathering food from his building.
      */
-    COOK_GATHERING,
+    COOK_GATHER_FOOD_FROM_BUILDING,
 
     /**
      * Retrieve the food from the furnace.
      */
-    COOK_RETRIEVE_FOOD,
+    COOK_GATHER_COOKED_FOOD_FROM_FURNACE,
 
     /**
      * Serve food to the citizen inside the building.
      */
-    COOK_SERVE,
+    COOK_SERVE_FOOD_TO_CITIZEN,
 
     /*
     ###Smelter###

--- a/src/main/resources/assets/minecolonies/lang/en_us.lang
+++ b/src/main/resources/assets/minecolonies/lang/en_us.lang
@@ -112,7 +112,6 @@ item.minecolonies.scepterGuard.name=Guard-scepter
 
 com.minecolonies.configgui.title=MineColonies Config
 
-com.minecolonies.coremod.status.herder.deciding=Deciding
 com.minecolonies.coremod.status.herder.goingToHut=Going to Hut
 com.minecolonies.coremod.status.herder.breeding=Breeding
 com.minecolonies.coremod.status.herder.searching=Searching
@@ -460,6 +459,7 @@ tile.minecolonies.blockTimberFrame.name=Plain Timber Frame
 tile.minecolonies.blockMinecoloniesRack.name=Rack
 
 com.minecolonies.coremod.status.waitingForWork=Searching job
+com.minecolonies.coremod.status.deciding=Deciding
 com.minecolonies.coremod.status.sleeping=Let me sleep
 com.minecolonies.coremod.status.waiting=Waiting for:
 com.minecolonies.coremod.status.rainStop=the rain to stop
@@ -516,6 +516,7 @@ item.minecolonies.scepterPermission.name=PermissionScepter
 
 com.minecolonies.coremod.request.delivery=Delivery of:
 com.minecolonies.coremod.request.food=Food
+com.minecolonies.coremod.request.cookedFood=Cooked Food
 com.minecolonies.coremod.request.burnable=Fuel
 com.minecolonies.coremod.request.tool.pretype=Tool of class:
 com.minecolonies.coremod.request.tool.preminlevel=with minimal level:


### PR DESCRIPTION
Changes proposed in this pull request:
- Add javadocs.
- Use translation constants.
- Use consistent naming for AI states and AI State methods.
- Note areas where changes should be made.
- Fix checkstyle warnings.
- Combine startWorking() and checkForAdditionalJobs() as the division is arbitrary.
- Move isSomethingInOven to EntityAiWorkCook
- Remove unused field isOvenFull and corresponding NBT tag "cooking"
- Set latest status at start of every AIState.

Review please
