### PR TITLE
Creating a possible workaround for Shaders not behaving with the buildtool.

### DIFF
--- a/src/main/java/com/minecolonies/structures/client/TemplateTessellator.java
+++ b/src/main/java/com/minecolonies/structures/client/TemplateTessellator.java
@@ -10,6 +10,8 @@ import net.minecraft.client.renderer.vertex.VertexFormatElement;
 import net.minecraft.util.Mirror;
 import net.minecraft.util.Rotation;
 import net.minecraft.util.math.BlockPos;
+import org.lwjgl.opengl.GL11;
+import org.lwjgl.opengl.GL20;
 
 import static org.lwjgl.opengl.GL11.*;
 
@@ -55,11 +57,11 @@ public class TemplateTessellator
 
         this.buffer.bindBuffer();
 
-        preTemplateDraw();
+        final int currentShader = preTemplateDraw();
 
         this.buffer.drawArrays(GL_QUADS);
 
-        postTemplateDraw();
+        postTemplateDraw(currentShader);
 
         this.buffer.unbindBuffer();
 
@@ -87,7 +89,7 @@ public class TemplateTessellator
         GlStateManager.pushMatrix();
     }
 
-    private static void preTemplateDraw()
+    private static int preTemplateDraw()
     {
         GlStateManager.glEnableClientState(GL_VERTEX_ARRAY);
         OpenGlHelper.setClientActiveTexture(OpenGlHelper.defaultTexUnit);
@@ -105,9 +107,14 @@ public class TemplateTessellator
         OpenGlHelper.setClientActiveTexture(OpenGlHelper.defaultTexUnit);
 
         GlStateManager.disableCull();
+
+        final int currentProgram = GL11.glGetInteger(GL20.GL_CURRENT_PROGRAM);
+        GL20.glUseProgram(0);
+
+        return currentProgram;
     }
 
-    private void postTemplateDraw()
+    private void postTemplateDraw(final int shaderProgramm)
     {
         GlStateManager.enableCull();
 
@@ -135,6 +142,8 @@ public class TemplateTessellator
                     break;
             }
         }
+
+        GL20.glUseProgram(shaderProgramm);
     }
 
     private void postTemplateBufferUnbinding()

--- a/src/main/java/com/minecolonies/structures/client/TemplateTessellator.java
+++ b/src/main/java/com/minecolonies/structures/client/TemplateTessellator.java
@@ -1,5 +1,6 @@
 package com.minecolonies.structures.client;
 
+import com.minecolonies.blockout.Log;
 import com.minecolonies.structures.lib.RenderUtil;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.renderer.*;
@@ -109,6 +110,7 @@ public class TemplateTessellator
         GlStateManager.disableCull();
 
         final int currentProgram = GL11.glGetInteger(GL20.GL_CURRENT_PROGRAM);
+        Log.getLogger().info(String.format("Disabled Shader Programm: %d", currentProgram));
         GL20.glUseProgram(0);
 
         return currentProgram;
@@ -144,6 +146,7 @@ public class TemplateTessellator
         }
 
         GL20.glUseProgram(shaderProgramm);
+        Log.getLogger().info(String.format("Enabled Shader programm: %d", shaderProgramm));
     }
 
     private void postTemplateBufferUnbinding()


### PR DESCRIPTION
This disables shaders all together when using the buildtool. It has no effect on vanilla gameplay.