### PR TITLE
Sapling checking: excluding empty stacks

### DIFF
--- a/src/main/java/com/minecolonies/coremod/entity/ai/citizen/lumberjack/Tree.java
+++ b/src/main/java/com/minecolonies/coremod/entity/ai/citizen/lumberjack/Tree.java
@@ -255,6 +255,13 @@ public class Tree
 
             for (final ItemStack stack : list)
             {
+
+                // Skip bad stacks from drops calc
+                if (stack.isEmpty())
+                {
+                    continue;
+                }
+
                 final int[] oreIds = OreDictionary.getOreIDs(stack);
                 for (final int oreId : oreIds)
                 {


### PR DESCRIPTION
small fix to not check empty stacks.