### PR TITLE
[HotFix] Attempting to fix the DMan and Crafters being stuck.

### DIFF
--- a/src/main/java/com/minecolonies/coremod/colony/jobs/AbstractJobCrafter.java
+++ b/src/main/java/com/minecolonies/coremod/colony/jobs/AbstractJobCrafter.java
@@ -161,7 +161,7 @@ public abstract class AbstractJobCrafter extends AbstractJob
         getColony().getRequestManager().updateRequestState(current, successful ? RequestState.COMPLETED : RequestState.CANCELLED);
 
         //Just to be sure lets delete them!
-        if (current == getTaskQueueFromDataStore().getFirst())
+        if (!getTaskQueueFromDataStore().isEmpty() && current == getTaskQueueFromDataStore().getFirst())
             getTaskQueueFromDataStore().removeFirst();
     }
 

--- a/src/main/java/com/minecolonies/coremod/colony/jobs/AbstractJobCrafter.java
+++ b/src/main/java/com/minecolonies/coremod/colony/jobs/AbstractJobCrafter.java
@@ -156,9 +156,13 @@ public abstract class AbstractJobCrafter extends AbstractJob
             return;
         }
 
-        final IToken<?> current = getTaskQueueFromDataStore().removeFirst();
+        final IToken<?> current = getTaskQueueFromDataStore().getFirst();
 
         getColony().getRequestManager().updateRequestState(current, successful ? RequestState.COMPLETED : RequestState.CANCELLED);
+
+        //Just to be sure lets delete them!
+        if (current == getTaskQueueFromDataStore().getFirst())
+            getTaskQueueFromDataStore().removeFirst();
     }
 
     /**

--- a/src/main/java/com/minecolonies/coremod/colony/jobs/JobDeliveryman.java
+++ b/src/main/java/com/minecolonies/coremod/colony/jobs/JobDeliveryman.java
@@ -194,9 +194,13 @@ public class JobDeliveryman extends AbstractJob
         }
 
         this.setReturning(true);
-        final IToken<?> current = getTaskQueueFromDataStore().removeFirst();
+        final IToken<?> current = getTaskQueueFromDataStore().getFirst();
 
         getColony().getRequestManager().updateRequestState(current, successful ? RequestState.COMPLETED : RequestState.CANCELLED);
+
+        //Just to be sure lets delete them!
+        if (current == getTaskQueueFromDataStore().getFirst())
+            getTaskQueueFromDataStore().removeFirst();
     }
 
     /**

--- a/src/main/java/com/minecolonies/coremod/colony/jobs/JobDeliveryman.java
+++ b/src/main/java/com/minecolonies/coremod/colony/jobs/JobDeliveryman.java
@@ -199,7 +199,7 @@ public class JobDeliveryman extends AbstractJob
         getColony().getRequestManager().updateRequestState(current, successful ? RequestState.COMPLETED : RequestState.CANCELLED);
 
         //Just to be sure lets delete them!
-        if (current == getTaskQueueFromDataStore().getFirst())
+        if (!getTaskQueueFromDataStore().isEmpty() && current == getTaskQueueFromDataStore().getFirst())
             getTaskQueueFromDataStore().removeFirst();
     }
 

--- a/src/main/java/com/minecolonies/coremod/colony/requestsystem/resolvers/DeliveryRequestResolver.java
+++ b/src/main/java/com/minecolonies/coremod/colony/requestsystem/resolvers/DeliveryRequestResolver.java
@@ -128,7 +128,7 @@ public class DeliveryRequestResolver extends AbstractRequestResolver<Delivery>
 
             if (freeDeliveryMan == null)
             {
-                MineColonies.getLogger().error("Parent cancellation failed! Unknown request: " + request.getToken());
+                MineColonies.getLogger().error("Parent cancellation of delivery request failed! Unknown request: " + request.getToken());
             }
             else
             {

--- a/src/main/java/com/minecolonies/coremod/colony/requestsystem/resolvers/PublicWorkerCraftingProductionResolver.java
+++ b/src/main/java/com/minecolonies/coremod/colony/requestsystem/resolvers/PublicWorkerCraftingProductionResolver.java
@@ -87,7 +87,7 @@ public class PublicWorkerCraftingProductionResolver extends AbstractCraftingProd
 
             if (holdingCrafter == null)
             {
-                MineColonies.getLogger().error("Parent cancellation failed! Unknown request: " + request.getToken());
+                MineColonies.getLogger().error("Parent cancellation of crafting production failed! Unknown request: " + request.getToken());
             }
             else
             {


### PR DESCRIPTION
### Part 1: Assignment fix.
While doing a general investigation of the current problems I backtracked this issue to the finishing of tasks. When a crafter or a dman finishes his task, he removes it from his queue, making it impossible for the RS to find  and associate the now finished request with any worker, failing to process it.