### PR TITLE
Feature: RS Reassign on rack update

### DIFF
--- a/src/api/java/com/minecolonies/api/colony/requestsystem/manager/AssigningStrategy.java
+++ b/src/api/java/com/minecolonies/api/colony/requestsystem/manager/AssigningStrategy.java
@@ -13,5 +13,5 @@ public enum AssigningStrategy
     /**
      * Strategy that will ensure that the request depth is small.
      */
-    FASTED_FIRST
+    FASTEST_FIRST
 }

--- a/src/api/java/com/minecolonies/api/colony/requestsystem/manager/IRequestManager.java
+++ b/src/api/java/com/minecolonies/api/colony/requestsystem/manager/IRequestManager.java
@@ -20,6 +20,7 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.Collection;
+import java.util.function.Predicate;
 
 /**
  * Interface used to describe classes that function as managers for requests inside a colony.
@@ -157,6 +158,12 @@ public interface IRequestManager extends INBTSerializable<NBTTagCompound>, ITick
      * @throws IllegalArgumentException is thrown when no provider with the same token is registered.
      */
     void onProviderRemovedFromColony(@NotNull IRequestResolverProvider provider) throws IllegalArgumentException;
+
+    /**
+     * Method used to indicate that a colony has updated their available items.
+     * @param shouldTriggerReassign The request assigned
+     */
+    void onColonyUpdate(@NotNull Predicate<IRequest> shouldTriggerReassign);
 
     /**
      * Get the player resolve.

--- a/src/api/java/com/minecolonies/api/colony/requestsystem/manager/IRequestManager.java
+++ b/src/api/java/com/minecolonies/api/colony/requestsystem/manager/IRequestManager.java
@@ -163,7 +163,7 @@ public interface IRequestManager extends INBTSerializable<NBTTagCompound>, ITick
      * Method used to indicate that a colony has updated their available items.
      * @param shouldTriggerReassign The request assigned
      */
-    void onColonyUpdate(@NotNull Predicate<IRequest> shouldTriggerReassign);
+    void onColonyUpdate(@NotNull final Predicate<IRequest> shouldTriggerReassign);
 
     /**
      * Get the player resolve.

--- a/src/api/java/com/minecolonies/api/colony/requestsystem/resolver/IRequestResolver.java
+++ b/src/api/java/com/minecolonies/api/colony/requestsystem/resolver/IRequestResolver.java
@@ -123,7 +123,7 @@ public interface IRequestResolver<R extends IRequestable> extends IRequester
      * @param manager The systems manager.
      * @param shouldTriggerReassign The request assigned
      */
-    default void onColonyUpdate(@NotNull IRequestManager manager, @NotNull Predicate<IRequest> shouldTriggerReassign)
+    default void onColonyUpdate(@NotNull final IRequestManager manager, @NotNull final Predicate<IRequest> shouldTriggerReassign)
     {
         //Noop
     }

--- a/src/api/java/com/minecolonies/api/colony/requestsystem/resolver/IRequestResolver.java
+++ b/src/api/java/com/minecolonies/api/colony/requestsystem/resolver/IRequestResolver.java
@@ -10,6 +10,7 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.List;
+import java.util.function.Predicate;
 
 /**
  * Used to resolve a request.
@@ -116,6 +117,16 @@ public interface IRequestResolver<R extends IRequestable> extends IRequester
      */
     @Nullable
     IRequest<?> onRequestCancelled(@NotNull IRequestManager manager, @NotNull IRequest<? extends R> request);
+
+    /**
+     * Called by manager given to indicate that a colony has updated their available items.
+     * @param manager The systems manager.
+     * @param shouldTriggerReassign The request assigned
+     */
+    default void onColonyUpdate(@NotNull IRequestManager manager, @NotNull Predicate<IRequest> shouldTriggerReassign)
+    {
+        //Noop
+    }
 
     /**
      * Method used to indicate to this resolver that a parent of a request assigned to him has been cancelled,

--- a/src/api/java/com/minecolonies/api/util/constant/NbtTagConstants.java
+++ b/src/api/java/com/minecolonies/api/util/constant/NbtTagConstants.java
@@ -330,6 +330,11 @@ public final class NbtTagConstants
     public static final String TAG_MAIN = "main";
 
     /**
+     * Tag used to store if the entity is in a Warehouse.
+     */
+    public static final String TAG_IN_WAREHOUSE = "inWarehouse";
+
+    /**
      * Tag used to store the team color of the colony.
      */
     public static final String TAG_TEAM_COLOR = "teamcolor";

--- a/src/main/java/com/minecolonies/coremod/colony/buildings/workerbuildings/BuildingWareHouse.java
+++ b/src/main/java/com/minecolonies/coremod/colony/buildings/workerbuildings/BuildingWareHouse.java
@@ -93,6 +93,25 @@ public class BuildingWareHouse extends AbstractBuilding
         super(c, l);
     }
 
+    @Override
+    public void requestRepair(BlockPos builder)
+    {
+        //To ensure that the racks are all set to in the warehouse when repaired.
+        for (final BlockPos pos : containerList)
+        {
+            if (getColony().getWorld() != null)
+            {
+                final TileEntity entity = getColony().getWorld().getTileEntity(pos);
+                if (entity instanceof TileEntityRack)
+                {
+                    ((TileEntityRack) entity).setInWarehouse(true);
+                }
+            }
+        }
+
+        super.requestRepair(builder);
+    }
+
     /**
      * Register deliveryman with the warehouse.
      *
@@ -230,6 +249,10 @@ public class BuildingWareHouse extends AbstractBuilding
             {
                 handleBuildingOverChest(pos, (TileEntityChest) entity, world);
             }
+            if (entity instanceof TileEntityRack)
+            {
+                ((TileEntityRack) entity).setInWarehouse(true);
+            }
             addContainerPosition(pos);
         }
     }
@@ -259,6 +282,7 @@ public class BuildingWareHouse extends AbstractBuilding
         final TileEntity entity = world.getTileEntity(pos);
         if (entity instanceof TileEntityRack)
         {
+            ((TileEntityRack) entity).setInWarehouse(true);
             for (final ItemStack stack : inventory)
             {
                 if (!ItemStackUtils.isEmpty(stack))

--- a/src/main/java/com/minecolonies/coremod/colony/buildings/workerbuildings/BuildingWareHouse.java
+++ b/src/main/java/com/minecolonies/coremod/colony/buildings/workerbuildings/BuildingWareHouse.java
@@ -94,7 +94,7 @@ public class BuildingWareHouse extends AbstractBuilding
     }
 
     @Override
-    public void requestRepair(BlockPos builder)
+    public void requestRepair(final BlockPos builder)
     {
         //To ensure that the racks are all set to in the warehouse when repaired.
         for (final BlockPos pos : containerList)

--- a/src/main/java/com/minecolonies/coremod/colony/requestsystem/management/handlers/RequestHandler.java
+++ b/src/main/java/com/minecolonies/coremod/colony/requestsystem/management/handlers/RequestHandler.java
@@ -90,7 +90,7 @@ public final class RequestHandler
         {
             case PRIORITY_BASED:
                 return assignRequestDefault(manager, request, resolverTokenBlackList);
-            case FASTED_FIRST:
+            case FASTEST_FIRST:
             {
                 MineColonies.getLogger().warn("Fastest First strategy not implemented yet.");
                 return assignRequestDefault(manager, request, resolverTokenBlackList);

--- a/src/main/java/com/minecolonies/coremod/colony/requestsystem/management/handlers/ResolverHandler.java
+++ b/src/main/java/com/minecolonies/coremod/colony/requestsystem/management/handlers/ResolverHandler.java
@@ -14,6 +14,7 @@ import com.minecolonies.coremod.colony.requestsystem.management.manager.wrapped.
 import org.jetbrains.annotations.Nullable;
 
 import java.util.*;
+import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
 import static com.minecolonies.api.util.constant.Suppression.RAWTYPES;
@@ -346,5 +347,16 @@ public final class ResolverHandler
     public static IRequestResolver<? extends IRequestable> getResolverForRequest(final IStandardRequestManager manager, final IRequest<?> request)
     {
         return getResolverForRequest(manager, (IToken<?>) request.getToken());
+    }
+
+    /**
+     * Method used to reassign requests based on a predicate
+     *
+     * @param manager The manager to update reassign requests on
+     * @param shouldTriggerReassign the predicate to determine whether a request should be reassigned
+     */
+    public static void OnColonyUpdate(final IStandardRequestManager manager, final Predicate<IRequest> shouldTriggerReassign)
+    {
+        manager.getRequestResolverIdentitiesDataStore().getIdentities().values().forEach(resolver -> resolver.onColonyUpdate(manager, shouldTriggerReassign));
     }
 }

--- a/src/main/java/com/minecolonies/coremod/colony/requestsystem/management/handlers/ResolverHandler.java
+++ b/src/main/java/com/minecolonies/coremod/colony/requestsystem/management/handlers/ResolverHandler.java
@@ -355,7 +355,7 @@ public final class ResolverHandler
      * @param manager The manager to update reassign requests on
      * @param shouldTriggerReassign the predicate to determine whether a request should be reassigned
      */
-    public static void OnColonyUpdate(final IStandardRequestManager manager, final Predicate<IRequest> shouldTriggerReassign)
+    public static void onColonyUpdate(final IStandardRequestManager manager, final Predicate<IRequest> shouldTriggerReassign)
     {
         manager.getRequestResolverIdentitiesDataStore().getIdentities().values().forEach(resolver -> resolver.onColonyUpdate(manager, shouldTriggerReassign));
     }

--- a/src/main/java/com/minecolonies/coremod/colony/requestsystem/management/manager/StandardRequestManager.java
+++ b/src/main/java/com/minecolonies/coremod/colony/requestsystem/management/manager/StandardRequestManager.java
@@ -28,6 +28,7 @@ import org.jetbrains.annotations.Nullable;
 import java.util.Collection;
 import java.util.function.BiFunction;
 import java.util.function.Consumer;
+import java.util.function.Predicate;
 
 import static com.minecolonies.api.util.constant.Suppression.BIG_CLASS;
 
@@ -326,6 +327,17 @@ public class StandardRequestManager implements IStandardRequestManager
     public void onProviderRemovedFromColony(@NotNull final IRequestResolverProvider provider) throws IllegalArgumentException
     {
         ProviderHandler.removeProvider(this, provider);
+    }
+
+    /**
+     * Method used to reassign requests based on a predicate.
+     *
+     * @param shouldTriggerReassign The predicate to determine if the request should be reassigned.
+     */
+    @Override
+    public void onColonyUpdate(@NotNull Predicate<IRequest> shouldTriggerReassign)
+    {
+        ResolverHandler.OnColonyUpdate(this, shouldTriggerReassign);
     }
 
     /**

--- a/src/main/java/com/minecolonies/coremod/colony/requestsystem/management/manager/StandardRequestManager.java
+++ b/src/main/java/com/minecolonies/coremod/colony/requestsystem/management/manager/StandardRequestManager.java
@@ -335,9 +335,9 @@ public class StandardRequestManager implements IStandardRequestManager
      * @param shouldTriggerReassign The predicate to determine if the request should be reassigned.
      */
     @Override
-    public void onColonyUpdate(@NotNull Predicate<IRequest> shouldTriggerReassign)
+    public void onColonyUpdate(@NotNull final Predicate<IRequest> shouldTriggerReassign)
     {
-        ResolverHandler.OnColonyUpdate(this, shouldTriggerReassign);
+        ResolverHandler.onColonyUpdate(this, shouldTriggerReassign);
     }
 
     /**

--- a/src/main/java/com/minecolonies/coremod/colony/requestsystem/management/manager/wrapped/AbstractWrappedRequestManager.java
+++ b/src/main/java/com/minecolonies/coremod/colony/requestsystem/management/manager/wrapped/AbstractWrappedRequestManager.java
@@ -21,6 +21,7 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.Collection;
+import java.util.function.Predicate;
 
 /**
  * Wrapper class for a Manager.
@@ -253,5 +254,11 @@ public abstract class AbstractWrappedRequestManager implements IRequestManager
     public void setDirty(final boolean isDirty)
     {
         wrappedManager.setDirty(isDirty);
+    }
+
+    @Override
+    public void onColonyUpdate(@NotNull Predicate<IRequest> shouldTriggerReassign)
+    {
+        throw new UnsupportedOperationException("This method cannot be used by Wrapped Request Managers!");
     }
 }

--- a/src/main/java/com/minecolonies/coremod/colony/requestsystem/management/manager/wrapped/AbstractWrappedRequestManager.java
+++ b/src/main/java/com/minecolonies/coremod/colony/requestsystem/management/manager/wrapped/AbstractWrappedRequestManager.java
@@ -257,7 +257,7 @@ public abstract class AbstractWrappedRequestManager implements IRequestManager
     }
 
     @Override
-    public void onColonyUpdate(@NotNull Predicate<IRequest> shouldTriggerReassign)
+    public void onColonyUpdate(@NotNull final Predicate<IRequest> shouldTriggerReassign)
     {
         throw new UnsupportedOperationException("This method cannot be used by Wrapped Request Managers!");
     }

--- a/src/main/java/com/minecolonies/coremod/colony/requestsystem/resolvers/StandardPlayerRequestResolver.java
+++ b/src/main/java/com/minecolonies/coremod/colony/requestsystem/resolvers/StandardPlayerRequestResolver.java
@@ -239,7 +239,7 @@ public class StandardPlayerRequestResolver implements IPlayerRequestResolver
     }
 
     @Override
-    public void onColonyUpdate(@NotNull IRequestManager manager, @NotNull Predicate<IRequest> shouldTriggerReassign)
+    public void onColonyUpdate(@NotNull final IRequestManager manager, @NotNull final Predicate<IRequest> shouldTriggerReassign)
     {
         new ArrayList<>(assignedRequests).stream()
                 .map(manager::getRequestForToken)
@@ -249,7 +249,7 @@ public class StandardPlayerRequestResolver implements IPlayerRequestResolver
                 {
                     final IToken newResolverToken = manager.reassignRequest(request.getToken(), ImmutableList.of(token));
 
-                    if (newResolverToken != token)
+                    if (newResolverToken != null && !newResolverToken.equals(token))
                     {
                         assignedRequests.remove(request.getToken());
                     }

--- a/src/main/java/com/minecolonies/coremod/colony/requestsystem/resolvers/StandardPlayerRequestResolver.java
+++ b/src/main/java/com/minecolonies/coremod/colony/requestsystem/resolvers/StandardPlayerRequestResolver.java
@@ -33,6 +33,7 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.*;
+import java.util.function.Predicate;
 
 import static com.minecolonies.api.util.RSConstants.STANDARD_PLAYER_REQUEST_PRIORITY;
 
@@ -235,6 +236,24 @@ public class StandardPlayerRequestResolver implements IPlayerRequestResolver
     public void onSystemReset()
     {
         assignedRequests.clear();
+    }
+
+    @Override
+    public void onColonyUpdate(@NotNull IRequestManager manager, @NotNull Predicate<IRequest> shouldTriggerReassign)
+    {
+        new ArrayList<>(assignedRequests).stream()
+                .map(manager::getRequestForToken)
+                .filter(shouldTriggerReassign)
+                .filter(Objects::nonNull)
+                .forEach(request ->
+                {
+                    final IToken newResolverToken = manager.reassignRequest(request.getToken(), ImmutableList.of(token));
+
+                    if (newResolverToken != token)
+                    {
+                        assignedRequests.remove(request.getToken());
+                    }
+                });
     }
 
     public void setAllAssignedRequests(final Set<IToken<?>> assignedRequests)

--- a/src/main/java/com/minecolonies/coremod/colony/requestsystem/resolvers/StandardRetryingRequestResolver.java
+++ b/src/main/java/com/minecolonies/coremod/colony/requestsystem/resolvers/StandardRetryingRequestResolver.java
@@ -266,7 +266,7 @@ public class StandardRetryingRequestResolver implements IRetryingRequestResolver
     }
 
     @Override
-    public void onColonyUpdate(@NotNull IRequestManager manager, @NotNull Predicate<IRequest> shouldTriggerReassign)
+    public void onColonyUpdate(@NotNull final IRequestManager manager, @NotNull final Predicate<IRequest> shouldTriggerReassign)
     {
         new ArrayList<>(assignedRequests.keySet()).stream()
                 .map(manager::getRequestForToken)

--- a/src/main/java/com/minecolonies/coremod/colony/requestsystem/resolvers/StandardRetryingRequestResolver.java
+++ b/src/main/java/com/minecolonies/coremod/colony/requestsystem/resolvers/StandardRetryingRequestResolver.java
@@ -18,10 +18,8 @@ import net.minecraft.util.text.TextComponentString;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
+import java.util.*;
+import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
 import static com.minecolonies.api.util.RSConstants.CONST_RETRYING_RESOLVER_PRIORITY;
@@ -265,5 +263,23 @@ public class StandardRetryingRequestResolver implements IRetryingRequestResolver
     public Map<IToken<?>, Integer> getAssignedRequests()
     {
         return assignedRequests;
+    }
+
+    @Override
+    public void onColonyUpdate(@NotNull IRequestManager manager, @NotNull Predicate<IRequest> shouldTriggerReassign)
+    {
+        new ArrayList<>(assignedRequests.keySet()).stream()
+                .map(manager::getRequestForToken)
+                .filter(shouldTriggerReassign)
+                .filter(Objects::nonNull)
+                .forEach(request ->
+                {
+                    final IToken newResolverToken = manager.reassignRequest(request.getToken(), ImmutableList.of(getRequesterId()));
+
+                    if (newResolverToken != getRequesterId())
+                    {
+                        assignedRequests.remove(request.getToken());
+                    }
+                });
     }
 }

--- a/src/main/java/com/minecolonies/coremod/entity/ai/citizen/deliveryman/EntityAIWorkDeliveryman.java
+++ b/src/main/java/com/minecolonies/coremod/entity/ai/citizen/deliveryman/EntityAIWorkDeliveryman.java
@@ -426,11 +426,6 @@ public class EntityAIWorkDeliveryman extends AbstractEntityAIInteract<JobDeliver
         gatherTarget = null;
         worker.getCitizenItemHandler().setHeldItem(EnumHand.MAIN_HAND, SLOT_HAND);
 
-        final Set<IToken> finallyAssignedTokens = worker.getCitizenColonyHandler().getColony().getRequestManager().getPlayerResolver()
-                .getAllAssignedRequests().stream().collect(Collectors.toSet());
-
-        finallyAssignedTokens.forEach(iToken -> worker.getCitizenColonyHandler().getColony().getRequestManager().reassignRequest(iToken, ImmutableList.of()));
-
         if (job.isReturning())
         {
             job.setReturning(false);

--- a/src/main/java/com/minecolonies/coremod/tileentities/TileEntityRack.java
+++ b/src/main/java/com/minecolonies/coremod/tileentities/TileEntityRack.java
@@ -87,7 +87,7 @@ public class TileEntityRack extends TileEntity
         }
 
         @Override
-        public void setStackInSlot(int slot, @Nonnull ItemStack stack)
+        public void setStackInSlot(final int slot, final @Nonnull ItemStack stack)
         {
             super.setStackInSlot(slot, stack);
 


### PR DESCRIPTION
Allows for the RS System to reassign a request when the needed item is added to a rack inside a warehouse.

Requires warehouses to be repaired to work, but will not be detrimental if they do not get repaired.