### PR TITLE
Name does not show up on builder huts gui. #2623

### DIFF
--- a/src/main/resources/assets/minecolonies/gui/windowhutbuilder.xml
+++ b/src/main/resources/assets/minecolonies/gui/windowhutbuilder.xml
@@ -17,10 +17,14 @@
             <label size="100% 11" pos="0 18"
                    label="$(com.minecolonies.coremod.gui.workerHuts.workerAssigned)"
                    textalign="MIDDLE" color="black"/>
-            <label id="workerName" size="100% 11" pos="0 28"
-                   textalign="MIDDLE" color="black"/>
-            <label id="workerLevel" size="100% 11" pos="0 44"
-                   textalign="MIDDLE" color="black"/>
+		    <list id="workers" size="92% 30" pos="3 32" align="TOP_MIDDLE">
+		         <view size="100% 20">
+		             <box size="100% 20" linewidth="2">
+					    <label id="workerName" size="100% 11" pos="1 0"  textalign="MIDDLE" color="black"/>
+					    <label id="workerLevel" size="100% 11" pos="0 9" textalign="MIDDLE" color="black"/>
+		             </box>
+		         </view>
+		    </list>
 
             <buttonimage id="hire" align="TOP_MIDDLE" size="129 17" pos="0 60"
                          source="minecolonies:textures/gui/builderhut/builder_button_medium_large.png"


### PR DESCRIPTION
When you click on the builder hut, you should see the name on the hut.
Builders hut gui doesn't use the windoworkerbuildingdefault.xml file like all other job huts. It doesn't call the default code and uses it own. I missed that.