### PR TITLE
approach to ignore nbt values for saplings

### DIFF
--- a/src/api/java/com/minecolonies/api/compatibility/CompatabilityManager.java
+++ b/src/api/java/com/minecolonies/api/compatibility/CompatabilityManager.java
@@ -72,9 +72,9 @@ public class CompatabilityManager implements ICompatabilityManager
     @Override
     public IBlockState getLeaveForSapling(final ItemStack stack)
     {
-        if(leavesToSaplingMap.inverse().containsKey(new ItemStorage(stack)))
+        if(leavesToSaplingMap.inverse().containsKey(new ItemStorage(stack, false, true)))
         {
-            return leavesToSaplingMap.inverse().get(new ItemStorage(stack));
+            return leavesToSaplingMap.inverse().get(new ItemStorage(stack, false, true));
         }
         return null;
     }
@@ -148,7 +148,7 @@ public class CompatabilityManager implements ICompatabilityManager
                                 .map(CompatabilityManager::readLeaveSaplingEntryFromNBT)
                                 .collect(Collectors.toMap(Tuple::getFirst, Tuple::getSecond)));
         final List<ItemStorage> storages = NBTUtils.streamCompound(compound.getTagList(TAG_SAPLINGS, Constants.NBT.TAG_COMPOUND))
-                .map(tempCompound -> new ItemStorage(new ItemStack(tempCompound)))
+                .map(tempCompound -> new ItemStorage(new ItemStack(tempCompound), false, true))
                 .collect(Collectors.toList());
 
         //Filter duplicated values.
@@ -178,9 +178,9 @@ public class CompatabilityManager implements ICompatabilityManager
     {
         final ItemStack tempStack = new ItemStack(leave.getBlock(), 1, leave.getBlock().getMetaFromState(leave));
         final IBlockState tempLeave = BlockLeaves.getBlockFromItem(tempStack.getItem()).getStateFromMeta(tempStack.getMetadata());
-        if(!leavesToSaplingMap.containsKey(tempLeave) && !leavesToSaplingMap.containsValue(new ItemStorage(stack)))
+        if(!leavesToSaplingMap.containsKey(tempLeave) && !leavesToSaplingMap.containsValue(new ItemStorage(stack, false, true)))
         {
-            leavesToSaplingMap.put(tempLeave, new ItemStorage(stack));
+            leavesToSaplingMap.put(tempLeave, new ItemStorage(stack, false, true));
         }
     }
 
@@ -223,9 +223,9 @@ public class CompatabilityManager implements ICompatabilityManager
                     for (final ItemStack stack : list)
                     {
                         //Just put it in if not in there already, don't mind the leave yet.
-                        if(!ItemStackUtils.isEmpty(stack) && !leavesToSaplingMap.containsValue(new ItemStorage(stack)) && !saplings.contains(new ItemStorage(stack)))
+                        if(!ItemStackUtils.isEmpty(stack) && !leavesToSaplingMap.containsValue(new ItemStorage(stack, false, true)) && !saplings.contains(new ItemStorage(stack, false, true)))
                         {
-                            saplings.add(new ItemStorage(stack));
+                            saplings.add(new ItemStorage(stack, false, true));
                         }
                     }
                 }
@@ -244,6 +244,6 @@ public class CompatabilityManager implements ICompatabilityManager
 
     private static Tuple<IBlockState, ItemStorage> readLeaveSaplingEntryFromNBT(final NBTTagCompound compound)
     {
-        return new Tuple<>(NBTUtil.readBlockState(compound), new ItemStorage(new ItemStack(compound)));
+        return new Tuple<>(NBTUtil.readBlockState(compound), new ItemStorage(new ItemStack(compound), false, true));
     }
 }

--- a/src/api/java/com/minecolonies/api/crafting/ItemStorage.java
+++ b/src/api/java/com/minecolonies/api/crafting/ItemStorage.java
@@ -25,6 +25,11 @@ public class ItemStorage
     private final boolean shouldIgnoreDamageValue;
 
     /**
+     * Set this to ignore the damage value in comparisons.
+     */
+    private final boolean shouldIgnoreNBTValue;
+
+    /**
      * Amount of the storage.
      */
     private int amount;
@@ -40,6 +45,22 @@ public class ItemStorage
     {
         this.stack = stack;
         this.shouldIgnoreDamageValue = ignoreDamageValue;
+        this.shouldIgnoreNBTValue = ignoreDamageValue;
+        this.amount = amount;
+    }
+
+    /**
+     * Creates an instance of the storage.
+     *
+     * @param stack                the stack.
+     * @param ignoreDamageValue    should the damage value be ignored?
+     * @param shouldIgnoreNBTValue should the nbt value be ignored?
+     */
+    public ItemStorage(@NotNull final ItemStack stack, final boolean ignoreDamageValue, final boolean shouldIgnoreNBTValue)
+    {
+        this.stack = stack;
+        this.shouldIgnoreDamageValue = ignoreDamageValue;
+        this.shouldIgnoreNBTValue = shouldIgnoreNBTValue;
         this.amount = amount;
     }
 
@@ -53,6 +74,7 @@ public class ItemStorage
     {
         this.stack = stack;
         this.shouldIgnoreDamageValue = ignoreDamageValue;
+        this.shouldIgnoreNBTValue = ignoreDamageValue;
         this.amount = ItemStackUtils.getSize(stack);
     }
 
@@ -65,6 +87,7 @@ public class ItemStorage
     {
         this.stack = stack;
         this.shouldIgnoreDamageValue = false;
+        this.shouldIgnoreNBTValue = false;
         this.amount = ItemStackUtils.getSize(stack);
     }
 
@@ -131,8 +154,8 @@ public class ItemStorage
     public int hashCode()
     {
         return Objects.hash(stack.getItem())
-                + (shouldIgnoreDamageValue ? 0 : (stack.getItemDamage() * 31))
-                + ((stack.getTagCompound() == null) ? 0 : stack.getTagCompound().hashCode());
+                + (this.shouldIgnoreDamageValue ? 0 : (this.stack.getItemDamage() * 31))
+                + (this.shouldIgnoreNBTValue ? 0 : ((this.stack.getTagCompound() == null) ? 0 : this.stack.getTagCompound().hashCode()));
     }
 
     @Override
@@ -152,7 +175,7 @@ public class ItemStorage
 
         return stack.isItemEqual(that.getItemStack())
                 && (this.shouldIgnoreDamageValue || that.getDamageValue() == this.getDamageValue())
-                &&  that.getItemStack().getTagCompound() == this.getItemStack().getTagCompound();
+                && (this.shouldIgnoreNBTValue || that.getItemStack().getTagCompound() == this.getItemStack().getTagCompound());
     }
 
     /**


### PR DESCRIPTION
Fixes sapling overload problem

# Changes proposed in this pull request:
- Saplings should ignore nbt to avoid millions of saplings like for example of forestry


Review please
