### PR TITLE
Citizen - Happiness - /Bug fix #2799

### DIFF
--- a/src/api/java/com/minecolonies/api/util/constant/TranslationConstants.java
+++ b/src/api/java/com/minecolonies/api/util/constant/TranslationConstants.java
@@ -275,6 +275,20 @@ public final class TranslationConstants
     public static final String ON_STRING                                                           = "com.minecolonies.coremod.gui.townHall.on";
     @NonNls
     public static final String OFF_STRING                                                          = "com.minecolonies.coremod.gui.townHall.off";
+    @NonNls
+    public static final String CMCG_HAPPINESS_HAPPINESSMODIFIER                                    = "com.minecolonies.coremod.gui.happiness.happinessModifier";
+    @NonNls
+    public static final String CMCG_HAPPINESS_FOOD                                                 = "com.minecolonies.coremod.gui.happiness.food";
+    @NonNls
+    public static final String CMCG_HAPPINESS_DAMAGE                                               = "com.minecolonies.coremod.gui.happiness.damage";
+    @NonNls
+    public static final String CMCG_HAPPINESS_HOUSE                                                = "com.minecolonies.coremod.gui.happiness.house";
+    @NonNls
+    public static final String CMCG_HAPPINESS_JOB                                                  = "com.minecolonies.coremod.gui.happiness.job";
+    @NonNls
+    public static final String CMCG_HAPPINESS_FARMS                                                = "com.minecolonies.coremod.gui.happiness.farms";
+    @NonNls
+    public static final String CMCG_HAPPINESS_TOOLS                                                = "com.minecolonies.coremod.gui.happiness.tools";
 
     private TranslationConstants()
     {

--- a/src/api/java/com/minecolonies/api/util/constant/WindowConstants.java
+++ b/src/api/java/com/minecolonies/api/util/constant/WindowConstants.java
@@ -1004,7 +1004,7 @@ public final class WindowConstants
     /**
      * ID for happiness modifier view
      */
-    public static final String FOOD_MODIFIER_PANE = "happinessModifierView";
+    public static final String HAPPINESS_MODIFIER_PANE = "happinessModifierView";
     
     /**
      * public constructor to hide implicit public one.

--- a/src/api/java/com/minecolonies/api/util/constant/WindowConstants.java
+++ b/src/api/java/com/minecolonies/api/util/constant/WindowConstants.java
@@ -697,6 +697,16 @@ public final class WindowConstants
     public static final String LABEL_CONSTRUCTION_POS =  "constructionPos";
 
     /**
+     * The fields used into the happiness
+     */
+    public static final String FOOD_MODIFIER    = "foodLevel";
+    public static final String HOUSE_MODIFIER   = "houseLevel";
+    public static final String DAMAGE_MODIFIER  = "damageLevel";
+    public static final String JOB_MODIFIER     = "jobLevel";
+    public static final String FIELDS_MODIFIER  = "farmsLevel";
+    public static final String TOOLS_MODIFIER   = "toolsLevel";
+
+    /**
      * Citizen view constants.
      */
 
@@ -981,6 +991,21 @@ public final class WindowConstants
      */
     public static final int LIFE_COUNT_DIVIDER = 30;
 
+    /**
+     * Button leading the player to the next page.
+     */
+    public static final String BUTTON_PREV_PAGE = "prevPage";
+
+    /**
+     * Button leading the player to the previous page.
+     */
+    public static final String BUTTON_NEXT_PAGE = "nextPage";
+
+    /**
+     * ID for happiness modifier view
+     */
+    public static final String FOOD_MODIFIER_PANE = "happinessModifierView";
+    
     /**
      * public constructor to hide implicit public one.
      */

--- a/src/main/java/com/minecolonies/coremod/client/gui/WindowCitizen.java
+++ b/src/main/java/com/minecolonies/coremod/client/gui/WindowCitizen.java
@@ -9,7 +9,6 @@ import com.minecolonies.api.colony.requestsystem.token.IToken;
 import com.minecolonies.api.util.InventoryUtils;
 import com.minecolonies.api.util.LanguageHandler;
 import com.minecolonies.api.util.constant.Constants;
-import com.minecolonies.api.util.constant.WindowConstants;
 import com.minecolonies.blockout.Alignment;
 import com.minecolonies.blockout.Pane;
 import com.minecolonies.blockout.controls.*;
@@ -514,7 +513,7 @@ public class WindowCitizen extends AbstractWindowSkeleton
                 fulfill(button);
                 break;
             case BUTTON_NEXT_PAGE:
-                findPaneOfTypeByID(VIEW_PAGES, SwitchView.class).setView("foodModifierPane");
+                findPaneOfTypeByID(VIEW_PAGES, SwitchView.class).setView(HAPPINESS_MODIFIER_PANE);
                 buttonPrevPage.setEnabled(true);
                 buttonNextPage.setEnabled(false);
                 break;
@@ -606,8 +605,8 @@ public class WindowCitizen extends AbstractWindowSkeleton
         final String[] imagesIds = new String[] {FOOD_MODIFIER, HOUSE_MODIFIER, DAMAGE_MODIFIER, JOB_MODIFIER, FIELDS_MODIFIER, TOOLS_MODIFIER};
         final double[] levels = new double[] {citizen.getFoodModifier(), citizen.getHouseModifier(), citizen.getDamageModifier(), citizen.getJobModifier(), citizen.getFieldsModifier(), citizen.getToolsModifiers()};
 
-        findPaneOfTypeByID(FOOD_MODIFIER_PANE, View.class).setAlignment(Alignment.MIDDLE_RIGHT);
-        if (findPaneByID(FOOD_MODIFIER_PANE) != null)
+        findPaneOfTypeByID(HAPPINESS_MODIFIER_PANE, View.class).setAlignment(Alignment.MIDDLE_RIGHT);
+        if (findPaneByID(HAPPINESS_MODIFIER_PANE) != null)
         {
             findPaneOfTypeByID("happinessModifier", Label.class).setLabelText(LanguageHandler.format("com.minecolonies.coremod.gui.happiness.happinessModifier"));
             findPaneOfTypeByID("food", Label.class).setLabelText(LanguageHandler.format("com.minecolonies.coremod.gui.happiness.food"));

--- a/src/main/java/com/minecolonies/coremod/client/gui/WindowCitizen.java
+++ b/src/main/java/com/minecolonies/coremod/client/gui/WindowCitizen.java
@@ -9,6 +9,7 @@ import com.minecolonies.api.colony.requestsystem.token.IToken;
 import com.minecolonies.api.util.InventoryUtils;
 import com.minecolonies.api.util.LanguageHandler;
 import com.minecolonies.api.util.constant.Constants;
+import com.minecolonies.api.util.constant.WindowConstants;
 import com.minecolonies.blockout.Alignment;
 import com.minecolonies.blockout.Pane;
 import com.minecolonies.blockout.controls.*;
@@ -58,7 +59,7 @@ public class WindowCitizen extends AbstractWindowSkeleton
     /**
      * Scrollinglist of the resources.
      */
-    private final ScrollingList   resourceList;
+    private ScrollingList   resourceList;
 
     /**
      * Inventory of the player.
@@ -74,6 +75,16 @@ public class WindowCitizen extends AbstractWindowSkeleton
      * Life count.
      */
     private       int             lifeCount  = 0;
+
+    /**
+     * Button leading to the previous page.
+     */
+    private Button buttonPrevPage;
+
+    /**
+     * Button leading to the next page.
+     */
+    private Button buttonNextPage;
 
     /**
      * Constructor to initiate the citizen windows.
@@ -107,12 +118,18 @@ public class WindowCitizen extends AbstractWindowSkeleton
     {
         findPaneOfTypeByID(WINDOW_ID_NAME, Label.class).setLabelText(citizen.getName());
 
+        findPaneOfTypeByID(WindowConstants.BUTTON_PREV_PAGE, Button.class).setEnabled(false);
+        buttonPrevPage = findPaneOfTypeByID(WindowConstants.BUTTON_PREV_PAGE, Button.class);
+        buttonNextPage = findPaneOfTypeByID(WindowConstants.BUTTON_NEXT_PAGE, Button.class);
+
         createHealthBar(citizen, findPaneOfTypeByID(WINDOW_ID_HEALTHBAR, View.class));
         createSaturationBar();
         createHappinessBar(); 
         createXpBar(citizen, this);
         createSkillContent(citizen, this);
-
+        updateHappiness();
+        
+        resourceList = findPaneOfTypeByID(WINDOW_ID_LIST_REQUESTS, ScrollingList.class);
         resourceList.setDataProvider(new ScrollingList.DataProvider()
         {
 
@@ -496,6 +513,16 @@ public class WindowCitizen extends AbstractWindowSkeleton
             case REQUEST_FULLFIL:
                 fulfill(button);
                 break;
+            case WindowConstants.BUTTON_NEXT_PAGE:
+                findPaneOfTypeByID(VIEW_PAGES, SwitchView.class).setView("foodModifierPane");
+                buttonPrevPage.setEnabled(true);
+                buttonNextPage.setEnabled(false);
+                break;
+            case WindowConstants.BUTTON_PREV_PAGE:
+                findPaneOfTypeByID(VIEW_PAGES, SwitchView.class).setView(PAGE_ACTIONS);
+                buttonPrevPage.setEnabled(false);
+                buttonNextPage.setEnabled(true);
+                break;
             default:
                 break;
         }
@@ -571,6 +598,46 @@ public class WindowCitizen extends AbstractWindowSkeleton
         button.disable();
     }
 
+    /**
+     * Update the display for the happiness
+     */
+    private void updateHappiness()
+    {
+        final String[] imagesIds = new String[] {FOOD_MODIFIER, HOUSE_MODIFIER, DAMAGE_MODIFIER, JOB_MODIFIER, FIELDS_MODIFIER, TOOLS_MODIFIER};
+        final double[] levels = new double[] {citizen.getFoodModifier(), citizen.getHouseModifier(), citizen.getDamageModifier(), citizen.getJobModifier(), citizen.getFieldsModifier(), citizen.getToolsModifiers()};
+
+        findPaneOfTypeByID(FOOD_MODIFIER_PANE, View.class).setAlignment(Alignment.MIDDLE_RIGHT);
+        if (findPaneByID(FOOD_MODIFIER_PANE) != null)
+        {
+            findPaneOfTypeByID("happinessModifier", Label.class).setLabelText(LanguageHandler.format("com.minecolonies.coremod.gui.happiness.happinessModifier"));
+            findPaneOfTypeByID("food", Label.class).setLabelText(LanguageHandler.format("com.minecolonies.coremod.gui.happiness.food"));
+            findPaneOfTypeByID("damage", Label.class).setLabelText(LanguageHandler.format("com.minecolonies.coremod.gui.happiness.damage"));
+            findPaneOfTypeByID("house", Label.class).setLabelText(LanguageHandler.format("com.minecolonies.coremod.gui.happiness.house"));
+            findPaneOfTypeByID("job", Label.class).setLabelText(LanguageHandler.format("com.minecolonies.coremod.gui.happiness.job"));
+            findPaneOfTypeByID("farms", Label.class).setLabelText(LanguageHandler.format("com.minecolonies.coremod.gui.happiness.farms"));
+            findPaneOfTypeByID("tools", Label.class).setLabelText(LanguageHandler.format("com.minecolonies.coremod.gui.happiness.tools"));
+    
+            
+            for (int i = 0; i < imagesIds.length; i++)
+            {
+                final Image image = findPaneOfTypeByID(imagesIds[i], Image.class);
+                if (levels[i] < 0)
+                {
+                    image.setImage(RED_ICON);
+                }
+                else if (levels[i] == 0)
+                {
+                    image.setImage(YELLOW_ICON);
+                }
+                else if (levels[i] > 0)
+                {
+                    image.setImage(GREEN_ICON);
+                }
+            }
+        }
+    }
+
+    
     private final class RequestWrapper
     {
         private final IRequest request;

--- a/src/main/java/com/minecolonies/coremod/client/gui/WindowCitizen.java
+++ b/src/main/java/com/minecolonies/coremod/client/gui/WindowCitizen.java
@@ -44,7 +44,7 @@ import java.util.function.Predicate;
 
 import static com.minecolonies.api.util.constant.Suppression.RAWTYPES;
 import static com.minecolonies.api.util.constant.WindowConstants.*;
-
+import static com.minecolonies.api.util.constant.TranslationConstants.*;
 /**
  * Window for the citizen.
  */
@@ -602,36 +602,36 @@ public class WindowCitizen extends AbstractWindowSkeleton
      */
     private void updateHappiness()
     {
-        final String[] imagesIds = new String[] {FOOD_MODIFIER, HOUSE_MODIFIER, DAMAGE_MODIFIER, JOB_MODIFIER, FIELDS_MODIFIER, TOOLS_MODIFIER};
+        int row = 1;
         final double[] levels = new double[] {citizen.getFoodModifier(), citizen.getHouseModifier(), citizen.getDamageModifier(), citizen.getJobModifier(), citizen.getFieldsModifier(), citizen.getToolsModifiers()};
+        final String[] labelIds = new String[] {CMCG_HAPPINESS_FOOD, CMCG_HAPPINESS_DAMAGE, CMCG_HAPPINESS_HOUSE, CMCG_HAPPINESS_JOB, CMCG_HAPPINESS_FARMS, CMCG_HAPPINESS_TOOLS};
 
         findPaneOfTypeByID(HAPPINESS_MODIFIER_PANE, View.class).setAlignment(Alignment.MIDDLE_RIGHT);
         if (findPaneByID(HAPPINESS_MODIFIER_PANE) != null)
         {
             findPaneOfTypeByID("happinessModifier", Label.class).setLabelText(LanguageHandler.format("com.minecolonies.coremod.gui.happiness.happinessModifier"));
-            findPaneOfTypeByID("food", Label.class).setLabelText(LanguageHandler.format("com.minecolonies.coremod.gui.happiness.food"));
-            findPaneOfTypeByID("damage", Label.class).setLabelText(LanguageHandler.format("com.minecolonies.coremod.gui.happiness.damage"));
-            findPaneOfTypeByID("house", Label.class).setLabelText(LanguageHandler.format("com.minecolonies.coremod.gui.happiness.house"));
-            findPaneOfTypeByID("job", Label.class).setLabelText(LanguageHandler.format("com.minecolonies.coremod.gui.happiness.job"));
-            findPaneOfTypeByID("farms", Label.class).setLabelText(LanguageHandler.format("com.minecolonies.coremod.gui.happiness.farms"));
-            findPaneOfTypeByID("tools", Label.class).setLabelText(LanguageHandler.format("com.minecolonies.coremod.gui.happiness.tools"));
-    
-            
-            for (int i = 0; i < imagesIds.length; i++)
+
+            for (int i = 0; i < levels.length; i++)
             {
-                final Image image = findPaneOfTypeByID(imagesIds[i], Image.class);
+                final Image image = findPaneOfTypeByID("modifierImage"+row, Image.class);
                 if (levels[i] < 0)
                 {
+                    findPaneOfTypeByID("modifier"+row, Label.class).setLabelText(LanguageHandler.format(labelIds[i]));
                     image.setImage(RED_ICON);
-                }
-                else if (levels[i] == 0)
-                {
-                    image.setImage(YELLOW_ICON);
+                    row++;
                 }
                 else if (levels[i] > 0)
                 {
+                    findPaneOfTypeByID("modifier"+row, Label.class).setLabelText(LanguageHandler.format(labelIds[i]));
                     image.setImage(GREEN_ICON);
+                    row++;
                 }
+            }
+            
+            for (int i = row; i<= levels.length; i++)
+            {
+                final Image image = findPaneOfTypeByID("modifierImage"+i, Image.class);
+                image.hide();
             }
         }
     }

--- a/src/main/java/com/minecolonies/coremod/client/gui/WindowCitizen.java
+++ b/src/main/java/com/minecolonies/coremod/client/gui/WindowCitizen.java
@@ -118,9 +118,9 @@ public class WindowCitizen extends AbstractWindowSkeleton
     {
         findPaneOfTypeByID(WINDOW_ID_NAME, Label.class).setLabelText(citizen.getName());
 
-        findPaneOfTypeByID(WindowConstants.BUTTON_PREV_PAGE, Button.class).setEnabled(false);
-        buttonPrevPage = findPaneOfTypeByID(WindowConstants.BUTTON_PREV_PAGE, Button.class);
-        buttonNextPage = findPaneOfTypeByID(WindowConstants.BUTTON_NEXT_PAGE, Button.class);
+        findPaneOfTypeByID(BUTTON_PREV_PAGE, Button.class).setEnabled(false);
+        buttonPrevPage = findPaneOfTypeByID(BUTTON_PREV_PAGE, Button.class);
+        buttonNextPage = findPaneOfTypeByID(BUTTON_NEXT_PAGE, Button.class);
 
         createHealthBar(citizen, findPaneOfTypeByID(WINDOW_ID_HEALTHBAR, View.class));
         createSaturationBar();
@@ -513,12 +513,12 @@ public class WindowCitizen extends AbstractWindowSkeleton
             case REQUEST_FULLFIL:
                 fulfill(button);
                 break;
-            case WindowConstants.BUTTON_NEXT_PAGE:
+            case BUTTON_NEXT_PAGE:
                 findPaneOfTypeByID(VIEW_PAGES, SwitchView.class).setView("foodModifierPane");
                 buttonPrevPage.setEnabled(true);
                 buttonNextPage.setEnabled(false);
                 break;
-            case WindowConstants.BUTTON_PREV_PAGE:
+            case BUTTON_PREV_PAGE:
                 findPaneOfTypeByID(VIEW_PAGES, SwitchView.class).setView(PAGE_ACTIONS);
                 buttonPrevPage.setEnabled(false);
                 buttonNextPage.setEnabled(true);

--- a/src/main/java/com/minecolonies/coremod/client/gui/WindowHutBaker.java
+++ b/src/main/java/com/minecolonies/coremod/client/gui/WindowHutBaker.java
@@ -2,6 +2,7 @@ package com.minecolonies.coremod.client.gui;
 
 import com.minecolonies.api.crafting.IRecipeStorage;
 import com.minecolonies.api.util.constant.Constants;
+import com.minecolonies.api.util.constant.WindowConstants;
 import com.minecolonies.blockout.Pane;
 import com.minecolonies.blockout.controls.Button;
 import com.minecolonies.blockout.controls.ItemIcon;
@@ -24,15 +25,6 @@ import java.util.List;
  */
 public class WindowHutBaker extends AbstractWindowWorkerBuilding<BuildingBaker.View>
 {
-    /**
-     * Button leading the player to the next page.
-     */
-    private static final String BUTTON_PREV_PAGE = "prevPage";
-
-    /**
-     * Button leading the player to the previous page.
-     */
-    private static final String BUTTON_NEXT_PAGE = "nextPage";
 
     /**
      * Id of the the assign button inside the GUI.
@@ -93,8 +85,8 @@ public class WindowHutBaker extends AbstractWindowWorkerBuilding<BuildingBaker.V
     public WindowHutBaker(final BuildingBaker.View building)
     {
         super(building, Constants.MOD_ID + ":gui/windowHutBaker.xml");
-        registerButton(BUTTON_PREV_PAGE, this::prevClicked);
-        registerButton(BUTTON_NEXT_PAGE, this::nextClicked);
+        registerButton(WindowConstants.BUTTON_PREV_PAGE, this::prevClicked);
+        registerButton(WindowConstants.BUTTON_NEXT_PAGE, this::nextClicked);
         registerButton(TAG_BUTTON_ASSIGN, this::assignClicked);
     }
 
@@ -130,9 +122,9 @@ public class WindowHutBaker extends AbstractWindowWorkerBuilding<BuildingBaker.V
 
         final List<IRecipeStorage> recipes = BakerRecipes.getRecipes();
 
-        findPaneOfTypeByID(BUTTON_PREV_PAGE, Button.class).setEnabled(false);
-        buttonPrevPage = findPaneOfTypeByID(BUTTON_PREV_PAGE, Button.class);
-        buttonNextPage = findPaneOfTypeByID(BUTTON_NEXT_PAGE, Button.class);
+        findPaneOfTypeByID(WindowConstants.BUTTON_PREV_PAGE, Button.class).setEnabled(false);
+        buttonPrevPage = findPaneOfTypeByID(WindowConstants.BUTTON_PREV_PAGE, Button.class);
+        buttonNextPage = findPaneOfTypeByID(WindowConstants.BUTTON_NEXT_PAGE, Button.class);
 
         recipeList = findPaneOfTypeByID(LIST_RECIPES, ScrollingList.class);
         recipeList.setDataProvider(new ScrollingList.DataProvider()

--- a/src/main/java/com/minecolonies/coremod/colony/CitizenData.java
+++ b/src/main/java/com/minecolonies/coremod/colony/CitizenData.java
@@ -881,6 +881,8 @@ public class CitizenData
         buf.writeDouble(getSaturation());
         buf.writeDouble(citizenHappinessHandler.getHappiness());
 
+        citizenHappinessHandler.serializeViewNetworkData(buf);
+
         ByteBufUtils.writeUTF8String(buf, (job != null) ? job.getName() : "");
 
         writeStatusToBuffer(buf);

--- a/src/main/java/com/minecolonies/coremod/colony/CitizenDataView.java
+++ b/src/main/java/com/minecolonies/coremod/colony/CitizenDataView.java
@@ -23,7 +23,7 @@ public class CitizenDataView
 {
 
     private static final String TAG_HELD_ITEM_SLOT = "HeldItemSlot";
-    public static final String TAG_OFFHAND_HELD_ITEM_SLOT        = "OffhandHeldItemSlot";
+    public static final String TAG_OFFHAND_HELD_ITEM_SLOT = "OffhandHeldItemSlot";
 
     /**
      * The max amount of lines the latest log allows.
@@ -33,10 +33,10 @@ public class CitizenDataView
     /**
      * Attributes.
      */
-    private final int     id;
-    private       int     entityId;
-    private       String  name;
-    private       boolean female;
+    private final int id;
+    private int entityId;
+    private String name;
+    private boolean female;
 
     /**
      * colony id of the citizen.
@@ -46,21 +46,32 @@ public class CitizenDataView
     /**
      * Placeholder skills.
      */
-    private int    level;
+    private int level;
     private double experience;
     private double health;
     private double maxHealth;
-    private int    strength;
-    private int    endurance;
-    private int    charisma;
-    private int    intelligence;
-    private int    dexterity;
+    private int strength;
+    private int endurance;
+    private int charisma;
+    private int intelligence;
+    private int dexterity;
     private double saturation;
 
-    /** 
-     * holds the current citizen happiness value 
+    /**
+     * holds the current citizen happiness value
      */
     private double happiness;
+
+    /**
+     * holds the current citizen happiness modifiers for
+     * each type of modifier.
+     */
+    private double foodModifier;
+    private double damageModifier;
+    private double houseModifier;
+    private double jobModifier;
+    private double fieldsModifier;
+    private double toolsModifiers;
 
     /**
      * The position of the guard.
@@ -90,7 +101,8 @@ public class CitizenDataView
     /**
      * Set View id.
      *
-     * @param id the id to set.
+     * @param id
+     *            the id to set.
      */
     protected CitizenDataView(final int id)
     {
@@ -229,15 +241,15 @@ public class CitizenDataView
         return charisma;
     }
 
-    /** 
-     * Gets the current Happiness value for the citizen 
+    /**
+     * Gets the current Happiness value for the citizen
      * 
-     * @return citizens current Happiness value 
-     */ 
-    public double getHappiness() 
-    { 
-      return happiness; 
-    } 
+     * @return citizens current Happiness value
+     */
+    public double getHappiness()
+    {
+        return happiness;
+    }
 
     /**
      * Get the saturation of the citizen.
@@ -291,6 +303,7 @@ public class CitizenDataView
 
     /**
      * Get the last registered position of the citizen.
+     * 
      * @return the BlockPos.
      */
     public BlockPos getPosition()
@@ -301,7 +314,8 @@ public class CitizenDataView
     /**
      * Deserialize the attributes and variables from transition.
      *
-     * @param buf Byte buffer to deserialize.
+     * @param buf
+     *            Byte buffer to deserialize.
      */
     public void deserialize(@NotNull final ByteBuf buf)
     {
@@ -312,7 +326,7 @@ public class CitizenDataView
         homeBuilding = buf.readBoolean() ? BlockPosUtil.readFromByteBuf(buf) : null;
         workBuilding = buf.readBoolean() ? BlockPosUtil.readFromByteBuf(buf) : null;
 
-        //  Attributes
+        // Attributes
         level = buf.readInt();
         experience = buf.readDouble();
         health = buf.readFloat();
@@ -325,6 +339,13 @@ public class CitizenDataView
         dexterity = buf.readInt();
         saturation = buf.readDouble();
         happiness = buf.readDouble();
+
+        foodModifier = buf.readDouble();
+        damageModifier = buf.readDouble();
+        houseModifier = buf.readDouble();
+        jobModifier = buf.readDouble();
+        fieldsModifier = buf.readDouble();
+        toolsModifiers = buf.readDouble();
 
         job = ByteBufUtils.readUTF8String(buf);
 
@@ -361,5 +382,53 @@ public class CitizenDataView
     public InventoryCitizen getInventory()
     {
         return inventory;
+    }
+
+    /**
+     * @return returns the current modifier related to food.
+     */
+    public double getFoodModifier()
+    {
+        return foodModifier;
+    }
+
+    /**
+     * @return returns the current modifier related to damage.
+     */
+    public double getDamageModifier()
+    {
+        return damageModifier;
+    }
+
+    /**
+     * @return returns the current modifier related to house.
+     */
+    public double getHouseModifier()
+    {
+        return houseModifier;
+    }
+
+    /**
+     * @return returns the current modifier related to job.
+     */
+    public double getJobModifier()
+    {
+        return jobModifier;
+    }
+
+    /**
+     * @return returns the current modifier related to fields.
+     */
+    public double getFieldsModifier()
+    {
+        return fieldsModifier;
+    }
+
+    /**
+     * @return returns the current modifier related to tools.
+     */
+    public double getToolsModifiers()
+    {
+        return toolsModifiers;
     }
 }

--- a/src/main/java/com/minecolonies/coremod/entity/citizenhandlers/CitizenHappinessHandler.java
+++ b/src/main/java/com/minecolonies/coremod/entity/citizenhandlers/CitizenHappinessHandler.java
@@ -6,8 +6,11 @@ import com.minecolonies.api.util.constant.IToolType;
 import com.minecolonies.api.util.constant.ToolType;
 import com.minecolonies.coremod.colony.CitizenData;
 import com.minecolonies.coremod.colony.FieldDataModifier;
+import com.minecolonies.coremod.colony.jobs.JobFarmer;
 import com.minecolonies.coremod.entity.EntityCitizen;
 import com.minecolonies.coremod.entity.ai.util.ChatSpamFilter;
+
+import io.netty.buffer.ByteBuf;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -275,7 +278,7 @@ public class CitizenHappinessHandler
             }
         }
 
-        if (hasNoFields)
+        if (hasNoFields && citizen.getJob() instanceof JobFarmer)
         {
             farmerModifier = NO_FIELD_MODIFIER;
         }
@@ -561,4 +564,18 @@ public class CitizenHappinessHandler
         }
     }
 
+    /**
+     * Write to the incoming variable all the related data to modifiers.
+     * 
+     * @param buf  buffer to witch values of the modifiers will be written to.
+     */
+    public void serializeViewNetworkData(@NotNull final ByteBuf buf)
+    {
+        buf.writeDouble(getFoodModifier());
+        buf.writeDouble(getDamageModifier());
+        buf.writeDouble(getHouseModifier());
+        buf.writeDouble(jobModifier);
+        buf.writeDouble(farmerModifier);
+        buf.writeDouble(noToolModifier);
+    }
 }

--- a/src/main/resources/assets/minecolonies/gui/windowcitizen.xml
+++ b/src/main/resources/assets/minecolonies/gui/windowcitizen.xml
@@ -13,6 +13,29 @@
         <view id="requestsView" size="100% 100%" pos="0 7">
             <layout source="minecolonies:gui/citizen/layouts/requests.xml"/>
         </view>
+        <view id="happinessModifierView" size="100% 100%" pos="0 7">
+			<label id="happinessModifier" pos="25 32" size="136 11" textalign="MIDDLE" color="black"/>
 
+			<label id="food" pos="45 52" size="136 11" textalign="MIDDLE_LEFT" color="black"/>
+			<image id="foodLevel" size="11 11" pos="20 52" source="minecolonies:textures/gui/red_icon.png"/>
+			
+			<label id="damage"  pos="45 74" size="136 11" textalign="MIDDLE_LEFT" color="black"/>
+			<image id="damageLevel" size="11 11" pos="20 72" source="minecolonies:textures/gui/red_icon.png"/>
+			
+			<label id="house" pos="45 94" size="136 11" textalign="MIDDLE_LEFT" color="black"/>
+			<image id="houseLevel" size="11 11" pos="20 92" source="minecolonies:textures/gui/red_icon.png"/>
+			
+			<label id="job" pos="45 114" size="136 11" textalign="MIDDLE_LEFT" color="black"/>
+			<image id="jobLevel" size="11 11" pos="20 112" source="minecolonies:textures/gui/red_icon.png"/>
+			
+			<label id="farms" pos="45 134" size="136 11" textalign="MIDDLE_LEFT" color="black"/>
+			<image id="farmsLevel" size="11 11" pos="20 132" source="minecolonies:textures/gui/red_icon.png"/>
+			
+			<label id="tools" pos="45 154" size="136 11" textalign="MIDDLE_LEFT" color="black"/>
+			<image id="toolsLevel" size="11 11" pos="20 152" source="minecolonies:textures/gui/red_icon.png"/>
+		</view>
     </switch>
+
+    <buttonimage id="prevPage" align="TOP_LEFT" size="26 8" pos="10 25" source="minecolonies:textures/gui/builderhut/builder_sketch_arrow_left_c.png"/>
+   	<buttonimage id="nextPage" align="TOP_RIGHT" size="26 8" pos="70 25" source="minecolonies:textures/gui/builderhut/builder_sketch_arrow_right_c.png"/>
 </window>

--- a/src/main/resources/assets/minecolonies/gui/windowcitizen.xml
+++ b/src/main/resources/assets/minecolonies/gui/windowcitizen.xml
@@ -13,7 +13,7 @@
         <view id="requestsView" size="100% 100%" pos="0 7">
             <layout source="minecolonies:gui/citizen/layouts/requests.xml"/>
         </view>
-        <view id="happinessModifierView" size="100% 100%" pos="0 7">
+        <view id="happinessModifierView" size="100% 100%" pos="0 -7">
 		    <image source="minecolonies:textures/gui/citizen/colonist_papper.png" size="190 244"/>
 			<label id="happinessModifier" pos="25 32" size="136 11" textalign="MIDDLE" color="black"/>
 

--- a/src/main/resources/assets/minecolonies/gui/windowcitizen.xml
+++ b/src/main/resources/assets/minecolonies/gui/windowcitizen.xml
@@ -14,25 +14,26 @@
             <layout source="minecolonies:gui/citizen/layouts/requests.xml"/>
         </view>
         <view id="happinessModifierView" size="100% 100%" pos="0 7">
+		    <image source="minecolonies:textures/gui/citizen/colonist_papper.png" size="190 244"/>
 			<label id="happinessModifier" pos="25 32" size="136 11" textalign="MIDDLE" color="black"/>
 
-			<label id="food" pos="45 52" size="136 11" textalign="MIDDLE_LEFT" color="black"/>
-			<image id="foodLevel" size="11 11" pos="20 52" source="minecolonies:textures/gui/red_icon.png"/>
+			<label id="modifier1" pos="45 52" size="136 11" textalign="MIDDLE_LEFT" color="black"/>
+			<image id="modifierImage1" size="11 11" pos="20 52" source="minecolonies:textures/gui/red_icon.png"/>
 			
-			<label id="damage"  pos="45 74" size="136 11" textalign="MIDDLE_LEFT" color="black"/>
-			<image id="damageLevel" size="11 11" pos="20 72" source="minecolonies:textures/gui/red_icon.png"/>
+			<label id="modifier2"  pos="45 74" size="136 11" textalign="MIDDLE_LEFT" color="black"/>
+			<image id="modifierImage2" size="11 11" pos="20 72" source="minecolonies:textures/gui/red_icon.png"/>
 			
-			<label id="house" pos="45 94" size="136 11" textalign="MIDDLE_LEFT" color="black"/>
-			<image id="houseLevel" size="11 11" pos="20 92" source="minecolonies:textures/gui/red_icon.png"/>
+			<label id="modifier3" pos="45 94" size="136 11" textalign="MIDDLE_LEFT" color="black"/>
+			<image id="modifierImage3" size="11 11" pos="20 92" source="minecolonies:textures/gui/red_icon.png"/>
 			
-			<label id="job" pos="45 114" size="136 11" textalign="MIDDLE_LEFT" color="black"/>
-			<image id="jobLevel" size="11 11" pos="20 112" source="minecolonies:textures/gui/red_icon.png"/>
+			<label id="modifier4" pos="45 114" size="136 11" textalign="MIDDLE_LEFT" color="black"/>
+			<image id="modifierImage4" size="11 11" pos="20 112" source="minecolonies:textures/gui/red_icon.png"/>
 			
-			<label id="farms" pos="45 134" size="136 11" textalign="MIDDLE_LEFT" color="black"/>
-			<image id="farmsLevel" size="11 11" pos="20 132" source="minecolonies:textures/gui/red_icon.png"/>
+			<label id="modifier5" pos="45 134" size="136 11" textalign="MIDDLE_LEFT" color="black"/>
+			<image id="modifierImage5" size="11 11" pos="20 132" source="minecolonies:textures/gui/red_icon.png"/>
 			
-			<label id="tools" pos="45 154" size="136 11" textalign="MIDDLE_LEFT" color="black"/>
-			<image id="toolsLevel" size="11 11" pos="20 152" source="minecolonies:textures/gui/red_icon.png"/>
+			<label id="modifier6" pos="45 154" size="136 11" textalign="MIDDLE_LEFT" color="black"/>
+			<image id="modifierImage6" size="11 11" pos="20 152" source="minecolonies:textures/gui/red_icon.png"/>
 		</view>
     </switch>
 

--- a/src/main/resources/assets/minecolonies/lang/en_us.lang
+++ b/src/main/resources/assets/minecolonies/lang/en_us.lang
@@ -301,6 +301,13 @@ com.minecolonies.coremod.gui.structure.delete=Delete Structure
 com.minecolonies.coremod.gui.structure.delete.title=Delete Structure
 com.minecolonies.coremod.gui.structure.delete.body=Do you want to delete %s?
 
+com.minecolonies.coremod.gui.happiness.happinessModifier=Happiness Modifiers
+com.minecolonies.coremod.gui.happiness.food=Food Modifier
+com.minecolonies.coremod.gui.happiness.damage=Damage Modifier
+com.minecolonies.coremod.gui.happiness.house=House Modifier
+com.minecolonies.coremod.gui.happiness.job=Job Modifier
+com.minecolonies.coremod.gui.happiness.farms=No Farm Modifier
+com.minecolonies.coremod.gui.happiness.tools=Tool Modifier
 //death achievements
 achievement.miner.death.lava=Dug too deep.
 achievement.miner.death.fall=It's the stop at the end.


### PR DESCRIPTION
On the citizen windows, there is now a "next" and "previous" button on the gui. This will allow you to toggle between the main view and the happiness view.

The Happiness view allows you to view the different modifiers that affect that citizens happiness. Each value has a color to it.
"RED" means has a negative affect on their happiness
"YELLOW" means that it has no affect on their happiness
"GREEN" means it has a positive affect on their happiness

Also, BUG. The no fields modifier was not checking to make sure they are a "FARMER" and was applying it to every citizen. That is why most citizen couldn't get above a value of 6.0

This window shows all modifiers and some of the modifiers will not apply to that citizen. Those values will be always "YELLOW" meaning no affect.

Having everything "YELLOW" will get you a value of 8. to get higher you need some in green.

Closes #
Closes #
Closes #

# Changes proposed in this pull request:
-
-
-

Review please
