### PR TITLE
Fix wrong naming of cached schems

### DIFF
--- a/src/main/java/com/minecolonies/coremod/network/messages/BuildToolPlaceMessage.java
+++ b/src/main/java/com/minecolonies/coremod/network/messages/BuildToolPlaceMessage.java
@@ -77,13 +77,14 @@ public class BuildToolPlaceMessage extends AbstractMessage<BuildToolPlaceMessage
     /**
      * Create the building that was made with the build tool.
      * Item in inventory required
-     *  @param structureName String representation of a structure
+     *
+     * @param structureName String representation of a structure
      * @param workOrderName String name of the work order
      * @param pos           BlockPos
      * @param rotation      int representation of the rotation
      * @param isHut         true if hut, false if decoration
      * @param mirror        the mirror of the building or decoration.
-     * @param state the state.
+     * @param state         the state.
      */
     public BuildToolPlaceMessage(
       final String structureName,
@@ -124,7 +125,6 @@ public class BuildToolPlaceMessage extends AbstractMessage<BuildToolPlaceMessage
         mirror = buf.readBoolean();
 
         state = NBTUtil.readBlockState(ByteBufUtils.readTag(buf));
-
     }
 
     /**
@@ -210,7 +210,8 @@ public class BuildToolPlaceMessage extends AbstractMessage<BuildToolPlaceMessage
 
                 boolean complete = false;
                 int level = 0;
-                final int slot = InventoryUtils.findFirstSlotInItemHandlerWith(new InvWrapper(player.inventory), itemStack -> itemStack.isItemEqual(new ItemStack(Item.getItemFromBlock(block), 1)));
+                final int slot = InventoryUtils.findFirstSlotInItemHandlerWith(new InvWrapper(player.inventory),
+                  itemStack -> itemStack.isItemEqual(new ItemStack(Item.getItemFromBlock(block), 1)));
                 if (slot != -1)
                 {
                     final ItemStack stack = player.inventory.getStackInSlot(slot);
@@ -224,10 +225,10 @@ public class BuildToolPlaceMessage extends AbstractMessage<BuildToolPlaceMessage
                         if (compound.hasKey(TAG_PASTEABLE))
                         {
                             String schematic = sn.toString();
-                            schematic = schematic.substring(0, schematic.length()-1);
+                            schematic = schematic.substring(0, schematic.length() - 1);
                             schematic += level;
                             InstantStructurePlacer.loadAndPlaceStructureWithRotation(player.world, schematic,
-                              buildPos, rotation,mirror ? Mirror.FRONT_BACK : Mirror.NONE, false);
+                              buildPos, rotation, mirror ? Mirror.FRONT_BACK : Mirror.NONE, false);
                             complete = true;
                         }
                     }
@@ -254,9 +255,9 @@ public class BuildToolPlaceMessage extends AbstractMessage<BuildToolPlaceMessage
      * @param mirror        Whether or not the strcture is mirrored.
      */
     private static void handleDecoration(
-                                          @NotNull final World world, @NotNull final EntityPlayer player,
-                                          final StructureName sn, final String workOrderName,
-                                          final int rotation, @NotNull final BlockPos buildPos, final boolean mirror)
+      @NotNull final World world, @NotNull final EntityPlayer player,
+      final StructureName sn, final String workOrderName,
+      final int rotation, @NotNull final BlockPos buildPos, final boolean mirror)
     {
         @Nullable final IColony colony = IColonyManager.getInstance().getColonyByPosFromWorld(world, buildPos);
         if (colony != null && colony.getPermissions().hasPermission(player, Action.PLACE_HUTS))
@@ -264,17 +265,20 @@ public class BuildToolPlaceMessage extends AbstractMessage<BuildToolPlaceMessage
             String schem = sn.toString();
             String woName = workOrderName;
 
-            if (schem.matches("^.*[a-zA-Z_-]\\d$"))
+            if (!schem.contains("cache"))
             {
+                if (schem.matches("^.*[a-zA-Z_-]\\d$"))
+                {
 
-                schem = schem.replaceAll("\\d$", "");
-                schem+='1';
-            }
+                    schem = schem.replaceAll("\\d$", "");
+                    schem += '1';
+                }
 
-            if (woName.matches("^.*[a-zA-Z_-]\\d$"))
-            {
-                woName = woName.replaceAll("\\d$", "");
-                woName+='1';
+                if (woName.matches("^.*[a-zA-Z_-]\\d$"))
+                {
+                    woName = woName.replaceAll("\\d$", "");
+                    woName += '1';
+                }
             }
 
             colony.getWorkManager().addWorkOrder(new WorkOrderBuildDecoration(schem, woName, rotation, buildPos, mirror), false);
@@ -287,14 +291,15 @@ public class BuildToolPlaceMessage extends AbstractMessage<BuildToolPlaceMessage
 
     /**
      * setup the building once it has been placed.
-     * @param world         World the hut is being placed into.
-     * @param player        Who placed the hut.
-     * @param sn            The name of the structure.
-     * @param rotation      The number of times the structure should be rotated.
-     * @param buildPos      The location the hut is being placed.
-     * @param mirror        Whether or not the structure is mirrored.
-     * @param level         the future initial building level.
-     * @param complete      if pasted.
+     *
+     * @param world    World the hut is being placed into.
+     * @param player   Who placed the hut.
+     * @param sn       The name of the structure.
+     * @param rotation The number of times the structure should be rotated.
+     * @param buildPos The location the hut is being placed.
+     * @param mirror   Whether or not the structure is mirrored.
+     * @param level    the future initial building level.
+     * @param complete if pasted.
      */
     private static void setupBuilding(
       @NotNull final World world, @NotNull final EntityPlayer player,


### PR DESCRIPTION
Closes #3950
Closes #
Closes #

# Changes proposed in this pull request:
- Cached schems might have a number in the end and letters before it making it seem like a leveled schem which breaks the flow
-
-

Review please
