### PR TITLE
Herder - if player gives to many animals - death #2737

### DIFF
--- a/src/main/java/com/minecolonies/coremod/entity/ai/citizen/herders/AbstractEntityAIHerder.java
+++ b/src/main/java/com/minecolonies/coremod/entity/ai/citizen/herders/AbstractEntityAIHerder.java
@@ -22,6 +22,7 @@ import org.jetbrains.annotations.Nullable;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.Stream;
 
 import static com.minecolonies.api.util.constant.ToolLevelConstants.TOOL_LEVEL_WOOD_OR_GOLD;
 import static com.minecolonies.coremod.entity.ai.util.AIState.*;
@@ -418,7 +419,11 @@ public abstract class AbstractEntityAIHerder<J extends AbstractJob, T extends En
     {
         if (getOwnBuilding() != null)
         {
-            final int numOfAnimals = searchForAnimals().size();
+            Stream<T> animal = searchForAnimals()
+                    .stream()
+                    .filter(animalToButcher -> animalToButcher.getGrowingAge() == 0);
+
+            final int numOfAnimals = (int) animal.count();
             final int maxAnimals = getOwnBuilding().getBuildingLevel() * getMaxAnimalMultiplier();
 
             return numOfAnimals > maxAnimals;

--- a/src/main/java/com/minecolonies/coremod/entity/ai/citizen/herders/AbstractEntityAIHerder.java
+++ b/src/main/java/com/minecolonies/coremod/entity/ai/citizen/herders/AbstractEntityAIHerder.java
@@ -419,7 +419,7 @@ public abstract class AbstractEntityAIHerder<J extends AbstractJob, T extends En
     {
         if (getOwnBuilding() != null)
         {
-            Stream<T> animal = searchForAnimals()
+            final Stream<T> animal = searchForAnimals()
                     .stream()
                     .filter(animalToButcher -> animalToButcher.getGrowingAge() == 0);
 


### PR DESCRIPTION
Any current version.

If a player put more animal in the pen more than the herder can handle. So level 1 build can handle 2 animals at a time. If the player puts 4 animals in there and 3 of them are babies.
The herder will go and kill 1 grown up and 2 babies. Even though the babies will not produce anything. The herder should wait until they are full grown and then kill excess animal. It is stupid to slaughter a baby when it will not produce anything.

Closes #
Closes #
Closes #

# Changes proposed in this pull request:
-
-
-

Review please
