### PR TITLE
Limiting the max citizen for each colony with a field in the configuration file

### DIFF
--- a/src/api/java/com/minecolonies/api/configuration/Configurations.java
+++ b/src/api/java/com/minecolonies/api/configuration/Configurations.java
@@ -49,6 +49,9 @@ public class Configurations
         @Config.Comment("Average citizen respawn interval (in seconds)")
         public int citizenRespawnInterval = 60;
 
+        @Config.Comment("Max citizens in one colony")
+        public int maxCitizenPerColony = 50;
+
         @Config.Comment("Should builder and miner build without resources? (this also turns off what they produce)")
         public boolean builderInfiniteResources = false;
 

--- a/src/main/java/com/minecolonies/coremod/colony/managers/CitizenManager.java
+++ b/src/main/java/com/minecolonies/coremod/colony/managers/CitizenManager.java
@@ -268,7 +268,7 @@ public class CitizenManager implements ICitizenManager
         newMaxCitizens = Math.max(Configurations.gameplay.maxCitizens, newMaxCitizens);
         if (getMaxCitizens() != newMaxCitizens)
         {
-            setMaxCitizens(newMaxCitizens);
+            setMaxCitizens(Math.min(newMaxCitizens,Configurations.gameplay.maxCitizenPerColony));
         }
         colony.markDirty();
     }


### PR DESCRIPTION
# Closes: 
#2435 
# Changes proposed in this pull request:
- Creating a field limiting the maximum citizens in a colony