### PR TITLE
Citizens Sleep - Random talking during sleep bug #2622

### DIFF
--- a/src/main/java/com/minecolonies/coremod/entity/EntityCitizen.java
+++ b/src/main/java/com/minecolonies/coremod/entity/EntityCitizen.java
@@ -580,7 +580,7 @@ public class EntityCitizen extends AbstractEntityCitizen
             {
                 SoundUtils.playRandomSound(CompatibilityUtils.getWorld(this), this, citizenData.getSaturation());
             }
-            else if (CompatibilityUtils.getWorld(this).isRaining() && 1 >= rand.nextInt(RANT_ABOUT_WEATHER_CHANCE) && citizenJobHandler.getColonyJob() != null)
+            else if (citizenStatusHandler.getStatus() != Status.SLEEPING && CompatibilityUtils.getWorld(this).isRaining() && 1 >= rand.nextInt(RANT_ABOUT_WEATHER_CHANCE) && citizenJobHandler.getColonyJob() != null)
             {
                 SoundUtils.playSoundAtCitizenWithChance(CompatibilityUtils.getWorld(this), this.getPosition(), citizenJobHandler.getColonyJob().getBadWeatherSound(), 1);
             }


### PR DESCRIPTION
Citizen would talk during sleep status if at night it was raining.  Added a check on the random speech that if sleeping to ignore them.

I think having sleep sounds would be cool.  Snoring and etc...  Then we could switch to another another of objects to play during sleep cycle.
