### PR TITLE
Fix RS NPE

### DIFF
--- a/src/main/java/com/minecolonies/coremod/colony/requestsystem/requests/AbstractRequest.java
+++ b/src/main/java/com/minecolonies/coremod/colony/requestsystem/requests/AbstractRequest.java
@@ -145,7 +145,7 @@ public abstract class AbstractRequest<R extends IRequestable> implements IReques
             {
                 manager.getRequestForToken(getParent()).childStateUpdated(manager, getToken());
             }
-            catch (final IllegalArgumentException ex)
+            catch (final IllegalArgumentException | NullPointerException ex)
             {
                 //Something went wrong... Logging. Continuing however. Might cause parent request to get stuck however......
                 Log.getLogger().error(new IllegalStateException("Failed to update parent state.", ex));


### PR DESCRIPTION
`manager.getRequestForToken` can be null, it sometimes is, i'm catching it here.
if you want me to *do* something instead of catch it (like remove it from the data store?) tell me :smile: