### PR TITLE
fix infinite crafting cycle loop

### DIFF
--- a/src/api/java/com/minecolonies/api/util/constant/Constants.java
+++ b/src/api/java/com/minecolonies/api/util/constant/Constants.java
@@ -64,6 +64,11 @@ public final class Constants
     public static final float  WATCH_CLOSEST2_FAR_CHANCE        = 0.02F;
 
     /**
+     * Max crafting cycle depth.
+     */
+    public static final int MAX_CRAFTING_CYCLE_DEPTH = 20;
+
+    /**
      * Each x blocks walked an action will be triggered to decrease saturation.
      */
     public static final int    ACTIONS_EACH_BLOCKS_WALKED       = 25;

--- a/src/main/java/com/minecolonies/coremod/colony/requestsystem/resolvers/core/AbstractCraftingRequestResolver.java
+++ b/src/main/java/com/minecolonies/coremod/colony/requestsystem/resolvers/core/AbstractCraftingRequestResolver.java
@@ -51,17 +51,7 @@ public abstract class AbstractCraftingRequestResolver extends AbstractBuildingDe
 
     protected boolean createsCraftingCycle(@NotNull final IRequestManager manager, @NotNull final IRequest<?> request, @NotNull final IRequest<? extends Stack> target)
     {
-        if (!request.equals(target) && request.getRequest().equals(target.getRequest()))
-        {
-            return true;
-        }
-
-        if (!request.hasParent())
-        {
-            return false;
-        }
-
-        return createsCraftingCycle(manager, manager.getRequestForToken(request.getParent()), target, 0);
+        return createsCraftingCycle(manager, request, target, 0);
     }
 
     protected boolean createsCraftingCycle(

--- a/src/main/java/com/minecolonies/coremod/colony/requestsystem/resolvers/core/AbstractCraftingRequestResolver.java
+++ b/src/main/java/com/minecolonies/coremod/colony/requestsystem/resolvers/core/AbstractCraftingRequestResolver.java
@@ -20,6 +20,8 @@ import org.jetbrains.annotations.Nullable;
 import java.util.List;
 import java.util.stream.Collectors;
 
+import static com.minecolonies.api.util.constant.Constants.MAX_CRAFTING_CYCLE_DEPTH;
+
 public abstract class AbstractCraftingRequestResolver extends AbstractBuildingDependentRequestResolver<Stack>
 {
     public AbstractCraftingRequestResolver(
@@ -59,7 +61,31 @@ public abstract class AbstractCraftingRequestResolver extends AbstractBuildingDe
             return false;
         }
 
-        return createsCraftingCycle(manager, manager.getRequestForToken(request.getParent()), target);
+        return createsCraftingCycle(manager, manager.getRequestForToken(request.getParent()), target, 0);
+    }
+
+    protected boolean createsCraftingCycle(
+            @NotNull final IRequestManager manager,
+            @NotNull final IRequest<?> request,
+            @NotNull final IRequest<? extends Stack> target,
+            final int count)
+    {
+        if (count > MAX_CRAFTING_CYCLE_DEPTH)
+        {
+            return false;
+        }
+
+        if (!request.equals(target) && request.getRequest().equals(target.getRequest()))
+        {
+            return true;
+        }
+
+        if (!request.hasParent())
+        {
+            return false;
+        }
+
+        return createsCraftingCycle(manager, manager.getRequestForToken(request.getParent()), target, count+1);
     }
 
     public abstract boolean canBuildingCraftStack(@NotNull final AbstractBuildingWorker building, ItemStack stack);


### PR DESCRIPTION
Closes #2339

Hotfixes a crash on our official server:


```
java.lang.StackOverflowError: Ticking entity
    at java.lang.String.valueOf(String.java:2994)
    at java.lang.StringBuilder.append(StringBuilder.java:131)
    at com.minecolonies.api.colony.requestsystem.token.StandardToken.toString(StandardToken.java:72)
    at java.lang.String.valueOf(String.java:2994)
    at java.lang.StringBuilder.append(StringBuilder.java:131)
    at com.minecolonies.coremod.colony.requestsystem.management.handlers.RequestHandler.getRequestOrNull(RequestHandler.java:520)
    at com.minecolonies.coremod.colony.requestsystem.management.manager.StandardRequestManager.getRequestForToken(StandardRequestManager.java:211)
    at com.minecolonies.coremod.colony.requestsystem.resolvers.core.AbstractCraftingRequestResolver.createsCraftingCycle(AbstractCraftingRequestResolver.java:62)
    at com.minecolonies.coremod.colony.requestsystem.resolvers.core.AbstractCraftingRequestResolver.createsCraftingCycle(AbstractCraftingRequestResolver.java:62)
    at com.minecolonies.coremod.colony.requestsystem.resolvers.core.AbstractCraftingRequestResolver.createsCraftingCycle(AbstractCraftingRequestResolver.java:62)
```

Review please
