### PR TITLE
barbarian - Spawn Difficulty #2693

### DIFF
--- a/src/api/java/com/minecolonies/api/util/constant/ColonyConstants.java
+++ b/src/api/java/com/minecolonies/api/util/constant/ColonyConstants.java
@@ -96,9 +96,11 @@ public final class ColonyConstants
     public static final ResourceLocation BARBARIAN                    = new ResourceLocation(Constants.MOD_ID, "Barbarian");
     public static final ResourceLocation ARCHER                       = new ResourceLocation(Constants.MOD_ID, "ArcherBarbarian");
     public static final ResourceLocation CHIEF                        = new ResourceLocation(Constants.MOD_ID, "ChiefBarbarian");
-    public static final int              MAX_SIZE                     = Configurations.gameplay.maxBarbarianHordeSize;
-    public static final double           BARBARIANS_MULTIPLIER        = 0.5;
-    public static final double           ARCHER_BARBARIANS_MULTIPLIER = 0.25;
+    public static final double           BARBARIAN_HORDE_DIFFICULTY   = ((double) Configurations.gameplay.barbarianHordeDifficulty * 0.1);
+    public static final double           BARBARIAN_SPAWN_SIZE         = ((double) Configurations.gameplay.spawnBarbarianSize * 0.1);
+    public static final int              BARBARIAN_MAX_SIZE           = Configurations.gameplay.maxBarbarianSize;
+    public static final double           BARBARIANS_MULTIPLIER        = 0.6;
+    public static final double           ARCHER_BARBARIANS_MULTIPLIER = 0.30;
     public static final double           CHIEF_BARBARIANS_MULTIPLIER  = 0.1;
     public static final int              PREFERRED_MAX_HORDE_SIZE     = 40;
     public static final int              PREFERRED_MAX_BARBARIANS     = 22;

--- a/src/api/java/com/minecolonies/api/util/constant/ColonyConstants.java
+++ b/src/api/java/com/minecolonies/api/util/constant/ColonyConstants.java
@@ -96,7 +96,6 @@ public final class ColonyConstants
     public static final ResourceLocation BARBARIAN                    = new ResourceLocation(Constants.MOD_ID, "Barbarian");
     public static final ResourceLocation ARCHER                       = new ResourceLocation(Constants.MOD_ID, "ArcherBarbarian");
     public static final ResourceLocation CHIEF                        = new ResourceLocation(Constants.MOD_ID, "ChiefBarbarian");
-    public static final double           BARBARIAN_HORDE_DIFFICULTY   = ((double) Configurations.gameplay.barbarianHordeDifficulty * 0.1);
     public static final int              MAX_SIZE                     = Configurations.gameplay.maxBarbarianHordeSize; 
     public static final double           BARBARIANS_MULTIPLIER        = 0.5; 
     public static final double           ARCHER_BARBARIANS_MULTIPLIER = 0.25; 

--- a/src/api/java/com/minecolonies/api/util/constant/ColonyConstants.java
+++ b/src/api/java/com/minecolonies/api/util/constant/ColonyConstants.java
@@ -97,10 +97,9 @@ public final class ColonyConstants
     public static final ResourceLocation ARCHER                       = new ResourceLocation(Constants.MOD_ID, "ArcherBarbarian");
     public static final ResourceLocation CHIEF                        = new ResourceLocation(Constants.MOD_ID, "ChiefBarbarian");
     public static final double           BARBARIAN_HORDE_DIFFICULTY   = ((double) Configurations.gameplay.barbarianHordeDifficulty * 0.1);
-    public static final double           BARBARIAN_SPAWN_SIZE         = ((double) Configurations.gameplay.spawnBarbarianSize * 0.1);
-    public static final int              BARBARIAN_MAX_SIZE           = Configurations.gameplay.maxBarbarianSize;
-    public static final double           BARBARIANS_MULTIPLIER        = 0.6;
-    public static final double           ARCHER_BARBARIANS_MULTIPLIER = 0.30;
+    public static final int              MAX_SIZE                     = Configurations.gameplay.maxBarbarianHordeSize; 
+    public static final double           BARBARIANS_MULTIPLIER        = 0.5; 
+    public static final double           ARCHER_BARBARIANS_MULTIPLIER = 0.25; 
     public static final double           CHIEF_BARBARIANS_MULTIPLIER  = 0.1;
     public static final int              PREFERRED_MAX_HORDE_SIZE     = 40;
     public static final int              PREFERRED_MAX_BARBARIANS     = 22;

--- a/src/main/java/com/minecolonies/coremod/entity/ai/mobs/util/BarbarianSpawnUtils.java
+++ b/src/main/java/com/minecolonies/coremod/entity/ai/mobs/util/BarbarianSpawnUtils.java
@@ -1,5 +1,6 @@
 package com.minecolonies.coremod.entity.ai.mobs.util;
 
+import com.minecolonies.api.configuration.Configurations;
 import com.minecolonies.api.util.BlockPosUtil;
 import com.minecolonies.api.util.CompatibilityUtils;
 import com.minecolonies.api.util.constant.ColonyConstants;
@@ -114,7 +115,7 @@ public final class BarbarianSpawnUtils
         if (colony != null)
         {
             final int raidLevel = (int) (MobEventsUtils.getColonyRaidLevel(colony) * BARBARIAN_HEALTH_MULTIPLIER);
-            return Math.max(BARBARIAN_BASE_HEALTH, (BARBARIAN_BASE_HEALTH + raidLevel) * ColonyConstants.BARBARIAN_HORDE_DIFFICULTY);
+            return Math.max(BARBARIAN_BASE_HEALTH, (BARBARIAN_BASE_HEALTH + raidLevel) * ((double) Configurations.gameplay.barbarianHordeDifficulty * 0.1));
         }
         return BARBARIAN_BASE_HEALTH;
     }

--- a/src/main/java/com/minecolonies/coremod/entity/ai/mobs/util/BarbarianSpawnUtils.java
+++ b/src/main/java/com/minecolonies/coremod/entity/ai/mobs/util/BarbarianSpawnUtils.java
@@ -2,6 +2,7 @@ package com.minecolonies.coremod.entity.ai.mobs.util;
 
 import com.minecolonies.api.util.BlockPosUtil;
 import com.minecolonies.api.util.CompatibilityUtils;
+import com.minecolonies.api.util.constant.ColonyConstants;
 import com.minecolonies.api.util.constant.Constants;
 import com.minecolonies.coremod.colony.Colony;
 import com.minecolonies.coremod.entity.EntityCitizen;
@@ -68,7 +69,7 @@ public final class BarbarianSpawnUtils
     private static final double MOVEMENT_SPEED              = 0.25D;
     private static final double ARMOR                       = 1.5D;
     private static final double CHIEF_ARMOR                 = 8D;
-    private static final double BARBARIAN_BASE_HEALTH       = 10;
+    private static final double BARBARIAN_BASE_HEALTH       = 5;
     private static final double BARBARIAN_HEALTH_MULTIPLIER = 0.2;
 
     /**
@@ -113,7 +114,7 @@ public final class BarbarianSpawnUtils
         if (colony != null)
         {
             final int raidLevel = (int) (MobEventsUtils.getColonyRaidLevel(colony) * BARBARIAN_HEALTH_MULTIPLIER);
-            return BARBARIAN_BASE_HEALTH + raidLevel;
+            return Math.max(BARBARIAN_BASE_HEALTH, (BARBARIAN_BASE_HEALTH + raidLevel) * ColonyConstants.BARBARIAN_HORDE_DIFFICULTY);
         }
         return BARBARIAN_BASE_HEALTH;
     }


### PR DESCRIPTION
When barbarians spawn. The health of the barbarian doesn't take into effect the horde difficulty. The change will cause the health of the spawn barbarian to reflect the difficulty settings from the config. So they will start with less health with the difficulty is set to 1 vs. 10.
barbarianHordeDifficulty = 1 - 10

This will be a percentage of what the game is asking for with a min. health for each. Can't have barbarians being spawned with 1 heart.
There is no max. a value of 10 = 100% of what the game is asking for.

Closes #
Closes #
Closes #

# Changes proposed in this pull request:
-
-
-

Review please
