### PR TITLE
Small changes to entering/leaving notifications

### DIFF
--- a/src/api/java/com/minecolonies/api/configuration/Configurations.java
+++ b/src/api/java/com/minecolonies/api/configuration/Configurations.java
@@ -77,6 +77,9 @@ public class Configurations
         @Config.Comment("Should the colony protection be enabled?")
         public boolean enableColonyProtection = true;
 
+        @Config.Comment("Should Players be sent entering/leaving colony notifications?")
+        public boolean sendEnteringLeavingMessages = true;
+
         @Config.Comment("Independent from the colony protection, should explosions be turned off?")
         public boolean turnOffExplosionsInColonies = true;
 

--- a/src/main/java/com/minecolonies/coremod/colony/Colony.java
+++ b/src/main/java/com/minecolonies/coremod/colony/Colony.java
@@ -1257,7 +1257,7 @@ public class Colony implements IColony
         {
             visitingPlayers.add(player);
             LanguageHandler.sendPlayerMessage(player, ENTERING_COLONY_MESSAGE, this.getPermissions().getOwnerName());
-            LanguageHandler.sendPlayersMessage(getMessageEntityPlayers(), ENTERING_COLONY_MESSAGE_NOTIFY, player.getName());
+            LanguageHandler.sendPlayersMessage(getMessageEntityPlayers(), ENTERING_COLONY_MESSAGE_NOTIFY, player.getName(), this.getName());
         }
     }
 
@@ -1268,7 +1268,7 @@ public class Colony implements IColony
         {
             visitingPlayers.remove(player);
             LanguageHandler.sendPlayerMessage(player, LEAVING_COLONY_MESSAGE, this.getPermissions().getOwnerName());
-            LanguageHandler.sendPlayersMessage(getMessageEntityPlayers(), LEAVING_COLONY_MESSAGE_NOTIFY, player.getName());
+            LanguageHandler.sendPlayersMessage(getMessageEntityPlayers(), LEAVING_COLONY_MESSAGE_NOTIFY, player.getName(), this.getName());
         }
     }
 

--- a/src/main/java/com/minecolonies/coremod/colony/Colony.java
+++ b/src/main/java/com/minecolonies/coremod/colony/Colony.java
@@ -1253,7 +1253,7 @@ public class Colony implements IColony
     public void addVisitingPlayer(final EntityPlayer player)
     {
         final Rank rank = getPermissions().getRank(player);
-        if(rank != Rank.OWNER && rank != Rank.OFFICER && !visitingPlayers.contains(player))
+        if(rank != Rank.OWNER && rank != Rank.OFFICER && !visitingPlayers.contains(player) && Configurations.gameplay.sendEnteringLeavingMessages)
         {
             visitingPlayers.add(player);
             LanguageHandler.sendPlayerMessage(player, ENTERING_COLONY_MESSAGE, this.getPermissions().getOwnerName());
@@ -1264,7 +1264,7 @@ public class Colony implements IColony
     @Override
     public void removeVisitingPlayer(final EntityPlayer player)
     {
-        if(!getMessageEntityPlayers().contains(player))
+        if(!getMessageEntityPlayers().contains(player) && Configurations.gameplay.sendEnteringLeavingMessages)
         {
             visitingPlayers.remove(player);
             LanguageHandler.sendPlayerMessage(player, LEAVING_COLONY_MESSAGE, this.getPermissions().getOwnerName());

--- a/src/main/resources/assets/minecolonies/lang/en_us.lang
+++ b/src/main/resources/assets/minecolonies/lang/en_us.lang
@@ -611,8 +611,8 @@ com.minecolonies.coremod.job.smelter=Smelter
 tile.minecolonies.blockHutSmeltery.name=Smeltery
 com.minecolonies.coremod.enteringColony=Beware, you're entering %s's colony.
 com.minecolonies.coremod.leavingColony=Farewell, you're leaving %s's colony.
-com.minecolonies.coremod.enteringColonyNotify=Beware, %s just entered your colony.
-com.minecolonies.coremod.leavingColonyNotify=Farewell %s, they just left your colony.
+com.minecolonies.coremod.enteringColonyNotify=Beware, %s just entered %s.
+com.minecolonies.coremod.leavingColonyNotify=Farewell %s, they just left %s.
 
 com.minecolonies.coremod.mourning=There has been a death in the colony. The colony will mourn %s tomorrow out of respect.
 


### PR DESCRIPTION
Closes #2755 

# Changes proposed in this pull request:
- Adds a config option to allow players to enable & disable the entering/leaving messages
- Changes notifying message so players within multiple colonies knows which one a player just entered/left

Review please
