### PR TITLE
Guard action count and food

### DIFF
--- a/src/main/java/com/minecolonies/coremod/entity/ai/citizen/guard/AbstractEntityAIGuard.java
+++ b/src/main/java/com/minecolonies/coremod/entity/ai/citizen/guard/AbstractEntityAIGuard.java
@@ -269,7 +269,7 @@ public abstract class AbstractEntityAIGuard<J extends AbstractJobGuard> extends 
     {
         if (target != null && target.isDead)
         {
-            incrementActionsDone();
+            incrementActionsDoneAndDecSaturation();
             worker.getCitizenExperienceHandler().addExperience(EXP_PER_MOB_DEATH);
             target = null;
         }

--- a/src/main/java/com/minecolonies/coremod/entity/ai/citizen/guard/EntityAIKnight.java
+++ b/src/main/java/com/minecolonies/coremod/entity/ai/citizen/guard/EntityAIKnight.java
@@ -26,7 +26,8 @@ import org.jetbrains.annotations.NotNull;
 import java.util.List;
 
 import static com.minecolonies.api.util.constant.GuardConstants.*;
-import static com.minecolonies.coremod.entity.ai.util.AIState.*;
+import static com.minecolonies.coremod.entity.ai.util.AIState.GUARD_ATTACK_PHYSICAL;
+import static com.minecolonies.coremod.entity.ai.util.AIState.GUARD_ATTACK_PROTECT;
 
 @SuppressWarnings("squid:MaximumInheritanceDepth")
 public class EntityAIKnight extends AbstractEntityAIGuard<JobKnight>
@@ -184,6 +185,7 @@ public class EntityAIKnight extends AbstractEntityAIGuard<JobKnight>
 
             target.attackEntityFrom(source, (float) damageToBeDealt);
             target.setRevengeTarget(worker);
+            worker.decreaseSaturationForContinuousAction();
 
             worker.getCitizenItemHandler().damageItemInHand(EnumHand.MAIN_HAND, 1);
         }
@@ -209,7 +211,6 @@ public class EntityAIKnight extends AbstractEntityAIGuard<JobKnight>
                     addDmg += TinkersWeaponHelper.getDamage(heldItem);
                 }
                 addDmg += EnchantmentHelper.getModifierForCreature(heldItem, target.getCreatureAttribute()) / 2.5;
-                this.incrementActionsDoneAndDecSaturation();
             }
 
             addDmg += getLevelDamage();

--- a/src/main/java/com/minecolonies/coremod/entity/ai/citizen/guard/EntityAIRanger.java
+++ b/src/main/java/com/minecolonies/coremod/entity/ai/citizen/guard/EntityAIRanger.java
@@ -350,7 +350,7 @@ public class EntityAIRanger extends AbstractEntityAIGuard<JobRanger>
                 currentAttackDelay = getAttackDelay();
                 worker.getCitizenItemHandler().damageItemInHand(EnumHand.MAIN_HAND, 1);
                 worker.resetActiveHand();
-                this.incrementActionsDoneAndDecSaturation();
+                worker.decreaseSaturationForContinuousAction();
             }
             else
             {


### PR DESCRIPTION
Fix guards dumping inventory a lot more often than intended and make them not drain food too fast.

Review please
