### PR TITLE
Baker skipping last Recipe

### DIFF
--- a/src/main/java/com/minecolonies/coremod/entity/ai/citizen/baker/EntityAIWorkBaker.java
+++ b/src/main/java/com/minecolonies/coremod/entity/ai/citizen/baker/EntityAIWorkBaker.java
@@ -300,7 +300,7 @@ public class EntityAIWorkBaker extends AbstractEntityAISkill<JobBaker>
         IRecipeStorage storage = null;
         final BuildingBaker building = getOwnBuilding();
         currentRecipe++;
-        if (currentRecipe + 1 >= BakerRecipes.getRecipes().size())
+        if (currentRecipe + 1 > BakerRecipes.getRecipes().size())
         {
             currentRecipe = 0;
         }


### PR DESCRIPTION
If the last item in the recipe list was checked it would skip over it and not make it.  The check to see what is the next recipe to make was doing >= on the array of recipes to check if they are makable and should be >  the equal prevented the code from checking the last recipe.
