### PR TITLE
Despawn barbarians faster and let dump into other chests

### DIFF
--- a/src/main/java/com/minecolonies/coremod/colony/requestsystem/requesters/BuildingBasedRequester.java
+++ b/src/main/java/com/minecolonies/coremod/colony/requestsystem/requesters/BuildingBasedRequester.java
@@ -98,18 +98,19 @@ public class BuildingBasedRequester implements IBuildingBasedRequester
 
     private void updateBuilding()
     {
-        if (building != null)
+        if (building != null || location == null)
         {
             return;
         }
 
-        if (location == null)
-        {
-            return;
-        }
 
         final World world = MineColonies.proxy.getWorld(location.getDimension());
         final IColony colony = ColonyManager.getClosestIColony(world, location.getInDimensionLocation());
+
+        if (colony == null)
+        {
+            return;
+        }
 
         building = colony.getRequesterBuildingForPosition(location.getInDimensionLocation());
     }

--- a/src/main/java/com/minecolonies/coremod/entity/ai/basic/AbstractEntityAIBasic.java
+++ b/src/main/java/com/minecolonies/coremod/entity/ai/basic/AbstractEntityAIBasic.java
@@ -49,6 +49,7 @@ import static com.minecolonies.api.util.constant.Suppression.RAWTYPES;
 import static com.minecolonies.api.util.constant.ToolLevelConstants.TOOL_LEVEL_WOOD_OR_GOLD;
 import static com.minecolonies.api.util.constant.TranslationConstants.*;
 import static com.minecolonies.coremod.entity.ai.util.AIState.*;
+import static net.minecraftforge.items.CapabilityItemHandler.ITEM_HANDLER_CAPABILITY;
 
 /**
  * This class provides basic ai functionality.
@@ -903,7 +904,7 @@ public abstract class AbstractEntityAIBasic<J extends AbstractJob> extends Abstr
             return INVENTORY_FULL;
         }
 
-        if(InventoryUtils.isProviderFull(getOwnBuilding().getTileEntity()))
+        if(InventoryUtils.isProviderFull(getOwnBuilding()))
         {
             getOwnBuilding().alterPickUpPriority(MAX_PRIO);
             chatSpamFilter.talkWithoutSpam(COM_MINECOLONIES_COREMOD_ENTITY_WORKER_INVENTORYFULLCHEST);
@@ -932,12 +933,11 @@ public abstract class AbstractEntityAIBasic<J extends AbstractJob> extends Abstr
         @Nullable final AbstractBuildingWorker buildingWorker = getOwnBuilding();
 
         return buildingWorker != null
-                 && (walkToBuilding()
-                       || InventoryFunctions.matchFirstInHandlerWithAction(new InvWrapper(worker.getInventoryCitizen()),
+                 && (walkToBuilding() || InventoryFunctions.matchFirstInHandlerWithAction(new InvWrapper(worker.getInventoryCitizen()),
           itemStack -> !ItemStackUtils.isEmpty(itemStack) && !buildingWorker.buildingRequiresCertainAmountOfItem(itemStack, alreadyKept),
           (handler, slot) ->
             InventoryUtils.transferItemStackIntoNextFreeSlotInItemHandlers(
-              new InvWrapper(worker.getInventoryCitizen()), slot, new InvWrapper(buildingWorker.getTileEntity()))
+              new InvWrapper(worker.getInventoryCitizen()), slot, buildingWorker.getCapability(ITEM_HANDLER_CAPABILITY, null))
         ));
     }
 

--- a/src/main/java/com/minecolonies/coremod/entity/ai/mobs/barbarians/AbstractEntityBarbarian.java
+++ b/src/main/java/com/minecolonies/coremod/entity/ai/mobs/barbarians/AbstractEntityBarbarian.java
@@ -62,7 +62,7 @@ public abstract class AbstractEntityBarbarian extends EntityMob
     /**
      * Amount of ticks to despawn the barbarian.
      */
-    private static final int TICKS_TO_DESPAWN = Constants.TICKS_SECOND * Constants.SECONDS_A_MINUTE * 10;
+    private static final int TICKS_TO_DESPAWN = Constants.TICKS_SECOND * Constants.SECONDS_A_MINUTE * 5;
 
     /**
      * Randomly execute it every this ticks.


### PR DESCRIPTION


# Changes proposed in this pull request:
- Decreases Barbarian despawn time from 10 to 5 minutes (Else citizens will be still for 10 minutes)
- Allows workers to dump into all their chests and not only the main one.

Review please
