### PR TITLE
Right align resource quantity in build building GUI

### DIFF
--- a/src/main/resources/assets/minecolonies/gui/windowbuildbuilding.xml
+++ b/src/main/resources/assets/minecolonies/gui/windowbuildbuilding.xml
@@ -16,9 +16,9 @@
 
     <list id="resources" size="80% 80%" pos="30 20">
         <box size="100% 30" linewidth="2">
-            <itemicon id="resourceIcon" size="24 24" pos="1 1"/>
-            <label id="resourceName" size="140 12" pos="30 9" color="white"/>
-            <label id="resourceQuantity" size="12 12" pos="170 9" color="white"/>
+            <itemicon id="resourceIcon" size="24 24" pos="3 3"/>
+            <label id="resourceName" size="140 12" pos="33 9" color="white"/>
+            <label id="resourceQuantity" align="MIDDLE_RIGHT" size="12 12" pos="20 0" color="white"/>
         </box>
     </list>
     <buttonimage id="cancel" align="TOP_MIDDLE" size="129 17" pos="-120 220"


### PR DESCRIPTION
# Changes proposed in this pull request:
- Clears the resource quantity being in the way of some longer text in the GUI (Also aligns the resource images a bit better)

Review please
