### PR TITLE
don't run the avoidance AI if guard

### DIFF
--- a/src/api/java/com/minecolonies/api/colony/jobs/IJob.java
+++ b/src/api/java/com/minecolonies/api/colony/jobs/IJob.java
@@ -209,4 +209,10 @@ public interface IJob<AI extends EntityAIBase> extends INBTSerializable<NBTTagCo
      * Reset the AI after eating at a restaurant
      */
     void resetAIAfterEating();
+
+    /**
+     * Method to check if the colony job allows avoidance.
+     * @return true if so.
+     */
+    boolean allowsAvoidance();
 }

--- a/src/api/java/com/minecolonies/api/entity/citizen/citizenhandlers/ICitizenJobHandler.java
+++ b/src/api/java/com/minecolonies/api/entity/citizen/citizenhandlers/ICitizenJobHandler.java
@@ -35,4 +35,10 @@ public interface ICitizenJobHandler
      */
     @Nullable
     IJob getColonyJob();
+
+    /**
+     * Method to check if the citizen job allows to run the avoidance task.
+     * @return true if so.
+     */
+    boolean shouldRunAvoidance();
 }

--- a/src/api/java/com/minecolonies/api/tileentities/TileEntityRack.java
+++ b/src/api/java/com/minecolonies/api/tileentities/TileEntityRack.java
@@ -530,6 +530,10 @@ public class TileEntityRack extends AbstractTileEntityRack
     @Override
     public BlockPos getNeighbor()
     {
+        if (relativeNeighbor == null)
+        {
+            return null;
+        }
         return pos.subtract(relativeNeighbor);
     }
 

--- a/src/main/java/com/minecolonies/coremod/colony/jobs/AbstractJob.java
+++ b/src/main/java/com/minecolonies/coremod/colony/jobs/AbstractJob.java
@@ -430,4 +430,10 @@ public abstract class AbstractJob<AI extends AbstractAISkeleton<J>, J extends Ab
             workerAI.get().resetAI();
         }
     }
+
+    @Override
+    public boolean allowsAvoidance()
+    {
+        return true;
+    }
 }

--- a/src/main/java/com/minecolonies/coremod/colony/jobs/AbstractJobGuard.java
+++ b/src/main/java/com/minecolonies/coremod/colony/jobs/AbstractJobGuard.java
@@ -83,6 +83,6 @@ public abstract class AbstractJobGuard extends AbstractJob
     @Override
     public boolean allowsAvoidance()
     {
-        return true;
+        return false;
     }
 }

--- a/src/main/java/com/minecolonies/coremod/colony/jobs/AbstractJobGuard.java
+++ b/src/main/java/com/minecolonies/coremod/colony/jobs/AbstractJobGuard.java
@@ -79,4 +79,10 @@ public abstract class AbstractJobGuard extends AbstractJob
         }
         return null;
     }
+
+    @Override
+    public boolean allowsAvoidance()
+    {
+        return true;
+    }
 }

--- a/src/main/java/com/minecolonies/coremod/entity/ai/minimal/EntityAICitizenAvoidEntity.java
+++ b/src/main/java/com/minecolonies/coremod/entity/ai/minimal/EntityAICitizenAvoidEntity.java
@@ -225,7 +225,7 @@ public class EntityAICitizenAvoidEntity extends EntityAIBase
     @Override
     public boolean shouldExecute()
     {
-        if (citizen.isCurrentlyFleeing() && !(citizen.getCitizenJobHandler().getColonyJob() instanceof AbstractJobGuard))
+        if (citizen.isCurrentlyFleeing() && citizen.getCitizenJobHandler().shouldRunAvoidance())
         {
             startingPos = citizen.getPosition();
             fleeingCounter = 0;
@@ -241,7 +241,7 @@ public class EntityAICitizenAvoidEntity extends EntityAIBase
     public boolean shouldContinueExecuting()
     {
         stateMachine.tick();
-        return citizen.isCurrentlyFleeing() && !(citizen.getCitizenJobHandler().getColonyJob() instanceof AbstractJobGuard);
+        return citizen.isCurrentlyFleeing() && citizen.getCitizenJobHandler().shouldRunAvoidance();
     }
 
     /**

--- a/src/main/java/com/minecolonies/coremod/entity/ai/minimal/EntityAICitizenAvoidEntity.java
+++ b/src/main/java/com/minecolonies/coremod/entity/ai/minimal/EntityAICitizenAvoidEntity.java
@@ -225,7 +225,7 @@ public class EntityAICitizenAvoidEntity extends EntityAIBase
     @Override
     public boolean shouldExecute()
     {
-        if (citizen.isCurrentlyFleeing())
+        if (citizen.isCurrentlyFleeing() && !(citizen.getCitizenJobHandler().getColonyJob() instanceof AbstractJobGuard))
         {
             startingPos = citizen.getPosition();
             fleeingCounter = 0;
@@ -241,7 +241,7 @@ public class EntityAICitizenAvoidEntity extends EntityAIBase
     public boolean shouldContinueExecuting()
     {
         stateMachine.tick();
-        return citizen.isCurrentlyFleeing();
+        return citizen.isCurrentlyFleeing() && !(citizen.getCitizenJobHandler().getColonyJob() instanceof AbstractJobGuard);
     }
 
     /**

--- a/src/main/java/com/minecolonies/coremod/entity/citizen/citizenhandlers/CitizenJobHandler.java
+++ b/src/main/java/com/minecolonies/coremod/entity/citizen/citizenhandlers/CitizenJobHandler.java
@@ -127,4 +127,10 @@ public class CitizenJobHandler implements ICitizenJobHandler
     {
         return citizen.getCitizenData() == null ? null : citizen.getCitizenData().getJob();
     }
+
+    @Override
+    public boolean shouldRunAvoidance()
+    {
+        return getColonyJob() != null && getColonyJob().allowsAvoidance();
+    }
 }

--- a/src/main/java/com/minecolonies/coremod/entity/citizen/citizenhandlers/CitizenJobHandler.java
+++ b/src/main/java/com/minecolonies/coremod/entity/citizen/citizenhandlers/CitizenJobHandler.java
@@ -131,6 +131,6 @@ public class CitizenJobHandler implements ICitizenJobHandler
     @Override
     public boolean shouldRunAvoidance()
     {
-        return getColonyJob() != null && getColonyJob().allowsAvoidance();
+        return getColonyJob() == null || getColonyJob().allowsAvoidance();
     }
 }


### PR DESCRIPTION
Closes ##3955

# Changes proposed in this pull request:
- After some time of debugging I found out that the reason the guards get stuck on pathing is the avoidance AI which is not disabled for them.
-
-

Review please
