### PR TITLE
Baker - default recipe values when upgrading

### DIFF
--- a/src/main/java/com/minecolonies/coremod/colony/buildings/workerbuildings/BuildingBaker.java
+++ b/src/main/java/com/minecolonies/coremod/colony/buildings/workerbuildings/BuildingBaker.java
@@ -222,19 +222,23 @@ public class BuildingBaker extends AbstractBuildingWorker
             furnaces.put(pos, bakingProduct);
         }
 
-    
-        final NBTTagList recipeTagList = compound.getTagList(TAG_RECIPES, Constants.NBT.TAG_COMPOUND);
-        if (recipesAllowed == null)
+        if (compound.hasKey(TAG_RECIPES))
         {
-        	recipesAllowed = new boolean[recipeTagList.tagCount()];
+            final NBTTagList recipeTagList = compound.getTagList(TAG_RECIPES, Constants.NBT.TAG_COMPOUND);
+            
+            for (int i = 0; i < recipeTagList.tagCount(); ++i)
+            {
+                final NBTTagCompound recipeCompound = recipeTagList.getCompoundTagAt(i);
+                recipesAllowed[i] = recipeCompound.getBoolean(TAG_RECIPE_POS);
+            }
         }
-        
-        for (int i = 0; i < recipeTagList.tagCount(); ++i)
+        else
         {
-            final NBTTagCompound recipeCompound = recipeTagList.getCompoundTagAt(i);
-            recipesAllowed[i] = recipeCompound.getBoolean(TAG_RECIPE_POS);
+            for (int i = 0; i < recipesAllowed.length; ++i)
+            {
+                recipesAllowed[i] = true;
+            }
         }
-
     }
 
     @Override


### PR DESCRIPTION
Added a check to readFromNBT to see if TAG is in the safe file.  If not it sets all recipes to makeable.  This way when upgrading the baker has something to do.
