### PR TITLE
fix memory and CPU leak

### DIFF
--- a/src/main/java/com/minecolonies/coremod/colony/buildings/workerbuildings/BuildingCowboy.java
+++ b/src/main/java/com/minecolonies/coremod/colony/buildings/workerbuildings/BuildingCowboy.java
@@ -98,7 +98,7 @@ public class BuildingCowboy extends AbstractBuildingWorker
         this.milkCows = compound.getBoolean(NBT_MILK_COWS);
     }
 
-    public boolean isMilkCows()
+    public boolean isMilkingCows()
     {
         return milkCows;
     }

--- a/src/main/java/com/minecolonies/coremod/entity/ai/citizen/herders/AbstractEntityAIHerder.java
+++ b/src/main/java/com/minecolonies/coremod/entity/ai/citizen/herders/AbstractEntityAIHerder.java
@@ -21,7 +21,6 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -114,7 +113,9 @@ public abstract class AbstractEntityAIHerder<J extends AbstractJob, T extends En
     @NotNull
     public List<ToolType> getExtraToolsNeeded()
     {
-        return Collections.emptyList();
+        final List<ToolType> toolsNeeded = new ArrayList<>();
+        toolsNeeded.add(ToolType.AXE);
+        return toolsNeeded;
     }
 
     /**
@@ -124,7 +125,9 @@ public abstract class AbstractEntityAIHerder<J extends AbstractJob, T extends En
     @NotNull
     public List<ItemStack> getExtraItemsNeeded()
     {
-        return Collections.emptyList();
+        final List<ItemStack> itemsNeeded = new ArrayList<>();
+        itemsNeeded.add(getBreedingItems());
+        return itemsNeeded;
     }
 
     /**
@@ -190,13 +193,7 @@ public abstract class AbstractEntityAIHerder<J extends AbstractJob, T extends En
     private AIState prepareForHerding()
     {
         setDelay(DECIDING_DELAY);
-        final List<ItemStack> itemsNeeded = new ArrayList<>(getExtraItemsNeeded());
-        final List<ToolType> toolsNeeded = new ArrayList<>(getExtraToolsNeeded());
-
-        toolsNeeded.add(ToolType.AXE);
-        itemsNeeded.add(getBreedingItems());
-
-        for (final ToolType tool : toolsNeeded)
+        for (final ToolType tool : getExtraToolsNeeded())
         {
             if (checkForToolOrWeapon(tool))
             {
@@ -204,7 +201,7 @@ public abstract class AbstractEntityAIHerder<J extends AbstractJob, T extends En
             }
         }
 
-        for (final ItemStack item : itemsNeeded)
+        for (final ItemStack item : getExtraItemsNeeded())
         {
             checkIfRequestForItemExistOrCreateAsynch(item);
         }

--- a/src/main/java/com/minecolonies/coremod/entity/ai/citizen/herders/AbstractEntityAIHerder.java
+++ b/src/main/java/com/minecolonies/coremod/entity/ai/citizen/herders/AbstractEntityAIHerder.java
@@ -21,6 +21,7 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -36,12 +37,6 @@ public abstract class AbstractEntityAIHerder<J extends AbstractJob, T extends En
      * How many animals per hut level the worker should max have.
      */
     private static final int ANIMAL_MULTIPLIER = 2;
-
-    /**
-     * Tools and Items needed by the worker.
-     */
-    public final List<ToolType>  toolsNeeded = new ArrayList<>();
-    public final List<ItemStack> itemsNeeded = new ArrayList<>();
 
     /**
      * Amount of animals needed to bread.
@@ -113,6 +108,26 @@ public abstract class AbstractEntityAIHerder<J extends AbstractJob, T extends En
     }
 
     /**
+     * Get the extra tools needed for this job.
+     * @return a list of tools or empty.
+     */
+    @NotNull
+    public List<ToolType> getExtraToolsNeeded()
+    {
+        return Collections.emptyList();
+    }
+
+    /**
+     * Get the extra items needed for this job.
+     * @return a list of items needed or empty.
+     */
+    @NotNull
+    public List<ItemStack> getExtraItemsNeeded()
+    {
+        return Collections.emptyList();
+    }
+
+    /**
      * Decides what job the herder should switch to, breeding or Butchering.
      *
      * @return The next {@link AIState} the herder should switch to, after executing this method.
@@ -174,7 +189,8 @@ public abstract class AbstractEntityAIHerder<J extends AbstractJob, T extends En
      */
     private AIState prepareForHerding()
     {
-        setDelay(DECIDING_DELAY);
+        final List<ItemStack> itemsNeeded = new ArrayList<>(getExtraItemsNeeded());
+        final List<ToolType> toolsNeeded = new ArrayList<>(getExtraToolsNeeded());
 
         toolsNeeded.add(ToolType.AXE);
         itemsNeeded.add(getBreedingItems());
@@ -192,6 +208,7 @@ public abstract class AbstractEntityAIHerder<J extends AbstractJob, T extends En
             checkIfRequestForItemExistOrCreateAsynch(item);
         }
 
+        setDelay(DECIDING_DELAY);
         return DECIDE;
     }
 

--- a/src/main/java/com/minecolonies/coremod/entity/ai/citizen/herders/AbstractEntityAIHerder.java
+++ b/src/main/java/com/minecolonies/coremod/entity/ai/citizen/herders/AbstractEntityAIHerder.java
@@ -189,6 +189,7 @@ public abstract class AbstractEntityAIHerder<J extends AbstractJob, T extends En
      */
     private AIState prepareForHerding()
     {
+        setDelay(DECIDING_DELAY);
         final List<ItemStack> itemsNeeded = new ArrayList<>(getExtraItemsNeeded());
         final List<ToolType> toolsNeeded = new ArrayList<>(getExtraToolsNeeded());
 
@@ -208,7 +209,6 @@ public abstract class AbstractEntityAIHerder<J extends AbstractJob, T extends En
             checkIfRequestForItemExistOrCreateAsynch(item);
         }
 
-        setDelay(DECIDING_DELAY);
         return DECIDE;
     }
 

--- a/src/main/java/com/minecolonies/coremod/entity/ai/citizen/herders/EntityAIWorkCowboy.java
+++ b/src/main/java/com/minecolonies/coremod/entity/ai/citizen/herders/EntityAIWorkCowboy.java
@@ -1,6 +1,7 @@
 package com.minecolonies.coremod.entity.ai.citizen.herders;
 
 import com.minecolonies.api.util.InventoryUtils;
+import com.minecolonies.api.util.constant.ToolType;
 import com.minecolonies.api.util.constant.TranslationConstants;
 import com.minecolonies.coremod.colony.buildings.workerbuildings.BuildingCowboy;
 import com.minecolonies.coremod.colony.jobs.JobCowboy;
@@ -14,6 +15,7 @@ import net.minecraft.util.text.TextComponentTranslation;
 import net.minecraftforge.items.wrapper.InvWrapper;
 import org.jetbrains.annotations.NotNull;
 
+import java.util.ArrayList;
 import java.util.List;
 
 import static com.minecolonies.coremod.entity.ai.util.AIState.*;
@@ -28,7 +30,6 @@ public class EntityAIWorkCowboy extends AbstractEntityAIHerder<JobCowboy, Entity
      */
     private static final int MAX_ANIMALS_PER_LEVEL = 2;
 
-    private final ItemStack bucketStack = new ItemStack(Items.BUCKET);
     /**
      * Creates the abstract part of the AI.
      * Always use this constructor!
@@ -72,28 +73,10 @@ public class EntityAIWorkCowboy extends AbstractEntityAIHerder<JobCowboy, Entity
     public AIState decideWhatToDo()
     {
         final AIState result = super.decideWhatToDo();
-        final BuildingCowboy building = (BuildingCowboy) worker.getCitizenColonyHandler().getWorkBuilding();
+        final BuildingCowboy building = getOwnBuilding();
 
-        if (!building.isMilkCows())
-        {
-            if (itemsNeeded.contains(bucketStack))
-            {
-                itemsNeeded.remove(bucketStack);
-            }
-            
-        }
-        else
-        {
-            if (!itemsNeeded.contains(bucketStack))
-            {
-                itemsNeeded.add(bucketStack);
-            }
-        }
-        
         final boolean hasBucket = InventoryUtils.hasItemInItemHandler(new InvWrapper(worker.getInventoryCitizen()), Items.BUCKET, 0);
-
-
-        if (building != null && building.isMilkCows() && result.equals(START_WORKING) && hasBucket)
+        if (building != null && building.isMilkingCows() && result.equals(START_WORKING) && hasBucket)
         {
             return COWBOY_MILK;
         }
@@ -102,14 +85,21 @@ public class EntityAIWorkCowboy extends AbstractEntityAIHerder<JobCowboy, Entity
 
     @NotNull
     @Override
-    protected List<ItemStack> itemsNiceToHave()
+    public List<ItemStack> getExtraItemsNeeded()
     {
-        final List<ItemStack> list = super.itemsNiceToHave();
-        if (! ((BuildingCowboy) worker.getCitizenColonyHandler().getWorkBuilding()).isMilkCows())
+        final List<ItemStack> list = new ArrayList<>();
+        if (getOwnBuilding(BuildingCowboy.class).isMilkingCows())
         {
-            list.add(new ItemStack(Items.BUCKET, 1));
+            list.add(new ItemStack(Items.BUCKET));
         }
         return list;
+    }
+
+    @NotNull
+    @Override
+    protected List<ItemStack> itemsNiceToHave()
+    {
+        return getExtraItemsNeeded();
     }
 
     /**

--- a/src/main/java/com/minecolonies/coremod/entity/ai/citizen/herders/EntityAIWorkCowboy.java
+++ b/src/main/java/com/minecolonies/coremod/entity/ai/citizen/herders/EntityAIWorkCowboy.java
@@ -87,7 +87,7 @@ public class EntityAIWorkCowboy extends AbstractEntityAIHerder<JobCowboy, Entity
     @Override
     public List<ItemStack> getExtraItemsNeeded()
     {
-        final List<ItemStack> list = new ArrayList<>();
+        final List<ItemStack> list = super.getExtraItemsNeeded();
         if (getOwnBuilding(BuildingCowboy.class).isMilkingCows())
         {
             list.add(new ItemStack(Items.BUCKET));

--- a/src/main/java/com/minecolonies/coremod/entity/ai/citizen/herders/EntityAIWorkShepherd.java
+++ b/src/main/java/com/minecolonies/coremod/entity/ai/citizen/herders/EntityAIWorkShepherd.java
@@ -58,10 +58,11 @@ public class EntityAIWorkShepherd extends AbstractEntityAIHerder<JobShepherd, En
         );
     }
 
+    @NotNull
     @Override
     public List<ToolType> getExtraToolsNeeded()
     {
-        final List<ToolType> toolsNeeded = new ArrayList<>();
+        final List<ToolType> toolsNeeded = super.getExtraToolsNeeded();
         toolsNeeded.add(ToolType.SHEARS);
         return toolsNeeded;
     }

--- a/src/main/java/com/minecolonies/coremod/entity/ai/citizen/herders/EntityAIWorkShepherd.java
+++ b/src/main/java/com/minecolonies/coremod/entity/ai/citizen/herders/EntityAIWorkShepherd.java
@@ -52,10 +52,18 @@ public class EntityAIWorkShepherd extends AbstractEntityAIHerder<JobShepherd, En
     {
         super(job);
         worker.getCitizenExperienceHandler().setSkillModifier(2 * worker.getCitizenData().getDexterity() + worker.getCitizenData().getStrength());
-        toolsNeeded.add(ToolType.SHEARS);
+
         super.registerTargets(
           new AITarget(SHEPHERD_SHEAR, false, this::shearSheep)
         );
+    }
+
+    @Override
+    public List<ToolType> getExtraToolsNeeded()
+    {
+        final List<ToolType> toolsNeeded = new ArrayList<>();
+        toolsNeeded.add(ToolType.SHEARS);
+        return toolsNeeded;
     }
 
     @Override


### PR DESCRIPTION

# Changes proposed in this pull request:
Fixes memory and CPU leaks at the herders:
- Don't request needed items every tick (set delay before every possible exit point)
- Don't fill up global lists, you have to either clear them or only build local lists..

Review please
