### PR TITLE
Updating the namespaces of Items, Blocks and TileEntities from "minecraft" to "minecolonies".

### DIFF
--- a/src/main/java/com/minecolonies/coremod/MineColonies.java
+++ b/src/main/java/com/minecolonies/coremod/MineColonies.java
@@ -1,5 +1,6 @@
 package com.minecolonies.coremod;
 
+import com.minecolonies.api.util.Log;
 import com.minecolonies.coremod.colony.IColonyManagerCapability;
 import com.minecolonies.api.colony.IColonyTagCapability;
 import com.minecolonies.api.colony.IChunkmanagerCapability;
@@ -14,27 +15,37 @@ import com.minecolonies.coremod.commands.CommandEntryPointNew;
 import com.minecolonies.coremod.event.BarbarianSpawnEventHandler;
 import com.minecolonies.coremod.event.EventHandler;
 import com.minecolonies.coremod.event.FMLEventHandler;
+import com.minecolonies.coremod.fixers.TileEntityIdFixer;
 import com.minecolonies.coremod.network.messages.*;
 import com.minecolonies.coremod.placementhandlers.MinecoloniesPlacementHandlers;
 import com.minecolonies.coremod.proxy.IProxy;
 import com.minecolonies.coremod.util.RecipeHandler;
+import net.minecraft.block.Block;
 import net.minecraft.init.Items;
+import net.minecraft.item.Item;
+import net.minecraft.tileentity.TileEntity;
+import net.minecraft.util.ResourceLocation;
+import net.minecraft.util.datafix.FixTypes;
 import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.common.capabilities.Capability;
 import net.minecraftforge.common.capabilities.CapabilityInject;
 import net.minecraftforge.common.capabilities.CapabilityManager;
 import net.minecraftforge.common.config.Configuration;
+import net.minecraftforge.event.RegistryEvent;
 import net.minecraftforge.fml.common.FMLCommonHandler;
 import net.minecraftforge.fml.common.Mod;
 import net.minecraftforge.fml.common.SidedProxy;
 import net.minecraftforge.fml.common.event.*;
+import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
 import net.minecraftforge.fml.common.network.NetworkRegistry;
 import net.minecraftforge.fml.common.network.simpleimpl.SimpleNetworkWrapper;
 import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.oredict.OreDictionary;
+import net.minecraftforge.registries.IForgeRegistryEntry;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 @Mod.EventBusSubscriber
 @Mod(modid = Constants.MOD_ID, name = Constants.MOD_NAME, version = Constants.VERSION, dependencies="after:gbook",
@@ -137,6 +148,8 @@ public class MineColonies
     @Mod.EventHandler
     public void init(final FMLInitializationEvent event)
     {
+        FMLCommonHandler.instance().getDataFixer().init(Constants.MOD_ID, TileEntityIdFixer.VERSION).registerFix(FixTypes.BLOCK_ENTITY, new TileEntityIdFixer());
+
         initializeNetwork();
 
         proxy.registerTileEntities();

--- a/src/main/java/com/minecolonies/coremod/blocks/AbstractBlockHut.java
+++ b/src/main/java/com/minecolonies/coremod/blocks/AbstractBlockHut.java
@@ -77,7 +77,7 @@ public abstract class AbstractBlockHut<B extends AbstractBlockHut<B>> extends Ab
      */
     private void initBlock()
     {
-        setRegistryName(getName());
+        setRegistryName(Constants.MOD_ID.toLowerCase() + ":" + getName());
         setTranslationKey(Constants.MOD_ID.toLowerCase() + "." + getName());
         setCreativeTab(ModCreativeTabs.MINECOLONIES);
         //Blast resistance for creepers etc. makes them explosion proof

--- a/src/main/java/com/minecolonies/coremod/blocks/BlockBarracksTowerSubstitution.java
+++ b/src/main/java/com/minecolonies/coremod/blocks/BlockBarracksTowerSubstitution.java
@@ -56,7 +56,7 @@ public class BlockBarracksTowerSubstitution extends AbstractBlockMinecolonies<Bl
      */
     private void initBlock()
     {
-        setRegistryName(BLOCK_NAME);
+        setRegistryName(Constants.MOD_ID.toLowerCase() + ":" + BLOCK_NAME);
         setTranslationKey(String.format("%s.%s", Constants.MOD_ID.toLowerCase(), BLOCK_NAME));
         setCreativeTab(ModCreativeTabs.MINECOLONIES);
         setHardness(BLOCK_HARDNESS);

--- a/src/main/java/com/minecolonies/coremod/blocks/BlockBarrel.java
+++ b/src/main/java/com/minecolonies/coremod/blocks/BlockBarrel.java
@@ -76,7 +76,7 @@ public class BlockBarrel extends AbstractBlockMinecoloniesDirectional<BlockBarre
     @SuppressWarnings(DEPRECATION)
     private void initBlock()
     {
-        setRegistryName(BLOCK_NAME);
+        setRegistryName(Constants.MOD_ID.toLowerCase() + ":" + BLOCK_NAME);
         setTranslationKey(String.format("%s.%s", Constants.MOD_ID.toLowerCase(), BLOCK_NAME));
         setCreativeTab(ModCreativeTabs.MINECOLONIES);
         setHardness(BLOCK_HARDNESS);

--- a/src/main/java/com/minecolonies/coremod/blocks/BlockInfoPoster.java
+++ b/src/main/java/com/minecolonies/coremod/blocks/BlockInfoPoster.java
@@ -53,7 +53,7 @@ public class BlockInfoPoster extends AbstractBlockMinecoloniesContainer<BlockInf
     private void initBlock()
     {
         this.setDefaultState(this.blockState.getBaseState().withProperty(FACING, NORTH));
-        setRegistryName(BLOCK_NAME);
+        setRegistryName(Constants.MOD_ID.toLowerCase() + ":" + BLOCK_NAME);
         setTranslationKey(String.format("%s.%s", Constants.MOD_ID.toLowerCase(Locale.ENGLISH), BLOCK_NAME));
     }
 

--- a/src/main/java/com/minecolonies/coremod/blocks/BlockMinecoloniesRack.java
+++ b/src/main/java/com/minecolonies/coremod/blocks/BlockMinecoloniesRack.java
@@ -84,7 +84,7 @@ public class BlockMinecoloniesRack extends AbstractBlockMinecolonies<BlockMineco
      */
     private void initBlock()
     {
-        setRegistryName(BLOCK_NAME);
+        setRegistryName(Constants.MOD_ID.toLowerCase() + ":" + BLOCK_NAME);
         setTranslationKey(String.format("%s.%s", Constants.MOD_ID.toLowerCase(), BLOCK_NAME));
         setCreativeTab(ModCreativeTabs.MINECOLONIES);
         this.setDefaultState(this.blockState.getBaseState().withProperty(FACING, EnumFacing.NORTH).withProperty(VARIANT, RackType.DEFAULT));

--- a/src/main/java/com/minecolonies/coremod/blocks/MultiBlock.java
+++ b/src/main/java/com/minecolonies/coremod/blocks/MultiBlock.java
@@ -56,7 +56,7 @@ public class MultiBlock extends AbstractBlockMinecolonies<MultiBlock>
      */
     private void initBlock()
     {
-        setRegistryName(BLOCK_NAME);
+        setRegistryName(Constants.MOD_ID.toLowerCase() + ":" + BLOCK_NAME);
         setTranslationKey(String.format("%s.%s", Constants.MOD_ID.toLowerCase(Locale.ENGLISH), BLOCK_NAME));
         setCreativeTab(ModCreativeTabs.MINECOLONIES);
         setHardness(BLOCK_HARDNESS);

--- a/src/main/java/com/minecolonies/coremod/blocks/cactus/BlockCactusDoor.java
+++ b/src/main/java/com/minecolonies/coremod/blocks/cactus/BlockCactusDoor.java
@@ -14,7 +14,7 @@ public class BlockCactusDoor extends AbstractBlockDoor<BlockCactusDoor>
     public BlockCactusDoor(final Block block)
     {
         super(Material.WOOD, block);
-        setRegistryName("blockcactusdoor");
+        setRegistryName(Constants.MOD_ID.toLowerCase() + ":" + "blockcactusdoor");
         setTranslationKey(Constants.MOD_ID.toLowerCase(Locale.ENGLISH) + "." + "blockcactusdoor");
         setSoundType(SoundType.WOOD);
         setLightOpacity(0);

--- a/src/main/java/com/minecolonies/coremod/blocks/cactus/BlockCactusPlank.java
+++ b/src/main/java/com/minecolonies/coremod/blocks/cactus/BlockCactusPlank.java
@@ -16,7 +16,7 @@ public class BlockCactusPlank extends AbstractBlockMinecolonies<BlockCactusPlank
     public BlockCactusPlank()
     {
         super(Material.WOOD, MapColor.GREEN);
-        setRegistryName("blockcactusplank");
+        setRegistryName(Constants.MOD_ID.toLowerCase() + ":" + "blockcactusplank");
         setTranslationKey(Constants.MOD_ID.toLowerCase(Locale.ENGLISH) + "." + "blockcactusplank");
         setCreativeTab(ModCreativeTabs.MINECOLONIES);
         setSoundType(SoundType.WOOD);

--- a/src/main/java/com/minecolonies/coremod/blocks/cactus/BlockCactusSlabDouble.java
+++ b/src/main/java/com/minecolonies/coremod/blocks/cactus/BlockCactusSlabDouble.java
@@ -29,7 +29,7 @@ public class BlockCactusSlabDouble extends AbstractBlockSlab<BlockCactusSlabDoub
     public BlockCactusSlabDouble()
     {
         super(Material.WOOD);
-        setRegistryName(NAME);
+        setRegistryName(Constants.MOD_ID.toLowerCase() + ":" + NAME);
         setTranslationKey(Constants.MOD_ID.toLowerCase(Locale.US) + "." + NAME);
         setSoundType(SoundType.WOOD);
     }

--- a/src/main/java/com/minecolonies/coremod/blocks/cactus/BlockCactusSlabHalf.java
+++ b/src/main/java/com/minecolonies/coremod/blocks/cactus/BlockCactusSlabHalf.java
@@ -24,7 +24,7 @@ public class BlockCactusSlabHalf extends AbstractBlockSlab<BlockCactusSlabHalf>
     public BlockCactusSlabHalf()
     {
         super(Material.WOOD);
-        setRegistryName(NAME);
+        setRegistryName(Constants.MOD_ID.toLowerCase() + ":" + NAME);
         setTranslationKey(Constants.MOD_ID.toLowerCase(Locale.ENGLISH) + "." + NAME);
         setCreativeTab(ModCreativeTabs.MINECOLONIES);
         setSoundType(SoundType.WOOD);

--- a/src/main/java/com/minecolonies/coremod/blocks/cactus/BlockCactusStair.java
+++ b/src/main/java/com/minecolonies/coremod/blocks/cactus/BlockCactusStair.java
@@ -14,7 +14,7 @@ public class BlockCactusStair extends AbstractBlockMinecoloniesStairs<BlockCactu
     public BlockCactusStair(final IBlockState modelState)
     {
         super(modelState);
-        setRegistryName("blockcactusstair");
+        setRegistryName(Constants.MOD_ID.toLowerCase() + ":" + "blockcactusstair");
         setTranslationKey(Constants.MOD_ID.toLowerCase(Locale.ENGLISH) + "." + "blockcactusstair");
         setCreativeTab(ModCreativeTabs.MINECOLONIES);
         setSoundType(SoundType.WOOD);

--- a/src/main/java/com/minecolonies/coremod/blocks/cactus/BlockCactusTrapdoor.java
+++ b/src/main/java/com/minecolonies/coremod/blocks/cactus/BlockCactusTrapdoor.java
@@ -14,7 +14,7 @@ public class BlockCactusTrapdoor extends AbstractBlockTrapdoor<BlockCactusTrapdo
     public BlockCactusTrapdoor()
     {
         super(Material.WOOD);
-        setRegistryName("blockcactustrapdoor");
+        setRegistryName(Constants.MOD_ID.toLowerCase() + ":" + "blockcactustrapdoor");
         setTranslationKey(Constants.MOD_ID.toLowerCase(Locale.ENGLISH) + "." + "blockcactustrapdoordoor");
         setCreativeTab(ModCreativeTabs.MINECOLONIES);
         setSoundType(SoundType.WOOD);

--- a/src/main/java/com/minecolonies/coremod/blocks/decorative/BlockConstructionTape.java
+++ b/src/main/java/com/minecolonies/coremod/blocks/decorative/BlockConstructionTape.java
@@ -212,7 +212,7 @@ public class BlockConstructionTape extends AbstractBlockMinecolonies<BlockConstr
      */
     private void initBlock()
     {
-        setRegistryName(BLOCK_NAME);
+        setRegistryName(Constants.MOD_ID.toLowerCase() + ":" + BLOCK_NAME);
         setTranslationKey(String.format("%s.%s", Constants.MOD_ID.toLowerCase(Locale.ENGLISH), BLOCK_NAME));
         setCreativeTab(ModCreativeTabs.MINECOLONIES);
         this.setDefaultState(this.blockState.getBaseState().withProperty(FACING, NORTH));

--- a/src/main/java/com/minecolonies/coremod/blocks/decorative/BlockPaperwall.java
+++ b/src/main/java/com/minecolonies/coremod/blocks/decorative/BlockPaperwall.java
@@ -47,7 +47,7 @@ public class BlockPaperwall extends AbstractBlockMinecoloniesPane<BlockPaperwall
 
     private void initBlock()
     {
-        setRegistryName(BLOCK_NAME);
+        setRegistryName(Constants.MOD_ID.toLowerCase() + ":" + BLOCK_NAME);
         setTranslationKey(String.format("%s.%s", Constants.MOD_ID.toLowerCase(), BLOCK_NAME));
         setCreativeTab(ModCreativeTabs.MINECOLONIES);
         setHardness(BLOCK_HARDNESS);

--- a/src/main/java/com/minecolonies/coremod/blocks/decorative/BlockShingle.java
+++ b/src/main/java/com/minecolonies/coremod/blocks/decorative/BlockShingle.java
@@ -37,7 +37,7 @@ public class BlockShingle extends AbstractBlockMinecoloniesStairs<BlockShingle>
 
     private void init(final String name)
     {
-        setRegistryName(name);
+        setRegistryName(Constants.MOD_ID.toLowerCase() + ":" + name);
         setTranslationKey(String.format("%s.%s", Constants.MOD_ID.toLowerCase(Locale.US), name));
         setCreativeTab(ModCreativeTabs.MINECOLONIES);
         setHardness(BLOCK_HARDNESS);

--- a/src/main/java/com/minecolonies/coremod/blocks/decorative/BlockShingleSlab.java
+++ b/src/main/java/com/minecolonies/coremod/blocks/decorative/BlockShingleSlab.java
@@ -70,7 +70,7 @@ public class BlockShingleSlab extends AbstractBlockMinecoloniesDirectional<Block
      */
     private void initBlock()
     {
-        setRegistryName(BLOCK_NAME);
+        setRegistryName(Constants.MOD_ID.toLowerCase() + ":" + BLOCK_NAME);
         setTranslationKey(String.format("%s.%s", Constants.MOD_ID.toLowerCase(Locale.ENGLISH), BLOCK_NAME));
         setCreativeTab(ModCreativeTabs.MINECOLONIES);
         setHardness(BLOCK_HARDNESS);

--- a/src/main/java/com/minecolonies/coremod/blocks/decorative/BlockTimberFrame.java
+++ b/src/main/java/com/minecolonies/coremod/blocks/decorative/BlockTimberFrame.java
@@ -48,7 +48,7 @@ public class BlockTimberFrame extends AbstractBlockMinecoloniesPillar<BlockTimbe
      */
     private void initBlock(final String name)
     {
-        setRegistryName(name);
+        setRegistryName(Constants.MOD_ID.toLowerCase() + ":" + name);
         setTranslationKey(String.format("%s.%s", Constants.MOD_ID.toLowerCase(Locale.US), name));
         setCreativeTab(ModCreativeTabs.MINECOLONIES);
         setHardness(BLOCK_HARDNESS);

--- a/src/main/java/com/minecolonies/coremod/blocks/huts/BlockHutField.java
+++ b/src/main/java/com/minecolonies/coremod/blocks/huts/BlockHutField.java
@@ -93,7 +93,7 @@ public class BlockHutField extends AbstractBlockMinecoloniesContainer<BlockHutFi
      */
     private void initBlock()
     {
-        setRegistryName(REGISTRY_NAME);
+        setRegistryName(Constants.MOD_ID.toLowerCase() + ":" + REGISTRY_NAME);
         setTranslationKey(Constants.MOD_ID.toLowerCase(Locale.ENGLISH) + "." + REGISTRY_NAME);
         setCreativeTab(ModCreativeTabs.MINECOLONIES);
         //Blast resistance for creepers etc. makes them explosion proof.

--- a/src/main/java/com/minecolonies/coremod/blocks/schematic/BlockSolidSubstitution.java
+++ b/src/main/java/com/minecolonies/coremod/blocks/schematic/BlockSolidSubstitution.java
@@ -47,7 +47,7 @@ public class BlockSolidSubstitution extends AbstractBlockMinecolonies<BlockSolid
      */
     private void initBlock()
     {
-        setRegistryName(BLOCK_NAME);
+        setRegistryName(Constants.MOD_ID.toLowerCase() + ":" + BLOCK_NAME);
         setTranslationKey(String.format("%s.%s", Constants.MOD_ID.toLowerCase(), BLOCK_NAME));
         setCreativeTab(ModCreativeTabs.MINECOLONIES);
         setHardness(BLOCK_HARDNESS);

--- a/src/main/java/com/minecolonies/coremod/blocks/schematic/BlockSubstitution.java
+++ b/src/main/java/com/minecolonies/coremod/blocks/schematic/BlockSubstitution.java
@@ -47,7 +47,7 @@ public class BlockSubstitution extends AbstractBlockMinecolonies<BlockSubstituti
      */
     private void initBlock()
     {
-        setRegistryName(BLOCK_NAME);
+        setRegistryName(Constants.MOD_ID.toLowerCase() + ":" + BLOCK_NAME);
         setTranslationKey(String.format("%s.%s", Constants.MOD_ID.toLowerCase(), BLOCK_NAME));
         setCreativeTab(ModCreativeTabs.MINECOLONIES);
         setHardness(BLOCK_HARDNESS);

--- a/src/main/java/com/minecolonies/coremod/blocks/schematic/BlockWaypoint.java
+++ b/src/main/java/com/minecolonies/coremod/blocks/schematic/BlockWaypoint.java
@@ -52,7 +52,7 @@ public class BlockWaypoint extends AbstractBlockMinecolonies<BlockWaypoint>
      */
     private void initBlock()
     {
-        setRegistryName(BLOCK_NAME);
+        setRegistryName(Constants.MOD_ID.toLowerCase() + ":" + BLOCK_NAME);
         setTranslationKey(String.format("%s.%s", Constants.MOD_ID.toLowerCase(Locale.ENGLISH), BLOCK_NAME));
         setCreativeTab(ModCreativeTabs.MINECOLONIES);
         setHardness(BLOCK_HARDNESS);

--- a/src/main/java/com/minecolonies/coremod/fixers/EventBasedIdFixer.java
+++ b/src/main/java/com/minecolonies/coremod/fixers/EventBasedIdFixer.java
@@ -1,0 +1,52 @@
+package com.minecolonies.coremod.fixers;
+
+import com.minecolonies.api.util.Log;
+import com.minecolonies.api.util.constant.Constants;
+import net.minecraft.block.Block;
+import net.minecraft.item.Item;
+import net.minecraft.util.ResourceLocation;
+import net.minecraftforge.event.RegistryEvent;
+import net.minecraftforge.fml.common.Mod;
+import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
+import net.minecraftforge.registries.IForgeRegistryEntry;
+import org.jetbrains.annotations.Nullable;
+
+@Mod.EventBusSubscriber(modid = Constants.MOD_ID)
+public class EventBasedIdFixer
+{
+    @SubscribeEvent
+    public static void onItemRegistryMissingMappings(final RegistryEvent.MissingMappings<Item> event)
+    {
+        Log.getLogger().warn("Remapping of minecolonies items started.");
+        final int remappedCount = onRegistryMissingMappings(event);
+        Log.getLogger().warn("Remapping completed. Remapped: " + remappedCount + " entries.");
+    }
+
+    @SubscribeEvent
+    public static void onBlockRegistryMissingMappings(final RegistryEvent.MissingMappings<Block> event)
+    {
+        Log.getLogger().warn("Remapping of minecolonies blocks started.");
+        final int remappedCount = onRegistryMissingMappings(event);
+        Log.getLogger().warn("Remapping completed. Remapped: " + remappedCount + " entries.");
+    }
+
+
+    private static <T extends IForgeRegistryEntry<T>> int onRegistryMissingMappings(final RegistryEvent.MissingMappings<T> event)
+    {
+        return event.getMappings().stream().mapToInt(missingMapping -> {
+            final String path = missingMapping.key.getPath();
+            final ResourceLocation remappedTargetId = new ResourceLocation(Constants.MOD_ID.toLowerCase() + ":" + path);
+
+            @Nullable
+            final T target = missingMapping.registry.getValue(remappedTargetId);
+            if (target != null)
+            {
+                Log.getLogger().info("Remapping: " + missingMapping.key + " to: " + remappedTargetId);
+                missingMapping.remap(target);
+                return 1;
+            }
+
+            return 0;
+        }).sum();
+    }
+}

--- a/src/main/java/com/minecolonies/coremod/fixers/TileEntityIdFixer.java
+++ b/src/main/java/com/minecolonies/coremod/fixers/TileEntityIdFixer.java
@@ -1,0 +1,46 @@
+package com.minecolonies.coremod.fixers;
+
+import com.google.common.collect.ImmutableMap;
+import com.minecolonies.api.util.constant.Constants;
+import com.minecolonies.coremod.tileentities.*;
+import net.minecraft.nbt.NBTTagCompound;
+import net.minecraft.util.datafix.IDataFixer;
+import net.minecraft.util.datafix.IFixableData;
+import net.minecraftforge.fml.common.registry.GameRegistry;
+
+import java.util.Map;
+
+public class TileEntityIdFixer implements IFixableData
+{
+
+    public static final int VERSION = 1;
+    private final Map<String, String> idsToFix;
+
+    public TileEntityIdFixer()
+    {
+        idsToFix = ImmutableMap.<String, String>builder()
+                     .put("minecraft:" + Constants.MOD_ID + ".ColonyBuilding", Constants.MOD_ID + ":ColonyBuilding")
+                     .put("minecraft:" + Constants.MOD_ID + ".Scarecrow", Constants.MOD_ID + ":Scarecrow")
+                     .put("minecraft:" + Constants.MOD_ID + ".WareHouse", Constants.MOD_ID + ":WareHouse")
+                     .put("minecraft:" + Constants.MOD_ID + ".rack", Constants.MOD_ID + ":rack")
+                     .put("minecraft:" + Constants.MOD_ID + ".InfoPoster", Constants.MOD_ID + ":InfoPoster")
+                     .put("minecraft:" + Constants.MOD_ID + ".MultiBlock", Constants.MOD_ID + ":MultiBlock")
+                     .put("minecraft:" + Constants.MOD_ID + ".Barrel", Constants.MOD_ID + ":Barrel")
+                     .build();
+    }
+
+    @Override
+    public int getFixVersion()
+    {
+        return VERSION;
+    }
+
+    @Override
+    public NBTTagCompound fixTagCompound(final NBTTagCompound compound)
+    {
+        String teID = compound.getString("id");
+
+        compound.setString("id", idsToFix.getOrDefault(teID, teID)); //only change value if teID is in the map
+        return compound;
+    }
+}

--- a/src/main/java/com/minecolonies/coremod/items/AbstractItemMinecolonies.java
+++ b/src/main/java/com/minecolonies/coremod/items/AbstractItemMinecolonies.java
@@ -24,7 +24,7 @@ public abstract class AbstractItemMinecolonies extends Item
         this.name = name;
 
         super.setTranslationKey(Constants.MOD_ID.toLowerCase() + "." + this.name);
-        setRegistryName(this.name);
+        setRegistryName(Constants.MOD_ID.toLowerCase() + ":" + this.name);
     }
 
     /**

--- a/src/main/java/com/minecolonies/coremod/items/ItemCactusDoor.java
+++ b/src/main/java/com/minecolonies/coremod/items/ItemCactusDoor.java
@@ -24,7 +24,7 @@ public class ItemCactusDoor extends Item
     {
         super();
         this.block = block;
-        setRegistryName(name);
+        setRegistryName(Constants.MOD_ID.toLowerCase() + ":" + name);
         super.setTranslationKey(Constants.MOD_ID.toLowerCase() + "." + name);
         this.setCreativeTab(ModCreativeTabs.MINECOLONIES);
 

--- a/src/main/java/com/minecolonies/coremod/items/ItemChiefSword.java
+++ b/src/main/java/com/minecolonies/coremod/items/ItemChiefSword.java
@@ -33,7 +33,7 @@ public class ItemChiefSword extends ItemSword
     {
         super(ToolMaterial.DIAMOND);
         super.setTranslationKey(Constants.MOD_ID.toLowerCase() + "." + CHIEFSWORD_NAME);
-        setRegistryName(CHIEFSWORD_NAME);
+        setRegistryName(Constants.MOD_ID.toLowerCase() + ":" + CHIEFSWORD_NAME);
         super.setCreativeTab(ModCreativeTabs.MINECOLONIES);
     }
 

--- a/src/main/java/com/minecolonies/coremod/items/ItemIronScimitar.java
+++ b/src/main/java/com/minecolonies/coremod/items/ItemIronScimitar.java
@@ -18,7 +18,7 @@ public class ItemIronScimitar extends ItemSword
     {
         super(ToolMaterial.IRON);
         super.setTranslationKey(Constants.MOD_ID.toLowerCase() + "." + SCIMITAR_NAME);
-        setRegistryName(SCIMITAR_NAME);
+        setRegistryName(Constants.MOD_ID.toLowerCase() + ":" + SCIMITAR_NAME);
         super.setCreativeTab(ModCreativeTabs.MINECOLONIES);
     }
 

--- a/src/main/java/com/minecolonies/coremod/items/ItemPirateGear.java
+++ b/src/main/java/com/minecolonies/coremod/items/ItemPirateGear.java
@@ -31,7 +31,7 @@ public class ItemPirateGear extends ItemArmor
     {
         super(materialIn, renderIndexIn, equipmentSlotIn);
         setTranslationKey(name);
-        setRegistryName(Constants.MOD_ID + ":" + name);
+        setRegistryName(Constants.MOD_ID.toLowerCase() + ":" +  name);
         setCreativeTab(tab);
     }
 }

--- a/src/main/java/com/minecolonies/coremod/proxy/CommonProxy.java
+++ b/src/main/java/com/minecolonies/coremod/proxy/CommonProxy.java
@@ -122,13 +122,13 @@ public class CommonProxy implements IProxy
     @Override
     public void registerTileEntities()
     {
-        GameRegistry.registerTileEntity(TileEntityColonyBuilding.class, Constants.MOD_ID + ".ColonyBuilding");
-        GameRegistry.registerTileEntity(ScarecrowTileEntity.class, Constants.MOD_ID + ".Scarecrow");
-        GameRegistry.registerTileEntity(TileEntityWareHouse.class, Constants.MOD_ID + ".WareHouse");
-        GameRegistry.registerTileEntity(TileEntityRack.class, Constants.MOD_ID + ".rack");
-        GameRegistry.registerTileEntity(TileEntityInfoPoster.class, Constants.MOD_ID + ".InfoPoster");
-        GameRegistry.registerTileEntity(TileEntityMultiBlock.class, Constants.MOD_ID + ".MultiBlock");
-        GameRegistry.registerTileEntity(TileEntityBarrel.class, Constants.MOD_ID + ".Barrel");
+        GameRegistry.registerTileEntity(TileEntityColonyBuilding.class, Constants.MOD_ID + ":ColonyBuilding");
+        GameRegistry.registerTileEntity(ScarecrowTileEntity.class, Constants.MOD_ID + ":Scarecrow");
+        GameRegistry.registerTileEntity(TileEntityWareHouse.class, Constants.MOD_ID + ":WareHouse");
+        GameRegistry.registerTileEntity(TileEntityRack.class, Constants.MOD_ID + ":rack");
+        GameRegistry.registerTileEntity(TileEntityInfoPoster.class, Constants.MOD_ID + ":InfoPoster");
+        GameRegistry.registerTileEntity(TileEntityMultiBlock.class, Constants.MOD_ID + ":MultiBlock");
+        GameRegistry.registerTileEntity(TileEntityBarrel.class, Constants.MOD_ID + ":Barrel");
 
         NetworkRegistry.INSTANCE.registerGuiHandler(MineColonies.instance, new GuiHandler());
     }


### PR DESCRIPTION
Closes: #3056 

This updates all registry keys from `minecraft:*` to `minecolonies:*`
It adds the relevant event handlers as well as datafixers for TileEntities.
Entities might need to restock some items (since the numeric Id of the item changes, but not the key, since those are updated automatically.)

Please test this on the test server first.