### PR TITLE
Changing exclusion handlers into transform handlers.

### DIFF
--- a/src/main/java/com/minecolonies/coremod/proxy/ClientProxy.java
+++ b/src/main/java/com/minecolonies/coremod/proxy/ClientProxy.java
@@ -20,6 +20,7 @@ import com.minecolonies.coremod.items.ModItems;
 import com.minecolonies.coremod.tileentities.ScarecrowTileEntity;
 import com.minecolonies.coremod.tileentities.TileEntityColonyBuilding;
 import com.minecolonies.coremod.tileentities.TileEntityInfoPoster;
+import com.minecolonies.structures.client.TemplateBlockAccessTransformHandler;
 import com.minecolonies.structures.client.TemplateRenderHandler;
 import com.minecolonies.structures.event.RenderEventHandler;
 import com.minecolonies.structures.helpers.Settings;
@@ -30,11 +31,13 @@ import net.minecraft.client.entity.EntityPlayerSP;
 import net.minecraft.client.renderer.block.model.ModelResourceLocation;
 import net.minecraft.client.renderer.block.statemap.StateMap;
 import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.init.Blocks;
 import net.minecraft.item.Item;
 import net.minecraft.stats.RecipeBook;
 import net.minecraft.util.ResourceLocation;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.World;
+import net.minecraft.world.gen.structure.template.Template;
 import net.minecraftforge.client.event.ModelRegistryEvent;
 import net.minecraftforge.client.model.ModelLoader;
 import net.minecraftforge.common.MinecraftForge;
@@ -264,8 +267,10 @@ public class ClientProxy extends CommonProxy
         }
 
         //Additionally we register an exclusion handler here;
-        TemplateRenderHandler.getInstance().registerExclusionHandler((b) -> b.blockState.getBlock() instanceof BlockSubstitution);
-
+        TemplateBlockAccessTransformHandler.getInstance().AddTransformHandler(
+          (b) -> b.blockState.getBlock() instanceof BlockSubstitution,
+          (b) -> new Template.BlockInfo(b.pos, Blocks.AIR.getDefaultState(), null)
+        );
     }
 
     @Override

--- a/src/main/java/com/minecolonies/structures/client/TemplateBlockAccessTransformHandler.java
+++ b/src/main/java/com/minecolonies/structures/client/TemplateBlockAccessTransformHandler.java
@@ -1,0 +1,40 @@
+package com.minecolonies.structures.client;
+
+import net.minecraft.world.gen.structure.template.Template;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.function.Predicate;
+
+public class TemplateBlockAccessTransformHandler
+{
+    private static TemplateBlockAccessTransformHandler ourInstance = new TemplateBlockAccessTransformHandler();
+
+    public static TemplateBlockAccessTransformHandler getInstance()
+    {
+        return ourInstance;
+    }
+
+    private Map<Predicate<Template.BlockInfo>, Function<Template.BlockInfo, Template.BlockInfo>> blockInfoTransformHandler = new HashMap<>();
+
+    private TemplateBlockAccessTransformHandler()
+    {
+    }
+
+    public void AddTransformHandler(@NotNull final Predicate<Template.BlockInfo> transformPredicate, @NotNull final Function<Template.BlockInfo, Template.BlockInfo> transformHandler)
+    {
+        blockInfoTransformHandler.put(transformPredicate, transformHandler);
+    }
+
+    public Template.BlockInfo Transform(@NotNull final Template.BlockInfo blockInfo)
+    {
+        return getTransformHandler(blockInfo).apply(blockInfo);
+    }
+
+    private Function<Template.BlockInfo, Template.BlockInfo> getTransformHandler(@NotNull final Template.BlockInfo blockInfo)
+    {
+        return blockInfoTransformHandler.keySet().stream().filter(p -> p.test(blockInfo)).findFirst().map(p -> blockInfoTransformHandler.get(p)).orElse(Function.identity());
+    }
+}

--- a/src/main/java/com/minecolonies/structures/client/TemplateRenderHandler.java
+++ b/src/main/java/com/minecolonies/structures/client/TemplateRenderHandler.java
@@ -32,8 +32,6 @@ public final class TemplateRenderHandler
         .build();
     private BlockRendererDispatcher              rendererDispatcher;
 
-    private final List<Predicate<BlockInfo>> exclusionBlockInfoHandlers = Lists.newArrayList();
-
     private TemplateRenderHandler()
     {
     }
@@ -58,9 +56,8 @@ public final class TemplateRenderHandler
                 final TemplateTessellator tessellator = new TemplateTessellator();
                 tessellator.getBuilder().begin(GL_QUADS, DefaultVertexFormats.BLOCK);
 
-                template.blocks.stream().filter(b -> exclusionBlockInfoHandlers
-                                                       .stream()
-                                                       .noneMatch(f -> f.test(b)))
+                template.blocks.stream()
+                  .map(b -> TemplateBlockAccessTransformHandler.getInstance().Transform(b))
                   .forEach(b -> rendererDispatcher.renderBlock(b.blockState, b.pos, blockAccess, tessellator.getBuilder()));
 
                 return tessellator;
@@ -70,10 +67,5 @@ public final class TemplateRenderHandler
         {
             Log.getLogger().error(e);
         }
-    }
-
-    public void registerExclusionHandler(@NotNull final Predicate<BlockInfo> exclusionHandler)
-    {
-        this.exclusionBlockInfoHandlers.add(exclusionHandler);
     }
 }

--- a/src/main/java/com/minecolonies/structures/lib/TemplateUtils.java
+++ b/src/main/java/com/minecolonies/structures/lib/TemplateUtils.java
@@ -5,6 +5,7 @@ import com.google.common.cache.Cache;
 import com.google.common.cache.CacheBuilder;
 import com.minecolonies.blockout.Log;
 import com.minecolonies.coremod.blocks.AbstractBlockHut;
+import com.minecolonies.structures.client.TemplateBlockAccessTransformHandler;
 import net.minecraft.init.Blocks;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.math.BlockPos;
@@ -42,10 +43,10 @@ public final class TemplateUtils
     {
         try
         {
-            return Optional.ofNullable(templateBlockInfoCache
+            return TemplateBlockAccessTransformHandler.getInstance().Transform(Optional.ofNullable(templateBlockInfoCache
                                          .get(template, () -> template.blocks.stream().collect(Collectors.toMap(bi -> bi.pos, Functions.identity())))
                                          .get(pos))
-                     .orElse(new Template.BlockInfo(pos, Blocks.AIR.getDefaultState(), null));
+                     .orElse(new Template.BlockInfo(pos, Blocks.AIR.getDefaultState(), null)));
         }
         catch (ExecutionException e)
         {
@@ -59,7 +60,9 @@ public final class TemplateUtils
     {
         return template.blocks.stream()
                  .filter(blockInfo -> blockInfo.blockState.getBlock() instanceof AbstractBlockHut<?>)
-                 .findFirst().map(blockInfo -> blockInfo.pos)
+                 .findFirst()
+                 .map(blockInfo -> TemplateBlockAccessTransformHandler.getInstance().Transform(blockInfo))
+                 .map(blockInfo -> blockInfo.pos)
                  .orElse(new BlockPos(template.getSize().getX() / 2, 0, template.getSize().getZ() / 2));
     }
 }


### PR DESCRIPTION
Fixes the artifacts People have been seeing when template holder blocks are placed next to normal blocks and occlusion hides them due to them being next to each other in the template but not being rendered.