### PR TITLE
Fixing lumberjack's sapling to leaf(blockstate) mapping

### DIFF
--- a/src/api/java/com/minecolonies/api/compatibility/CompatibilityManager.java
+++ b/src/api/java/com/minecolonies/api/compatibility/CompatibilityManager.java
@@ -267,7 +267,7 @@ public class CompatibilityManager implements ICompatibilityManager
     @Override
     public ItemStack getSaplingForLeaf(final IBlockState block)
     {
-        BlockStateStorage tempLeaf = new BlockStateStorage(block, leafCompareWithoutProperties, true);
+        final BlockStateStorage tempLeaf = new BlockStateStorage(block, leafCompareWithoutProperties, true);
 
         if (leavesToSaplingMap.containsKey(tempLeaf))
         {
@@ -348,7 +348,7 @@ public class CompatibilityManager implements ICompatibilityManager
     @Override
     public void connectLeafToSapling(final IBlockState leaf, final ItemStack stack)
     {
-        BlockStateStorage store = new BlockStateStorage(leaf, leafCompareWithoutProperties, true);
+        final BlockStateStorage store = new BlockStateStorage(leaf, leafCompareWithoutProperties, true);
         if (!leavesToSaplingMap.containsKey(store))
         {
             leavesToSaplingMap.put(store, new ItemStorage(stack, false, true));

--- a/src/api/java/com/minecolonies/api/compatibility/CompatibilityManager.java
+++ b/src/api/java/com/minecolonies/api/compatibility/CompatibilityManager.java
@@ -6,13 +6,16 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.minecolonies.api.configuration.Configurations;
 import com.minecolonies.api.crafting.ItemStorage;
+import com.minecolonies.api.util.BlockStateStorage;
 import com.minecolonies.api.util.ItemStackUtils;
 import com.minecolonies.api.util.Log;
 import com.minecolonies.api.util.NBTUtils;
 import net.minecraft.block.Block;
-import net.minecraft.block.BlockLeaves;
 import net.minecraft.block.BlockOre;
 import net.minecraft.block.BlockRedstoneOre;
+import net.minecraft.block.properties.IProperty;
+import net.minecraft.block.properties.PropertyBool;
+import net.minecraft.block.properties.PropertyInteger;
 import net.minecraft.block.state.IBlockState;
 import net.minecraft.creativetab.CreativeTabs;
 import net.minecraft.init.Items;
@@ -33,9 +36,7 @@ import java.util.*;
 import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
 
-import static com.minecolonies.api.util.constant.Constants.ONE_HUNDRED_PERCENT;
-import static com.minecolonies.api.util.constant.Constants.ORE_STRING;
-import static com.minecolonies.api.util.constant.Constants.SAPLINGS;
+import static com.minecolonies.api.util.constant.Constants.*;
 import static com.minecolonies.api.util.constant.NbtTagConstants.TAG_SAP_LEAF;
 
 /**
@@ -46,13 +47,25 @@ public class CompatibilityManager implements ICompatibilityManager
     /**
      * BiMap of saplings and leaves.
      */
-    private final BiMap<IBlockState, ItemStorage> leavesToSaplingMap = HashBiMap.create();
+    private final BiMap<BlockStateStorage, ItemStorage> leavesToSaplingMap = HashBiMap.create();
 
     /**
      * List of saplings.
      * Works on client and server-side.
      */
     private final List<ItemStorage> saplings = new ArrayList<>();
+
+    /**
+     * List of properties we're ignoring when comparing leaves.
+     */
+    private final List<IProperty> leafCompareWithoutProperties = ImmutableList.of(checkDecay, decayable, DYN_PROP_HYDRO);
+
+    /**
+     * Properties for leaves we're ignoring upon comparing.
+     */
+    public static final PropertyBool    checkDecay     = PropertyBool.create("check_decay");
+    public static final PropertyBool    decayable      = PropertyBool.create("decayable");
+    public static final PropertyInteger DYN_PROP_HYDRO = PropertyInteger.create("hydro", 1, 4);
 
     /**
      * List of all ore-like blocks.
@@ -165,7 +178,7 @@ public class CompatibilityManager implements ICompatibilityManager
      */
     private void discoverBlockList()
     {
-        allBlocks =  ImmutableList.copyOf(StreamSupport.stream(Spliterators.spliteratorUnknownSize(Item.REGISTRY.iterator(), Spliterator.ORDERED), false).flatMap(item -> {
+        allBlocks = ImmutableList.copyOf(StreamSupport.stream(Spliterators.spliteratorUnknownSize(Item.REGISTRY.iterator(), Spliterator.ORDERED), false).flatMap(item -> {
             final NonNullList<ItemStack> stacks = NonNullList.create();
             try
             {
@@ -182,6 +195,7 @@ public class CompatibilityManager implements ICompatibilityManager
 
     /**
      * Getter for the list.
+     *
      * @return the list of itemStacks.
      */
     @Override
@@ -245,7 +259,7 @@ public class CompatibilityManager implements ICompatibilityManager
     {
         if (leavesToSaplingMap.inverse().containsKey(new ItemStorage(stack, false, true)))
         {
-            return leavesToSaplingMap.inverse().get(new ItemStorage(stack, false, true));
+            return leavesToSaplingMap.inverse().get(new ItemStorage(stack, false, true)).getState();
         }
         return null;
     }
@@ -253,8 +267,8 @@ public class CompatibilityManager implements ICompatibilityManager
     @Override
     public ItemStack getSaplingForLeaf(final IBlockState block)
     {
-        final ItemStack stack = new ItemStack(block.getBlock(), 1, block.getBlock().getMetaFromState(block));
-        final IBlockState tempLeaf = BlockLeaves.getBlockFromItem(stack.getItem()).getStateFromMeta(stack.getMetadata());
+        BlockStateStorage tempLeaf = new BlockStateStorage(block, leafCompareWithoutProperties, true);
+
         if (leavesToSaplingMap.containsKey(tempLeaf))
         {
             return leavesToSaplingMap.get(tempLeaf).getItemStack();
@@ -305,6 +319,7 @@ public class CompatibilityManager implements ICompatibilityManager
 
     /**
      * Getter for all the crusher modes.
+     *
      * @return an immutable copy of the map.
      */
     @Override
@@ -317,7 +332,7 @@ public class CompatibilityManager implements ICompatibilityManager
     public void writeToNBT(@NotNull final NBTTagCompound compound)
     {
         @NotNull final NBTTagList saplingsLeavesTagList =
-          leavesToSaplingMap.entrySet().stream().map(entry -> writeLeafSaplingEntryToNBT(entry.getKey(), entry.getValue())).collect(NBTUtils.toNBTTagList());
+          leavesToSaplingMap.entrySet().stream().map(entry -> writeLeafSaplingEntryToNBT(entry.getKey().getState(), entry.getValue())).collect(NBTUtils.toNBTTagList());
         compound.setTag(TAG_SAP_LEAF, saplingsLeavesTagList);
     }
 
@@ -327,17 +342,16 @@ public class CompatibilityManager implements ICompatibilityManager
         NBTUtils.streamCompound(compound.getTagList(TAG_SAP_LEAF, Constants.NBT.TAG_COMPOUND))
           .map(CompatibilityManager::readLeafSaplingEntryFromNBT)
           .filter(key -> !leavesToSaplingMap.containsKey(key.getFirst()) && !leavesToSaplingMap.containsValue(key.getSecond()))
-          .forEach(key -> leavesToSaplingMap.put(key.getFirst(), key.getSecond()));
+          .forEach(key -> leavesToSaplingMap.put(new BlockStateStorage(key.getFirst(), leafCompareWithoutProperties, true), key.getSecond()));
     }
 
     @Override
     public void connectLeafToSapling(final IBlockState leaf, final ItemStack stack)
     {
-        final ItemStack tempStack = new ItemStack(leaf.getBlock(), 1, leaf.getBlock().getMetaFromState(leaf));
-        final IBlockState tempLeaf = BlockLeaves.getBlockFromItem(tempStack.getItem()).getStateFromMeta(tempStack.getMetadata());
-        if (!leavesToSaplingMap.containsKey(tempLeaf) && !leavesToSaplingMap.containsValue(new ItemStorage(stack, false, true)))
+        BlockStateStorage store = new BlockStateStorage(leaf, leafCompareWithoutProperties, true);
+        if (!leavesToSaplingMap.containsKey(store))
         {
-            leavesToSaplingMap.put(tempLeaf, new ItemStorage(stack, false, true));
+            leavesToSaplingMap.put(store, new ItemStorage(stack, false, true));
         }
     }
 
@@ -462,7 +476,7 @@ public class CompatibilityManager implements ICompatibilityManager
                 final String[] split = ore.split("!");
                 if (split.length < 2)
                 {
-                    Log.getLogger().warn("Wrong configured ore: " +  ore);
+                    Log.getLogger().warn("Wrong configured ore: " + ore);
                     continue;
                 }
 
@@ -515,7 +529,7 @@ public class CompatibilityManager implements ICompatibilityManager
 
             if (mesh.length != 2)
             {
-                Log.getLogger().warn("Couldn't parse the mesh: " +  string);
+                Log.getLogger().warn("Couldn't parse the mesh: " + string);
                 continue;
             }
 
@@ -651,7 +665,7 @@ public class CompatibilityManager implements ICompatibilityManager
                 {
                     final ItemStorage storage = drops.getKey();
                     final double probability = drops.getValue();
-                    probabilitySum+=probability;
+                    probabilitySum += probability;
                     for (int i = 0; i < probability; i++)
                     {
                         theDrops.add(storage);

--- a/src/api/java/com/minecolonies/api/util/BlockStateStorage.java
+++ b/src/api/java/com/minecolonies/api/util/BlockStateStorage.java
@@ -52,7 +52,7 @@ public class BlockStateStorage
         if (!exclude)
         {
             // hashcode only for included properties
-            for (IProperty prop : compareProperties)
+            for (final IProperty prop : compareProperties)
             {
                 if (state.getPropertyKeys().contains(prop))
                 {
@@ -64,7 +64,7 @@ public class BlockStateStorage
         else
         {
             // hashcode for all except the excluded properties
-            for (IProperty prop : state.getPropertyKeys())
+            for (final IProperty prop : state.getPropertyKeys())
             {
                 if (!compareProperties.contains(prop))
                 {

--- a/src/api/java/com/minecolonies/api/util/BlockStateStorage.java
+++ b/src/api/java/com/minecolonies/api/util/BlockStateStorage.java
@@ -122,7 +122,7 @@ public class BlockStateStorage
 
         if (exclude)
         {
-            for (IProperty prop : state.getPropertyKeys())
+            for (final IProperty prop : state.getPropertyKeys())
             {
                 // skip excluded properties upon comparing
                 if (getCompareProperties().contains(prop))

--- a/src/api/java/com/minecolonies/api/util/BlockStateStorage.java
+++ b/src/api/java/com/minecolonies/api/util/BlockStateStorage.java
@@ -1,0 +1,162 @@
+package com.minecolonies.api.util;
+
+import net.minecraft.block.properties.IProperty;
+import net.minecraft.block.state.IBlockState;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.List;
+
+/**
+ * Stores a blockstate for comparing.
+ */
+public class BlockStateStorage
+{
+    /**
+     * The state to store.
+     */
+    private final IBlockState state;
+
+    /**
+     * List of properties used to compare
+     */
+    private final List<IProperty> propertyList;
+
+    /**
+     * Hashcode of the storage.
+     */
+    private int hashCode;
+
+    /**
+     * True: states are compared ignoring the properties in the given propertyList.
+     * False: states are only compared within the properties on the propertyList.
+     */
+    private final boolean exclude;
+
+    /**
+     * Create an instance of the storage.
+     *
+     * @param state             The blockstate to store
+     * @param compareProperties the list of properties to compare
+     * @param exclude           True: states are compared ignoring the properties in the given list.
+     *                          False: states are only compared within the properties on the list.
+     */
+    public BlockStateStorage(@NotNull final IBlockState state, @NotNull final List<IProperty> compareProperties, final boolean exclude)
+    {
+        this.state = state;
+        this.propertyList = compareProperties;
+        this.exclude = exclude;
+
+        // Calculating the hashcode once
+        hashCode = state.getBlock().hashCode();
+
+        if (!exclude)
+        {
+            // hashcode only for included properties
+            for (IProperty prop : compareProperties)
+            {
+                if (state.getPropertyKeys().contains(prop))
+                {
+                    hashCode += prop.hashCode();
+                    hashCode += state.getValue(prop).hashCode();
+                }
+            }
+        }
+        else
+        {
+            // hashcode for all except the excluded properties
+            for (IProperty prop : state.getPropertyKeys())
+            {
+                if (!compareProperties.contains(prop))
+                {
+                    hashCode += prop.hashCode();
+                    hashCode += state.getValue(prop).hashCode();
+                }
+            }
+        }
+    }
+
+    /**
+     * Returns the stored state
+     *
+     * @return state
+     */
+    public IBlockState getState()
+    {
+        return state;
+    }
+
+    /**
+     * Gets the list of the properties this storage uses to compare storages.
+     *
+     * @return property list
+     */
+    public List<IProperty> getCompareProperties()
+    {
+        return propertyList;
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return hashCode;
+    }
+
+    @Override
+    public boolean equals(final Object o)
+    {
+        if (this == o)
+        {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass())
+        {
+            return false;
+        }
+
+        final BlockStateStorage comparingToStorage = (BlockStateStorage) o;
+
+        if (comparingToStorage.getState() == state)
+        {
+            return true;
+        }
+
+        if (exclude)
+        {
+            for (IProperty prop : state.getPropertyKeys())
+            {
+                // skip excluded properties upon comparing
+                if (getCompareProperties().contains(prop))
+                {
+                    continue;
+                }
+
+                if (!comparingToStorage.getState().getPropertyKeys().contains(prop))
+                {
+                    return false;
+                }
+
+                if (!comparingToStorage.getState().getValue(prop).equals(state.getValue(prop)))
+                {
+                    return false;
+                }
+            }
+        }
+        else
+        {
+            for (final IProperty prop : propertyList)
+            {
+                if (!comparingToStorage.getState().getPropertyKeys().contains(prop))
+                {
+                    return false;
+                }
+
+                if (!comparingToStorage.getState().getValue(prop).equals(state.getValue(prop)))
+                {
+                    return false;
+                }
+            }
+        }
+
+        return true;
+    }
+}

--- a/src/main/java/com/minecolonies/coremod/entity/ai/citizen/lumberjack/Tree.java
+++ b/src/main/java/com/minecolonies/coremod/entity/ai/citizen/lumberjack/Tree.java
@@ -437,12 +437,16 @@ public class Tree
      */
     private static boolean supposedToCut(final IBlockAccess world, final List<ItemStorage> treesToNotCut, final BlockPos leafPos)
     {
+        final ItemStack sap = ColonyManager.getCompatibilityManager().getSaplingForLeaf(world.getBlockState(leafPos));
+
+        if (sap == null)
+        {
+            return true;
+        }
+
         for (final ItemStorage stack : treesToNotCut)
         {
-            IBlockState bState = world.getBlockState(leafPos);
-
-            final ItemStack sap = ColonyManager.getCompatibilityManager().getSaplingForLeaf(bState);
-            if (sap != null && ItemStackUtils.compareItemStacksIgnoreStackSize(sap, stack.getItemStack()))
+            if (ItemStackUtils.compareItemStacksIgnoreStackSize(sap, stack.getItemStack()))
             {
                 return false;
             }

--- a/src/main/java/com/minecolonies/coremod/entity/ai/citizen/lumberjack/Tree.java
+++ b/src/main/java/com/minecolonies/coremod/entity/ai/citizen/lumberjack/Tree.java
@@ -13,7 +13,6 @@ import net.minecraft.block.Block;
 import net.minecraft.block.BlockLeaves;
 import net.minecraft.block.material.Material;
 import net.minecraft.block.properties.IProperty;
-import net.minecraft.block.properties.PropertyInteger;
 import net.minecraft.block.state.IBlockState;
 import net.minecraft.init.Blocks;
 import net.minecraft.item.ItemStack;
@@ -34,6 +33,7 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Random;
 
+import static com.minecolonies.api.compatibility.CompatibilityManager.DYN_PROP_HYDRO;
 import static com.minecolonies.api.util.constant.Constants.SAPLINGS;
 import static com.minecolonies.api.util.constant.NbtTagConstants.*;
 
@@ -116,12 +116,6 @@ public class Tree
      * If the tree is a Dynamic Tree
      */
     private boolean dynamicTree = false;
-
-    /**
-     * Properties used by DynamicTree's leaves
-     */
-    private static final PropertyInteger DYN_PROP_HYDRO = PropertyInteger.create("hydro", 1, 4);
-    private static final PropertyInteger DYN_PROP_TREE  = PropertyInteger.create("tree", 0, 3);
 
     /**
      * Private constructor of the tree.
@@ -246,7 +240,7 @@ public class Tree
             if (Compatibility.isDynamicLeaf(block))
             {
                 list = (Compatibility.getDropsForDynamicLeaf(world, pos, blockState, A_LOT_OF_LUCK, block));
-                blockState = blockState.withProperty(DYN_PROP_HYDRO, 1).withProperty(DYN_PROP_TREE, 1);
+                blockState = blockState.withProperty(DYN_PROP_HYDRO, 1);
             }
             else
             {
@@ -446,12 +440,9 @@ public class Tree
         for (final ItemStorage stack : treesToNotCut)
         {
             IBlockState bState = world.getBlockState(leafPos);
-            if (Compatibility.isDynamicLeaf(bState.getBlock()))
-            {
-                bState = bState.withProperty(DYN_PROP_HYDRO, 1).withProperty(DYN_PROP_TREE, 1);
-            }
+
             final ItemStack sap = ColonyManager.getCompatibilityManager().getSaplingForLeaf(bState);
-            if (sap != null && sap.isItemEqual(stack.getItemStack()))
+            if (sap != null && ItemStackUtils.compareItemStacksIgnoreStackSize(sap, stack.getItemStack()))
             {
                 return false;
             }


### PR DESCRIPTION
# Changes proposed in this pull request:
-fixes the lumberjack's sapling to leaf mapping, so the on/off toggles in the gui are correct
-added a BlockStateStorage, similar to Itemstorage for using states as map keys and comparing them easily

Review please
