### PR TITLE
lag: control possible lag in building's onWorldTick()

### DIFF
--- a/src/api/java/com/minecolonies/api/util/constant/ColonyConstants.java
+++ b/src/api/java/com/minecolonies/api/util/constant/ColonyConstants.java
@@ -14,6 +14,11 @@ public final class ColonyConstants
     //  Settings
     public static final int CLEANUP_TICK_INCREMENT = 5 * TICKS_SECOND;
 
+    /**
+     * Default average randomization for onWorldTick() methods
+    */
+    public static final int ONWORLD_TICK_AVERAGE = 1 * TICKS_SECOND;
+
     public static final int NUM_ACHIEVEMENT_FIRST  = 1;
     public static final int NUM_ACHIEVEMENT_SECOND = 25;
     public static final int NUM_ACHIEVEMENT_THIRD  = 100;

--- a/src/main/java/com/minecolonies/coremod/colony/buildings/AbstractBuildingWorker.java
+++ b/src/main/java/com/minecolonies/coremod/colony/buildings/AbstractBuildingWorker.java
@@ -40,6 +40,7 @@ import org.jetbrains.annotations.Nullable;
 import java.util.*;
 import java.util.stream.Collectors;
 
+import static com.minecolonies.api.util.constant.ColonyConstants.ONWORLD_TICK_AVERAGE;
 import static com.minecolonies.api.util.constant.NbtTagConstants.*;
 import static com.minecolonies.api.util.constant.ToolLevelConstants.TOOL_LEVEL_MAXIMUM;
 import static com.minecolonies.api.util.constant.ToolLevelConstants.TOOL_LEVEL_WOOD_OR_GOLD;
@@ -368,6 +369,14 @@ public abstract class AbstractBuildingWorker extends AbstractBuilding
     public void onWorldTick(@NotNull final TickEvent.WorldTickEvent event)
     {
         super.onWorldTick(event);
+
+        //
+        // Code below this check won't lag each tick anymore
+        //
+        if (getColony() == null || !getColony().shallUpdate(event, ONWORLD_TICK_AVERAGE))
+        {
+            return;
+        }
 
         // If we have no active worker, grab one from the Colony
         // TODO Maybe the Colony should assign jobs out, instead?

--- a/src/main/java/com/minecolonies/coremod/colony/buildings/workerbuildings/BuildingBaker.java
+++ b/src/main/java/com/minecolonies/coremod/colony/buildings/workerbuildings/BuildingBaker.java
@@ -30,6 +30,8 @@ import org.jetbrains.annotations.NotNull;
 
 import java.util.*;
 
+import static com.minecolonies.api.util.constant.ColonyConstants.TICKS_SECOND;
+
 /**
  * Building for the baker.
  */
@@ -72,7 +74,7 @@ public class BuildingBaker extends AbstractBuildingWorker
     /**
      * Wait this amount of ticks before checking again.
      */
-    private static final int WAIT_TICKS = 320;
+    private static final int WAIT_TICKS = 16 * TICKS_SECOND;
     /**
      * Always try to keep at least 2 stacks of wheat in the inventory and in the worker chest.
      */
@@ -85,10 +87,6 @@ public class BuildingBaker extends AbstractBuildingWorker
      * Map of tasks for the baker to work on.
      */
     private final Map<ProductState, List<BakingProduct>> tasks = new EnumMap<>(ProductState.class);
-    /**
-     * Ticks past since the last check.
-     */
-    private int ticksPassed = 0;
 
     /**
      * Constructor for the baker building.
@@ -254,13 +252,13 @@ public class BuildingBaker extends AbstractBuildingWorker
     {
         super.onWorldTick(event);
 
-        if (ticksPassed != WAIT_TICKS)
+        //
+        // Code below this check won't lag each tick anymore
+        //
+        if (getColony() == null || !getColony().shallUpdate(event, WAIT_TICKS))
         {
-            ticksPassed++;
             return;
         }
-        ticksPassed = 0;
-
 
         checkFurnaces();
     }

--- a/src/main/java/com/minecolonies/coremod/colony/buildings/workerbuildings/BuildingHome.java
+++ b/src/main/java/com/minecolonies/coremod/colony/buildings/workerbuildings/BuildingHome.java
@@ -25,6 +25,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 
+import static com.minecolonies.api.util.constant.ColonyConstants.ONWORLD_TICK_AVERAGE;
 import static com.minecolonies.api.util.constant.ColonyConstants.NUM_ACHIEVEMENT_FIRST;
 import static com.minecolonies.api.util.constant.Constants.MAX_BUILDING_LEVEL;
 import static com.minecolonies.api.util.constant.NbtTagConstants.TAG_BEDS;
@@ -184,6 +185,14 @@ public class BuildingHome extends AbstractBuilding
     @Override
     public void onWorldTick(@NotNull final TickEvent.WorldTickEvent event)
     {
+        //
+        // Code below this check won't lag each tick anymore
+        //
+        if (getColony() == null || !getColony().shallUpdate(event, ONWORLD_TICK_AVERAGE))
+        {
+            return;
+        }
+
         if (getAssignedCitizen().size() < getMaxInhabitants() && getColony() != null && !getColony().isManualHousing())
         {
             // 'Capture' as many citizens into this house as possible


### PR DESCRIPTION
add ColonyConstants.ONWORLD_TICK_AVERAGE and use Colony.shallUpdate()
method in onWorldTick() methods. thus, we skip execution of code that is
not required to run each tick by controllable and randomized average
delay.

see #2634

Closes # nothing yet

# Changes proposed in this pull request:
- Baker still checks furnaces in 16 seconds, but on average
-
-

Review please
