### PR TITLE
Rename EXP_PER_MOD_DEATH to EXP_PER_MOB_DEATH - fixing a typo!

### DIFF
--- a/src/main/java/com/minecolonies/coremod/entity/ai/citizen/guard/AbstractEntityAIGuard.java
+++ b/src/main/java/com/minecolonies/coremod/entity/ai/citizen/guard/AbstractEntityAIGuard.java
@@ -233,7 +233,7 @@ public abstract class AbstractEntityAIGuard<J extends AbstractJobGuard> extends 
 
         if (target != null && target.isDead)
         {
-            worker.getCitizenExperienceHandler().addExperience(EXP_PER_MOD_DEATH);
+            worker.getCitizenExperienceHandler().addExperience(EXP_PER_MOB_DEATH);
             target = null;
         }
 
@@ -360,7 +360,7 @@ public abstract class AbstractEntityAIGuard<J extends AbstractJobGuard> extends 
 
         if (target == null || target.isDead)
         {
-            worker.getCitizenExperienceHandler().addExperience(EXP_PER_MOD_DEATH);
+            worker.getCitizenExperienceHandler().addExperience(EXP_PER_MOB_DEATH);
             return DECIDE;
         }
 
@@ -440,7 +440,7 @@ public abstract class AbstractEntityAIGuard<J extends AbstractJobGuard> extends 
 
         if (target == null || target.isDead)
         {
-            worker.getCitizenExperienceHandler().addExperience(EXP_PER_MOD_DEATH);
+            worker.getCitizenExperienceHandler().addExperience(EXP_PER_MOB_DEATH);
             return DECIDE;
         }
 

--- a/src/main/java/com/minecolonies/coremod/entity/ai/citizen/guard/GuardConstants.java
+++ b/src/main/java/com/minecolonies/coremod/entity/ai/citizen/guard/GuardConstants.java
@@ -29,7 +29,7 @@ public final class GuardConstants
     /**
      * Experience to add when a mob is killed
      */
-    public static final int EXP_PER_MOD_DEATH = 5;
+    public static final int EXP_PER_MOB_DEATH = 5;
 
     // -- Delays -- \\
 


### PR DESCRIPTION
# Changes proposed in this pull request:
- Fix a typo in the name of the constant used to define the exp gained by a guard for killing a mob from EXP_PER_MOD_DEATH to EXP_PER_MOB_DEATH

Review please
