### PR TITLE
Added check to empty stacks

### DIFF
--- a/src/main/java/com/minecolonies/coremod/tileentities/TileEntityBarrel.java
+++ b/src/main/java/com/minecolonies/coremod/tileentities/TileEntityBarrel.java
@@ -157,6 +157,11 @@ public class TileEntityBarrel extends TileEntity implements ITickable
 
     private boolean checkCorrectItem(final ItemStack itemStack)
     {
+        if(itemStack.isEmpty())
+        {
+            return false;
+        }
+
         for(final String string : Configurations.gameplay.listOfCompostableItems)
         {
             if(itemStack.getItem().getRegistryName().toString().equals(string))


### PR DESCRIPTION
OreDictionary throws an Illegal Argument Exception if you try to get the ID of an empty stack, so if the player is holding an empty stack, we are not doing any operations at all, and returning false.

Closes #2629 

# Changes proposed in this pull request:
- Added a check on the tile entity to ensure that we dont pass an empty stack as parametter to the OreDictionary.

Review please
