### PR TITLE
Fixes Citizen item Stacking bug

### DIFF
--- a/src/api/java/com/minecolonies/api/util/InventoryUtils.java
+++ b/src/api/java/com/minecolonies/api/util/InventoryUtils.java
@@ -574,12 +574,17 @@ public class InventoryUtils
     {
         @NotNull final Predicate<ItemStack> firstWorthySlotPredicate = ItemStackUtils.NOT_EMPTY_PREDICATE.and(itemStackSelectionPredicate);
 
-        if(firstSlot >= itemHandler.getSlots())
+        if(firstSlot >= itemHandler.getSlots()) {
         	return -1;
-        if(firstSlot < 0)
-        	firstSlot = 0;
+        }
+        final int realFirstSlot;
+        if(firstSlot < 0) {
+        	realFirstSlot = 0;
+        }else {
+        	realFirstSlot = firstSlot;
+        }
         
-        for (int slot = firstSlot; slot < itemHandler.getSlots(); slot++)
+        for (int slot = realFirstSlot; slot < itemHandler.getSlots(); slot++)
         {
             if (firstWorthySlotPredicate.test(itemHandler.getStackInSlot(slot)))
             {
@@ -743,45 +748,7 @@ public class InventoryUtils
      */
     public static boolean addItemStackToItemHandler(@NotNull final IItemHandler itemHandler, @Nullable final ItemStack itemStack)
     {
-        if (!ItemStackUtils.isEmpty(itemStack))
-        {
-            int slot;
-
-            if (itemStack.isItemDamaged())
-            {
-                slot = getFirstOpenSlotFromItemHandler(itemHandler);
-
-                if (slot >= 0)
-                {
-                    itemHandler.insertItem(slot, itemStack, false);
-                    return true;
-                }
-                else
-                {
-                    return false;
-                }
-            }
-            else
-            {
-                ItemStack resultStack = itemStack;
-                slot = itemHandler.getSlots() == 0 ? -1 : 0;
-                while (!ItemStackUtils.isEmpty(resultStack) && slot != -1 && slot != itemHandler.getSlots())
-                {
-                    resultStack = itemHandler.insertItem(slot, resultStack, false);
-                    if (!ItemStackUtils.isEmpty(resultStack))
-                    {
-                        slot++;
-                    }
-                }
-
-
-                return ItemStackUtils.isEmpty(resultStack);
-            }
-        }
-        else
-        {
-            return false;
-        }
+        return addItemStackToItemHandlerWithResult(itemHandler, itemStack).isEmpty();
     }
 
     /**
@@ -843,10 +810,11 @@ public class InventoryUtils
             	while(slot < itemHandler.getSlots() && slot > -1) {
             		resultStack = itemHandler.insertItem(slot, resultStack, false);
             		
-            		if(resultStack.isEmpty())
+            		if(resultStack.isEmpty()) {
             			return resultStack;
+            		}
             		
-            		slot = findFirstSlotInItemHandlerNotEmptyWith(itemHandler, slot, itemStack::isItemEqual);
+            		slot = findFirstSlotInItemHandlerNotEmptyWith(itemHandler, slot+1, itemStack::isItemEqual);
             	}
             	
             	 slot = getFirstOpenSlotFromItemHandler(itemHandler);

--- a/src/api/java/com/minecolonies/api/util/InventoryUtils.java
+++ b/src/api/java/com/minecolonies/api/util/InventoryUtils.java
@@ -809,16 +809,22 @@ public class InventoryUtils
             else
             {
                 ItemStack resultStack = itemStack;
-                slot = itemHandler.getSlots() == 0 ? -1 : 0;
-                while (!ItemStackUtils.isEmpty(resultStack) && slot != -1 && slot != itemHandler.getSlots())
-                {
-                    resultStack = itemHandler.insertItem(slot, resultStack, false);
-                    if (!ItemStackUtils.isEmpty(resultStack))
+                ArrayList<Integer> emptySlots = new ArrayList<Integer>();
+                for(int i = 0; i < itemHandler.getSlots() && !ItemStackUtils.isEmpty(resultStack); i++) {
+                	ItemStack stackInSlot = itemHandler.getStackInSlot(i);
+                	if(ItemStackUtils.isEmpty(stackInSlot)) {
+                		emptySlots.add(i);
+                	}else if(ItemStackUtils.compareItemStacksIgnoreStackSize(stackInSlot, resultStack)) {
+                		resultStack = itemHandler.insertItem(i, resultStack, false);
+                	}
+                }
+                for(Integer s : emptySlots) {
+                	resultStack = itemHandler.insertItem(s, resultStack, false);
+                    if (ItemStackUtils.isEmpty(resultStack))
                     {
-                        slot++;
+                        return resultStack;
                     }
                 }
-
                 return resultStack;
             }
         }


### PR DESCRIPTION
If a citizen picked up an item (ex: builder grabbing items while working) for which it had an existing partial stack and it also had a free (empty) item slot in the inventory before reaching that stack, it would place the item right there, and not join it to the existing stack.
For example, a lumberjack has an oak sapling and a stack of 15 oak wood in its inventory. It plants the sapling and goes to collect more wood (same type). When it finishes collecting, it now has a stack of 3 oak wood and a stack of 15 oak wood.
This is especially a problem for Builders, that manage to get 3 to 4 stacks of slabs/stairs with 5-10 each, and then complain they cannot pickup any more materials in the chest.

Depositing items in the chest had the same problem. When a deliveryman picks up some supplies, a hole  gets formed that is stuffed with whatever materials it encounters, regardless of existing stacks, filling up lots of space.

This commit fixes those instances by making sure to iterate over the target inventory once (and only once), merging stacks as it goes.