### PR TITLE
Correctly handle liquids in scan tool and builder

### DIFF
--- a/src/api/java/com/minecolonies/api/crafting/RecipeStorage.java
+++ b/src/api/java/com/minecolonies/api/crafting/RecipeStorage.java
@@ -190,7 +190,11 @@ public class RecipeStorage implements IRecipeStorage
         final List<ItemStack> secondaryStacks = new ArrayList<>();
         for(final ItemStack stack: input)
         {
-            stack.getItem().getContainerItem(stack);
+            final ItemStack container = stack.getItem().getContainerItem(stack);
+            if (!ItemStackUtils.isEmpty(container))
+            {
+                secondaryStacks.add(container);
+            }
         }
         if(secondaryStacks.size() > getInput().size())
         {
@@ -270,7 +274,11 @@ public class RecipeStorage implements IRecipeStorage
         final List<ItemStack> secondaryStacks = new ArrayList<>();
         for(final ItemStack stack: input)
         {
-            stack.getItem().getContainerItem(stack);
+            final ItemStack container = stack.getItem().getContainerItem(stack);
+            if (!ItemStackUtils.isEmpty(container))
+            {
+                secondaryStacks.add(container);
+            }
         }
         for (final ItemStack stack : secondaryStacks)
         {

--- a/src/api/java/com/minecolonies/api/util/BlockUtils.java
+++ b/src/api/java/com/minecolonies/api/util/BlockUtils.java
@@ -2,7 +2,6 @@ package com.minecolonies.api.util;
 
 import com.minecolonies.api.entity.ai.citizen.builder.IBuilderUndestroyable;
 import net.minecraft.block.*;
-import net.minecraft.block.material.Material;
 import net.minecraft.block.properties.PropertyBool;
 import net.minecraft.block.state.IBlockState;
 import net.minecraft.init.Blocks;
@@ -12,6 +11,9 @@ import net.minecraft.util.EnumFacing;
 import net.minecraft.util.Rotation;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.World;
+import net.minecraftforge.fluids.FluidStack;
+import net.minecraftforge.fluids.FluidUtil;
+import net.minecraftforge.fluids.IFluidBlock;
 import net.minecraftforge.registries.GameData;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -191,7 +193,7 @@ public final class BlockUtils
 
     private static Item getItem(@NotNull final IBlockState blockState)
     {
-        if (blockState.getMaterial().equals(Material.LAVA))
+        if (blockState.getBlock().equals(Blocks.LAVA))
         {
             return Items.LAVA_BUCKET;
         }
@@ -355,6 +357,10 @@ public final class BlockUtils
      */
     public static ItemStack getItemStackFromBlockState(@NotNull final IBlockState blockState)
     {
+        if(blockState.getBlock() instanceof IFluidBlock)
+        {
+            return FluidUtil.getFilledBucket(new FluidStack(((IFluidBlock) blockState.getBlock()).getFluid(), 1000));
+        }
         final Item item = getItem(blockState);
 
         if (item == null)

--- a/src/api/java/com/minecolonies/api/util/constant/CitizenConstants.java
+++ b/src/api/java/com/minecolonies/api/util/constant/CitizenConstants.java
@@ -13,7 +13,7 @@ public final class CitizenConstants
     /**
      * Base movement speed of every citizen.
      */
-    public static final  double                 BASE_MOVEMENT_SPEED  = 0.3D;
+    public static final  double BASE_MOVEMENT_SPEED  = 0.3D;
     /**
      * The middle saturation point. smaller than this = bad and bigger than this = good.
      */

--- a/src/main/java/com/minecolonies/coremod/client/gui/WindowScan.java
+++ b/src/main/java/com/minecolonies/coremod/client/gui/WindowScan.java
@@ -325,8 +325,7 @@ public class WindowScan extends AbstractWindowSkeleton
                     {
                         if (tileEntity != null)
                         {
-                            final List<ItemStack> itemList = new ArrayList<>();
-                            itemList.addAll(ItemStackUtils.getItemStacksOfTileEntity(tileEntity.writeToNBT(new NBTTagCompound()), world));
+                            final List<ItemStack> itemList = new ArrayList<>(ItemStackUtils.getItemStacksOfTileEntity(tileEntity.writeToNBT(new NBTTagCompound()), world));
                             for (final ItemStack stack : itemList)
                             {
                                 addNeededResource(stack, 1);
@@ -365,10 +364,11 @@ public class WindowScan extends AbstractWindowSkeleton
      */
     public void addNeededResource(@Nullable final ItemStack res, final int amount)
     {
-        if (ItemStackUtils.isEmpty(res) || amount == 0)
+        if (res == null || amount == 0)
         {
             return;
         }
+
         final int hashCode = res.hasTagCompound() ? res.getTagCompound().hashCode() : 0;
         ItemStorage resource = resources.get(res.getUnlocalizedName() + ":" + res.getItemDamage() + "-" + hashCode);
         if (resource == null)

--- a/src/main/java/com/minecolonies/coremod/colony/buildings/workerbuildings/BuildingDeliveryman.java
+++ b/src/main/java/com/minecolonies/coremod/colony/buildings/workerbuildings/BuildingDeliveryman.java
@@ -14,12 +14,17 @@ import com.minecolonies.coremod.colony.buildings.AbstractBuildingWorker;
 import com.minecolonies.coremod.colony.jobs.AbstractJob;
 import com.minecolonies.coremod.colony.jobs.JobDeliveryman;
 import com.minecolonies.coremod.colony.requestsystem.resolvers.DeliveryRequestResolver;
+import com.minecolonies.coremod.entity.EntityCitizen;
 import io.netty.buffer.ByteBuf;
+import net.minecraft.entity.SharedMonsterAttributes;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.util.math.BlockPos;
 import org.jetbrains.annotations.NotNull;
 
+import java.util.Optional;
+
 import static com.minecolonies.api.util.constant.BuildingConstants.CONST_DEFAULT_MAX_BUILDING_LEVEL;
+import static com.minecolonies.api.util.constant.CitizenConstants.BASE_MOVEMENT_SPEED;
 
 /**
  * Class of the warehouse building.
@@ -121,6 +126,18 @@ public class BuildingDeliveryman extends AbstractBuildingWorker
     public void serializeToView(@NotNull final ByteBuf buf)
     {
         super.serializeToView(buf);
+    }
+
+    @Override
+    public void removeCitizen(final CitizenData citizen)
+    {
+        if (citizen != null)
+        {
+            final Optional<EntityCitizen> optCitizen = citizen.getCitizenEntity();
+            optCitizen.ifPresent(entityCitizen -> entityCitizen.getEntityAttribute(SharedMonsterAttributes.MOVEMENT_SPEED)
+                                                    .setBaseValue(BASE_MOVEMENT_SPEED));
+        }
+        super.removeCitizen(citizen);
     }
 
     /**

--- a/src/main/java/com/minecolonies/coremod/entity/ai/basic/AbstractEntityAIStructure.java
+++ b/src/main/java/com/minecolonies/coremod/entity/ai/basic/AbstractEntityAIStructure.java
@@ -456,9 +456,14 @@ public abstract class AbstractEntityAIStructure<J extends AbstractJob> extends A
             if (!ItemStackUtils.isEmpty(tempStack))
             {
                 final int slot = worker.getCitizenInventoryHandler().findFirstSlotInInventoryWith(tempStack.getItem(), tempStack.getItemDamage());
-                if (slot != -1)
+                if (slot != -1 )
                 {
+                    final ItemStack container = tempStack.getItem().getContainerItem(tempStack);
                     new InvWrapper(getInventory()).extractItem(slot, 1, false);
+                    if (!ItemStackUtils.isEmpty(container))
+                    {
+                        new InvWrapper(getInventory()).insertItem(slot, container, false);
+                    }
                     reduceNeededResources(tempStack);
                 }
             }

--- a/src/main/java/com/minecolonies/coremod/entity/ai/citizen/deliveryman/EntityAIWorkDeliveryman.java
+++ b/src/main/java/com/minecolonies/coremod/entity/ai/citizen/deliveryman/EntityAIWorkDeliveryman.java
@@ -21,6 +21,7 @@ import com.minecolonies.coremod.entity.ai.basic.AbstractEntityAIInteract;
 import com.minecolonies.coremod.entity.ai.util.AIState;
 import com.minecolonies.coremod.entity.ai.util.AITarget;
 import com.minecolonies.coremod.tileentities.TileEntityColonyBuilding;
+import net.minecraft.entity.SharedMonsterAttributes;
 import net.minecraft.item.ItemFood;
 import net.minecraft.item.ItemStack;
 import net.minecraft.tileentity.TileEntity;
@@ -629,6 +630,7 @@ public class EntityAIWorkDeliveryman extends AbstractEntityAIInteract<JobDeliver
         {
             return START_WORKING;
         }
+        worker.getEntityAttribute(SharedMonsterAttributes.MOVEMENT_SPEED).setBaseValue(BASE_MOVEMENT_SPEED + BASE_MOVEMENT_SPEED * worker.getCitizenExperienceHandler().getLevel() / WALKING_SPEED_MULTIPLIER);
 
         final AbstractBuildingWorker ownBuilding = getOwnBuilding();
 
@@ -660,8 +662,6 @@ public class EntityAIWorkDeliveryman extends AbstractEntityAIInteract<JobDeliver
      */
     private boolean checkIfExecute()
     {
-        worker.setAIMoveSpeed((float) (BASE_MOVEMENT_SPEED + BASE_MOVEMENT_SPEED * worker.getCitizenExperienceHandler().getLevel() / WALKING_SPEED_MULTIPLIER));
-
         if (getWareHouse() != null && getWareHouse().getTileEntity() != null)
         {
             return false;

--- a/src/main/java/com/minecolonies/coremod/entity/ai/citizen/deliveryman/EntityAIWorkDeliveryman.java
+++ b/src/main/java/com/minecolonies/coremod/entity/ai/citizen/deliveryman/EntityAIWorkDeliveryman.java
@@ -37,6 +37,7 @@ import org.jetbrains.annotations.Nullable;
 import java.util.*;
 import java.util.stream.Collectors;
 
+import static com.minecolonies.api.util.constant.CitizenConstants.BASE_MOVEMENT_SPEED;
 import static com.minecolonies.api.util.constant.Constants.TICKS_SECOND;
 import static com.minecolonies.api.util.constant.TranslationConstants.*;
 import static com.minecolonies.coremod.entity.ai.util.AIState.*;
@@ -55,11 +56,6 @@ public class EntityAIWorkDeliveryman extends AbstractEntityAIInteract<JobDeliver
      * Walking speed double at this level.
      */
     private static final double WALKING_SPEED_MULTIPLIER = 25;
-
-    /**
-     * The base movement speed of the deliveryman.
-     */
-    private static final double BASE_MOVEMENT_SPEED = 0.2D;
 
     /**
      * Delay in ticks between every inventory operation.

--- a/src/main/java/com/minecolonies/coremod/network/messages/ReplaceBlockMessage.java
+++ b/src/main/java/com/minecolonies/coremod/network/messages/ReplaceBlockMessage.java
@@ -209,8 +209,9 @@ public class ReplaceBlockMessage extends AbstractMessage<ReplaceBlockMessage, IM
      */
     public static boolean correctBlockToRemoveOrReplace(final ItemStack worldStack, final IBlockState worldState, final ItemStack compareStack)
     {
-        return worldStack != null && (worldStack.isItemEqual(compareStack)
+        return (worldStack != null && worldStack.isItemEqual(compareStack)
                 || (compareStack.getItem() == Items.LAVA_BUCKET && (worldState.getBlock() == Blocks.LAVA || worldState.getBlock() == Blocks.FLOWING_LAVA))
-                || (compareStack.getItem() == Items.WATER_BUCKET && (worldState.getBlock() == Blocks.WATER || worldState.getBlock() == Blocks.FLOWING_WATER)));
+                || (compareStack.getItem() == Items.WATER_BUCKET && (worldState.getBlock() == Blocks.WATER || worldState.getBlock() == Blocks.FLOWING_WATER))
+                || (compareStack.getItem() == Items.AIR && (worldState.getBlock() == Blocks.AIR)));
     }
 }

--- a/src/main/java/com/minecolonies/coremod/tileentities/TileEntityRack.java
+++ b/src/main/java/com/minecolonies/coremod/tileentities/TileEntityRack.java
@@ -305,6 +305,17 @@ public class TileEntityRack extends TileEntity
                 world.setBlockState(neighbor, typeNeighbor);
             }
         }
+        else if (!single && !main && world != null && neighbor != null)
+        {
+            final TileEntity entity = world.getTileEntity(getNeighbor());
+            if (entity instanceof TileEntityRack)
+            {
+                if (!((TileEntityRack) entity).main)
+                {
+                    this.main = true;
+                }
+            }
+        }
     }
 
     /**

--- a/src/main/java/com/minecolonies/coremod/tileentities/TileEntityRack.java
+++ b/src/main/java/com/minecolonies/coremod/tileentities/TileEntityRack.java
@@ -308,12 +308,9 @@ public class TileEntityRack extends TileEntity
         else if (!single && !main && world != null && neighbor != null)
         {
             final TileEntity entity = world.getTileEntity(getNeighbor());
-            if (entity instanceof TileEntityRack)
+            if (entity instanceof TileEntityRack && !((TileEntityRack) entity).main)
             {
-                if (!((TileEntityRack) entity).main)
-                {
-                    this.main = true;
-                }
+                this.main = true;
             }
         }
     }


### PR DESCRIPTION
# Changes proposed in this pull request:
- Builder should now request the correct liquid to build (Emerald, Iron, Lava etc)
- Builder will not lose the bucket anymore when building the liquids.
- ScanTool can now be used to replace Air and liquids.
- Increase the Deliveryman walking speed (Or better, fix the dman walking speed)

Review please
