### PR TITLE
Cowboy - requiring bucket when not needed #2657

### DIFF
--- a/src/main/java/com/minecolonies/coremod/entity/ai/citizen/herders/EntityAIWorkCowboy.java
+++ b/src/main/java/com/minecolonies/coremod/entity/ai/citizen/herders/EntityAIWorkCowboy.java
@@ -39,7 +39,6 @@ public class EntityAIWorkCowboy extends AbstractEntityAIHerder<JobCowboy, Entity
     {
         super(job);
         worker.getCitizenExperienceHandler().setSkillModifier(2 * worker.getCitizenData().getDexterity() + worker.getCitizenData().getStrength());
-        itemsNeeded.add(bucketStack);
         super.registerTargets(
           new AITarget(COWBOY_MILK, this::milkCows)
         );


### PR DESCRIPTION
Found another issue. On load the game automatically requested the bucket in the init class function. I removed it so it only decided to request a bucket on decide what to do. This way it can check if the milk cow is checked or not.

Closes #
Closes #
Closes #

# Changes proposed in this pull request:
-
-
-

Review please
