### PR TITLE
only refresh request manager if dirty

### DIFF
--- a/src/api/java/com/minecolonies/api/colony/requestsystem/manager/IRequestManager.java
+++ b/src/api/java/com/minecolonies/api/colony/requestsystem/manager/IRequestManager.java
@@ -185,4 +185,10 @@ public interface IRequestManager extends INBTSerializable<NBTTagCompound>, ITick
      * Called to reset the RS.
      */
     void reset();
+
+    /**
+     * Checks if dirty and needs to be updated.
+     * @return true if so.
+     */
+    boolean isDirty();
 }

--- a/src/main/java/com/minecolonies/coremod/colony/ColonyView.java
+++ b/src/main/java/com/minecolonies/coremod/colony/ColonyView.java
@@ -198,7 +198,15 @@ public final class ColonyView implements IColony
         buf.writeBoolean(colony.isManualHousing());
         //  Citizens are sent as a separate packet
 
-        ByteBufUtils.writeTag(buf, colony.getRequestManager().serializeNBT());
+        if (colony.getRequestManager() != null && colony.getRequestManager().isDirty())
+        {
+            buf.writeBoolean(true);
+            ByteBufUtils.writeTag(buf, colony.getRequestManager().serializeNBT());
+        }
+        else
+        {
+            buf.writeBoolean(false);
+        }
 
         buf.writeInt(colony.getBarbManager().getLastSpawnPoints().size());
         for (final BlockPos block : colony.getBarbManager().getLastSpawnPoints())
@@ -508,9 +516,9 @@ public final class ColonyView implements IColony
         this.lastContactInHours = buf.readInt();
         this.manualHousing = buf.readBoolean();
 
-        final NBTTagCompound compound = ByteBufUtils.readTag(buf);
-        if (new Random().nextInt(TICKS_SECOND) == 0)
+        if (buf.readBoolean())
         {
+            final NBTTagCompound compound = ByteBufUtils.readTag(buf);
             this.requestManager = new StandardRequestManager(this);
             this.requestManager.deserializeNBT(compound);
         }

--- a/src/main/java/com/minecolonies/coremod/colony/requestsystem/management/manager/wrapped/AbstractWrappedRequestManager.java
+++ b/src/main/java/com/minecolonies/coremod/colony/requestsystem/management/manager/wrapped/AbstractWrappedRequestManager.java
@@ -82,7 +82,6 @@ public abstract class AbstractWrappedRequestManager implements IRequestManager
      * @param token The token of the request to assign.
      * @throws IllegalArgumentException when the token is not registered to a request, or is already assigned to a resolver.
      */
-    @NotNull
     @Override
     public void assignRequest(@NotNull final IToken token) throws IllegalArgumentException
     {
@@ -163,7 +162,6 @@ public abstract class AbstractWrappedRequestManager implements IRequestManager
      * @param state The new state of that request.
      * @throws IllegalArgumentException when the token is unknown to this manager.
      */
-    @NotNull
     @Override
     public void updateRequestState(@NotNull final IToken<?> token, @NotNull final RequestState state) throws IllegalArgumentException
     {
@@ -243,5 +241,11 @@ public abstract class AbstractWrappedRequestManager implements IRequestManager
     public void reset()
     {
         wrappedManager.reset();
+    }
+
+    @Override
+    public boolean isDirty()
+    {
+        return wrappedManager.isDirty();
     }
 }

--- a/src/main/java/com/minecolonies/coremod/colony/requestsystem/management/manager/wrapped/WrappedBlacklistAssignmentRequestManager.java
+++ b/src/main/java/com/minecolonies/coremod/colony/requestsystem/management/manager/wrapped/WrappedBlacklistAssignmentRequestManager.java
@@ -29,7 +29,6 @@ public final class WrappedBlacklistAssignmentRequestManager extends AbstractWrap
      * @param token The token of the request to assign.
      * @throws IllegalArgumentException when the token is not registered to a request, or is already assigned to a resolver.
      */
-    @NotNull
     @Override
     public void assignRequest(@NotNull final IToken token) throws IllegalArgumentException
     {

--- a/src/main/java/com/minecolonies/coremod/colony/requestsystem/management/manager/wrapped/WrappedStaticStateRequestManager.java
+++ b/src/main/java/com/minecolonies/coremod/colony/requestsystem/management/manager/wrapped/WrappedStaticStateRequestManager.java
@@ -17,8 +17,6 @@ public final class WrappedStaticStateRequestManager extends AbstractWrappedReque
         super(wrappedManager);
     }
 
-    @NotNull
-    @Override
     /**
      * Method to update the state of a given request.
      *
@@ -26,6 +24,7 @@ public final class WrappedStaticStateRequestManager extends AbstractWrappedReque
      * @param state The new state of that request.
      * @throws IllegalArgumentException when the token is unknown to this manager.
      */
+    @Override
     public void updateRequestState(@NotNull final IToken token, @NotNull final RequestState state) throws IllegalArgumentException
     {
         //TODO: implement when link is created with worker

--- a/src/main/resources/assets/minecolonies/gui/windowmultiblock.xml
+++ b/src/main/resources/assets/minecolonies/gui/windowmultiblock.xml
@@ -12,7 +12,7 @@
         <buttonimage id="confirm" source="minecolonies:textures/gui/buildtool/confirm.png" size="32" pos="-10 96"/>
         <buttonimage id="cancel" source="minecolonies:textures/gui/buildtool/cancel.png" size="32" pos="74 96"/>
         <label size="16 16" pos="19 32" label="range:"/>
-        <label size="16 16" pos="19 49scs" label="speed:"/>
+        <label size="16 16" pos="19 49" label="speed:"/>
         <input id="range" size="20 16" pos="54 32" maxlength="2"/>
         <input id="speed" size="20 16" pos="54 48" maxlength="1"/>
     </view>


### PR DESCRIPTION
# Changes proposed in this pull request:
- Improves FPS and TPS by only refreshing the client side of the request manager if really dirty
- Resulting in less: Time for deserialization and serialization and initialization

Review please
