### PR TITLE
Fix executing disable barbs command when player isn't OP

### DIFF
--- a/src/main/java/com/minecolonies/coremod/commands/colonycommands/DisableBarbarianSpawnsCommand.java
+++ b/src/main/java/com/minecolonies/coremod/commands/colonycommands/DisableBarbarianSpawnsCommand.java
@@ -102,6 +102,7 @@ public class DisableBarbarianSpawnsCommand extends AbstractSingleCommand impleme
         if (sender instanceof EntityPlayer && !isPlayerOpped(sender))
         {
             sender.sendMessage(new TextComponentString("Must be OP to use this command"));
+            return;
         }
 
         colony.getBarbManager().setCanHaveBarbEvents(canHaveBarbEvents);


### PR DESCRIPTION
# Changes proposed in this pull request:
- Stops the disable barbarian command being executed if the player isn't opped

Review please
