### PR TITLE
Allow adding extra ores for miners to recognize in the config

### DIFF
--- a/src/api/java/com/minecolonies/api/compatibility/CompatibilityManager.java
+++ b/src/api/java/com/minecolonies/api/compatibility/CompatibilityManager.java
@@ -236,6 +236,15 @@ public class CompatibilityManager implements ICompatibilityManager
                 }
             }
         }
+        
+        for (final String oreString : Configurations.gameplay.extraOres) 
+        {
+            final Block block = Block.getBlockFromName(oreString);
+            if (!(block == null || ores.contains(block)))
+            {
+                ores.add(block);
+            }
+        }
     }
 
     private void discoverSaplings()

--- a/src/api/java/com/minecolonies/api/configuration/Configurations.java
+++ b/src/api/java/com/minecolonies/api/configuration/Configurations.java
@@ -64,13 +64,20 @@ public class Configurations
         @Config.Comment("Delay modifier to mine a block (Decreasing it, decreases the delay)")
         public int blockMiningDelayModifier = 500;
 
+        @Config.Comment("Ores for the miner to mine that aren't autodetected")
+        public String[] extraOres = new String[]
+                {
+                        "minestuck:ore_cruxite",
+                        "minestuck:ore_uranium",
+                };
+
         @Config.Comment("Should workers work during the rain?")
         public boolean workersAlwaysWorkInRain = false;
 
         @Config.Comment("Should the colony protection be enabled?")
         public boolean enableColonyProtection = true;
 
-        @Config.Comment("Independend from the colony protection, should explosions be turned off?")
+        @Config.Comment("Independent from the colony protection, should explosions be turned off?")
         public boolean turnOffExplosionsInColonies = true;
 
         @Config.Comment("Whether or not to spawn barbarians")
@@ -164,7 +171,7 @@ public class Configurations
         public boolean canPlayerUseBackupCommand = false;
 
         /* Colony TP configs */
-        @Config.Comment("Amount of attemps to find a save rtp")
+        @Config.Comment("Amount of attempts to find a save rtp")
         public int numberOfAttemptsForSafeTP = 4;
 
         @Config.Comment("Should the min/max distance from spawn also affect colony placement?")


### PR DESCRIPTION
Allows defining a list of resource locations as strings in the config for ores for the miner to recognize in case there are ores that weren't automatically found