### PR TITLE
Lumberjack improvements/fixes

### DIFF
--- a/src/api/java/com/minecolonies/api/compatibility/Compatibility.java
+++ b/src/api/java/com/minecolonies/api/compatibility/Compatibility.java
@@ -235,4 +235,16 @@ public final class Compatibility
     {
         return DynamicTreeCompat.isDynamicTreeSapling(stack.getItem());
     }
+
+    /**
+     * Method to check if two given blocks have the same Tree family
+     *
+     * @param block1 First blockpos to compare
+     * @param block2 Second blockpos to compare
+     * @return true when same family
+     */
+    public static boolean isDynamicFamilyFitting(final BlockPos block1, final BlockPos block2, final IBlockAccess world)
+    {
+        return DynamicTreeCompat.hasFittingTreeFamily(block1, block2, world);
+    }
 }

--- a/src/api/java/com/minecolonies/api/compatibility/dynamictrees/DynamicTreeProxy.java
+++ b/src/api/java/com/minecolonies/api/compatibility/dynamictrees/DynamicTreeProxy.java
@@ -82,4 +82,12 @@ public class DynamicTreeProxy
      * @return false
      */
     protected boolean plantDynamicSaplingCompat(final World world, final BlockPos location, final ItemStack sapling) {return false;}
+
+    /**
+     * Default method to check if two given blocks have the same Tree family
+     *
+     * @param block1 First blockpos to compare
+     * @param block2 Second blockpos to compare
+     */
+    protected boolean hasFittingTreeFamilyCompat(final BlockPos block1, final BlockPos block2, final IBlockAccess world) {return false;}
 }

--- a/src/api/java/com/minecolonies/api/util/BlockStateUtils.java
+++ b/src/api/java/com/minecolonies/api/util/BlockStateUtils.java
@@ -1,7 +1,6 @@
 package com.minecolonies.api.util;
 
 import net.minecraft.block.properties.IProperty;
-import net.minecraft.block.state.BlockStateContainer;
 import net.minecraft.block.state.IBlockState;
 import org.jetbrains.annotations.NotNull;
 
@@ -89,7 +88,7 @@ public class BlockStateUtils
      */
     public static IProperty getPropertyByNameFromState(@NotNull final IBlockState state, @NotNull final String name)
     {
-        IProperty property = propertyBlockMap.get(state.getBlock().getClass().getName() + name);
+        IProperty property = propertyBlockMap.get(state.getBlock().getRegistryName() + ":prop:" + name);
 
         if (property != null && state.getPropertyKeys().contains(property))
         {
@@ -102,7 +101,7 @@ public class BlockStateUtils
 
             if (property != null)
             {
-                propertyBlockMap.put(state.getBlock().getClass().getName() + name, property);
+                propertyBlockMap.put(state.getBlock().getRegistryName() + ":prop:" + name, property);
             }
             return property;
         }
@@ -125,38 +124,6 @@ public class BlockStateUtils
             }
         }
         return null;
-    }
-
-    /**
-     * Returns a copy of the state without the given property
-     *
-     * @param state    The state to use
-     * @param property The property to remove
-     * @return State without property
-     */
-    public static IBlockState getStateWithoutProperty(@NotNull final IBlockState state, final IProperty property)
-    {
-        final Collection<IProperty<?>> tList = state.getPropertyKeys();
-
-        for (final IProperty prop : state.getPropertyKeys())
-        {
-            if (prop == property)
-            {
-                tList.remove(prop);
-                break;
-            }
-        }
-
-        final IProperty[] tempArray = new IProperty[tList.size()];
-        tList.toArray(tempArray);
-
-        IBlockState newState = new BlockStateContainer(state.getBlock(), tempArray).getBaseState();
-
-        for (final IProperty prop : tList)
-        {
-            newState = newState.withProperty(prop, state.getValue(prop));
-        }
-        return newState;
     }
 
     /**

--- a/src/api/java/com/minecolonies/api/util/BlockStateUtils.java
+++ b/src/api/java/com/minecolonies/api/util/BlockStateUtils.java
@@ -88,7 +88,7 @@ public class BlockStateUtils
      */
     public static IProperty getPropertyByNameFromState(@NotNull final IBlockState state, @NotNull final String name)
     {
-        IProperty property = propertyBlockMap.get(state.getBlock().getRegistryName() + ":prop:" + name);
+        IProperty property = propertyBlockMap.get(state.getBlock().getRegistryName().toString() + ":" + name);
 
         if (property != null && state.getPropertyKeys().contains(property))
         {
@@ -101,7 +101,7 @@ public class BlockStateUtils
 
             if (property != null)
             {
-                propertyBlockMap.put(state.getBlock().getRegistryName() + ":prop:" + name, property);
+                propertyBlockMap.put(state.getBlock().getRegistryName().toString() + ":" + name, property);
             }
             return property;
         }

--- a/src/api/java/com/minecolonies/api/util/BlockStateUtils.java
+++ b/src/api/java/com/minecolonies/api/util/BlockStateUtils.java
@@ -1,0 +1,218 @@
+package com.minecolonies.api.util;
+
+import net.minecraft.block.properties.IProperty;
+import net.minecraft.block.state.BlockStateContainer;
+import net.minecraft.block.state.IBlockState;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Utility class for handling block states and their properties
+ */
+public class BlockStateUtils
+{
+
+    /**
+     * Hashmap which links a block class + property name to its IProperty object
+     * Used to shorten name searches
+     */
+    private static final Map<String, IProperty> propertyBlockMap = new HashMap<>();
+
+    /**
+     * Private constructor to hide the public one.
+     */
+    private BlockStateUtils()
+    {
+        //Hides implicit constructor.
+    }
+
+    /**
+     * Checks if two states contain the same block and are equal in the given property, or all properties
+     *
+     * @param state1       First state to compare
+     * @param state2       Second state to compare
+     * @param propertyName property name to search for
+     * @return true or false
+     */
+    public static boolean stateEqualsStateByBlockAndProp(@NotNull final IBlockState state1, @NotNull final IBlockState state2, @NotNull final String propertyName)
+    {
+        if (state1.getBlock() != state2.getBlock())
+        {
+            return false;
+        }
+
+        if (stateEqualsStateInPropertyByName(state1, state2, propertyName))
+        {
+            return true;
+        }
+
+        // Compare states in case the property wasn't found
+        return state1 == state2;
+    }
+
+    /**
+     * Compares two states by a property matching the given propertyName.
+     * Compared by the name of the Property-value, use when property is an enum without an actual value.
+     *
+     * @param state1       First state to compare
+     * @param state2       Second state to compare
+     * @param propertyName the property name we're searching for
+     * @return true if states match in the property
+     */
+    public static boolean stateEqualsStateInPropertyByName(@NotNull final IBlockState state1, @NotNull final IBlockState state2, @NotNull final String propertyName)
+    {
+        final IProperty propertyOne = getPropertyByNameFromState(state1, propertyName);
+
+        if (propertyOne != null && state2.getPropertyKeys().contains(propertyOne))
+        {
+            return state1.getValue(propertyOne) == state2.getValue(propertyOne);
+        }
+
+        final IProperty propertyTwo = getPropertyByNameFromState(state2, propertyName);
+
+        if (propertyOne != null && propertyTwo != null && state1.getPropertyKeys().contains(propertyOne) && state2.getPropertyKeys().contains(propertyTwo))
+        {
+            return state1.getValue(propertyOne).toString().equals((state2.getValue(propertyTwo)).toString());
+        }
+        return false;
+    }
+
+    /**
+     * Get the property object of a state matching the given name
+     * Caches lookups in the propertyBlockMap hashmap
+     *
+     * @param state Blockstate we're checking for a property
+     * @param name  name of the property to find
+     */
+    public static IProperty getPropertyByNameFromState(@NotNull final IBlockState state, @NotNull final String name)
+    {
+        IProperty property = propertyBlockMap.get(state.getBlock().getClass().getName() + name);
+
+        if (property != null && state.getPropertyKeys().contains(property))
+        {
+            return property;
+        }
+        else
+        {
+            // Cached map entry nonexistant or wrong, calculate new
+            property = getPropertyByName(state.getPropertyKeys(), name);
+
+            if (property != null)
+            {
+                propertyBlockMap.put(state.getBlock().getClass().getName() + name, property);
+            }
+            return property;
+        }
+    }
+
+    /**
+     * Checks a list of properties for a matching name.
+     *
+     * @param properties the properties to check
+     * @param name       the property name we're looking for
+     * @return IProperty object found
+     */
+    public static IProperty getPropertyByName(@NotNull final Collection<IProperty<?>> properties, @NotNull final String name)
+    {
+        for (final IProperty tProperty : properties)
+        {
+            if (tProperty.getName().equals(name))
+            {
+                return tProperty;
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Returns a copy of the state without the given property
+     *
+     * @param state    The state to use
+     * @param property The property to remove
+     * @return State without property
+     */
+    public static IBlockState getStateWithoutProperty(@NotNull final IBlockState state, final IProperty property)
+    {
+        final Collection<IProperty<?>> tList = state.getPropertyKeys();
+
+        for (final IProperty prop : state.getPropertyKeys())
+        {
+            if (prop == property)
+            {
+                tList.remove(prop);
+                break;
+            }
+        }
+
+        final IProperty[] tempArray = new IProperty[tList.size()];
+        tList.toArray(tempArray);
+
+        IBlockState newState = new BlockStateContainer(state.getBlock(), tempArray).getBaseState();
+
+        for (final IProperty prop : tList)
+        {
+            newState = newState.withProperty(prop, state.getValue(prop));
+        }
+        return newState;
+    }
+
+    /**
+     * Compare two Blockstates ignoring one Property
+     *
+     * @param state1 First state to compare
+     * @param state2 Second state to compare
+     * @param prop   IProperty to not compare
+     * @return true if states are equal without the property
+     */
+    public static boolean stateEqualsStateWithoutProp(@NotNull final IBlockState state1, @NotNull final IBlockState state2, @NotNull final IProperty prop)
+    {
+        if (!state1.getPropertyKeys().contains(prop) || !state2.getPropertyKeys().contains(prop))
+        {
+            return state1 == state2;
+        }
+
+        return state1.withProperty(prop, state2.getValue(prop)) == state2;
+    }
+
+    /**
+     * Check if two states are equal in Block and Properties
+     *
+     * @param state1 First state to compare
+     * @param state2 Second state to compare
+     * @return True if states are equal
+     */
+    public static boolean stateEqualsStateInBlockAndProp(final IBlockState state1, final IBlockState state2)
+    {
+        if (state1 == null || state2 == null)
+        {
+            return false;
+        }
+
+        if (state1.getBlock() != state2.getBlock())
+        {
+            return false;
+        }
+
+        if (state1.getPropertyKeys().size() != state2.getPropertyKeys().size())
+        {
+            return false;
+        }
+
+        for (final IProperty prop : state1.getPropertyKeys())
+        {
+            if (!state2.getPropertyKeys().contains(prop))
+            {
+                return false;
+            }
+
+            if (state1.getValue(prop) != state2.getValue(prop))
+            {
+                return false;
+            }
+        }
+        return true;
+    }
+}

--- a/src/api/java/com/minecolonies/api/util/ItemStackUtils.java
+++ b/src/api/java/com/minecolonies/api/util/ItemStackUtils.java
@@ -2,7 +2,6 @@ package com.minecolonies.api.util;
 
 import com.minecolonies.api.compatibility.Compatibility;
 import com.minecolonies.api.compatibility.candb.ChiselAndBitsCheck;
-import com.minecolonies.api.compatibility.tinkers.TinkersWeaponHelper;
 import com.minecolonies.api.util.constant.IToolType;
 import com.minecolonies.api.util.constant.ToolType;
 import net.minecraft.entity.Entity;
@@ -22,6 +21,7 @@ import net.minecraft.tileentity.*;
 import net.minecraft.util.math.RayTraceResult;
 import net.minecraft.world.World;
 import net.minecraft.world.gen.structure.template.Template;
+import net.minecraftforge.oredict.OreDictionary;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -30,6 +30,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.function.Predicate;
 
+import static com.minecolonies.api.util.constant.Constants.SAPLINGS;
 import static com.minecolonies.api.util.constant.Suppression.DEPRECATION;
 
 /**
@@ -748,6 +749,29 @@ public final class ItemStackUtils
         return stack.isItemEqualIgnoreDurability(new ItemStack(Items.COAL))
                 || stack.isItemEqualIgnoreDurability(new ItemStack(Blocks.LOG))
                 || stack.isItemEqualIgnoreDurability(new ItemStack(Blocks.LOG2));
+    }
+
+    /**
+     * Checks if a stack is a type of sapling, using Oredict
+     *
+     * @param stack the stack to check.
+     * @return true if sapling.
+     */
+    public static boolean isStackSapling(@Nullable final ItemStack stack)
+    {
+        if (ItemStackUtils.isEmpty(stack))
+        {
+            return false;
+        }
+
+        for (final int oreId : OreDictionary.getOreIDs(stack))
+        {
+            if (OreDictionary.getOreName(oreId).equals(SAPLINGS))
+            {
+                return true;
+            }
+        }
+        return false;
     }
 }
 

--- a/src/main/java/com/minecolonies/coremod/colony/buildings/workerbuildings/BuildingLumberjack.java
+++ b/src/main/java/com/minecolonies/coremod/colony/buildings/workerbuildings/BuildingLumberjack.java
@@ -15,7 +15,6 @@ import com.minecolonies.coremod.colony.buildings.AbstractBuildingWorker;
 import com.minecolonies.coremod.colony.jobs.AbstractJob;
 import com.minecolonies.coremod.colony.jobs.JobLumberjack;
 import io.netty.buffer.ByteBuf;
-import net.minecraft.init.Blocks;
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.nbt.NBTTagList;
@@ -54,10 +53,6 @@ public class BuildingLumberjack extends AbstractBuildingWorker
      * Whether or not the LJ should replant saplings
      */
     private boolean replant = true;
-    /**
-     * A default sapling itemStack.
-     */
-    private static final ItemStack SAPLING_STACK = new ItemStack(Blocks.SAPLING);
 
     /**
      * The maximum upgrade of the building.
@@ -99,13 +94,7 @@ public class BuildingLumberjack extends AbstractBuildingWorker
             {
                 final ItemStack stack = getMainCitizen().getInventory().getStackInSlot(i);
 
-                if (ItemStackUtils.isEmpty(stack))
-                {
-                    continue;
-                }
-
-                // Check if item is sapling by Oredict
-                if (ItemStackUtils.isStackSapling(stack))
+                if (ItemStackUtils.isEmpty(stack) || !ItemStackUtils.isStackSapling(stack))
                 {
                     continue;
                 }

--- a/src/main/java/com/minecolonies/coremod/colony/buildings/workerbuildings/BuildingLumberjack.java
+++ b/src/main/java/com/minecolonies/coremod/colony/buildings/workerbuildings/BuildingLumberjack.java
@@ -22,14 +22,12 @@ import net.minecraft.nbt.NBTTagList;
 import net.minecraft.util.math.BlockPos;
 import net.minecraftforge.common.util.Constants;
 import net.minecraftforge.fml.common.network.ByteBufUtils;
-import net.minecraftforge.oredict.OreDictionary;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.*;
 import java.util.function.Predicate;
 
 import static com.minecolonies.api.util.constant.ColonyConstants.NUM_ACHIEVEMENT_FIRST;
-import static com.minecolonies.api.util.constant.Constants.SAPLINGS;
 import static com.minecolonies.api.util.constant.ToolLevelConstants.TOOL_LEVEL_WOOD_OR_GOLD;
 
 /**
@@ -107,7 +105,7 @@ public class BuildingLumberjack extends AbstractBuildingWorker
                 }
 
                 // Check if item is sapling by Oredict
-                if (!Arrays.stream(OreDictionary.getOreIDs(stack)).anyMatch(x -> OreDictionary.getOreName(x).equals(SAPLINGS)))
+                if (ItemStackUtils.isStackSapling(stack))
                 {
                     continue;
                 }

--- a/src/main/java/com/minecolonies/coremod/colony/buildings/workerbuildings/BuildingLumberjack.java
+++ b/src/main/java/com/minecolonies/coremod/colony/buildings/workerbuildings/BuildingLumberjack.java
@@ -22,12 +22,14 @@ import net.minecraft.nbt.NBTTagList;
 import net.minecraft.util.math.BlockPos;
 import net.minecraftforge.common.util.Constants;
 import net.minecraftforge.fml.common.network.ByteBufUtils;
+import net.minecraftforge.oredict.OreDictionary;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.*;
 import java.util.function.Predicate;
 
 import static com.minecolonies.api.util.constant.ColonyConstants.NUM_ACHIEVEMENT_FIRST;
+import static com.minecolonies.api.util.constant.Constants.SAPLINGS;
 import static com.minecolonies.api.util.constant.ToolLevelConstants.TOOL_LEVEL_WOOD_OR_GOLD;
 
 /**
@@ -99,7 +101,13 @@ public class BuildingLumberjack extends AbstractBuildingWorker
             {
                 final ItemStack stack = getMainCitizen().getInventory().getStackInSlot(i);
 
-                if (ItemStackUtils.isEmpty(stack) || stack.getItem() != SAPLING_STACK.getItem())
+                if (ItemStackUtils.isEmpty(stack))
+                {
+                    continue;
+                }
+
+                // Check if item is sapling by Oredict
+                if (!Arrays.stream(OreDictionary.getOreIDs(stack)).anyMatch(x -> OreDictionary.getOreName(x).equals(SAPLINGS)))
                 {
                     continue;
                 }

--- a/src/main/java/com/minecolonies/coremod/entity/ai/citizen/lumberjack/EntityAIWorkLumberjack.java
+++ b/src/main/java/com/minecolonies/coremod/entity/ai/citizen/lumberjack/EntityAIWorkLumberjack.java
@@ -23,13 +23,11 @@ import net.minecraft.util.math.AxisAlignedBB;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.text.TextComponentTranslation;
 import net.minecraftforge.items.wrapper.InvWrapper;
-import net.minecraftforge.oredict.OreDictionary;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.Objects;
 
-import static com.minecolonies.api.util.constant.Constants.SAPLINGS;
 import static com.minecolonies.coremod.entity.ai.util.AIState.*;
 
 /**
@@ -716,7 +714,7 @@ public class EntityAIWorkLumberjack extends AbstractEntityAIInteract<JobLumberja
      */
     private boolean isCorrectSapling(final ItemStack stack)
     {
-        if (!isStackSapling(stack))
+        if (!ItemStackUtils.isStackSapling(stack))
         {
             return false;
         }
@@ -729,29 +727,6 @@ public class EntityAIWorkLumberjack extends AbstractEntityAIInteract<JobLumberja
         {
             return job.tree.getSapling().isItemEqual(stack);
         }
-    }
-
-    /**
-     * Checks if a stack is a type of sapling, using Oredict
-     *
-     * @param stack the stack to check.
-     * @return true if sapling.
-     */
-    private static boolean isStackSapling(@Nullable final ItemStack stack)
-    {
-        if (ItemStackUtils.isEmpty(stack))
-        {
-            return false;
-        }
-
-        for (final int oreId : OreDictionary.getOreIDs(stack))
-        {
-            if (OreDictionary.getOreName(oreId).equals(SAPLINGS))
-            {
-                return true;
-            }
-        }
-        return false;
     }
 
     /**

--- a/src/main/java/com/minecolonies/coremod/entity/pathfinding/AbstractPathJob.java
+++ b/src/main/java/com/minecolonies/coremod/entity/pathfinding/AbstractPathJob.java
@@ -363,9 +363,10 @@ public abstract class AbstractPathJob implements Callable<Path>
         {
             return search();
         }
-        catch (final RuntimeException e)
+        catch (final Exception e)
         {
-            Log.getLogger().debug(e);
+            // Log everything, so exceptions of the pathfinding-thread show in Log
+            Log.getLogger().warn("Pathfinding Exception", e);
         }
 
         return null;


### PR DESCRIPTION
**Lumberjack**:
Errors:
- Using oredict sapling when dumping, so nonvanilla saplings are also kept
- Added dynamic tree compat function to compare tree families(variants)
- Fixing error where a check during tree creation fails, but the LC still tried to use that Tree
- Fixing error where the LC kept trying to plant a sapling on an occupied spot
- Fixing error where all slime saplings were correct for any slimetree
- Using oredict to check if a stack is a sapling instead of instanceof, fixes replanting of some BOP trees
- If tree creationg fails it will now set isTree to false

Added:
- Trees now use an IProperty field to set their variant, instead of meta
- Calculating the sapling from a leaf for the tree now checks the Tree's variant to fit(fixes close/combined trees)
- Trees now only add fitting woodtypes as log to be cut, so combined Tree's of different variants are chopped and planted seperatly

Util:
- Added BlockStateUtils for helper functions for using blockstates and their properties
- Logging all exceptions during pathfinding, prev only Runtimeexceptions

Closes #2885
Closes #2937
Closes #3062

Review please
