### PR TITLE
Dumping can cause an exception

### DIFF
--- a/src/main/java/com/minecolonies/coremod/colony/CitizenData.java
+++ b/src/main/java/com/minecolonies/coremod/colony/CitizenData.java
@@ -1093,7 +1093,11 @@ public class CitizenData
      */
     public boolean isRequestAsync(@NotNull final IToken token)
     {
-        return job.getAsyncRequests().contains(token);
+        if (job != null)
+        {
+            return job.getAsyncRequests().contains(token);
+        }
+        return false;
     }
 
     /**


### PR DESCRIPTION
When the dman went to dump,  it would cause an exception.  Something related to citizen had a job and and request but has been fired.  Now they have no job.

Closes #
Closes #
Closes #

# Changes proposed in this pull request:
-
-
-

Review please
