### PR TITLE
Automatic hire mode only disables fire button in fire/hire GUI

### DIFF
--- a/src/api/java/com/minecolonies/api/util/constant/TranslationConstants.java
+++ b/src/api/java/com/minecolonies/api/util/constant/TranslationConstants.java
@@ -250,6 +250,8 @@ public final class TranslationConstants
     @NonNls
     public static final String COM_MINECOLONIES_COREMOD_GUI_WORKERHUTS_MODE_MANUAL                 = "com.minecolonies.coremod.gui.workerHuts.modeM";
     @NonNls
+    public static final String AUTOMATIC_HIRE_WARNING                                              = "com.minecolonies.coremod.gui.auto.hire.warning";
+    @NonNls
     public static final String RAID_EVENT_MESSAGE                                                  = "event.minecolonies.raidMessage";
     @NonNls
     public static final String ONLY_X_BARBARIANS_LEFT_MESSAGE                                      = "com.minecolonies.coremod.barbarians.left";

--- a/src/main/java/com/minecolonies/coremod/client/gui/AbstractWindowWorkerBuilding.java
+++ b/src/main/java/com/minecolonies/coremod/client/gui/AbstractWindowWorkerBuilding.java
@@ -104,17 +104,14 @@ public abstract class AbstractWindowWorkerBuilding<B extends AbstractBuildingWor
      */
     private void hireClicked(@NotNull final Button button)
     {
-        if (building.getColony().isManualHiring())
+        if (building.getBuildingLevel() == 0 && !BUILDER_HUT_NAME.equals(getBuildingName()))
         {
-            if (building.getBuildingLevel() == 0 && !BUILDER_HUT_NAME.equals(getBuildingName()))
-            {
-                LanguageHandler.sendPlayerMessage(Minecraft.getMinecraft().player, "com.minecolonies.coremod.gui.workerHuts.level0");
-                return;
-            }
-
-            @NotNull final WindowHireWorker window = new WindowHireWorker(building.getColony(), building.getLocation());
-            window.open();
+            LanguageHandler.sendPlayerMessage(Minecraft.getMinecraft().player, "com.minecolonies.coremod.gui.workerHuts.level0");
+            return;
         }
+
+        @NotNull final WindowHireWorker window = new WindowHireWorker(building.getColony(), building.getLocation());
+        window.open();
     }
 
     /**

--- a/src/main/java/com/minecolonies/coremod/client/gui/WindowHireWorker.java
+++ b/src/main/java/com/minecolonies/coremod/client/gui/WindowHireWorker.java
@@ -69,6 +69,11 @@ public class WindowHireWorker extends Window implements ButtonHandler
     private static final String BUTTON_FIRE = "fire";
 
     /**
+     * Id of the automatic hiring warning
+     */
+    private static final String AUTO_HIRE_WARN = "autoHireWarn";
+
+    /**
      * Id of the pause button
      */
     private static final String BUTTON_PAUSE = "pause";
@@ -176,6 +181,7 @@ public class WindowHireWorker extends Window implements ButtonHandler
                     if (!building.getColony().isManualHiring())
                     {
                         rowPane.findPaneOfTypeByID(BUTTON_FIRE, Button.class).disable();
+                        findPaneOfTypeByID(AUTO_HIRE_WARN, Label.class).setLabelText(LanguageHandler.format(AUTOMATIC_HIRE_WARNING));
                     }
 
                     isPaused.on();
@@ -203,7 +209,7 @@ public class WindowHireWorker extends Window implements ButtonHandler
                   LanguageHandler.format(COM_MINECOLONIES_COREMOD_GUI_CITIZEN_SKILLS_INTELLIGENCE, citizen.getIntelligence()));
 
                 //Creates the list of attributes for each citizen
-                @NotNull final String attributes = strength + charisma + dexterity + endurance + intelligence;
+                @NotNull final String attributes = strength + " | " + charisma + " | " + dexterity + " | " + endurance + " | " + intelligence;
 
                 rowPane.findPaneOfTypeByID(CITIZEN_LABEL, Label.class).setLabelText(citizen.getName());
                 rowPane.findPaneOfTypeByID(ATTRIBUTES_LABEL, Label.class).setLabelText(attributes);

--- a/src/main/java/com/minecolonies/coremod/client/gui/WindowHireWorker.java
+++ b/src/main/java/com/minecolonies/coremod/client/gui/WindowHireWorker.java
@@ -172,6 +172,12 @@ public class WindowHireWorker extends Window implements ButtonHandler
                 {
                     rowPane.findPaneOfTypeByID(BUTTON_DONE, Button.class).off();
                     rowPane.findPaneOfTypeByID(BUTTON_FIRE, Button.class).on();
+
+                    if (!building.getColony().isManualHiring())
+                    {
+                        rowPane.findPaneOfTypeByID(BUTTON_FIRE, Button.class).disable();
+                    }
+
                     isPaused.on();
                     isPaused.setLabel(LanguageHandler.format(citizen.isPaused() ? COM_MINECOLONIES_COREMOD_GUI_HIRE_UNPAUSE : COM_MINECOLONIES_COREMOD_GUI_HIRE_PAUSE));
                 }

--- a/src/main/java/com/minecolonies/coremod/client/gui/WindowHireWorker.java
+++ b/src/main/java/com/minecolonies/coremod/client/gui/WindowHireWorker.java
@@ -167,6 +167,8 @@ public class WindowHireWorker extends Window implements ButtonHandler
 
                 final Button isPaused = rowPane.findPaneOfTypeByID(BUTTON_PAUSE, Button.class);
 
+                findPaneOfTypeByID(AUTO_HIRE_WARN, Label.class).off();
+
                 if (citizen.getWorkBuilding() == null)
                 {
                     rowPane.findPaneOfTypeByID(BUTTON_FIRE, Button.class).off();
@@ -181,7 +183,7 @@ public class WindowHireWorker extends Window implements ButtonHandler
                     if (!building.getColony().isManualHiring())
                     {
                         rowPane.findPaneOfTypeByID(BUTTON_FIRE, Button.class).disable();
-                        findPaneOfTypeByID(AUTO_HIRE_WARN, Label.class).setLabelText(LanguageHandler.format(AUTOMATIC_HIRE_WARNING));
+                        findPaneOfTypeByID(AUTO_HIRE_WARN, Label.class).on();
                     }
 
                     isPaused.on();

--- a/src/main/resources/assets/minecolonies/gui/windowhireworker.xml
+++ b/src/main/resources/assets/minecolonies/gui/windowhireworker.xml
@@ -13,5 +13,6 @@
             <label id="attributes" size="100% 12" pos="0 16" textalign="MIDDLE_LEFT" color="white" textscale="0.8"/>
         </view>
     </list>
-    <button id="cancel" size="200 20" pos="110 194" label="$(gui.cancel)"/>
+    <label id="autoHireWarn" size="100% 11" pos="0 195" textalign="MIDDLE" color="white" label=""/>
+    <button id="cancel" size="200 20" pos="110 210" label="$(gui.cancel)"/>
 </window>

--- a/src/main/resources/assets/minecolonies/gui/windowhireworker.xml
+++ b/src/main/resources/assets/minecolonies/gui/windowhireworker.xml
@@ -13,6 +13,6 @@
             <label id="attributes" size="100% 12" pos="0 16" textalign="MIDDLE_LEFT" color="white" textscale="0.8"/>
         </view>
     </list>
-    <label id="autoHireWarn" size="100% 11" pos="0 195" textalign="MIDDLE" color="white" label=""/>
+    <label id="autoHireWarn" size="100% 11" pos="0 195" textalign="MIDDLE" color="white" label="$(com.minecolonies.coremod.gui.auto.hire.warning)"/>
     <button id="cancel" size="200 20" pos="110 210" label="$(gui.cancel)"/>
 </window>

--- a/src/main/resources/assets/minecolonies/lang/en_us.lang
+++ b/src/main/resources/assets/minecolonies/lang/en_us.lang
@@ -800,3 +800,5 @@ com.minecolonies.coremod.gui.hiring.restartMessage=Restart for citizen %s schedu
 com.minecolonies.coremod.gui.hiring.restartMessageDone=Citizen %s succesfully restarted.
 com.minecolonies.coremod.gui.townHall.buildingLevel=Building level
 com.minecolonies.coremod.job.composter=Composter
+
+com.minecolonies.coremod.gui.auto.hire.warning=Turn off Automatic Hiring in your Town Hall options to enable Firing!


### PR DESCRIPTION
# Changes proposed in this pull request:
- Allows players to manage workers in manual or auto hiring (So they can always be paused/unpaused), but now disables the fire button while in automatic mode

Review please
