### PR TITLE
Fix and optimize conversion of chiseled blocks into bit stacks, and depend only on C&B's API.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -90,7 +90,7 @@ dependencies {
     contained "com.ldtteam:structurize:${config.minecraft_version}-${config.structurize_version}"
     deobfCompile "com.ldtteam:structurize:${config.minecraft_version}-${config.structurize_version}"
 
-    compile "mod.chiselsandbits:chiselsandbits:${config.c_b_version}"
+    compile "mod.chiselsandbits:chiselsandbits:${config.c_b_version}:api"
     deobfCompile "slimeknights.mantle:Mantle:1.12-${config.mantle_version}"
     deobfCompile "slimeknights:TConstruct:1.12.2-${config.tinker_version}"
     deobfCompile "com.ferreusveritas.dynamictrees:DynamicTrees:1.12.2-${config.dynamic_tree_version}"

--- a/build.properties
+++ b/build.properties
@@ -12,5 +12,5 @@ mantle_version=1.3.1.+
 tinker_version=2.10.0.+
 dynamic_tree_version=0.7.+
 jei_version=4.8.5.147
-c_b_version=14.0.128
+c_b_version=14.0.162
 structurize_version=0.10.66-ALPHA

--- a/src/api/java/com/minecolonies/api/compatibility/candb/ChiselAndBitsCheck.java
+++ b/src/api/java/com/minecolonies/api/compatibility/candb/ChiselAndBitsCheck.java
@@ -78,36 +78,36 @@ public final class ChiselAndBitsCheck extends AbstractChiselAndBitsProxy
 
             access.getStateCounts().forEach(stateCount ->
             {
-            	if (stateCount.stateId == 0)
-            		return;
+                if (stateCount.stateId == 0)
+                    return;
 
-            	final ItemStack bitStack;
-    			try
-    			{
-    				bitStack = ChiselsAndBitsAPI.instance().getBitItem(Block.getStateById(stateCount.stateId));
-    			}
-    			catch (InvalidBitItem e)
-    			{
-    				return;
-    			}
-    			if (bitStack.isEmpty())
-    				return;
+                final ItemStack bitStack;
+                try
+                {
+                    bitStack = ChiselsAndBitsAPI.instance().getBitItem(Block.getStateById(stateCount.stateId));
+                }
+                catch (InvalidBitItem e)
+                {
+                    return;
+                }
+                if (bitStack.isEmpty())
+                    return;
 
-    			int count = stateCount.quantity;
-    			int max = bitStack.getMaxStackSize();
-    			while (count > max)
-    			{
-    				final ItemStack copy = bitStack.copy();
-    				copy.setCount(max);
-    				stacks.add(copy);
-    				count -= max;
-    			}
-    			if (count > 0)
-    			{
-    				bitStack.setCount(count);
-    				stacks.add(bitStack);
-    			}
-    		});
+                int count = stateCount.quantity;
+                int max = bitStack.getMaxStackSize();
+                while (count > max)
+                {
+                    final ItemStack copy = bitStack.copy();
+                    copy.setCount(max);
+                    stacks.add(copy);
+                    count -= max;
+                }
+                if (count > 0)
+                {
+                    bitStack.setCount(count);
+                    stacks.add(bitStack);
+                }
+            });
 
             return stacks;
         }

--- a/src/api/java/com/minecolonies/api/compatibility/candb/ChiselAndBitsCheck.java
+++ b/src/api/java/com/minecolonies/api/compatibility/candb/ChiselAndBitsCheck.java
@@ -1,10 +1,6 @@
 package com.minecolonies.api.compatibility.candb;
 
-import mod.chiselsandbits.api.IBitAccess;
-import mod.chiselsandbits.api.IBitBrush;
-import mod.chiselsandbits.api.IBitVisitor;
-import mod.chiselsandbits.api.IChiseledBlockTileEntity;
-import mod.chiselsandbits.chiseledblock.BlockChiseled;
+import mod.chiselsandbits.api.*;
 import net.minecraft.block.state.IBlockState;
 import net.minecraft.item.ItemStack;
 import net.minecraft.tileentity.TileEntity;
@@ -59,7 +55,7 @@ public final class ChiselAndBitsCheck extends AbstractChiselAndBitsProxy
     @Optional.Method(modid = CANDB)
     public boolean checkForChiselAndBitsBlock(@NotNull final IBlockState blockState)
     {
-        return blockState.getBlock() instanceof BlockChiseled;
+        return blockState.getBlock() instanceof IMultiStateBlock;
     }
 
     @Override

--- a/src/api/java/com/minecolonies/api/compatibility/candb/ChiselAndBitsCheck.java
+++ b/src/api/java/com/minecolonies/api/compatibility/candb/ChiselAndBitsCheck.java
@@ -94,7 +94,7 @@ public final class ChiselAndBitsCheck extends AbstractChiselAndBitsProxy
                     return;
 
                 int count = stateCount.quantity;
-                int max = bitStack.getMaxStackSize();
+                final int max = bitStack.getMaxStackSize();
                 while (count > max)
                 {
                     final ItemStack copy = bitStack.copy();

--- a/src/api/java/com/minecolonies/api/compatibility/candb/ChiselsAndBitsAPI.java
+++ b/src/api/java/com/minecolonies/api/compatibility/candb/ChiselsAndBitsAPI.java
@@ -1,0 +1,20 @@
+package com.minecolonies.api.compatibility.candb;
+
+import mod.chiselsandbits.api.*;
+
+@ChiselsAndBitsAddon
+public class ChiselsAndBitsAPI implements IChiselsAndBitsAddon
+{
+	private static IChiselAndBitsAPI api;
+
+	@Override
+	public void onReadyChiselsAndBits(IChiselAndBitsAPI api)
+	{
+		this.api = api;
+	}
+
+	public static IChiselAndBitsAPI instance()
+	{
+		return api;
+	}
+}

--- a/src/api/java/com/minecolonies/api/compatibility/candb/ChiselsAndBitsAPI.java
+++ b/src/api/java/com/minecolonies/api/compatibility/candb/ChiselsAndBitsAPI.java
@@ -5,16 +5,16 @@ import mod.chiselsandbits.api.*;
 @ChiselsAndBitsAddon
 public class ChiselsAndBitsAPI implements IChiselsAndBitsAddon
 {
-	private static IChiselAndBitsAPI api;
+    private static IChiselAndBitsAPI api;
 
-	@Override
-	public void onReadyChiselsAndBits(IChiselAndBitsAPI api)
-	{
-		this.api = api;
-	}
+    @Override
+    public void onReadyChiselsAndBits(IChiselAndBitsAPI api)
+    {
+        this.api = api;
+    }
 
-	public static IChiselAndBitsAPI instance()
-	{
-		return api;
-	}
+    public static IChiselAndBitsAPI instance()
+    {
+        return api;
+    }
 }


### PR DESCRIPTION
Possibly fixes #3466

# Changes proposed in this pull request:
1. Depend only on C&B's API, rather than referring to core classes.
2. Fix bug where the size of the stack generated for given bit in a chiseled block is equal to its x position in the blockspace, rather than 1.
3. Optimize the conversion of chiseled blocks into bit stacks by replacing the use of an `IBitVisitor` with the use of a `StateCount` list.

@Raycoms When I looked over the _[block -> bit stack]_ code and said it was fine yesterday, I overlooked  point 2 in the list above, but later noticed it.

Also, I've never used this mod before, and have not tested to verify that this change definitively fixes #3466, but it's quite likely since point 2 is certainly a bit dupe bug.

Review please