### PR TITLE
Barbarian - Attack Rate - not using difficulty settings in progress #…

### DIFF
--- a/src/main/java/com/minecolonies/coremod/entity/ai/mobs/barbarians/EntityAIAttackArcher.java
+++ b/src/main/java/com/minecolonies/coremod/entity/ai/mobs/barbarians/EntityAIAttackArcher.java
@@ -1,6 +1,9 @@
 package com.minecolonies.coremod.entity.ai.mobs.barbarians;
 
+import com.minecolonies.api.configuration.Configurations;
 import com.minecolonies.api.util.CompatibilityUtils;
+import com.minecolonies.api.util.constant.Constants;
+
 import net.minecraft.entity.EntityCreature;
 import net.minecraft.entity.EntityLivingBase;
 import net.minecraft.entity.ai.EntityAIBase;
@@ -14,7 +17,7 @@ import net.minecraft.util.math.MathHelper;
  */
 public class EntityAIAttackArcher extends EntityAIBase
 {
-    private static final int    CYCLES_TO_WAIT                 = 32;
+    private static final int    CYCLES_TO_WAIT                 = 200;
     private static final double PITCH_MULTIPLIER               = 0.4;
     private static final double HALF_ROTATION                  = 180;
     private static final double ATTACK_SPEED                   = 1.3;
@@ -102,13 +105,23 @@ public class EntityAIAttackArcher extends EntityAIBase
             CompatibilityUtils.spawnEntity(CompatibilityUtils.getWorld(entity), arrowEntity);
             entity.swingArm(EnumHand.MAIN_HAND);
             entity.playSound(SoundEvents.ENTITY_SKELETON_SHOOT, (float) 1.0D, (float) getRandomPitch());
-            lastAttack = CYCLES_TO_WAIT;
+            lastAttack = getAttackDelay();
         }
 
         if (lastAttack > 0)
         {
             lastAttack -= 1;
         }
+    }
+
+    /**
+     * Gets the delay time for a next attack by the barbarian.
+     *
+     * @return the reload time
+     */
+    protected int getAttackDelay()
+    {
+        return CYCLES_TO_WAIT / Math.max(1, (int) ((Constants.MAX_BARBARIAN_DIFFICULTY - Configurations.gameplay.barbarianHordeDifficulty) * 0.1));
     }
 
     /**

--- a/src/main/java/com/minecolonies/coremod/entity/ai/mobs/barbarians/EntityAIBarbarianAttackMelee.java
+++ b/src/main/java/com/minecolonies/coremod/entity/ai/mobs/barbarians/EntityAIBarbarianAttackMelee.java
@@ -1,5 +1,9 @@
 package com.minecolonies.coremod.entity.ai.mobs.barbarians;
 
+import static com.minecolonies.coremod.entity.ai.citizen.guard.GuardConstants.RANGED_ATTACK_DELAY_BASE;
+
+import com.minecolonies.api.configuration.Configurations;
+import com.minecolonies.api.util.constant.Constants;
 import com.minecolonies.coremod.entity.ai.mobs.util.BarbarianSpawnUtils;
 import net.minecraft.entity.EntityLivingBase;
 import net.minecraft.entity.ai.EntityAIBase;
@@ -13,7 +17,7 @@ import net.minecraft.util.EnumHand;
 public class EntityAIBarbarianAttackMelee extends EntityAIBase
 {
 
-    private static final int    CYCLES_TO_WAIT          = 16;
+    private static final int    CYCLES_TO_WAIT          = 100;
     private static final double PITCH_MULTIPLIER        = 0.4;
     private static final double PITCH_ADDER             = 0.8;
     private static final double HALF_ROTATION           = 180;
@@ -90,7 +94,7 @@ public class EntityAIBarbarianAttackMelee extends EntityAIBase
                 entity.swingArm(EnumHand.MAIN_HAND);
                 entity.playSound(SoundEvents.ENTITY_PLAYER_ATTACK_SWEEP, (float) 1.0D, (float) getRandomPitch());
                 target.setRevengeTarget(entity);
-                lastAttack = CYCLES_TO_WAIT;
+                lastAttack = getAttackDelay();
             }
             if (lastAttack > 0)
             {
@@ -102,6 +106,16 @@ public class EntityAIBarbarianAttackMelee extends EntityAIBase
 
             entity.getNavigator().tryMoveToEntityLiving(target, ATTACK_SPEED);
         }
+    }
+
+    /**
+     * Gets the delay time for a next attack by the barbarian.
+     *
+     * @return the reload time
+     */
+    protected int getAttackDelay()
+    {
+        return CYCLES_TO_WAIT / Math.max(1, (int) ((Constants.MAX_BARBARIAN_DIFFICULTY - Configurations.gameplay.barbarianHordeDifficulty) * 0.1));
     }
 
     /**


### PR DESCRIPTION
…2697

This change is to affect the barbarians so that based on the difficulty level in the settings that rate at which the barbarians will attack will be affected.
This way on a very low settings in difficulty, the barbarians will have a slow attack rate vs. higher rates. This will make it a little more different game player overall.
