### PR TITLE
Fixing lumberjacks sapling map to support modded leaves

### DIFF
--- a/src/api/java/com/minecolonies/api/compatibility/CompatibilityManager.java
+++ b/src/api/java/com/minecolonies/api/compatibility/CompatibilityManager.java
@@ -1,7 +1,5 @@
 package com.minecolonies.api.compatibility;
 
-import com.google.common.collect.BiMap;
-import com.google.common.collect.HashBiMap;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.minecolonies.api.configuration.Configurations;
@@ -47,7 +45,7 @@ public class CompatibilityManager implements ICompatibilityManager
     /**
      * BiMap of saplings and leaves.
      */
-    private final BiMap<BlockStateStorage, ItemStorage> leavesToSaplingMap = HashBiMap.create();
+    private final HashMap<BlockStateStorage, ItemStorage> leavesToSaplingMap = new HashMap<>();
 
     /**
      * List of saplings.
@@ -252,16 +250,6 @@ public class CompatibilityManager implements ICompatibilityManager
             }
         }
         return false;
-    }
-
-    @Override
-    public IBlockState getLeafForSapling(final ItemStack stack)
-    {
-        if (leavesToSaplingMap.inverse().containsKey(new ItemStorage(stack, false, true)))
-        {
-            return leavesToSaplingMap.inverse().get(new ItemStorage(stack, false, true)).getState();
-        }
-        return null;
     }
 
     @Override

--- a/src/api/java/com/minecolonies/api/compatibility/CompatibilityManager.java
+++ b/src/api/java/com/minecolonies/api/compatibility/CompatibilityManager.java
@@ -45,7 +45,7 @@ public class CompatibilityManager implements ICompatibilityManager
     /**
      * BiMap of saplings and leaves.
      */
-    private final HashMap<BlockStateStorage, ItemStorage> leavesToSaplingMap = new HashMap<>();
+    private final Map<BlockStateStorage, ItemStorage> leavesToSaplingMap = new HashMap<>();
 
     /**
      * List of saplings.

--- a/src/api/java/com/minecolonies/api/compatibility/ICompatibilityManager.java
+++ b/src/api/java/com/minecolonies/api/compatibility/ICompatibilityManager.java
@@ -43,13 +43,6 @@ public interface ICompatibilityManager
     void discover();
 
     /**
-     * Gets the leave matching a sapling.
-     * @param stack the sapling.
-     * @return the leave block.
-     */
-    IBlockState getLeafForSapling(final ItemStack stack);
-
-    /**
      * Gets the sapling matching a leave.
      * @param block the leave.
      * @return the sapling stack.

--- a/src/main/java/com/minecolonies/coremod/entity/ai/citizen/lumberjack/Tree.java
+++ b/src/main/java/com/minecolonies/coremod/entity/ai/citizen/lumberjack/Tree.java
@@ -311,7 +311,8 @@ public class Tree
 
         // Only harvest nearly fully grown dynamic trees(8 max)
         if (Compatibility.isDynamicBlock(block)
-              && (int) state.getValue(BlockStateUtils.getPropertyByNameFromState(state, DYNAMICTREERADIUS)) < Configurations.compatibility.dynamicTreeHarvestSize)
+              && BlockStateUtils.getPropertyByNameFromState(state, DYNAMICTREERADIUS) != null
+              && ((int) state.getValue(BlockStateUtils.getPropertyByNameFromState(state, DYNAMICTREERADIUS)) < Configurations.compatibility.dynamicTreeHarvestSize))
         {
             return false;
         }


### PR DESCRIPTION
Closes #3684 
Closes #3672

# Changes proposed in this pull request:
- Fixing lumberjacks sapling map to support modded leaves
- Fix tree detection exception with dynamic cacti(they still do not count as tree and are not cut)

Changed the HashBIMap to a normal Hashmap as with modded leaves properties like hydration gives us multiple valid states for the same sapling which drops from them all, thus the 1:1 relation of the HashBiMap doesnt work for it.

Review please
