### PR TITLE
Pathfinding fixes:

### DIFF
--- a/src/api/java/com/minecolonies/api/configuration/Configurations.java
+++ b/src/api/java/com/minecolonies/api/configuration/Configurations.java
@@ -275,6 +275,10 @@ public class Configurations
 
         @Config.Comment("Amount of additional threads to be used for pathfinding")
         public int pathfindingMaxThreadCount = 2;
+
+        @Config.Comment("Max amount of Nodes(positions) to map during pathfinding. Default 5000: Lowering increases performance, but might lead to pathing glitches")
+        public int pathfindingMaxNodes = 5000;
+
     }
 
     public static class Names

--- a/src/api/java/com/minecolonies/api/util/EntityUtils.java
+++ b/src/api/java/com/minecolonies/api/util/EntityUtils.java
@@ -250,7 +250,11 @@ public final class EntityUtils
      */
     public static boolean tryMoveLivingToXYZ(@NotNull final EntityLiving living, final int x, final int y, final int z, final double speed)
     {
-        return living.getNavigator().tryMoveToXYZ(x, y, z, speed);
+        if (living.getNavigator().noPath())
+        {
+            return living.getNavigator().tryMoveToXYZ(x, y, z, speed);
+        }
+        return false;
     }
 
     /**

--- a/src/main/java/com/minecolonies/coremod/entity/EntityCitizen.java
+++ b/src/main/java/com/minecolonies/coremod/entity/EntityCitizen.java
@@ -23,6 +23,7 @@ import com.minecolonies.coremod.entity.ai.mobs.barbarians.AbstractEntityBarbaria
 import com.minecolonies.coremod.entity.citizenhandlers.*;
 import com.minecolonies.coremod.entity.pathfinding.EntityCitizenWalkToProxy;
 import com.minecolonies.coremod.entity.pathfinding.PathNavigate;
+import com.minecolonies.coremod.entity.pathfinding.PathResult;
 import com.minecolonies.coremod.inventory.InventoryCitizen;
 import com.minecolonies.coremod.network.messages.OpenInventoryMessage;
 import com.minecolonies.coremod.util.PermissionUtils;
@@ -80,6 +81,11 @@ public class EntityCitizen extends AbstractEntityCitizen
      * The New PathNavigate navigator.
      */
     private final PathNavigate newNavigator;
+
+    /**
+     * The path-result of trying to move away
+     */
+    private PathResult moveAwayPath;
 
     /**
      * It's citizen Id.
@@ -607,9 +613,9 @@ public class EntityCitizen extends AbstractEntityCitizen
             }
         }
 
-        if (isEntityInsideOpaqueBlock() || isInsideOfMaterial(Material.LEAVES))
+        if ((isEntityInsideOpaqueBlock() || isInsideOfMaterial(Material.LEAVES)) && (moveAwayPath == null || !moveAwayPath.isInProgress()))
         {
-            getNavigator().moveAwayFromXYZ(this.getPosition(), MOVE_AWAY_RANGE, MOVE_AWAY_SPEED);
+            moveAwayPath = getNavigator().moveAwayFromXYZ(this.getPosition(), MOVE_AWAY_RANGE, MOVE_AWAY_SPEED);
         }
 
         citizenExperienceHandler.gatherXp();

--- a/src/main/java/com/minecolonies/coremod/entity/ai/citizen/deliveryman/EntityAIWorkDeliveryman.java
+++ b/src/main/java/com/minecolonies/coremod/entity/ai/citizen/deliveryman/EntityAIWorkDeliveryman.java
@@ -11,7 +11,9 @@ import com.minecolonies.api.util.InventoryUtils;
 import com.minecolonies.api.util.ItemStackUtils;
 import com.minecolonies.blockout.Log;
 import com.minecolonies.coremod.colony.Colony;
-import com.minecolonies.coremod.colony.buildings.*;
+import com.minecolonies.coremod.colony.buildings.AbstractBuilding;
+import com.minecolonies.coremod.colony.buildings.AbstractBuildingContainer;
+import com.minecolonies.coremod.colony.buildings.AbstractBuildingWorker;
 import com.minecolonies.coremod.colony.buildings.workerbuildings.BuildingCook;
 import com.minecolonies.coremod.colony.buildings.workerbuildings.BuildingDeliveryman;
 import com.minecolonies.coremod.colony.buildings.workerbuildings.BuildingTownHall;
@@ -55,9 +57,9 @@ public class EntityAIWorkDeliveryman extends AbstractEntityAIInteract<JobDeliver
     private static final int MIN_DISTANCE_TO_WAREHOUSE = 5;
 
     /**
-     * Walking speed double at this level.
+     * Walking speed bonus per level
      */
-    private static final double WALKING_SPEED_MULTIPLIER = 25;
+    private static final double BONUS_SPEED_PER_LEVEL = 0.003;
 
     /**
      * Delay in ticks between every inventory operation.
@@ -635,7 +637,9 @@ public class EntityAIWorkDeliveryman extends AbstractEntityAIInteract<JobDeliver
         {
             return START_WORKING;
         }
-        worker.getEntityAttribute(SharedMonsterAttributes.MOVEMENT_SPEED).setBaseValue(BASE_MOVEMENT_SPEED + BASE_MOVEMENT_SPEED * worker.getCitizenExperienceHandler().getLevel() / WALKING_SPEED_MULTIPLIER);
+        worker.getEntityAttribute(SharedMonsterAttributes.MOVEMENT_SPEED)
+          .setBaseValue(
+            BASE_MOVEMENT_SPEED + (worker.getCitizenExperienceHandler().getLevel() > 50 ? 50 : worker.getCitizenExperienceHandler().getLevel()) * BONUS_SPEED_PER_LEVEL);
 
         final AbstractBuildingWorker ownBuilding = getOwnBuilding();
 

--- a/src/main/java/com/minecolonies/coremod/entity/ai/citizen/fisherman/EntityAIWorkFisherman.java
+++ b/src/main/java/com/minecolonies/coremod/entity/ai/citizen/fisherman/EntityAIWorkFisherman.java
@@ -380,7 +380,11 @@ public class EntityAIWorkFisherman extends AbstractEntityAISkill<JobFisherman>
             {
                 chatSpamFilter.talkWithoutSpam("entity.fisherman.messageWaterTooFar");
             }
-            pathResult = worker.getNavigator().moveToWater(SEARCH_RANGE, 1.0D, job.getPonds());
+
+            if (pathResult == null || !pathResult.isInProgress())
+            {
+                pathResult = worker.getNavigator().moveToWater(SEARCH_RANGE, 1.0D, job.getPonds());
+            }
             return getState();
         }
         job.setWater(job.getPonds().get(random.nextInt(job.getPonds().size())));

--- a/src/main/java/com/minecolonies/coremod/entity/ai/citizen/guard/AbstractEntityAIGuard.java
+++ b/src/main/java/com/minecolonies/coremod/entity/ai/citizen/guard/AbstractEntityAIGuard.java
@@ -26,12 +26,12 @@ import net.minecraft.world.WorldServer;
 import net.minecraftforge.items.wrapper.InvWrapper;
 import org.jetbrains.annotations.NotNull;
 
-import java.util.*;
+import java.util.List;
 
 import static com.minecolonies.api.util.constant.ColonyConstants.TEAM_COLONY_NAME;
+import static com.minecolonies.api.util.constant.Constants.*;
 import static com.minecolonies.api.util.constant.GuardConstants.*;
 import static com.minecolonies.coremod.entity.ai.util.AIState.*;
-import static com.minecolonies.api.util.constant.Constants.*;
 
 /**
  * Class taking of the abstract guard methods for all fighting AIs.
@@ -165,6 +165,7 @@ public abstract class AbstractEntityAIGuard<J extends AbstractJobGuard> extends 
             if (!isWithinPersecutionDistance(buildingGuards.getPlayerToFollow()))
             {
                 worker.getNavigator().clearPath();
+                worker.getMoveHelper().strafe(0, 0);
             }
             else
             {

--- a/src/main/java/com/minecolonies/coremod/entity/ai/minimal/EntityAICitizenAvoidEntity.java
+++ b/src/main/java/com/minecolonies/coremod/entity/ai/minimal/EntityAICitizenAvoidEntity.java
@@ -36,7 +36,7 @@ public class EntityAICitizenAvoidEntity extends EntityAIBase
     /**
      * The pathresult of trying to move away
      */
-    PathResult moveAwayPath;
+    private PathResult moveAwayPath;
 
     /**
      * Constructor.

--- a/src/main/java/com/minecolonies/coremod/entity/ai/minimal/EntityAICitizenAvoidEntity.java
+++ b/src/main/java/com/minecolonies/coremod/entity/ai/minimal/EntityAICitizenAvoidEntity.java
@@ -4,6 +4,7 @@ import com.minecolonies.api.util.CompatibilityUtils;
 import com.minecolonies.coremod.colony.jobs.AbstractJobGuard;
 import com.minecolonies.coremod.entity.EntityCitizen;
 import com.minecolonies.coremod.entity.ai.mobs.barbarians.AbstractEntityBarbarian;
+import com.minecolonies.coremod.entity.pathfinding.PathResult;
 import net.minecraft.entity.Entity;
 import net.minecraft.entity.ai.EntityAIBase;
 import net.minecraft.entity.player.EntityPlayer;
@@ -31,6 +32,11 @@ public class EntityAICitizenAvoidEntity extends EntityAIBase
     private final Class<? extends Entity> targetEntityClass;
     @Nullable
     private       Entity                  closestLivingEntity;
+
+    /**
+     * The pathresult of trying to move away
+     */
+    PathResult moveAwayPath;
 
     /**
      * Constructor.
@@ -129,7 +135,10 @@ public class EntityAICitizenAvoidEntity extends EntityAIBase
             return;
         }
 
-        theEntity.getNavigator().moveAwayFromEntityLiving(closestLivingEntity, distanceFromEntity * 2D, nearSpeed);
+        if (moveAwayPath == null || !moveAwayPath.isInProgress())
+        {
+            moveAwayPath = theEntity.getNavigator().moveAwayFromEntityLiving(closestLivingEntity, distanceFromEntity * 2D, nearSpeed);
+        }
     }
 
     /**

--- a/src/main/java/com/minecolonies/coremod/entity/ai/mobs/barbarians/EntityAIBarbarianAttackMelee.java
+++ b/src/main/java/com/minecolonies/coremod/entity/ai/mobs/barbarians/EntityAIBarbarianAttackMelee.java
@@ -26,6 +26,11 @@ public class EntityAIBarbarianAttackMelee extends EntityAIBase
     private int lastAttack = 0;
 
     /**
+     * Timer for the update rate of attack logic
+     */
+    private int tickTimer = 0;
+
+    /**
      * Constructor method for AI
      *
      * @param creatureIn The creature which is using the AI
@@ -70,12 +75,21 @@ public class EntityAIBarbarianAttackMelee extends EntityAIBase
     }
 
     /**
-     * AI for an Entity to attack the target
+     * AI for an Entity to attack the target, Called every Tick(20tps)
      *
      * @param target The target to attack
      */
     private void attack(final EntityLivingBase target)
     {
+        // Limit Actions to every 10 Ticks
+        if (tickTimer > 0)
+        {
+            tickTimer--;
+            lastAttack--;
+            return;
+        }
+        tickTimer = 10;
+
         if (target != null)
         {
             double damageToBeDealt = BarbarianSpawnUtils.ATTACK_DAMAGE;

--- a/src/main/java/com/minecolonies/coremod/entity/ai/mobs/barbarians/EntityAIWalkToRandomHuts.java
+++ b/src/main/java/com/minecolonies/coremod/entity/ai/mobs/barbarians/EntityAIWalkToRandomHuts.java
@@ -6,6 +6,7 @@ import com.minecolonies.coremod.colony.Colony;
 import com.minecolonies.coremod.colony.ColonyManager;
 import com.minecolonies.coremod.colony.buildings.AbstractBuilding;
 import com.minecolonies.coremod.entity.pathfinding.GeneralEntityWalkToProxy;
+import com.minecolonies.coremod.entity.pathfinding.PathResult;
 import net.minecraft.block.BlockLadder;
 import net.minecraft.block.state.IBlockState;
 import net.minecraft.entity.ai.EntityAIBase;
@@ -18,7 +19,7 @@ import org.jetbrains.annotations.NotNull;
 
 import java.util.*;
 
-import static com.minecolonies.api.util.constant.BarbarianConstants.*;
+import static com.minecolonies.api.util.constant.BarbarianConstants.LADDERS_TO_PLACE;
 import static com.minecolonies.api.util.constant.Constants.TICKS_SECOND;
 
 /**
@@ -86,6 +87,11 @@ public class EntityAIWalkToRandomHuts extends EntityAIBase
      * The amount of passed ticks.
      */
     private int passedTicks = 0;
+
+    /**
+     * The pathresult of trying to move away from a point
+     */
+    private PathResult moveAwayPath;
 
     /**
      * Constructor for AI
@@ -279,7 +285,10 @@ public class EntityAIWalkToRandomHuts extends EntityAIBase
             }
             else
             {
-                entity.getNavigator().moveAwayFromXYZ(entity.getPosition(), random.nextInt(4), 2);
+                if (moveAwayPath == null || !moveAwayPath.isInProgress())
+                {
+                    moveAwayPath = entity.getNavigator().moveAwayFromXYZ(entity.getPosition(), random.nextInt(4), 2);
+                }
             }
             return false;
         }

--- a/src/main/java/com/minecolonies/coremod/entity/pathfinding/AbstractPathJob.java
+++ b/src/main/java/com/minecolonies/coremod/entity/pathfinding/AbstractPathJob.java
@@ -52,6 +52,11 @@ public abstract class AbstractPathJob implements Callable<Path>
     private static final   int      MIN_Y                 = 0;
 
     /**
+     * The maximum amount of nodes to Map
+     */
+    private static final int MAX_NODES_VISITED = 5000;
+
+    /**
      * Additional cost of jumping and dropping - base 1.
      */
     private static final double JUMP_DROP_COST = 2.5D;
@@ -388,6 +393,12 @@ public abstract class AbstractPathJob implements Callable<Path>
             final Node currentNode = nodesOpen.poll();
 
             totalNodesVisited++;
+
+            // Limiting max amount of nodes mapped
+            if (totalNodesVisited > MAX_NODES_VISITED)
+            {
+                break;
+            }
             currentNode.setCounterVisited(totalNodesVisited);
 
             handleDebugOptions(currentNode);

--- a/src/main/java/com/minecolonies/coremod/entity/pathfinding/AbstractPathJob.java
+++ b/src/main/java/com/minecolonies/coremod/entity/pathfinding/AbstractPathJob.java
@@ -52,9 +52,9 @@ public abstract class AbstractPathJob implements Callable<Path>
     private static final   int      MIN_Y                 = 0;
 
     /**
-     * The maximum amount of nodes to Map
+     * The maximum amount of nodes to Map, set in the config.
      */
-    private static final int MAX_NODES_VISITED = 5000;
+    private static final int MAX_NODES_VISITED = Configurations.pathfinding.pathfindingMaxNodes;
 
     /**
      * Additional cost of jumping and dropping - base 1.


### PR DESCRIPTION
# Changes proposed in this pull request:

Pathfinding fixes:
-Capping deliveryman movementspeed increase
-Fixing various Movementpaths to not be recreated before the prev is completed
-Reducing Barbarian logic to 2 tps from 20, also reduces their path creation on each tick
-Introducing a cap to the amount of nodes the pathfinding can map, to reduce unnecessary calculations(e.g. prev stuck nodes:31000, new max:5000)

Review please
