### PR TITLE
faster builder

### DIFF
--- a/src/main/java/com/minecolonies/coremod/entity/ai/basic/AbstractEntityAIBasic.java
+++ b/src/main/java/com/minecolonies/coremod/entity/ai/basic/AbstractEntityAIBasic.java
@@ -1040,8 +1040,18 @@ public abstract class AbstractEntityAIBasic<J extends AbstractJob> extends Abstr
 
         @Nullable final AbstractBuildingWorker buildingWorker = getOwnBuilding();
 
-        final ItemStack stackToDump = worker.getInventoryCitizen().getStackInSlot(slotAt);
+        ItemStack stackToDump = worker.getInventoryCitizen().getStackInSlot(slotAt);
         final int totalSize = worker.getInventoryCitizen().getSizeInventory();
+
+        while (stackToDump.isEmpty())
+        {
+            if (slotAt >= totalSize)
+            {
+                return false;
+            }
+            slotAt++;
+            stackToDump = worker.getInventoryCitizen().getStackInSlot(slotAt);
+        }
 
         boolean dumpAnyway = false;
         if (slotAt + MIN_OPEN_SLOTS * 2 >= totalSize)

--- a/src/main/java/com/minecolonies/coremod/entity/ai/citizen/builder/EntityAIStructureBuilder.java
+++ b/src/main/java/com/minecolonies/coremod/entity/ai/citizen/builder/EntityAIStructureBuilder.java
@@ -171,8 +171,12 @@ public class EntityAIStructureBuilder extends AbstractEntityAIStructureWithWorkO
         {
             return getState();
         }
+        else if (InventoryUtils.hasItemInProvider(building.getTileEntity(), needsCurrently))
+        {
+            return GATHERING_REQUIRED_MATERIALS;
+        }
 
-        return GATHERING_REQUIRED_MATERIALS;
+        return pickUpMaterial();
     }
 
     @Override


### PR DESCRIPTION
Makes the builder faster with two measurements:

# Changes proposed in this pull request:
- Let him shortcut dumping stacks which are empty (no delay between empty slots)
- Let him shortcut when a needed item is not in his building (no need to try to pick it up)

Review please
