### PR TITLE
Fix crash when C&B is not installed.

### DIFF
--- a/src/api/java/com/minecolonies/api/compatibility/candb/ChiselAndBitsCheck.java
+++ b/src/api/java/com/minecolonies/api/compatibility/candb/ChiselAndBitsCheck.java
@@ -1,7 +1,6 @@
 package com.minecolonies.api.compatibility.candb;
 
 import mod.chiselsandbits.api.*;
-import mod.chiselsandbits.api.APIExceptions.InvalidBitItem;
 import net.minecraft.block.Block;
 import net.minecraft.block.state.IBlockState;
 import net.minecraft.item.ItemStack;
@@ -81,15 +80,7 @@ public final class ChiselAndBitsCheck extends AbstractChiselAndBitsProxy
                 if (stateCount.stateId == 0)
                     return;
 
-                final ItemStack bitStack;
-                try
-                {
-                    bitStack = ChiselsAndBitsAPI.instance().getBitItem(Block.getStateById(stateCount.stateId));
-                }
-                catch (InvalidBitItem e)
-                {
-                    return;
-                }
+                final ItemStack bitStack = ChiselsAndBitsAPI.getBitStack(stateCount.stateId);
                 if (bitStack.isEmpty())
                     return;
 

--- a/src/api/java/com/minecolonies/api/compatibility/candb/ChiselsAndBitsAPI.java
+++ b/src/api/java/com/minecolonies/api/compatibility/candb/ChiselsAndBitsAPI.java
@@ -1,6 +1,9 @@
 package com.minecolonies.api.compatibility.candb;
 
 import mod.chiselsandbits.api.*;
+import net.minecraft.block.Block;
+import net.minecraft.block.state.IBlockState;
+import net.minecraft.item.ItemStack;
 
 @ChiselsAndBitsAddon
 public class ChiselsAndBitsAPI implements IChiselsAndBitsAddon
@@ -13,8 +16,15 @@ public class ChiselsAndBitsAPI implements IChiselsAndBitsAddon
         this.api = api;
     }
 
-    public static IChiselAndBitsAPI instance()
+    public static ItemStack getBitStack(int stateId)
     {
-        return api;
+    	try
+        {
+    		return api.getBitItem(Block.getStateById(stateId));
+        }
+        catch (APIExceptions.InvalidBitItem e)
+        {
+            return ItemStack.EMPTY;
+        }
     }
 }

--- a/src/api/java/com/minecolonies/api/compatibility/candb/ChiselsAndBitsAPI.java
+++ b/src/api/java/com/minecolonies/api/compatibility/candb/ChiselsAndBitsAPI.java
@@ -18,9 +18,9 @@ public class ChiselsAndBitsAPI implements IChiselsAndBitsAddon
 
     public static ItemStack getBitStack(int stateId)
     {
-    	try
+        try
         {
-    		return api.getBitItem(Block.getStateById(stateId));
+            return api.getBitItem(Block.getStateById(stateId));
         }
         catch (APIExceptions.InvalidBitItem e)
         {


### PR DESCRIPTION
Addresses crashing mentioned in #3491
# Changes proposed in this pull request:
- Fixes NCD crash caused by InvalidBitItem import when C&B is not installed by moving the code that references it to ChiselsAndBitsAPI.

Review please