### PR TITLE
Guards - standing around like crash dummies. #2610

### DIFF
--- a/src/main/java/com/minecolonies/coremod/colony/buildings/AbstractBuildingGuards.java
+++ b/src/main/java/com/minecolonies/coremod/colony/buildings/AbstractBuildingGuards.java
@@ -226,7 +226,8 @@ public abstract class AbstractBuildingGuards extends AbstractBuildingWorker
         {
             final NBTTagCompound mobCompound = mobsTagList.getCompoundTagAt(i);
             final MobEntryView mobEntry = MobEntryView.readFromNBT(mobCompound, NBT_MOB_VIEW);
-            mobsToAttack.add(mobEntry);
+            if (mobEntry.getEntityEntry() != null)
+            	mobsToAttack.add(mobEntry);
         }
 
         guardPos = NBTUtil.getPosFromTag(compound.getCompoundTag(NBT_GUARD));

--- a/src/main/java/com/minecolonies/coremod/colony/buildings/AbstractBuildingGuards.java
+++ b/src/main/java/com/minecolonies/coremod/colony/buildings/AbstractBuildingGuards.java
@@ -227,7 +227,9 @@ public abstract class AbstractBuildingGuards extends AbstractBuildingWorker
             final NBTTagCompound mobCompound = mobsTagList.getCompoundTagAt(i);
             final MobEntryView mobEntry = MobEntryView.readFromNBT(mobCompound, NBT_MOB_VIEW);
             if (mobEntry.getEntityEntry() != null)
+            {
             	mobsToAttack.add(mobEntry);
+            }
         }
 
         guardPos = NBTUtil.getPosFromTag(compound.getCompoundTag(NBT_GUARD));


### PR DESCRIPTION
Real problem is the NBT load routine does check to make sure the mob located in the save data still exists. If the mod has been removed since last save or an update to a mob that removed a mob. The mob is deleted MC will crash (exception caught) and many things about MC doesn't work. patrolling, some of the guis.
