### PR TITLE
Happinesss - possible changes. enhancement in progress #2600

### DIFF
--- a/src/api/java/com/minecolonies/api/util/constant/CitizenConstants.java
+++ b/src/api/java/com/minecolonies/api/util/constant/CitizenConstants.java
@@ -161,27 +161,4 @@ public final class CitizenConstants
      * Distance between Barbarian and Citizen to not remove happiness.
      */
     public static final int BARB_DISTANCE_FOR_FREE_DEATH = 21;
-
-
-
-    /**
-     * Tag names for NBT fields
-     */
-    public static final String TAG_NAME = "happiness";
-    public static final String TAG_BASE = "base";
-    public static final String TAG_FOOD = "foodModifier";
-    public static final String TAG_DAMAGE = "damageModifier";
-    public static final String TAG_HOUSE = "houseModifier";
-    public static final String TAG_NUMBER_OF_DAYS_HOUSE = "numberOfDaysWithoutHouse";
-    public static final String TAG_JOB = "jobModifier";
-    public static final String TAG_NUMBER_OF_DAYS_JOB = "numberOfDaysWithoutJob";
-    public static final String TAG_FIELDS = "fields";
-    public static final String TAG_HAS_NO_FIELDS = "hasNoFields";
-    public static final String TAG_FIELD_DAYS_INACTIVE = "daysinactive";
-    public static final String TAG_FIELD_ID = "id";
-    public static final String TAG_FIELD_CAN_FARM = "canfarm";
-    public static final String TAG_NO_TOOLS = "noTools";
-    public static final String TAG_NO_TOOLS_NUMBER_DAYS = "numberOfDaysNoTools";
-    public static final String TAG_NO_TOOLS_TOOL_TYPE = "toolType";
-
 }

--- a/src/api/java/com/minecolonies/api/util/constant/CitizenConstants.java
+++ b/src/api/java/com/minecolonies/api/util/constant/CitizenConstants.java
@@ -161,4 +161,27 @@ public final class CitizenConstants
      * Distance between Barbarian and Citizen to not remove happiness.
      */
     public static final int BARB_DISTANCE_FOR_FREE_DEATH = 21;
+
+
+
+    /**
+     * Tag names for NBT fields
+     */
+    public static final String TAG_NAME = "happiness";
+    public static final String TAG_BASE = "base";
+    public static final String TAG_FOOD = "foodModifier";
+    public static final String TAG_DAMAGE = "damageModifier";
+    public static final String TAG_HOUSE = "houseModifier";
+    public static final String TAG_NUMBER_OF_DAYS_HOUSE = "numberOfDaysWithoutHouse";
+    public static final String TAG_JOB = "jobModifier";
+    public static final String TAG_NUMBER_OF_DAYS_JOB = "numberOfDaysWithoutJob";
+    public static final String TAG_FIELDS = "fields";
+    public static final String TAG_HAS_NO_FIELDS = "hasNoFields";
+    public static final String TAG_FIELD_DAYS_INACTIVE = "daysinactive";
+    public static final String TAG_FIELD_ID = "id";
+    public static final String TAG_FIELD_CAN_FARM = "canfarm";
+    public static final String TAG_NO_TOOLS = "noTools";
+    public static final String TAG_NO_TOOLS_NUMBER_DAYS = "numberOfDaysNoTools";
+    public static final String TAG_NO_TOOLS_TOOL_TYPE = "toolType";
+
 }

--- a/src/api/java/com/minecolonies/api/util/constant/NbtTagConstants.java
+++ b/src/api/java/com/minecolonies/api/util/constant/NbtTagConstants.java
@@ -65,6 +65,21 @@ public final class NbtTagConstants
     public static final String TAG_DAY                    = "day";
     public static final String OWNED_CHUNKS_TO_LOAD_TAG   = "ownedChunks";
     public static final String CLOSE_CHUNKS_TO_LOAD_TAG   = "closeChunks";
+    public static final String TAG_HAPPINESS_NAME         = "happiness";
+    public static final String TAG_BASE                   = "base";
+    public static final String TAG_FOOD                   = "foodModifier";
+    public static final String TAG_DAMAGE                 = "damageModifier";
+    public static final String TAG_HOUSE                  = "houseModifier";
+    public static final String TAG_NUMBER_OF_DAYS_HOUSE   = "numberOfDaysWithoutHouse";
+    public static final String TAG_JOB                    = "jobModifier";
+    public static final String TAG_NUMBER_OF_DAYS_JOB     = "numberOfDaysWithoutJob";
+    public static final String TAG_HAS_NO_FIELDS          = "hasNoFields";
+    public static final String TAG_FIELD_DAYS_INACTIVE    = "daysinactive";
+    public static final String TAG_FIELD_CAN_FARM         = "canfarm";
+    public static final String TAG_NO_TOOLS               = "noTools";
+    public static final String TAG_NO_TOOLS_NUMBER_DAYS   = "numberOfDaysNoTools";
+    public static final String TAG_NO_TOOLS_TOOL_TYPE     = "toolType";
+
 
     /**
      * Tag used to store the containers to NBT.

--- a/src/main/java/com/minecolonies/coremod/client/gui/WindowCitizen.java
+++ b/src/main/java/com/minecolonies/coremod/client/gui/WindowCitizen.java
@@ -22,6 +22,7 @@ import com.minecolonies.coremod.colony.CitizenDataView;
 import com.minecolonies.coremod.colony.ColonyManager;
 import com.minecolonies.coremod.colony.ColonyView;
 import com.minecolonies.coremod.colony.buildings.views.AbstractBuildingView;
+import com.minecolonies.coremod.entity.citizenhandlers.CitizenHappinessHandler; 
 import com.minecolonies.coremod.network.messages.OpenInventoryMessage;
 import com.minecolonies.coremod.network.messages.TransferItemsToCitizenRequestMessage;
 import com.minecolonies.coremod.network.messages.UpdateRequestStateMessage;
@@ -139,11 +140,22 @@ public class WindowCitizen extends AbstractWindowSkeleton
     private static final int XP_BAR_EMPTY_ROW = 64;
 
     /**
+     * The row where the emtpy Happiness bar starts. 
+     */ 
+
+    private static final int HAPPINESS_BAR_EMPTY_ROW = 74; 
+ 
+    /** 
      * The row where the full xpBar starts.
      */
     private static final int XP_BAR_FULL_ROW = 69;
 
     /**
+     * The row where the full happiness bar starts. 
+     */ 
+    private static final int HAPPINESS_BAR_FULL_ROW = 79; 
+ 
+    /** 
      * Row position of the empty heart icon.
      */
     private static final int EMPTY_HEART_ICON_ROW_POS = 16;
@@ -219,6 +231,11 @@ public class WindowCitizen extends AbstractWindowSkeleton
     private static final String WINDOW_ID_XP = "xpLabel";
 
     /**
+     * The label to find the happiness label in the gui. 
+     */ 
+    private static final String WINDOW_ID_HAPPINESS = "happinessLabel"; 
+
+    /** 
      * The label to find xpBar in the gui.
      */
     private static final String WINDOW_ID_XPBAR = "xpBar";
@@ -249,6 +266,11 @@ public class WindowCitizen extends AbstractWindowSkeleton
     private static final String WINDOW_ID_SATURATION_BAR = "saturationBar";
 
     /**
+     * The saturation bar of the citizen. 
+     */ 
+    private static final String WINDOW_ID_HAPPINESS_BAR = "happinessBar"; 
+ 
+    /** 
      * Id of the gender button.
      */
     private static final String WINDOW_ID_GENDER = "gender";
@@ -367,6 +389,7 @@ public class WindowCitizen extends AbstractWindowSkeleton
 
         createHealthBar();
         createSaturationBar();
+        createHappinessBar(); 
         createXpBar(citizen, this);
         createSkillContent(citizen, this);
 
@@ -528,6 +551,39 @@ public class WindowCitizen extends AbstractWindowSkeleton
         }
     }
 
+    
+   /** 
++
+    * Creates an Happiness bar according to the citizen maxHappiness and currentHappiness. 
+    */ 
+   private void createHappinessBar() 
+   { 
+       final double experienceRatio = (citizen.getHappiness() / CitizenHappinessHandler.MAX_HAPPINESS) * XP_BAR_WIDTH; 
+       findPaneOfTypeByID(WINDOW_ID_HAPPINESS_BAR, View.class).setAlignment(Alignment.MIDDLE_RIGHT); 
+       window.findPaneOfTypeByID(WINDOW_ID_HAPPINESS, Label.class).setLabelText(Integer.toString((int)citizen.getHappiness())); 
+
+        
+       @NotNull final Image xpBar = new Image(); 
+       xpBar.setImage(Gui.ICONS, XP_BAR_ICON_COLUMN, HAPPINESS_BAR_EMPTY_ROW, XP_BAR_WIDTH, XP_HEIGHT, false); 
+       xpBar.setPosition(LEFT_BORDER_X, LEFT_BORDER_Y); 
+
+       @NotNull final Image xpBar2 = new Image(); 
+       xpBar2.setImage(Gui.ICONS, XP_BAR_ICON_COLUMN_END, HAPPINESS_BAR_EMPTY_ROW, XP_BAR_ICON_COLUMN_END_WIDTH, XP_HEIGHT, false); 
+       xpBar2.setPosition(XP_BAR_ICON_END_OFFSET + LEFT_BORDER_X, LEFT_BORDER_Y); 
+
+       window.findPaneOfTypeByID(WINDOW_ID_HAPPINESS_BAR, View.class).addChild(xpBar); 
+       window.findPaneOfTypeByID(WINDOW_ID_HAPPINESS_BAR, View.class).addChild(xpBar2); 
+
+       if (experienceRatio > 0) 
+       { 
+           @NotNull final Image xpBarFull = new Image(); 
+           xpBarFull.setImage(Gui.ICONS, XP_BAR_ICON_COLUMN, HAPPINESS_BAR_FULL_ROW, (int) experienceRatio, XP_HEIGHT, false); 
+           xpBarFull.setPosition(LEFT_BORDER_X, LEFT_BORDER_Y); 
+           window.findPaneOfTypeByID(WINDOW_ID_HAPPINESS_BAR, View.class).addChild(xpBarFull); 
+       } 
+   } 
+
+
     /**
      * Creates the xp bar for each citizen.
      * Calculates an xpBarCap which is the maximum of xp to fit into the bar.
@@ -561,6 +617,39 @@ public class WindowCitizen extends AbstractWindowSkeleton
         }
     }
 
+    /** 
+     * Creates an Happiness bar according to the citizen maxHappiness and currentHappiness. 
+     *  
+     * @param citizen  pointer to the citizen data view 
+     * @param window  pointer to the current window 
+     */ 
+    public static void createHappinessBar(final CitizenDataView citizen, final AbstractWindowSkeleton window) 
+    { 
+        //Calculates how much percent of the next level has been completed. 
+        final double experienceRatio = (citizen.getHappiness() / CitizenHappinessHandler.MAX_HAPPINESS) * XP_BAR_WIDTH; 
+        window.findPaneOfTypeByID(WINDOW_ID_HAPPINESS_BAR, View.class).setAlignment(Alignment.MIDDLE_RIGHT); 
+        window.findPaneOfTypeByID(WINDOW_ID_HAPPINESS, Label.class).setLabelText(Integer.toString((int)citizen.getHappiness())); 
+ 
+        @NotNull final Image xpBar = new Image(); 
+        xpBar.setImage(Gui.ICONS, XP_BAR_ICON_COLUMN, HAPPINESS_BAR_EMPTY_ROW, XP_BAR_WIDTH, XP_HEIGHT, false); 
+        xpBar.setPosition(LEFT_BORDER_X, LEFT_BORDER_Y); 
+ 
+        @NotNull final Image xpBar2 = new Image(); 
+        xpBar2.setImage(Gui.ICONS, XP_BAR_ICON_COLUMN_END, HAPPINESS_BAR_EMPTY_ROW, XP_BAR_ICON_COLUMN_END_WIDTH, XP_HEIGHT, false); 
+        xpBar2.setPosition(XP_BAR_ICON_END_OFFSET + LEFT_BORDER_X, LEFT_BORDER_Y); 
+ 
+        window.findPaneOfTypeByID(WINDOW_ID_HAPPINESS_BAR, View.class).addChild(xpBar); 
+        window.findPaneOfTypeByID(WINDOW_ID_HAPPINESS_BAR, View.class).addChild(xpBar2); 
+ 
+        if (experienceRatio > 0) 
+        { 
+            @NotNull final Image xpBarFull = new Image(); 
+            xpBarFull.setImage(Gui.ICONS, XP_BAR_ICON_COLUMN, HAPPINESS_BAR_FULL_ROW, (int) experienceRatio, XP_HEIGHT, false); 
+            xpBarFull.setPosition(LEFT_BORDER_X, LEFT_BORDER_Y); 
+            window.findPaneOfTypeByID(WINDOW_ID_HAPPINESS_BAR, View.class).addChild(xpBarFull); 
+        } 
+    } 
+ 
     /**
      * Fills the citizen gui with it's skill values.
      * @param citizen the citizen to use.

--- a/src/main/java/com/minecolonies/coremod/client/gui/WindowTownHall.java
+++ b/src/main/java/com/minecolonies/coremod/client/gui/WindowTownHall.java
@@ -857,6 +857,7 @@ public class WindowTownHall extends AbstractWindowBuilding<BuildingTownHall.View
         button.disable();
         final CitizenDataView view = citizens.get(row);
         WindowCitizen.createXpBar(view, this);
+        WindowCitizen.createHappinessBar(view, this); 
         WindowCitizen.createSkillContent(view, this);
         findPaneOfTypeByID(JOB_LABEL, Label.class).setLabelText("§l" + LanguageHandler.format(view.getJob().trim().isEmpty() ? GUI_TOWNHALL_CITIZEN_JOB_UNEMPLOYED : view.getJob()));
         findPaneOfTypeByID(HIDDEN_CITIZEN_ID, Label.class).setLabelText(String.valueOf(view.getId()));

--- a/src/main/java/com/minecolonies/coremod/colony/CitizenData.java
+++ b/src/main/java/com/minecolonies/coremod/colony/CitizenData.java
@@ -781,8 +781,8 @@ public class CitizenData
 
     /**
      * Writes the citizen data to an NBT-compound.
-     *
      * @param compound NBT-Tag compound.
+     * @return return the data in NBT format
      */
     public NBTTagCompound writeToNBT(@NotNull final NBTTagCompound compound)
     {
@@ -817,7 +817,7 @@ public class CitizenData
         compound.setTag(TAG_INVENTORY, inventory.writeToNBT(new NBTTagList()));
         compound.setInteger(TAG_HELD_ITEM_SLOT, inventory.getHeldItemSlot(EnumHand.MAIN_HAND));
         compound.setInteger(TAG_OFFHAND_HELD_ITEM_SLOT, inventory.getHeldItemSlot(EnumHand.OFF_HAND));
-        citizenHappinessHandler.writeToNBT(compound); 
+        citizenHappinessHandler.writeToNBT(compound);
         return compound;
     }
 
@@ -859,7 +859,7 @@ public class CitizenData
         buf.writeInt(getIntelligence());
         buf.writeInt(getDexterity());
         buf.writeDouble(getSaturation());
-        buf.writeDouble(citizenHappinessHandler.getHappiness()); 
+        buf.writeDouble(citizenHappinessHandler.getHappiness());
         
         ByteBufUtils.writeUTF8String(buf, (job != null) ? job.getName() : "");
 
@@ -1091,11 +1091,12 @@ public class CitizenData
         return job.getAsyncRequests().contains(token);
     }
 
-    /** 
-     * The Handler for the citizens happiness. 
-     * @return the instance of the handler. 
-     */ 
-    public CitizenHappinessHandler getCitizenHappinessHandler() { 
-        return citizenHappinessHandler; 
-    } 
+    /**
+     * The Handler for the citizens happiness.
+     * @return the instance of the handler
+     */
+    public CitizenHappinessHandler getCitizenHappinessHandler()
+    {
+        return citizenHappinessHandler;
+    }
 }

--- a/src/main/java/com/minecolonies/coremod/colony/CitizenData.java
+++ b/src/main/java/com/minecolonies/coremod/colony/CitizenData.java
@@ -15,6 +15,7 @@ import com.minecolonies.coremod.colony.jobs.AbstractJob;
 import com.minecolonies.coremod.colony.managers.ICitizenManager;
 import com.minecolonies.coremod.entity.EntityCitizen;
 import com.minecolonies.coremod.entity.ai.basic.AbstractAISkeleton;
+import com.minecolonies.coremod.entity.citizenhandlers.CitizenHappinessHandler; 
 import com.minecolonies.coremod.inventory.InventoryCitizen;
 import com.minecolonies.coremod.util.TeleportHelper;
 import io.netty.buffer.ByteBuf;
@@ -168,6 +169,12 @@ public class CitizenData
      */
     private BlockPos lastPosition = new BlockPos(0, 0, 0);
 
+    /** 
+     * The citizen happiness handler. 
++
+     */ 
+    private final CitizenHappinessHandler citizenHappinessHandler; 
+ 
     /**
      * Create a CitizenData given an ID.
      * Used as a super-constructor or during loading.
@@ -180,6 +187,7 @@ public class CitizenData
         this.id = id;
         this.colony = colony;
         inventory = new InventoryCitizen("Minecolonies Inventory", true, this);
+        this.citizenHappinessHandler = new CitizenHappinessHandler(this); 
     }
 
     /**
@@ -235,6 +243,7 @@ public class CitizenData
             this.inventory.setHeldItem(EnumHand.MAIN_HAND, compound.getInteger(TAG_HELD_ITEM_SLOT));
             this.inventory.setHeldItem(EnumHand.OFF_HAND, compound.getInteger(TAG_OFFHAND_HELD_ITEM_SLOT));
         }
+        citizenHappinessHandler.readFromNBT(compound); 
     }
 
     /**
@@ -808,6 +817,7 @@ public class CitizenData
         compound.setTag(TAG_INVENTORY, inventory.writeToNBT(new NBTTagList()));
         compound.setInteger(TAG_HELD_ITEM_SLOT, inventory.getHeldItemSlot(EnumHand.MAIN_HAND));
         compound.setInteger(TAG_OFFHAND_HELD_ITEM_SLOT, inventory.getHeldItemSlot(EnumHand.OFF_HAND));
+        citizenHappinessHandler.writeToNBT(compound); 
         return compound;
     }
 
@@ -849,7 +859,8 @@ public class CitizenData
         buf.writeInt(getIntelligence());
         buf.writeInt(getDexterity());
         buf.writeDouble(getSaturation());
-
+        buf.writeDouble(citizenHappinessHandler.getHappiness()); 
+        
         ByteBufUtils.writeUTF8String(buf, (job != null) ? job.getName() : "");
 
         writeStatusToBuffer(buf);
@@ -1079,4 +1090,12 @@ public class CitizenData
     {
         return job.getAsyncRequests().contains(token);
     }
+
+    /** 
+     * The Handler for the citizens happiness. 
+     * @return the instance of the handler. 
+     */ 
+    public CitizenHappinessHandler getCitizenHappinessHandler() { 
+        return citizenHappinessHandler; 
+    } 
 }

--- a/src/main/java/com/minecolonies/coremod/colony/CitizenDataView.java
+++ b/src/main/java/com/minecolonies/coremod/colony/CitizenDataView.java
@@ -57,6 +57,12 @@ public class CitizenDataView
     private int    dexterity;
     private double saturation;
 
+    /** 
+     * holds the current citizen happiness value 
+     */ 
+
+    private double happiness; 
+
     /**
      * Job identifier.
      */
@@ -219,6 +225,16 @@ public class CitizenDataView
         return charisma;
     }
 
+    /** 
+     * Gets the current Happiness value for the citizen 
+     * 
+     * @return citizens current Happiness value 
+     */ 
+    public double getHappiness() 
+    { 
+      return happiness; 
+    } 
+
     /**
      * Get the saturation of the citizen.
      *
@@ -295,6 +311,7 @@ public class CitizenDataView
         intelligence = buf.readInt();
         dexterity = buf.readInt();
         saturation = buf.readDouble();
+        happiness = buf.readDouble();
 
         job = ByteBufUtils.readUTF8String(buf);
 

--- a/src/main/java/com/minecolonies/coremod/colony/Colony.java
+++ b/src/main/java/com/minecolonies/coremod/colony/Colony.java
@@ -170,11 +170,6 @@ public class Colony implements IColony
     private Permissions permissions;
 
     /**
-     * Overall happyness of the colony.
-     */
-    private double overallHappiness = DEFAULT_OVERALL_HAPPYNESS;
-
-    /**
      * The request manager assigned to the colony.
      */
     private IRequestManager requestManager;
@@ -348,7 +343,7 @@ public class Colony implements IColony
             freePositions.add(block);
         }
 
-        this.overallHappiness = compound.getDouble(TAG_HAPPINESS);
+        happinessData.readFromNBT(compound); 
         packageManager.setLastContactInHours(compound.getInteger(TAG_ABANDONED));
         manualHousing = compound.getBoolean(TAG_MANUAL_HOUSING);
 
@@ -460,7 +455,7 @@ public class Colony implements IColony
         }
         compound.setTag(TAG_FREE_POSITIONS, freePositionsTagList);
 
-        compound.setDouble(TAG_HAPPINESS, overallHappiness);
+        happinessData.writeToNBT(compound); 
         compound.setInteger(TAG_ABANDONED, packageManager.getLastContactInHours());
         compound.setBoolean(TAG_MANUAL_HOUSING, manualHousing);
         compound.setTag(TAG_REQUESTMANAGER, getRequestManager().serializeNBT());
@@ -669,6 +664,7 @@ public class Colony implements IColony
             {
                 citizenManager.checkCitizensForHappiness();
             }
+            happinessData.processDeathModifiers(); 
         }
         else if (!isDay && world.isDaytime())
         {
@@ -879,28 +875,6 @@ public class Colony implements IColony
         return buildingManager.getBuilding(pos);
     }
 
-    /**
-     * Increase the overall happiness by an amount, cap at max.
-     *
-     * @param amount the amount.
-     */
-    public void increaseOverallHappiness(final double amount)
-    {
-        this.overallHappiness = Math.min(this.overallHappiness + Math.abs(amount), MAX_OVERALL_HAPPINESS);
-        this.markDirty();
-    }
-
-    /**
-     * Decrease the overall happiness by an amount, cap at min.
-     *
-     * @param amount the amount.
-     */
-    public void decreaseOverallHappiness(final double amount)
-    {
-        this.overallHappiness = Math.max(this.overallHappiness - Math.abs(amount), MIN_OVERALL_HAPPINESS);
-        this.markDirty();
-    }
-
     @NotNull
     public List<EntityPlayer> getMessageEntityPlayers()
     {
@@ -1033,7 +1007,19 @@ public class Colony implements IColony
      */
     public double getOverallHappiness()
     {
-        return this.overallHappiness;
+        double happinessTotal = 0; 
+        for (final CitizenData citizen : citizenManager.getCitizens()) 
+        { 
+            happinessTotal += citizen.getCitizenHappinessHandler().getHappiness(); 
+        } 
+        final double happinessAverage = happinessTotal /  citizenManager.getCitizens().size(); 
+         
+        happinessTotal = happinessAverage + happinessData.getTotalHappinessModifier();  
+        if (happinessTotal > HappinessData.MAX_HAPPINESS) 
+        { 
+            happinessTotal = HappinessData.MIN_HAPPINESS; 
+        } 
+        return happinessTotal; 
     }
 
     /**

--- a/src/main/java/com/minecolonies/coremod/colony/FieldDataModifier.java
+++ b/src/main/java/com/minecolonies/coremod/colony/FieldDataModifier.java
@@ -38,7 +38,7 @@ public class FieldDataModifier
      *
      * @return returns a boolean indicating if a field can be farmed
      */
-    public boolean getCanFarm()
+    public boolean isCanFarm()
     {
         return canFarm;
     }

--- a/src/main/java/com/minecolonies/coremod/colony/FieldDataModifier.java
+++ b/src/main/java/com/minecolonies/coremod/colony/FieldDataModifier.java
@@ -1,0 +1,76 @@
+package com.minecolonies.coremod.colony;
+
+/**
+ * class that holds data related to happiness
+ * modifier for the citizen with a Farmer
+ * job.
+ *
+ */
+public class FieldDataModifier
+{
+    /**
+     * Indicated if the field can be farmed or not.
+     */
+    private boolean canFarm;
+
+    /**
+     * Number of days the fields has been inactiv.e
+     */
+    private int numberDaysInactive;
+
+    /**
+     * Call to set if the field can be farmed or not.
+     *
+     * @param value
+     *            boolean to indicate if the field can be farmed
+     */
+    public void setCanFarm(final boolean value)
+    {
+        canFarm = value;
+        if (value)
+        {
+            numberDaysInactive = 0;
+        }
+    }
+
+    /**
+     * Call to get indicater if the field can be farmed.
+     *
+     * @return returns a boolean indicating if a field can be farmed
+     */
+    public boolean getCanFarm()
+    {
+        return canFarm;
+    }
+
+    /**
+     * Call in increase the number of days the field
+     * has be inactive. Meaning the farmer can't farm the field.
+     */
+    public void increaseInactiveDays()
+    {
+        numberDaysInactive++;
+    }
+
+    /**
+     * Call to get the number of days the field has be inactive.
+     *
+     * @return int that return the number of days the fields has be inactive
+     */
+    public int getInactiveDays()
+    {
+        return numberDaysInactive;
+    }
+
+    /**
+     * Call to set the number of days the field has be inactive.
+     *
+     * @param days
+     *            value to set the number of inactive days for field too.
+     */
+    public void setInactiveDays(final int days)
+    {
+        numberDaysInactive = days;
+    }
+
+}

--- a/src/main/java/com/minecolonies/coremod/colony/FieldDataModifier.java
+++ b/src/main/java/com/minecolonies/coremod/colony/FieldDataModifier.java
@@ -24,7 +24,7 @@ public class FieldDataModifier
      * @param value
      *            boolean to indicate if the field can be farmed
      */
-    public void setCanFarm(final boolean value)
+    public void isCanFarm(final boolean value)
     {
         canFarm = value;
         if (value)

--- a/src/main/java/com/minecolonies/coremod/colony/HappinessData.java
+++ b/src/main/java/com/minecolonies/coremod/colony/HappinessData.java
@@ -16,7 +16,7 @@ import net.minecraftforge.fml.common.network.simpleimpl.IMessage;
  * Datas about the happiness level
  */
 
-public class HappinessData implements IMessage
+public class HappinessData 
 {
     /**
     *  TAGS for string pointer for the NBT field data.
@@ -164,7 +164,6 @@ public class HappinessData implements IMessage
      * {@inheritDoc}
      * @param byteBuf
      */
-    @Override
     public void fromBytes(final ByteBuf byteBuf)
     {
         this.guards = byteBuf.readInt();
@@ -190,7 +189,6 @@ public class HappinessData implements IMessage
      * {@inheritDoc}
      * @param byteBuf
      */
-    @Override
     public void toBytes(final ByteBuf byteBuf)
     {
         byteBuf.writeInt(guards);

--- a/src/main/java/com/minecolonies/coremod/colony/HappinessData.java
+++ b/src/main/java/com/minecolonies/coremod/colony/HappinessData.java
@@ -1,13 +1,63 @@
 package com.minecolonies.coremod.colony;
 
+import java.util.ArrayList;
+import java.util.List;
+
+import org.jetbrains.annotations.NotNull;
+
 import io.netty.buffer.ByteBuf;
+import net.minecraft.nbt.NBTTagCompound;
+import net.minecraft.nbt.NBTTagList;
+import net.minecraftforge.common.util.Constants;
+import net.minecraftforge.common.util.Constants.NBT;
 import net.minecraftforge.fml.common.network.simpleimpl.IMessage;
 
 /**
  * Datas about the happiness level
  */
+
 public class HappinessData implements IMessage
 {
+    /**
+    *  TAGS for string pointer for the NBT field data.
+    */
+    private static final String TAG_TASKS = "happiness";
+    private static final String TAG_GUARDS = "guards";
+    private static final String TAG_HOUSING = "housing";
+    private static final String TAG_SATURATION = "saturation";
+    private static final String TAG_HOUSING_MODIFIER = "housingRatioModifier";
+    private static final String TAG_DEATH_MODIFIER = "deathModifier";
+    private static final String TAG_TOTAL_DEATH_MODIFIER = "totalDeathModifier";
+    private static final String TAG_DEATH_NUMOFDAYS = "numOfDays";
+    private static final String TAG_DEATH_NUMOFDAYS_LAST = "numOfDaysLast";
+    private static final String TAG_DEATH_MODIFIER_VALUE = "modifier";
+    private static final String TAG_DEATH_ADJUSTMENT_MODIFIER = "adjustmentModifier";
+
+    /**
+    * The max number of days a death adjusted the modifier
+    */
+    public static final int MAX_DAYS_DEATH_MODIFIER_LAST = 20;
+
+    /**
+     * The max number of days a death of a guard adjusts the modifier
+     */
+    public static final int MAX_DAYS_DEATH_MODIFIER_LAST_GUARDS = 5;
+
+    /**
+     * Max happiness for the colony
+     */
+    public static final int MAX_HAPPINESS = 10;
+
+    /**
+     * Min happiness for the colony
+     */
+    public static final int MIN_HAPPINESS = 1;
+
+    /**
+     * Max modifier amount for total deaths in colony.
+     * Raids can cause many loses and colony could be 1.
+     */
+    public static final int MAX_DEATH_MODIFIER = 6;
 
     /**
      * Constant used to assign value
@@ -15,6 +65,7 @@ public class HappinessData implements IMessage
     public static final int INCREASE = 1;
     public static final int STABLE   = 0;
     public static final int DECREASE = -1;
+
 
     /**
      * Ratio Guards/Citizens
@@ -30,6 +81,18 @@ public class HappinessData implements IMessage
     private int saturation;
 
     /**
+     * Indicates the housing ratio modifier.
+     */
+    private double housingRatioModifier;
+
+    /**
+     * Array of all the deaths that occur in the colony
+     * for the alst 30 days.
+     */
+    private List<DeathModifierData> deathModifier = new ArrayList();
+
+
+    /**
      * Creating a default constructor
      */
     public HappinessData()
@@ -38,7 +101,7 @@ public class HappinessData implements IMessage
     }
 
     /**
-     * Get the Guards/Citizens ratio level
+     * Get the Guards/Citizens ratio level.
      *
      * @return 1 if great, 0 if normal, -1 if bad
      */
@@ -48,7 +111,7 @@ public class HappinessData implements IMessage
     }
 
     /**
-     * Set the Guards/Citizens ratio level
+     * Set the Guards/Citizens ratio level.
      *
      * @param guards 1 if great, 0 if normal, -1 if bad
      */
@@ -58,7 +121,7 @@ public class HappinessData implements IMessage
     }
 
     /**
-     * Get the Houses/Citizens ratio level
+     * Get the Houses/Citizens ratio level.
      *
      * @return 1 if great, 0 if normal, -1 if bad
      */
@@ -68,7 +131,7 @@ public class HappinessData implements IMessage
     }
 
     /**
-     * Set the Houses/Citizens ratio level
+     * Set the Houses/Citizens ratio level.
      *
      * @param housing 1 if great, 0 if normal, -1 if bad
      */
@@ -78,7 +141,7 @@ public class HappinessData implements IMessage
     }
 
     /**
-     * Get the average saturation level for all citizens in a Colony
+     * Get the average saturation level for all citizens in a Colony.
      *
      * @return 1 if great, 0 if normal, -1 if bad
      */
@@ -88,7 +151,7 @@ public class HappinessData implements IMessage
     }
 
     /**
-     * Set the average saturation level for all citizens in a colony
+     * Set the average saturation level for all citizens in a colony.
      *
      * @param saturation 1 if great, 0 if normal, -1 if bad
      */
@@ -107,6 +170,20 @@ public class HappinessData implements IMessage
         this.guards = byteBuf.readInt();
         this.housing = byteBuf.readInt();
         this.saturation = byteBuf.readInt();
+        this.housingRatioModifier = byteBuf.readDouble();
+
+
+        final int numDeaths = byteBuf.readInt();
+        for (int index = 0; index < numDeaths; index++)
+        {
+            final int numDays = byteBuf.readInt();
+            final double modifier = byteBuf.readDouble();
+            final int numDayslast = byteBuf.readInt();
+            final double adjustment = byteBuf.readDouble();
+            final DeathModifierData data = new DeathModifierData(numDays, modifier, numDayslast);
+            data.setAdjustment(adjustment);
+            deathModifier.add(data);
+        }
     }
 
     /**
@@ -119,6 +196,79 @@ public class HappinessData implements IMessage
         byteBuf.writeInt(guards);
         byteBuf.writeInt(housing);
         byteBuf.writeInt(saturation);
+        byteBuf.writeDouble(housingRatioModifier);
+
+        byteBuf.writeInt(deathModifier.size());
+        for (int index = 0; index < deathModifier.size(); index++)
+        {
+            byteBuf.writeInt(deathModifier.get(index).getDaysSinceEvent());
+            byteBuf.writeDouble(deathModifier.get(index).getModifier());
+            byteBuf.writeInt(deathModifier.get(index).getNumDaysLast());
+            byteBuf.writeDouble(deathModifier.get(index).getAdjustmentModifier());
+        }
+    }
+
+    /**
+    * Reads in Happiness data from the NBT file.
+    *
+    * @param compound pointer to NBT fields
+    */
+    public void readFromNBT(@NotNull final NBTTagCompound compound)
+    {
+        final NBTTagList happinessTagList = compound.getTagList(TAG_TASKS, NBT.TAG_COMPOUND);
+        final NBTTagCompound tagCompound = happinessTagList.getCompoundTagAt(0);
+
+        guards = tagCompound.getInteger(TAG_GUARDS);
+        housing = tagCompound.getInteger(TAG_HOUSING);
+        saturation = tagCompound.getInteger(TAG_SATURATION);
+        housingRatioModifier = tagCompound.getDouble(TAG_HOUSING_MODIFIER);
+
+        final int numDeaths = tagCompound.getInteger(TAG_TOTAL_DEATH_MODIFIER);
+        final NBTTagList deathTagList = tagCompound.getTagList(TAG_DEATH_MODIFIER, Constants.NBT.TAG_COMPOUND);
+        for (int i = 0; i < numDeaths; ++i)
+        {
+            final NBTTagCompound deathCompound = deathTagList.getCompoundTagAt(i);
+            final int numDays = deathCompound.getInteger(TAG_DEATH_NUMOFDAYS);
+            final double value = deathCompound.getDouble(TAG_DEATH_MODIFIER_VALUE);
+            final int numDaysLast = deathCompound.getInteger(TAG_DEATH_NUMOFDAYS_LAST);
+            final double adjustment = deathCompound.getDouble(TAG_DEATH_ADJUSTMENT_MODIFIER);
+            final DeathModifierData data = new DeathModifierData(numDays, value, numDaysLast);
+            data.setAdjustment(adjustment);
+            deathModifier.add(data);
+        }
+    }
+
+
+    /**
+     * Store the level to nbt.
+     *
+     * @param compound compound to use.
+     */
+    public void writeToNBT(@NotNull final NBTTagCompound compound)
+    {
+        @NotNull final NBTTagList tasksTagList = new NBTTagList();
+        @NotNull final NBTTagCompound taskCompound = new NBTTagCompound();
+        taskCompound.setInteger(TAG_GUARDS, guards);
+        taskCompound.setInteger(TAG_HOUSING, housing);
+        taskCompound.setInteger(TAG_SATURATION, saturation);
+        taskCompound.setDouble(TAG_HOUSING_MODIFIER, housingRatioModifier);
+
+        taskCompound.setInteger(TAG_TOTAL_DEATH_MODIFIER, deathModifier.size());
+        @NotNull final NBTTagList deathTagList = new NBTTagList();
+        for (int i = 0; i < deathModifier.size(); i++)
+        {
+            @NotNull final NBTTagCompound deathCompound = new NBTTagCompound();
+        	final DeathModifierData data = deathModifier.get(i);
+        	deathCompound.setInteger(TAG_DEATH_NUMOFDAYS, data.getDaysSinceEvent());
+            deathCompound.setDouble(TAG_DEATH_MODIFIER_VALUE, data.getModifier());
+            deathCompound.setInteger(TAG_DEATH_NUMOFDAYS_LAST, data.getNumDaysLast());
+            deathCompound.setDouble(TAG_DEATH_ADJUSTMENT_MODIFIER, data.getAdjustmentModifier());
+            deathTagList.appendTag(deathCompound);
+        }
+        taskCompound.setTag(TAG_DEATH_MODIFIER, deathTagList);
+
+        tasksTagList.appendTag(taskCompound);
+        compound.setTag(TAG_TASKS, tasksTagList);
     }
 
     /**
@@ -130,5 +280,174 @@ public class HappinessData implements IMessage
         this.guards = data.guards;
         this.saturation = data.saturation;
         this.housing = data.housing;
+
+        this.deathModifier = data.deathModifier;
+        this.housingRatioModifier = data.housingRatioModifier;
     }
+
+
+
+    /**
+     * Call when a citizen dies in the colony.  It will add the citizen death
+     * to the death modifier for the next so many days.
+     */
+    public void setDeathModifier(final double modifier, final boolean isGuard)
+    {
+        int numDays = MAX_DAYS_DEATH_MODIFIER_LAST;
+        if (isGuard)
+            numDays = MAX_DAYS_DEATH_MODIFIER_LAST_GUARDS;
+    	final DeathModifierData data = new DeathModifierData(0, modifier, numDays);
+    	deathModifier.add(data);
+    }
+
+    /**
+     * Call to retrieve the death modifier for the entire colony.
+     *
+     * @return returns the Death modifier
+     */
+    public double getDeathModifier()
+    {
+        double value = 0;
+        for (int index = 0; index < deathModifier.size(); index++)
+        {
+            value += deathModifier.get(index).getModifier();
+    	}
+
+        if (value > MAX_DEATH_MODIFIER)
+        {
+            value = MAX_DEATH_MODIFIER;
+        }
+
+        return value;
+    }
+
+
+    /**
+     * Called to set the housing Ratio Modifier.
+     *
+     * @param modifier the amount to add to the housing Raio Modifier for
+     * the entire Colony.
+     */
+    public void setHousingModifier(final double modifier)
+    {
+        housingRatioModifier = modifier;
+    }
+
+    /**
+     * Call to get the total Housing modifier for the Entire Colony.
+     *
+     * @return housing modifier total
+     */
+    public double getHousingModifier()
+    {
+        return housingRatioModifier;
+    }
+
+    /**
+     * called once a day to process death modifiers.
+     * After a period of time a citizen death is removed from the modifier
+     *
+     */
+    public void processDeathModifiers()
+    {
+        for (int index = 0; index < deathModifier.size(); index++)
+        {
+            final DeathModifierData data = deathModifier.get(index);
+            data.increaseDay();
+            if (data.getDaysSinceEvent() > data.getNumDaysLast())
+            {
+                deathModifier.remove(index);
+                index--;
+            }
+        }
+
+    }
+
+
+    public double getTotalHappinessModifier()
+    {
+        return housingRatioModifier + getDeathModifier();
+    }
+
+
+    /**
+     * Class that holds the data related to a citizens death.
+     *
+     */
+    public class DeathModifierData
+    {
+        /**
+         * Number of days since the citizens death
+         */
+        private int daysSinceEvent;
+        /**
+         * modifier amount for the citizens death
+         */
+        private double modifier;
+        
+        private int numDaysLast;
+
+        private double adjustment;
+        
+        /**
+         * @param daysSinceEvent
+         *            number of days since the citizens death
+         * @param modifier
+         *            value of the modifier for the citizens death
+         */
+        public DeathModifierData(final int daysSinceEvent, final double modifier, final int numDaysLast)
+        {
+            this.daysSinceEvent = daysSinceEvent;
+            this.modifier = modifier;
+            this.numDaysLast = numDaysLast;
+            this.adjustment = (double) (modifier / numDaysLast);
+        }
+
+        /**
+         * @return number of days since the citizens death
+         */
+        public int getDaysSinceEvent()
+        {
+            return daysSinceEvent;
+        }
+
+        public double getAdjustmentModifier()
+        {
+            return adjustment;
+        }
+
+        public void setAdjustment(final double adjustment)
+        {
+            this.adjustment = adjustment;
+        }
+
+        public void setModifier(final double modifier)
+        {
+            this.modifier =modifier;
+        }
+
+        /**
+         * @return the modifier amount for the citizens death
+         */
+        public double getModifier()
+        {
+            return modifier;
+        }
+
+        public int getNumDaysLast()
+        {
+            return numDaysLast;
+        }
+
+        /**
+         * Increase the number of days since the citizens death and
+         * update the modifier to reflect the current days modifier
+         */
+        public void increaseDay()
+        {
+            daysSinceEvent++;
+            modifier -= adjustment;
+        }
+    }
+
 }

--- a/src/main/java/com/minecolonies/coremod/colony/HappinessData.java
+++ b/src/main/java/com/minecolonies/coremod/colony/HappinessData.java
@@ -295,7 +295,9 @@ public class HappinessData implements IMessage
     {
         int numDays = MAX_DAYS_DEATH_MODIFIER_LAST;
         if (isGuard)
+        {
             numDays = MAX_DAYS_DEATH_MODIFIER_LAST_GUARDS;
+        }
     	final DeathModifierData data = new DeathModifierData(0, modifier, numDays);
     	deathModifier.add(data);
     }
@@ -385,7 +387,7 @@ public class HappinessData implements IMessage
          */
         private double modifier;
         
-        private int numDaysLast;
+        final private int numDaysLast;
 
         private double adjustment;
         

--- a/src/main/java/com/minecolonies/coremod/colony/managers/CitizenManager.java
+++ b/src/main/java/com/minecolonies/coremod/colony/managers/CitizenManager.java
@@ -375,7 +375,6 @@ public class CitizenManager implements ICitizenManager
 
             if (citizen.getCitizenEntity().isPresent()) 
             { 
-              final EntityCitizen citizenEnity = citizen.getCitizenEntity().get(); 
               citizen.getCitizenHappinessHandler().processDailyHappiness(hasHouse, hasJob); 
             } 
             saturation += citizen.getSaturation();

--- a/src/main/java/com/minecolonies/coremod/entity/EntityCitizen.java
+++ b/src/main/java/com/minecolonies/coremod/entity/EntityCitizen.java
@@ -325,7 +325,11 @@ public class EntityCitizen extends AbstractEntityCitizen
         }
 
         citizenItemHandler.updateArmorDamage(damage);
-
+        if (citizenData != null) 
+        { 
+            getCitizenData().getCitizenHappinessHandler().setDamageModifier(); 
+        } 
+        
         return result;
     }
 
@@ -408,7 +412,7 @@ public class EntityCitizen extends AbstractEntityCitizen
 
             citizenExperienceHandler.dropExperience();
             this.setDead();
-            citizenColonyHandler.getColony().decreaseOverallHappiness(penalty);
+            citizenColonyHandler.getColony().getHappinessData().setDeathModifier(penalty,citizenJobHandler.getColonyJob() instanceof AbstractJobGuard); 
             triggerDeathAchievement(damageSource, citizenJobHandler.getColonyJob());
             citizenChatHandler.notifyDeath(damageSource);
             citizenColonyHandler.getColony().getCitizenManager().removeCitizen(getCitizenData());
@@ -605,7 +609,11 @@ public class EntityCitizen extends AbstractEntityCitizen
 
             if (citizenData.getSaturation() < HIGH_SATURATION)
             {
-                tryToEat();
+                citizenData.getCitizenHappinessHandler().setFoodModifier(tryToEat()); 
+            } 
+            else  
+            { 
+                citizenData.getCitizenHappinessHandler().setSaturated();
             }
 
             if((distanceWalkedModified + 1.0) % ACTIONS_EACH_BLOCKS_WALKED == 0)
@@ -670,16 +678,18 @@ public class EntityCitizen extends AbstractEntityCitizen
     }
 
     /**
-     * Lets the citizen tryToEat to replentish saturation.
+     * Lets the citizen tryToEat to replenish saturation. 
+     *  
+     * @return return true or not if citizen eat food. 
      */
-    private void tryToEat()
+    private boolean tryToEat()
     {
         final int slot = InventoryUtils.findFirstSlotInProviderWith(this,
           itemStack -> !ItemStackUtils.isEmpty(itemStack) && itemStack.getItem() instanceof ItemFood);
 
         if (slot == -1)
         {
-            return;
+            return false;
         }
 
         final ItemStack stack = getCitizenData().getInventory().getStackInSlot(slot);
@@ -690,6 +700,7 @@ public class EntityCitizen extends AbstractEntityCitizen
             getCitizenData().getInventory().decrStackSize(slot, 1);
             citizenData.markDirty();
         }
+        return true;
     }
 
     /**

--- a/src/main/java/com/minecolonies/coremod/entity/ai/citizen/farmer/EntityAIWorkFarmer.java
+++ b/src/main/java/com/minecolonies/coremod/entity/ai/citizen/farmer/EntityAIWorkFarmer.java
@@ -4,6 +4,7 @@ import com.minecolonies.api.compatibility.Compatibility;
 import com.minecolonies.api.util.BlockUtils;
 import com.minecolonies.api.util.InventoryUtils;
 import com.minecolonies.api.util.ItemStackUtils;
+import com.minecolonies.api.util.constant.IToolType; 
 import com.minecolonies.api.util.constant.ToolType;
 import com.minecolonies.coremod.blocks.huts.BlockHutField;
 import com.minecolonies.coremod.colony.Colony;
@@ -152,6 +153,7 @@ public class EntityAIWorkFarmer extends AbstractEntityAIInteract<JobFarmer>
         if (building.hasNoFields())
         {
             chatSpamFilter.talkWithoutSpam("entity.farmer.noFreeFields");
+            worker.getCitizenData().getCitizenHappinessHandler().setNoFieldsToFarm(); 
             return PREPARING;
         }
 
@@ -258,8 +260,10 @@ public class EntityAIWorkFarmer extends AbstractEntityAIInteract<JobFarmer>
         {
             chatSpamFilter.talkWithoutSpam("entity.farmer.noSeedSet");
             buildingFarmer.setCurrentField(null);
+            worker.getCitizenData().getCitizenHappinessHandler().setNoFieldForFarmerModifier(currentField.getPos(), false); 
             return PREPARING;
         }
+        worker.getCitizenData().getCitizenHappinessHandler().setNoFieldForFarmerModifier(currentField.getPos(), true); 
 
         final ItemStack seeds = currentField.getSeed();
         final int slot = worker.getCitizenInventoryHandler().findFirstSlotInInventoryWith(seeds.getItem(), seeds.getItemDamage());
@@ -603,4 +607,12 @@ public class EntityAIWorkFarmer extends AbstractEntityAIInteract<JobFarmer>
     {
         return worker;
     }
+
+    @Override 
+    protected boolean checkForToolOrWeapon(@NotNull final IToolType toolType) 
+    { 
+        final boolean needTool = super.checkForToolOrWeapon(toolType); 
+        worker.getCitizenData().getCitizenHappinessHandler().setNeedsATool(toolType, needTool); 
+        return needTool; 
+    } 
 }

--- a/src/main/java/com/minecolonies/coremod/entity/ai/citizen/fisherman/EntityAIWorkFisherman.java
+++ b/src/main/java/com/minecolonies/coremod/entity/ai/citizen/fisherman/EntityAIWorkFisherman.java
@@ -2,6 +2,7 @@ package com.minecolonies.coremod.entity.ai.citizen.fisherman;
 
 import com.minecolonies.api.util.InventoryUtils;
 import com.minecolonies.api.util.Utils;
+import com.minecolonies.api.util.constant.IToolType;
 import com.minecolonies.api.util.constant.ToolType;
 import com.minecolonies.coremod.colony.buildings.workerbuildings.BuildingFisherman;
 import com.minecolonies.coremod.colony.jobs.JobFisherman;
@@ -645,4 +646,12 @@ public class EntityAIWorkFisherman extends AbstractEntityAISkill<JobFisherman>
     {
         return worker;
     }
+
+    @Override 
+    protected boolean checkForToolOrWeapon(@NotNull final IToolType toolType) 
+    { 
+        final boolean needTool = super.checkForToolOrWeapon(toolType); 
+        worker.getCitizenData().getCitizenHappinessHandler().setNeedsATool(toolType,needTool); 
+        return needTool; 
+    } 
 }

--- a/src/main/java/com/minecolonies/coremod/entity/citizenhandlers/CitizenHappinessHandler.java
+++ b/src/main/java/com/minecolonies/coremod/entity/citizenhandlers/CitizenHappinessHandler.java
@@ -167,7 +167,7 @@ public class CitizenHappinessHandler
     /**
      * holds an array of all the fields the farmer has assigned to them.
      */
-    private Map<BlockPos, FieldDataModifier> fieldModifier = new HashMap<BlockPos, FieldDataModifier>();
+    private final Map<BlockPos, FieldDataModifier> fieldModifier = new HashMap<BlockPos, FieldDataModifier>();
 
     /**
      * holds an indicator citizen needing a tool
@@ -232,10 +232,8 @@ public class CitizenHappinessHandler
      * Called once a day to update the citizens daily happiness
      * modifiers.
      *
-     * @param hasHouse
-     *            boolean if the citizen is assigned to a house
-     * @param hasJob
-     *            boolean to indicate if citizen has a job
+     * @param hasHouse  boolean if the citizen is assigned to a house
+     * @param hasJob boolean to indicate if citizen has a job
      */
     public void processDailyHappiness(final boolean hasHouse, final boolean hasJob)
     {
@@ -279,7 +277,7 @@ public class CitizenHappinessHandler
         hasNoFields = true;
         for (final FieldDataModifier field : fieldModifier.values())
         {
-            if (field.getCanFarm())
+            if (field.isCanFarm())
             {
                 farmerModifier += FIELD_MODIFIER_POSITIVE;
                 hasNoFields = false;
@@ -489,8 +487,7 @@ public class CitizenHappinessHandler
     /**
      * Store the level to nbt.
      *
-     * @param compound
-     *            compound to use.
+     * @param compound  compound to use.
      */
     public void writeToNBT(final NBTTagCompound compound)
     {
@@ -517,7 +514,7 @@ public class CitizenHappinessHandler
             @NotNull
             final NBTTagCompound fieldCompound = new NBTTagCompound();
             fieldCompound.setInteger(TAG_FIELD_DAYS_INACTIVE, field.getInactiveDays());
-            fieldCompound.setBoolean(TAG_FIELD_CAN_FARM, field.getCanFarm());
+            fieldCompound.setBoolean(TAG_FIELD_CAN_FARM, field.isCanFarm());
 
             @NotNull
             final NBTTagList containerTagList = new NBTTagList();
@@ -551,8 +548,7 @@ public class CitizenHappinessHandler
     /**
      * Reads in Happiness data from the NBT file.
      *
-     * @param compound
-     *            pointer to NBT fields
+     * @param compound pointer to NBT fields
      */
     public void readFromNBT(final NBTTagCompound compound)
     {

--- a/src/main/java/com/minecolonies/coremod/entity/citizenhandlers/CitizenHappinessHandler.java
+++ b/src/main/java/com/minecolonies/coremod/entity/citizenhandlers/CitizenHappinessHandler.java
@@ -23,7 +23,7 @@ import org.jetbrains.annotations.NotNull;
 /**
  * Handler for the citizens happiness.
  * This keeps all the modifiers related to the citizen.
- * 
+ *
  * @author kevin
  *
  */
@@ -86,6 +86,7 @@ public class CitizenHappinessHandler
     public static final double FIELD_MODIFIER_MIN = -0.15;
     public static final double FIELD_MODIFIER_POSITIVE = 0.2;
     public static final double NO_FIELD_MODIFIER = -3.0;
+    public static final int NO_FIELDS_COMPLAINS_DAYS = 7;
 
     /**
      * constants for damage modifiers
@@ -93,7 +94,10 @@ public class CitizenHappinessHandler
     public static final int DAMAGE_MODIFIER_MAX = -2;
     public static final int DAMAGE_MODIFIER_MID = -1;
     public static final double DAMAGE_MODIFIER_MIN = -0.5;
-
+    public static final double DAMAGE_LOWEST_POINT = 0.25d;
+    public static final double DAMAGE_MEDIUM_POINT = 0.50d;
+    public static final double DAMAGE_HIGHEST_POINT = 0.75d;
+    
     /**
      * constants for happiness min/max and start happines values.
      */
@@ -168,7 +172,7 @@ public class CitizenHappinessHandler
     /**
      * holds an indicator citizen needing a tool
      */
-    private Map<IToolType, Integer> needsTool = new HashMap<IToolType, Integer>();
+    private final Map<IToolType, Integer> needsTool = new HashMap<IToolType, Integer>();
 
     /**
      * holds the modifier for citizen not having a tool.
@@ -177,7 +181,7 @@ public class CitizenHappinessHandler
 
     /**
      * Constructor for the experience handler.
-     * 
+     *
      * @param citizen
      *            the citizen owning the handler.
      */
@@ -283,7 +287,7 @@ public class CitizenHappinessHandler
             else
             {
                 field.increaseInactiveDays();
-                if (field.getInactiveDays() < 7)
+                if (field.getInactiveDays() < NO_FIELDS_COMPLAINS_DAYS)
                 {
                     farmerModifier += FIELD_MODIFIER_MIN;
                 }
@@ -339,15 +343,15 @@ public class CitizenHappinessHandler
         if (entityCitizen.isPresent())
         {
             final double health = entityCitizen.get().getHealth() / entityCitizen.get().getMaxHealth();
-            if (health < 0.24d)
+            if (health < DAMAGE_LOWEST_POINT)
             {
                 damageModifier = DAMAGE_MODIFIER_MAX;
-            } 
-            else if (health < 0.5d)
+            }
+            else if (health < DAMAGE_MEDIUM_POINT)
             {
                 damageModifier = DAMAGE_MODIFIER_MID;
-            } 
-            else if (health < 0.75d)
+            }
+            else if (health < DAMAGE_HIGHEST_POINT)
             {
                 damageModifier = DAMAGE_MODIFIER_MIN;
             }
@@ -372,26 +376,36 @@ public class CitizenHappinessHandler
             fieldModifier.put(pos, field);
         }
 
-        field.setCanFarm(canFarm);
+        field.isCanFarm(canFarm);
     }
 
+    /**
+     * Indicates the farmer has not fields to farm.
+     */
     public void setNoFieldsToFarm()
     {
         hasNoFields = true;
     }
 
-    public void setNeedsATool(@NotNull final IToolType toolType, final boolean needsTool)
+    /**
+     * Call this function to add a tool type that is needed by the citizen.
+     * If citizen gets its tool, then passing in false will remove it from the needed tools.
+     *
+     * @param toolType Tooltype to indicate
+     * @param needs indicate if the tool type is needed
+     */
+    public void setNeedsATool(@NotNull final IToolType toolType, final boolean needs)
     {
-        if (needsTool)
+        if (needs)
         {
-            if (!this.needsTool.containsKey(toolType))
+            if (!needsTool.containsKey(toolType))
             {
-                this.needsTool.put(toolType, 0);
+                needsTool.put(toolType, 0);
             }
         }
         else
         {
-            this.needsTool.remove(toolType);
+            needsTool.remove(toolType);
         }
     }
 
@@ -560,7 +574,7 @@ public class CitizenHappinessHandler
             final FieldDataModifier field = new FieldDataModifier();
             final NBTTagCompound containerCompound = fieldTagList.getCompoundTagAt(i);
             field.setInactiveDays(containerCompound.getInteger(TAG_FIELD_DAYS_INACTIVE));
-            field.setCanFarm(containerCompound.getBoolean(TAG_FIELD_CAN_FARM));
+            field.isCanFarm(containerCompound.getBoolean(TAG_FIELD_CAN_FARM));
 
             final NBTTagList blockPosTagList = containerCompound.getTagList(TAG_FIELD_ID, Constants.NBT.TAG_COMPOUND);
             final NBTTagCompound blockPoCompound = blockPosTagList.getCompoundTagAt(0);

--- a/src/main/java/com/minecolonies/coremod/entity/citizenhandlers/CitizenHappinessHandler.java
+++ b/src/main/java/com/minecolonies/coremod/entity/citizenhandlers/CitizenHappinessHandler.java
@@ -34,26 +34,6 @@ public class CitizenHappinessHandler
     protected final ChatSpamFilter chatSpamFilter;
 
     /**
-     * Tag names for NBT fields
-     */
-    private static final String TAG_NAME = "happiness";
-    private static final String TAG_BASE = "base";
-    private static final String TAG_FOOD = "foodModifier";
-    private static final String TAG_DAMAGE = "damageModifier";
-    private static final String TAG_HOUSE = "houseModifier";
-    private static final String TAG_NUMBER_OF_DAYS_HOUSE = "numberOfDaysWithoutHouse";
-    private static final String TAG_JOB = "jobModifier";
-    private static final String TAG_NUMBER_OF_DAYS_JOB = "numberOfDaysWithoutJob";
-    private static final String TAG_FIELDS = "fields";
-    private static final String TAG_HAS_NO_FIELDS = "hasNoFields";
-    private static final String TAG_FIELD_DAYS_INACTIVE = "daysinactive";
-    private static final String TAG_FIELD_ID = "id";
-    private static final String TAG_FIELD_CAN_FARM = "canfarm";
-    private static final String TAG_NO_TOOLS = "noTools";
-    private static final String TAG_NO_TOOLS_NUMBER_DAYS = "numberOfDaysNoTools";
-    private static final String TAG_NO_TOOLS_TOOL_TYPE = "toolType";
-
-    /**
      * constants for house modifier.
      */
     public static final int MAX_DAYS_WITHOUT_HOUSE = 30;
@@ -495,15 +475,15 @@ public class CitizenHappinessHandler
         final NBTTagList tasksTagList = new NBTTagList();
         @NotNull
         final NBTTagCompound taskCompound = new NBTTagCompound();
-        taskCompound.setDouble(TAG_BASE, baseHappiness);
-        taskCompound.setDouble(TAG_FOOD, foodModifier);
-        taskCompound.setDouble(TAG_DAMAGE, damageModifier);
-        taskCompound.setDouble(TAG_HOUSE, houseModifier);
-        taskCompound.setInteger(TAG_NUMBER_OF_DAYS_HOUSE, numberOfDaysWithoutHouse);
+        taskCompound.setDouble(CitizenConstants.TAG_BASE, baseHappiness);
+        taskCompound.setDouble(CitizenConstants.TAG_FOOD, foodModifier);
+        taskCompound.setDouble(CitizenConstants.TAG_DAMAGE, damageModifier);
+        taskCompound.setDouble(CitizenConstants.TAG_HOUSE, houseModifier);
+        taskCompound.setInteger(CitizenConstants.TAG_NUMBER_OF_DAYS_HOUSE, numberOfDaysWithoutHouse);
 
-        taskCompound.setDouble(TAG_JOB, jobModifier);
-        taskCompound.setInteger(TAG_NUMBER_OF_DAYS_JOB, numberOfDaysWithoutJob);
-        taskCompound.setBoolean(TAG_HAS_NO_FIELDS, hasNoFields);
+        taskCompound.setDouble(CitizenConstants.TAG_JOB, jobModifier);
+        taskCompound.setInteger(CitizenConstants.TAG_NUMBER_OF_DAYS_JOB, numberOfDaysWithoutJob);
+        taskCompound.setBoolean(CitizenConstants.TAG_HAS_NO_FIELDS, hasNoFields);
 
         @NotNull
         final NBTTagList fieldsTagList = new NBTTagList();
@@ -513,17 +493,17 @@ public class CitizenHappinessHandler
             final FieldDataModifier field = entry.getValue();
             @NotNull
             final NBTTagCompound fieldCompound = new NBTTagCompound();
-            fieldCompound.setInteger(TAG_FIELD_DAYS_INACTIVE, field.getInactiveDays());
-            fieldCompound.setBoolean(TAG_FIELD_CAN_FARM, field.isCanFarm());
+            fieldCompound.setInteger(CitizenConstants.TAG_FIELD_DAYS_INACTIVE, field.getInactiveDays());
+            fieldCompound.setBoolean(CitizenConstants.TAG_FIELD_CAN_FARM, field.isCanFarm());
 
             @NotNull
             final NBTTagList containerTagList = new NBTTagList();
             containerTagList.appendTag(NBTUtil.createPosTag(pos));
-            fieldCompound.setTag(TAG_FIELD_ID, containerTagList);
+            fieldCompound.setTag(CitizenConstants.TAG_FIELD_ID, containerTagList);
 
             fieldsTagList.appendTag(fieldCompound);
         }
-        taskCompound.setTag(TAG_FIELDS, fieldsTagList);
+        taskCompound.setTag(CitizenConstants.TAG_FIELDS, fieldsTagList);
 
         @NotNull
         final NBTTagList noToolsTagList = new NBTTagList();
@@ -533,16 +513,16 @@ public class CitizenHappinessHandler
             final int numDays = entry.getValue();
             @NotNull
             final NBTTagCompound noToolsCompound = new NBTTagCompound();
-            noToolsCompound.setInteger(TAG_NO_TOOLS_NUMBER_DAYS, numDays);
-            noToolsCompound.setString(TAG_NO_TOOLS_TOOL_TYPE, toolType.getName());
+            noToolsCompound.setInteger(CitizenConstants.TAG_NO_TOOLS_NUMBER_DAYS, numDays);
+            noToolsCompound.setString(CitizenConstants.TAG_NO_TOOLS_TOOL_TYPE, toolType.getName());
 
             noToolsTagList.appendTag(noToolsCompound);
         }
-        taskCompound.setTag(TAG_FIELDS, fieldsTagList);
+        taskCompound.setTag(CitizenConstants.TAG_FIELDS, fieldsTagList);
 
         tasksTagList.appendTag(taskCompound);
 
-        compound.setTag(TAG_NAME, tasksTagList);
+        compound.setTag(CitizenConstants.TAG_NAME, tasksTagList);
     }
 
     /**
@@ -552,38 +532,38 @@ public class CitizenHappinessHandler
      */
     public void readFromNBT(final NBTTagCompound compound)
     {
-        final NBTTagList tagListCompound = compound.getTagList(TAG_NAME, Constants.NBT.TAG_COMPOUND);
+        final NBTTagList tagListCompound = compound.getTagList(CitizenConstants.TAG_NAME, Constants.NBT.TAG_COMPOUND);
         final NBTTagCompound tagCompound = tagListCompound.getCompoundTagAt(0);
-        baseHappiness = tagCompound.getDouble(TAG_BASE);
-        foodModifier = tagCompound.getDouble(TAG_FOOD);
-        damageModifier = tagCompound.getDouble(TAG_DAMAGE);
-        houseModifier = tagCompound.getDouble(TAG_HOUSE);
-        numberOfDaysWithoutHouse = tagCompound.getInteger(TAG_NUMBER_OF_DAYS_HOUSE);
+        baseHappiness = tagCompound.getDouble(CitizenConstants.TAG_BASE);
+        foodModifier = tagCompound.getDouble(CitizenConstants.TAG_FOOD);
+        damageModifier = tagCompound.getDouble(CitizenConstants.TAG_DAMAGE);
+        houseModifier = tagCompound.getDouble(CitizenConstants.TAG_HOUSE);
+        numberOfDaysWithoutHouse = tagCompound.getInteger(CitizenConstants.TAG_NUMBER_OF_DAYS_HOUSE);
 
-        jobModifier = tagCompound.getDouble(TAG_JOB);
-        numberOfDaysWithoutJob = tagCompound.getInteger(TAG_NUMBER_OF_DAYS_JOB);
-        hasNoFields = tagCompound.getBoolean(TAG_HAS_NO_FIELDS);
+        jobModifier = tagCompound.getDouble(CitizenConstants.TAG_JOB);
+        numberOfDaysWithoutJob = tagCompound.getInteger(CitizenConstants.TAG_NUMBER_OF_DAYS_JOB);
+        hasNoFields = tagCompound.getBoolean(CitizenConstants.TAG_HAS_NO_FIELDS);
 
-        final NBTTagList fieldTagList = tagCompound.getTagList(TAG_FIELDS, Constants.NBT.TAG_COMPOUND);
+        final NBTTagList fieldTagList = tagCompound.getTagList(CitizenConstants.TAG_FIELDS, Constants.NBT.TAG_COMPOUND);
         for (int i = 0; i < fieldTagList.tagCount(); ++i)
         {
             final FieldDataModifier field = new FieldDataModifier();
             final NBTTagCompound containerCompound = fieldTagList.getCompoundTagAt(i);
-            field.setInactiveDays(containerCompound.getInteger(TAG_FIELD_DAYS_INACTIVE));
-            field.isCanFarm(containerCompound.getBoolean(TAG_FIELD_CAN_FARM));
+            field.setInactiveDays(containerCompound.getInteger(CitizenConstants.TAG_FIELD_DAYS_INACTIVE));
+            field.isCanFarm(containerCompound.getBoolean(CitizenConstants.TAG_FIELD_CAN_FARM));
 
-            final NBTTagList blockPosTagList = containerCompound.getTagList(TAG_FIELD_ID, Constants.NBT.TAG_COMPOUND);
+            final NBTTagList blockPosTagList = containerCompound.getTagList(CitizenConstants.TAG_FIELD_ID, Constants.NBT.TAG_COMPOUND);
             final NBTTagCompound blockPoCompound = blockPosTagList.getCompoundTagAt(0);
             final BlockPos pos = NBTUtil.getPosFromTag(blockPoCompound);
             fieldModifier.put(pos, field);
         }
 
-        final NBTTagList noToolsTagList = tagCompound.getTagList(TAG_NO_TOOLS, Constants.NBT.TAG_COMPOUND);
+        final NBTTagList noToolsTagList = tagCompound.getTagList(CitizenConstants.TAG_NO_TOOLS, Constants.NBT.TAG_COMPOUND);
         for (int i = 0; i < noToolsTagList.tagCount(); ++i)
         {
             final NBTTagCompound containerCompound = noToolsTagList.getCompoundTagAt(i);
-            final int numDays = containerCompound.getInteger(TAG_NO_TOOLS_NUMBER_DAYS);
-            final IToolType toolType = ToolType.getToolType(containerCompound.getString(TAG_NO_TOOLS_TOOL_TYPE));
+            final int numDays = containerCompound.getInteger(CitizenConstants.TAG_NO_TOOLS_NUMBER_DAYS);
+            final IToolType toolType = ToolType.getToolType(containerCompound.getString(CitizenConstants.TAG_NO_TOOLS_TOOL_TYPE));
             needsTool.put(toolType, numDays);
         }
 

--- a/src/main/java/com/minecolonies/coremod/entity/citizenhandlers/CitizenHappinessHandler.java
+++ b/src/main/java/com/minecolonies/coremod/entity/citizenhandlers/CitizenHappinessHandler.java
@@ -1,0 +1,586 @@
+package com.minecolonies.coremod.entity.citizenhandlers;
+
+import com.minecolonies.api.util.constant.CitizenConstants;
+import com.minecolonies.api.util.constant.IToolType;
+import com.minecolonies.api.util.constant.ToolType;
+import com.minecolonies.coremod.colony.CitizenData;
+import com.minecolonies.coremod.colony.FieldDataModifier;
+import com.minecolonies.coremod.entity.EntityCitizen;
+import com.minecolonies.coremod.entity.ai.util.ChatSpamFilter;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+
+import net.minecraft.nbt.NBTTagCompound;
+import net.minecraft.nbt.NBTTagList;
+import net.minecraft.nbt.NBTUtil;
+import net.minecraft.util.math.BlockPos;
+import net.minecraftforge.common.util.Constants;
+
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * Handler for the citizens happiness.
+ * This keeps all the modifiers related to the citizen.
+ * 
+ * @author kevin
+ *
+ */
+public class CitizenHappinessHandler
+{
+
+    @NotNull
+    protected final ChatSpamFilter chatSpamFilter;
+
+    /**
+     * Tag names for NBT fields
+     */
+    private static final String TAG_NAME = "happiness";
+    private static final String TAG_BASE = "base";
+    private static final String TAG_FOOD = "foodModifier";
+    private static final String TAG_DAMAGE = "damageModifier";
+    private static final String TAG_HOUSE = "houseModifier";
+    private static final String TAG_NUMBER_OF_DAYS_HOUSE = "numberOfDaysWithoutHouse";
+    private static final String TAG_JOB = "jobModifier";
+    private static final String TAG_NUMBER_OF_DAYS_JOB = "numberOfDaysWithoutJob";
+    private static final String TAG_FIELDS = "fields";
+    private static final String TAG_HAS_NO_FIELDS = "hasNoFields";
+    private static final String TAG_FIELD_DAYS_INACTIVE = "daysinactive";
+    private static final String TAG_FIELD_ID = "id";
+    private static final String TAG_FIELD_CAN_FARM = "canfarm";
+    private static final String TAG_NO_TOOLS = "noTools";
+    private static final String TAG_NO_TOOLS_NUMBER_DAYS = "numberOfDaysNoTools";
+    private static final String TAG_NO_TOOLS_TOOL_TYPE = "toolType";
+
+    /**
+     * constants for house modifier.
+     */
+    public static final int MAX_DAYS_WITHOUT_HOUSE = 30;
+    public static final int MAX_HOUSE_PENALTY = 5;
+    public static final double HOUSE_MODIFIER_POSITIVE = 0.5;
+    public static final int COMPLAIN_DAYS_WITHOUT_HOUSE = 7;
+    public static final int DEMANDS_DAYS_WITHOUT_HOUSE = 14;
+
+    /**
+     * constants for job modifier.
+     */
+    public static final int MAX_DAYS_WITHOUT_JOB = 30;
+    public static final int COMPLAIN_DAYS_WITHOUT_JOB = 7;
+    public static final int DEMANDS_DAYS_WITHOUT_JOB = 14;
+    public static final int MAX_JOB_PENALTY = 5;
+    public static final double JOB_MODIFIER_POSITIVE = 0.5;
+
+    /**
+     * constants for food modifier.
+     */
+    public static final int FOOD_MODIFIER_MAX = -2;
+    public static final int FOOD_MODIFIER_MIN = -1;
+    public static final double FOOD_MODIFIER_POSITIVE = 0.5;
+
+    /**
+     * constants for field modifiers
+     */
+    public static final int FIELD_MAX_DAYS_MODIFIER = 30;
+    public static final double FIELD_MODIFIER_MAX = -0.75;
+    public static final double FIELD_MODIFIER_MIN = -0.15;
+    public static final double FIELD_MODIFIER_POSITIVE = 0.2;
+    public static final double NO_FIELD_MODIFIER = -3.0;
+
+    /**
+     * constants for damage modifiers
+     */
+    public static final int DAMAGE_MODIFIER_MAX = -2;
+    public static final int DAMAGE_MODIFIER_MID = -1;
+    public static final double DAMAGE_MODIFIER_MIN = -0.5;
+
+    /**
+     * constants for happiness min/max and start happines values.
+     */
+    public static final int MAX_HAPPINESS = 10;
+    public static final int MIN_HAPPINESS = 1;
+    public static final int BASE_HAPPINESS = 8;
+
+    /**
+     * constants for no tools.
+     */
+    public static final double NO_TOOL_MODIFIER = -3.0;
+    public static final int NO_TOOLS_MODIFIER = 3;
+    public static final int NO_TOOLS_COMPLAINS_DAYS = 7;
+    public static final int NO_TOOLS_DEMANDS_DAYS = 14;
+    public static final int NO_TOOLS_MAX_DAYS_MODIFIER = 30;
+
+    /**
+     * The citizen assigned to this manager.
+     */
+    private final CitizenData citizen;
+
+    /**
+     * holds the base happiness value.
+     */
+    private double baseHappiness;
+
+    /**
+     * holds the modifier for food.
+     */
+    private double foodModifier;
+
+    /**
+     * holds the modifier for damage.
+     */
+    private double damageModifier;
+
+    /**
+     * holds the modifier for house.
+     */
+    private double houseModifier;
+
+    /**
+     * holds the numbers of days without a house.
+     */
+    private int numberOfDaysWithoutHouse;
+
+    /**
+     * holds the modifier for job.
+     */
+    private double jobModifier;
+
+    /**
+     * holds the numbers of days without a job.
+     */
+    private int numberOfDaysWithoutJob;
+
+    /**
+     * holds the modifier for farms that the farmer can't farm.
+     */
+    private double farmerModifier;
+
+    /**
+     * holds an indicator of the farmer has no fields to farm
+     */
+    private boolean hasNoFields;
+
+    /**
+     * holds an array of all the fields the farmer has assigned to them.
+     */
+    private Map<BlockPos, FieldDataModifier> fieldModifier = new HashMap<BlockPos, FieldDataModifier>();
+
+    /**
+     * holds an indicator citizen needing a tool
+     */
+    private Map<IToolType, Integer> needsTool = new HashMap<IToolType, Integer>();
+
+    /**
+     * holds the modifier for citizen not having a tool.
+     */
+    private double noToolModifier;
+
+    /**
+     * Constructor for the experience handler.
+     * 
+     * @param citizen
+     *            the citizen owning the handler.
+     */
+    public CitizenHappinessHandler(final CitizenData citizen)
+    {
+        this.citizen = citizen;
+        baseHappiness = BASE_HAPPINESS;
+        foodModifier = 0;
+        damageModifier = 0;
+        houseModifier = 0;
+        numberOfDaysWithoutHouse = 0;
+        jobModifier = 0;
+        numberOfDaysWithoutJob = 0;
+        farmerModifier = 0;
+        hasNoFields = false;
+        needsTool.clear();
+        chatSpamFilter = new ChatSpamFilter(citizen);
+
+    }
+
+    /**
+     * This function applies eating adjust to the base hapiness for
+     * the citizen.
+     *
+     * @param eatFood
+     *            true or false indicate citizen was unable to eat
+     */
+    public void setFoodModifier(final boolean eatFood)
+    {
+        if (!eatFood)
+        {
+            if (citizen.getSaturation() < CitizenConstants.LOW_SATURATION)
+            {
+                foodModifier = FOOD_MODIFIER_MAX;
+            }
+            else
+            {
+                foodModifier = FOOD_MODIFIER_MIN;
+            }
+        }
+        else
+        {
+            foodModifier = 0;
+        }
+    }
+
+    /**
+     * Called once a day to update the citizens daily happiness
+     * modifiers.
+     *
+     * @param hasHouse
+     *            boolean if the citizen is assigned to a house
+     * @param hasJob
+     *            boolean to indicate if citizen has a job
+     */
+    public void processDailyHappiness(final boolean hasHouse, final boolean hasJob)
+    {
+        if (!hasHouse)
+        {
+            numberOfDaysWithoutHouse++;
+            if (numberOfDaysWithoutHouse > DEMANDS_DAYS_WITHOUT_HOUSE)
+            {
+                chatSpamFilter.talkWithoutSpam("entity.citizen.demandsHouse", citizen.getName());
+            }
+            else if (numberOfDaysWithoutHouse > COMPLAIN_DAYS_WITHOUT_HOUSE)
+            {
+                chatSpamFilter.talkWithoutSpam("entity.citizen.noHouse", citizen.getName());
+            }
+        }
+        else
+        {
+            numberOfDaysWithoutHouse = 0;
+        }
+        setHomeModifier(hasHouse);
+
+        if (!hasJob)
+        {
+            numberOfDaysWithoutJob++;
+            if (numberOfDaysWithoutJob > DEMANDS_DAYS_WITHOUT_JOB)
+            {
+                chatSpamFilter.talkWithoutSpam("entity.citizen.demandsJob", citizen.getName());
+            }
+            else if (numberOfDaysWithoutJob > COMPLAIN_DAYS_WITHOUT_JOB)
+            {
+                chatSpamFilter.talkWithoutSpam("entity.citizen.noJob", citizen.getName());
+            }
+        }
+        else
+        {
+            numberOfDaysWithoutJob = 0;
+        }
+        setJobModifier(hasJob);
+
+        farmerModifier = 0;
+        hasNoFields = true;
+        for (final FieldDataModifier field : fieldModifier.values())
+        {
+            if (field.getCanFarm())
+            {
+                farmerModifier += FIELD_MODIFIER_POSITIVE;
+                hasNoFields = false;
+            }
+            else
+            {
+                field.increaseInactiveDays();
+                if (field.getInactiveDays() < 7)
+                {
+                    farmerModifier += FIELD_MODIFIER_MIN;
+                }
+                else
+                {
+                    farmerModifier += ((double) ((double) field.getInactiveDays() / FIELD_MAX_DAYS_MODIFIER) * FIELD_MODIFIER_MAX) + FIELD_MODIFIER_MIN;
+                }
+            }
+        }
+
+        if (hasNoFields)
+        {
+            farmerModifier = NO_FIELD_MODIFIER;
+        }
+
+        noToolModifier = 0;
+        for (Map.Entry<IToolType, Integer> entry : needsTool.entrySet())
+        {
+            final int numDays = entry.getValue() + 1;
+            final IToolType toolType = entry.getKey();
+            needsTool.put(toolType, numDays);
+            if (numDays > NO_TOOLS_DEMANDS_DAYS)
+            {
+                chatSpamFilter.talkWithoutSpam("entity.citizen.noTool", citizen.getName(), toolType.getDisplayName());
+            }
+            else if (numDays > NO_TOOLS_COMPLAINS_DAYS)
+            {
+                chatSpamFilter.talkWithoutSpam("entity.citizen.demandsTool", citizen.getName(), toolType.getDisplayName());
+            }
+            noToolModifier += ((double) ((double) numDays / NO_TOOLS_MAX_DAYS_MODIFIER) * NO_TOOLS_MODIFIER);
+        }
+
+        citizen.markDirty();
+
+    }
+
+    /**
+     * this function applies adjust to happiness.
+     * This would mean the citizen is full.
+     */
+    public void setSaturated()
+    {
+        foodModifier = FOOD_MODIFIER_POSITIVE;
+    }
+
+    /**
+     * set the Damage modifier on the citizens happiness
+     * depending on how hurt they are.
+     */
+    public void setDamageModifier()
+    {
+        Optional<EntityCitizen> entityCitizen = citizen.getCitizenEntity();
+        if (entityCitizen.isPresent())
+        {
+            final double health = entityCitizen.get().getHealth() / entityCitizen.get().getMaxHealth();
+            if (health < 0.24d)
+            {
+                damageModifier = DAMAGE_MODIFIER_MAX;
+            } 
+            else if (health < 0.5d)
+            {
+                damageModifier = DAMAGE_MODIFIER_MID;
+            } 
+            else if (health < 0.75d)
+            {
+                damageModifier = DAMAGE_MODIFIER_MIN;
+            }
+            citizen.markDirty();
+        }
+    }
+
+    /**
+     * Called to set if the farmer can farm a specific field.
+     *
+     * @param pos
+     *            position of the scarecrow block
+     * @param canFarm
+     *            boolean to indicate if the field can be farmed
+     */
+    public void setNoFieldForFarmerModifier(final BlockPos pos, final boolean canFarm)
+    {
+        FieldDataModifier field = fieldModifier.get(pos);
+        if (field == null)
+        {
+            field = new FieldDataModifier();
+            fieldModifier.put(pos, field);
+        }
+
+        field.setCanFarm(canFarm);
+    }
+
+    public void setNoFieldsToFarm()
+    {
+        hasNoFields = true;
+    }
+
+    public void setNeedsATool(@NotNull final IToolType toolType, final boolean needsTool)
+    {
+        if (needsTool)
+        {
+            if (!this.needsTool.containsKey(toolType))
+            {
+                this.needsTool.put(toolType, 0);
+            }
+        }
+        else
+        {
+            this.needsTool.remove(toolType);
+        }
+    }
+
+    /**
+     * @param hasHouse
+     *            indicate the citizen has an assigned house
+     */
+    public void setHomeModifier(final boolean hasHouse)
+    {
+        if (hasHouse)
+        {
+            houseModifier = HOUSE_MODIFIER_POSITIVE;
+        }
+        else
+        {
+            houseModifier = (MAX_HOUSE_PENALTY * ((double) numberOfDaysWithoutHouse / MAX_DAYS_WITHOUT_HOUSE)) * -1;
+            citizen.markDirty();
+        }
+    }
+
+    /**
+     * Called to set if the citizen has a job or not.
+     *
+     * @param hasJob
+     *            boolean to indicate if the citizen has a job
+     */
+    public void setJobModifier(final boolean hasJob)
+    {
+        if (hasJob)
+        {
+            jobModifier = JOB_MODIFIER_POSITIVE;
+        }
+        else
+        {
+            jobModifier = (MAX_JOB_PENALTY * ((double) numberOfDaysWithoutHouse / MAX_DAYS_WITHOUT_JOB)) * -1;
+        }
+    }
+
+    /**
+     * @return current citizens overall happiness
+     */
+    public double getHappiness()
+    {
+        double value = baseHappiness + foodModifier + damageModifier + houseModifier + jobModifier + farmerModifier + noToolModifier;
+        if (value > MAX_HAPPINESS)
+        {
+            value = MAX_HAPPINESS;
+        }
+        else if (value < MIN_HAPPINESS)
+        {
+            value = MIN_HAPPINESS;
+        }
+
+        return value;
+    }
+
+    /**
+     * @return current food modifier for happiness
+     */
+    public double getFoodModifier()
+    {
+        return foodModifier;
+    }
+
+    /**
+     * @return current damage modifier for happiness
+     */
+    public double getDamageModifier()
+    {
+        return damageModifier;
+    }
+
+    /**
+     * @return current house modifier for happiness
+     */
+    public double getHouseModifier()
+    {
+        return houseModifier;
+    }
+
+    /**
+     * Store the level to nbt.
+     *
+     * @param compound
+     *            compound to use.
+     */
+    public void writeToNBT(final NBTTagCompound compound)
+    {
+        @NotNull
+        final NBTTagList tasksTagList = new NBTTagList();
+        @NotNull
+        final NBTTagCompound taskCompound = new NBTTagCompound();
+        taskCompound.setDouble(TAG_BASE, baseHappiness);
+        taskCompound.setDouble(TAG_FOOD, foodModifier);
+        taskCompound.setDouble(TAG_DAMAGE, damageModifier);
+        taskCompound.setDouble(TAG_HOUSE, houseModifier);
+        taskCompound.setInteger(TAG_NUMBER_OF_DAYS_HOUSE, numberOfDaysWithoutHouse);
+
+        taskCompound.setDouble(TAG_JOB, jobModifier);
+        taskCompound.setInteger(TAG_NUMBER_OF_DAYS_JOB, numberOfDaysWithoutJob);
+        taskCompound.setBoolean(TAG_HAS_NO_FIELDS, hasNoFields);
+
+        @NotNull
+        final NBTTagList fieldsTagList = new NBTTagList();
+        for (final Map.Entry<BlockPos, FieldDataModifier> entry : fieldModifier.entrySet())
+        {
+            final BlockPos pos = entry.getKey();
+            final FieldDataModifier field = entry.getValue();
+            @NotNull
+            final NBTTagCompound fieldCompound = new NBTTagCompound();
+            fieldCompound.setInteger(TAG_FIELD_DAYS_INACTIVE, field.getInactiveDays());
+            fieldCompound.setBoolean(TAG_FIELD_CAN_FARM, field.getCanFarm());
+
+            @NotNull
+            final NBTTagList containerTagList = new NBTTagList();
+            containerTagList.appendTag(NBTUtil.createPosTag(pos));
+            fieldCompound.setTag(TAG_FIELD_ID, containerTagList);
+
+            fieldsTagList.appendTag(fieldCompound);
+        }
+        taskCompound.setTag(TAG_FIELDS, fieldsTagList);
+
+        @NotNull
+        final NBTTagList noToolsTagList = new NBTTagList();
+        for (final Map.Entry<IToolType, Integer> entry : needsTool.entrySet())
+        {
+            final IToolType toolType = entry.getKey();
+            final int numDays = entry.getValue();
+            @NotNull
+            final NBTTagCompound noToolsCompound = new NBTTagCompound();
+            noToolsCompound.setInteger(TAG_NO_TOOLS_NUMBER_DAYS, numDays);
+            noToolsCompound.setString(TAG_NO_TOOLS_TOOL_TYPE, toolType.getName());
+
+            noToolsTagList.appendTag(noToolsCompound);
+        }
+        taskCompound.setTag(TAG_FIELDS, fieldsTagList);
+
+        tasksTagList.appendTag(taskCompound);
+
+        compound.setTag(TAG_NAME, tasksTagList);
+    }
+
+    /**
+     * Reads in Happiness data from the NBT file.
+     *
+     * @param compound
+     *            pointer to NBT fields
+     */
+    public void readFromNBT(final NBTTagCompound compound)
+    {
+        final NBTTagList tagListCompound = compound.getTagList(TAG_NAME, Constants.NBT.TAG_COMPOUND);
+        final NBTTagCompound tagCompound = tagListCompound.getCompoundTagAt(0);
+        baseHappiness = tagCompound.getDouble(TAG_BASE);
+        foodModifier = tagCompound.getDouble(TAG_FOOD);
+        damageModifier = tagCompound.getDouble(TAG_DAMAGE);
+        houseModifier = tagCompound.getDouble(TAG_HOUSE);
+        numberOfDaysWithoutHouse = tagCompound.getInteger(TAG_NUMBER_OF_DAYS_HOUSE);
+
+        jobModifier = tagCompound.getDouble(TAG_JOB);
+        numberOfDaysWithoutJob = tagCompound.getInteger(TAG_NUMBER_OF_DAYS_JOB);
+        hasNoFields = tagCompound.getBoolean(TAG_HAS_NO_FIELDS);
+
+        final NBTTagList fieldTagList = tagCompound.getTagList(TAG_FIELDS, Constants.NBT.TAG_COMPOUND);
+        for (int i = 0; i < fieldTagList.tagCount(); ++i)
+        {
+            final FieldDataModifier field = new FieldDataModifier();
+            final NBTTagCompound containerCompound = fieldTagList.getCompoundTagAt(i);
+            field.setInactiveDays(containerCompound.getInteger(TAG_FIELD_DAYS_INACTIVE));
+            field.setCanFarm(containerCompound.getBoolean(TAG_FIELD_CAN_FARM));
+
+            final NBTTagList blockPosTagList = containerCompound.getTagList(TAG_FIELD_ID, Constants.NBT.TAG_COMPOUND);
+            final NBTTagCompound blockPoCompound = blockPosTagList.getCompoundTagAt(0);
+            final BlockPos pos = NBTUtil.getPosFromTag(blockPoCompound);
+            fieldModifier.put(pos, field);
+        }
+
+        final NBTTagList noToolsTagList = tagCompound.getTagList(TAG_NO_TOOLS, Constants.NBT.TAG_COMPOUND);
+        for (int i = 0; i < noToolsTagList.tagCount(); ++i)
+        {
+            final NBTTagCompound containerCompound = noToolsTagList.getCompoundTagAt(i);
+            final int numDays = containerCompound.getInteger(TAG_NO_TOOLS_NUMBER_DAYS);
+            final IToolType toolType = ToolType.getToolType(containerCompound.getString(TAG_NO_TOOLS_TOOL_TYPE));
+            needsTool.put(toolType, numDays);
+        }
+
+        if (baseHappiness == 0)
+        {
+            baseHappiness = BASE_HAPPINESS;
+        }
+    }
+
+}

--- a/src/main/java/com/minecolonies/coremod/entity/citizenhandlers/CitizenHappinessHandler.java
+++ b/src/main/java/com/minecolonies/coremod/entity/citizenhandlers/CitizenHappinessHandler.java
@@ -300,7 +300,7 @@ public class CitizenHappinessHandler
         }
 
         noToolModifier = 0;
-        for (Map.Entry<IToolType, Integer> entry : needsTool.entrySet())
+        for (final Map.Entry<IToolType, Integer> entry : needsTool.entrySet())
         {
             final int numDays = entry.getValue() + 1;
             final IToolType toolType = entry.getKey();
@@ -335,7 +335,7 @@ public class CitizenHappinessHandler
      */
     public void setDamageModifier()
     {
-        Optional<EntityCitizen> entityCitizen = citizen.getCitizenEntity();
+        final Optional<EntityCitizen> entityCitizen = citizen.getCitizenEntity();
         if (entityCitizen.isPresent())
         {
             final double health = entityCitizen.get().getHealth() / entityCitizen.get().getMaxHealth();

--- a/src/main/java/com/minecolonies/coremod/entity/citizenhandlers/CitizenHappinessHandler.java
+++ b/src/main/java/com/minecolonies/coremod/entity/citizenhandlers/CitizenHappinessHandler.java
@@ -1,6 +1,7 @@
 package com.minecolonies.coremod.entity.citizenhandlers;
 
 import com.minecolonies.api.util.constant.CitizenConstants;
+import com.minecolonies.api.util.constant.NbtTagConstants;
 import com.minecolonies.api.util.constant.IToolType;
 import com.minecolonies.api.util.constant.ToolType;
 import com.minecolonies.coremod.colony.CitizenData;
@@ -475,15 +476,15 @@ public class CitizenHappinessHandler
         final NBTTagList tasksTagList = new NBTTagList();
         @NotNull
         final NBTTagCompound taskCompound = new NBTTagCompound();
-        taskCompound.setDouble(CitizenConstants.TAG_BASE, baseHappiness);
-        taskCompound.setDouble(CitizenConstants.TAG_FOOD, foodModifier);
-        taskCompound.setDouble(CitizenConstants.TAG_DAMAGE, damageModifier);
-        taskCompound.setDouble(CitizenConstants.TAG_HOUSE, houseModifier);
-        taskCompound.setInteger(CitizenConstants.TAG_NUMBER_OF_DAYS_HOUSE, numberOfDaysWithoutHouse);
+        taskCompound.setDouble(NbtTagConstants.TAG_BASE, baseHappiness);
+        taskCompound.setDouble(NbtTagConstants.TAG_FOOD, foodModifier);
+        taskCompound.setDouble(NbtTagConstants.TAG_DAMAGE, damageModifier);
+        taskCompound.setDouble(NbtTagConstants.TAG_HOUSE, houseModifier);
+        taskCompound.setInteger(NbtTagConstants.TAG_NUMBER_OF_DAYS_HOUSE, numberOfDaysWithoutHouse);
 
-        taskCompound.setDouble(CitizenConstants.TAG_JOB, jobModifier);
-        taskCompound.setInteger(CitizenConstants.TAG_NUMBER_OF_DAYS_JOB, numberOfDaysWithoutJob);
-        taskCompound.setBoolean(CitizenConstants.TAG_HAS_NO_FIELDS, hasNoFields);
+        taskCompound.setDouble(NbtTagConstants.TAG_JOB, jobModifier);
+        taskCompound.setInteger(NbtTagConstants.TAG_NUMBER_OF_DAYS_JOB, numberOfDaysWithoutJob);
+        taskCompound.setBoolean(NbtTagConstants.TAG_HAS_NO_FIELDS, hasNoFields);
 
         @NotNull
         final NBTTagList fieldsTagList = new NBTTagList();
@@ -493,17 +494,17 @@ public class CitizenHappinessHandler
             final FieldDataModifier field = entry.getValue();
             @NotNull
             final NBTTagCompound fieldCompound = new NBTTagCompound();
-            fieldCompound.setInteger(CitizenConstants.TAG_FIELD_DAYS_INACTIVE, field.getInactiveDays());
-            fieldCompound.setBoolean(CitizenConstants.TAG_FIELD_CAN_FARM, field.isCanFarm());
+            fieldCompound.setInteger(NbtTagConstants.TAG_FIELD_DAYS_INACTIVE, field.getInactiveDays());
+            fieldCompound.setBoolean(NbtTagConstants.TAG_FIELD_CAN_FARM, field.isCanFarm());
 
             @NotNull
             final NBTTagList containerTagList = new NBTTagList();
             containerTagList.appendTag(NBTUtil.createPosTag(pos));
-            fieldCompound.setTag(CitizenConstants.TAG_FIELD_ID, containerTagList);
+            fieldCompound.setTag(NbtTagConstants.TAG_ID, containerTagList);
 
             fieldsTagList.appendTag(fieldCompound);
         }
-        taskCompound.setTag(CitizenConstants.TAG_FIELDS, fieldsTagList);
+        taskCompound.setTag(NbtTagConstants.TAG_FIELDS, fieldsTagList);
 
         @NotNull
         final NBTTagList noToolsTagList = new NBTTagList();
@@ -513,16 +514,16 @@ public class CitizenHappinessHandler
             final int numDays = entry.getValue();
             @NotNull
             final NBTTagCompound noToolsCompound = new NBTTagCompound();
-            noToolsCompound.setInteger(CitizenConstants.TAG_NO_TOOLS_NUMBER_DAYS, numDays);
-            noToolsCompound.setString(CitizenConstants.TAG_NO_TOOLS_TOOL_TYPE, toolType.getName());
+            noToolsCompound.setInteger(NbtTagConstants.TAG_NO_TOOLS_NUMBER_DAYS, numDays);
+            noToolsCompound.setString(NbtTagConstants.TAG_NO_TOOLS_TOOL_TYPE, toolType.getName());
 
             noToolsTagList.appendTag(noToolsCompound);
         }
-        taskCompound.setTag(CitizenConstants.TAG_FIELDS, fieldsTagList);
+        taskCompound.setTag(NbtTagConstants.TAG_FIELDS, fieldsTagList);
 
         tasksTagList.appendTag(taskCompound);
 
-        compound.setTag(CitizenConstants.TAG_NAME, tasksTagList);
+        compound.setTag(NbtTagConstants.TAG_NAME, tasksTagList);
     }
 
     /**
@@ -532,38 +533,38 @@ public class CitizenHappinessHandler
      */
     public void readFromNBT(final NBTTagCompound compound)
     {
-        final NBTTagList tagListCompound = compound.getTagList(CitizenConstants.TAG_NAME, Constants.NBT.TAG_COMPOUND);
+        final NBTTagList tagListCompound = compound.getTagList(NbtTagConstants.TAG_NAME, Constants.NBT.TAG_COMPOUND);
         final NBTTagCompound tagCompound = tagListCompound.getCompoundTagAt(0);
-        baseHappiness = tagCompound.getDouble(CitizenConstants.TAG_BASE);
-        foodModifier = tagCompound.getDouble(CitizenConstants.TAG_FOOD);
-        damageModifier = tagCompound.getDouble(CitizenConstants.TAG_DAMAGE);
-        houseModifier = tagCompound.getDouble(CitizenConstants.TAG_HOUSE);
-        numberOfDaysWithoutHouse = tagCompound.getInteger(CitizenConstants.TAG_NUMBER_OF_DAYS_HOUSE);
+        baseHappiness = tagCompound.getDouble(NbtTagConstants.TAG_BASE);
+        foodModifier = tagCompound.getDouble(NbtTagConstants.TAG_FOOD);
+        damageModifier = tagCompound.getDouble(NbtTagConstants.TAG_DAMAGE);
+        houseModifier = tagCompound.getDouble(NbtTagConstants.TAG_HOUSE);
+        numberOfDaysWithoutHouse = tagCompound.getInteger(NbtTagConstants.TAG_NUMBER_OF_DAYS_HOUSE);
 
-        jobModifier = tagCompound.getDouble(CitizenConstants.TAG_JOB);
-        numberOfDaysWithoutJob = tagCompound.getInteger(CitizenConstants.TAG_NUMBER_OF_DAYS_JOB);
-        hasNoFields = tagCompound.getBoolean(CitizenConstants.TAG_HAS_NO_FIELDS);
+        jobModifier = tagCompound.getDouble(NbtTagConstants.TAG_JOB);
+        numberOfDaysWithoutJob = tagCompound.getInteger(NbtTagConstants.TAG_NUMBER_OF_DAYS_JOB);
+        hasNoFields = tagCompound.getBoolean(NbtTagConstants.TAG_HAS_NO_FIELDS);
 
-        final NBTTagList fieldTagList = tagCompound.getTagList(CitizenConstants.TAG_FIELDS, Constants.NBT.TAG_COMPOUND);
+        final NBTTagList fieldTagList = tagCompound.getTagList(NbtTagConstants.TAG_FIELDS, Constants.NBT.TAG_COMPOUND);
         for (int i = 0; i < fieldTagList.tagCount(); ++i)
         {
             final FieldDataModifier field = new FieldDataModifier();
             final NBTTagCompound containerCompound = fieldTagList.getCompoundTagAt(i);
-            field.setInactiveDays(containerCompound.getInteger(CitizenConstants.TAG_FIELD_DAYS_INACTIVE));
-            field.isCanFarm(containerCompound.getBoolean(CitizenConstants.TAG_FIELD_CAN_FARM));
+            field.setInactiveDays(containerCompound.getInteger(NbtTagConstants.TAG_FIELD_DAYS_INACTIVE));
+            field.isCanFarm(containerCompound.getBoolean(NbtTagConstants.TAG_FIELD_CAN_FARM));
 
-            final NBTTagList blockPosTagList = containerCompound.getTagList(CitizenConstants.TAG_FIELD_ID, Constants.NBT.TAG_COMPOUND);
+            final NBTTagList blockPosTagList = containerCompound.getTagList(NbtTagConstants.TAG_ID, Constants.NBT.TAG_COMPOUND);
             final NBTTagCompound blockPoCompound = blockPosTagList.getCompoundTagAt(0);
             final BlockPos pos = NBTUtil.getPosFromTag(blockPoCompound);
             fieldModifier.put(pos, field);
         }
 
-        final NBTTagList noToolsTagList = tagCompound.getTagList(CitizenConstants.TAG_NO_TOOLS, Constants.NBT.TAG_COMPOUND);
+        final NBTTagList noToolsTagList = tagCompound.getTagList(NbtTagConstants.TAG_NO_TOOLS, Constants.NBT.TAG_COMPOUND);
         for (int i = 0; i < noToolsTagList.tagCount(); ++i)
         {
             final NBTTagCompound containerCompound = noToolsTagList.getCompoundTagAt(i);
-            final int numDays = containerCompound.getInteger(CitizenConstants.TAG_NO_TOOLS_NUMBER_DAYS);
-            final IToolType toolType = ToolType.getToolType(containerCompound.getString(CitizenConstants.TAG_NO_TOOLS_TOOL_TYPE));
+            final int numDays = containerCompound.getInteger(NbtTagConstants.TAG_NO_TOOLS_NUMBER_DAYS);
+            final IToolType toolType = ToolType.getToolType(containerCompound.getString(NbtTagConstants.TAG_NO_TOOLS_TOOL_TYPE));
             needsTool.put(toolType, numDays);
         }
 

--- a/src/main/resources/assets/minecolonies/gui/citizen/layouts/main.xml
+++ b/src/main/resources/assets/minecolonies/gui/citizen/layouts/main.xml
@@ -7,8 +7,10 @@
     <view id="healthBar" size="100% 11" pos="30 28"/>
     <view id="saturationBar" size="100% 11" pos="30 40"/>
     <view id="xpBar" size="100% 11" pos="30 52"/>
-    <label id="xpLabel" size="100% 11" color="black" pos="90 70"/>
-
+    <label id="xpLabel" size="100% 11" color="black" pos="145 58"/> 
+    <view id="happinessBar" size="100% 11" pos="30 60"/> 
+    <label id="happinessLabel" size="100% 11" color="black" pos="145 69"/> 
+    
     <image id="deco2" size="73 16" source="minecolonies:textures/gui/citizen/colonist_decor_down.png" pos="16 85"/>
     <label id="title" size="100% 11" pos="40 93" color="black"
            label="§l$(com.minecolonies.coremod.gui.citizen.skills)"/>

--- a/src/main/resources/assets/minecolonies/gui/windowtownhall.xml
+++ b/src/main/resources/assets/minecolonies/gui/windowtownhall.xml
@@ -216,8 +216,10 @@
                 <label id="hiddenCitizenId" visible="false"/>
                 <label id="job" size="100% 11" color="black" pos="0 5" textalign="MIDDLE"/>
                 <view id="xpBar" size="100% 11" pos="12 10"/>
-                <label id="xpLabel" size="100% 11" color="black" pos="0 30" textalign="MIDDLE"/>
-
+                <label id="xpLabel" size="100% 11" color="black" pos="128 18"/> 
+                <view id="happinessBar" size="100% 11" pos="15 20"/> 
+                <label id="happinessLabel" size="100% 11" color="black" pos="128 28"/> 
+                
                 <image id="deco2" size="73 16" source="minecolonies:textures/gui/citizen/colonist_decor_down.png" pos="36 40"/>
                 <label id="title" size="100% 11" pos="0 48" color="black" textalign="MIDDLE"
                        label="§l$(com.minecolonies.coremod.gui.citizen.skills)"/>

--- a/src/main/resources/assets/minecolonies/lang/en_us.lang
+++ b/src/main/resources/assets/minecolonies/lang/en_us.lang
@@ -97,6 +97,12 @@ entity.farmer.noSeedSet=Please define a seed to grow in the scarecrow.
 entity.farmer.NeedSeed=I need %s to plant.
 entity.farmer.noFreeFields=Place more fields to get me working.
 achievement.upgrade.fisher.first=A fisherman.
+entity.citizen.noJob=%s would like to have a job.
+entity.citizen.demandsJob=%s demands to have a job and is getting very upset standing around.
+entity.citizen.noHouse=%s would like to have a house to go to every night.
+entity.citizen.demandsHouse=%s demands to have a house to live in and is getting very upset.
+entity.citizen.noTool=%s would like to get %s.
+entity.citizen.demandsTool=%s demand to get a %s. achievement.upgrade.fisher.first=A fisherman.
 achievement.upgrade.fisher.max=The whale catcher!
 achievement.upgrade.farmer.first=A farmer.
 achievement.upgrade.farmer.first.desc=agricultural economy.


### PR DESCRIPTION
This is an update on some of the new features of the new happiness system.
Features of the new happiness system:

Each citizen has their own happiness indicator.
You can view the citizen happiness indicator by right clicking on citizen.
Also, can view citizen happiness through Town Hall
Colony has its own happiness indicator.

Total happiness on the Town Gui is a combination of the two items from above.

Colony Happiness:
Citizen to Guard Ratio will modify the happiness
Average food Saturation for all citizens will modify the happiness
Citizen to Housing ration will modify the happiness
When a citizen dies it will modify the happiness
Death modifier will stay around for a period of days before it drops off.
It keeps a list of all death in a certain period of time and each death modifies happiness

Citizen Happiness:
base happiness
Food saturation will modify the happiness
If player is unable to eat when they go to eat will affect happiness
Citizen getting hit will modify happiness
Citizen not having a house will modify happiness
Citizen will start demanding a house to live in after a period of time without a house.
Citizen not have a job will modify happiness
will start demanding a job to work at after a period of time without a job.
A farmer having fields they are not able to farm will modify happiness
A farmer having no fields will modify happiness
Citizen not having a required tool to do their job will modify happiness
will start demanding the tool after a period of day without requesting being fulfilled.

Closes #
Closes #
Closes #

# Changes proposed in this pull request:
-
-
-

Review please
