### PR TITLE
Sleeping citizens - remove tool/weapon from hand while sleep #2598

### DIFF
--- a/src/main/java/com/minecolonies/coremod/entity/citizenhandlers/CitizenSleepHandler.java
+++ b/src/main/java/com/minecolonies/coremod/entity/citizenhandlers/CitizenSleepHandler.java
@@ -110,6 +110,9 @@ public class CitizenSleepHandler
         citizen.motionY = 0.0D;
         citizen.motionZ = 0.0D;
 
+        //Remove item while citizen is asleep.
+        citizen.getCitizenItemHandler().removeHeldItem();
+
         setIsAsleep(true);
 
         citizen.getDataManager().set(DATA_BED_POS, bedLocation);


### PR DESCRIPTION
…le sleeping 

cosmetic change.  When a citizen goes to sleep.  Items in hand are removed.  They don't sleep hold a hoe/rishing rod, etc.....  Its just in the inventory.
