### PR TITLE
Prohibit Citizens From gong to work right after a raid

### DIFF
--- a/src/main/java/com/minecolonies/coremod/entity/EntityCitizen.java
+++ b/src/main/java/com/minecolonies/coremod/entity/EntityCitizen.java
@@ -925,6 +925,7 @@ public class EntityCitizen extends AbstractEntityCitizen
 
         if (getCitizenColonyHandler().getColony() != null && !world.isRemote && (!getCitizenColonyHandler().getColony().getRaiderManager().getHorde((WorldServer) world).isEmpty()))
         {
+            isDay = false;
             return DesiredActivity.SLEEP;
         }
 


### PR DESCRIPTION

# Changes proposed in this pull request:
-Citizen now continue sleeping after a raid until the next daytime/weather check


Review please
