### PR TITLE
Improve backup loading

### DIFF
--- a/src/api/java/com/minecolonies/api/colony/HappinessData.java
+++ b/src/api/java/com/minecolonies/api/colony/HappinessData.java
@@ -212,6 +212,7 @@ public class HappinessData
 
         final int numDeaths = tagCompound.getInteger(TAG_TOTAL_DEATH_MODIFIER);
         final NBTTagList deathTagList = tagCompound.getTagList(TAG_DEATH_MODIFIER, Constants.NBT.TAG_COMPOUND);
+        deathModifier.clear();
         for (int i = 0; i < numDeaths; ++i)
         {
             final NBTTagCompound deathCompound = deathTagList.getCompoundTagAt(i);

--- a/src/main/java/com/minecolonies/coremod/colony/Colony.java
+++ b/src/main/java/com/minecolonies/coremod/colony/Colony.java
@@ -448,6 +448,7 @@ public class Colony implements IColony
         //  Workload
         workManager.readFromNBT(compound.getCompoundTag(TAG_WORK));
 
+        wayPoints.clear();
         // Waypoints
         final NBTTagList wayPointTagList = compound.getTagList(TAG_WAYPOINT, NBT.TAG_COMPOUND);
         for (int i = 0; i < wayPointTagList.tagCount(); ++i)
@@ -458,6 +459,7 @@ public class Colony implements IColony
             wayPoints.put(pos, state);
         }
 
+        freeBlocks.clear();
         // Free blocks
         final NBTTagList freeBlockTagList = compound.getTagList(TAG_FREE_BLOCKS, NBT.TAG_STRING);
         for (int i = 0; i < freeBlockTagList.tagCount(); ++i)
@@ -465,6 +467,7 @@ public class Colony implements IColony
             freeBlocks.add(Block.getBlockFromName(freeBlockTagList.getStringTagAt(i)));
         }
 
+        freePositions.clear();
         // Free positions
         final NBTTagList freePositionTagList = compound.getTagList(TAG_FREE_POSITIONS, NBT.TAG_COMPOUND);
         for (int i = 0; i < freePositionTagList.tagCount(); ++i)

--- a/src/main/java/com/minecolonies/coremod/colony/ColonyManager.java
+++ b/src/main/java/com/minecolonies/coremod/colony/ColonyManager.java
@@ -917,6 +917,8 @@ public final class ColonyManager implements IColonyManager
                 c.onWorldLoad(world);
             }
 
+            BackUpHelper.loadMissingColonies();
+
             world.addEventListener(new ColonyManagerWorldAccess());
         }
     }

--- a/src/main/java/com/minecolonies/coremod/colony/ColonyManager.java
+++ b/src/main/java/com/minecolonies/coremod/colony/ColonyManager.java
@@ -910,14 +910,13 @@ public final class ColonyManager implements IColonyManager
                     Log.getLogger().info(String.format("Server UUID %s", serverUUID));
                 }
                 loaded = true;
+                BackUpHelper.loadMissingColonies();
             }
 
             for (@NotNull final IColony c : getColonies(world))
             {
                 c.onWorldLoad(world);
             }
-
-            BackUpHelper.loadMissingColonies();
 
             world.addEventListener(new ColonyManagerWorldAccess());
         }

--- a/src/main/java/com/minecolonies/coremod/colony/managers/BuildingManager.java
+++ b/src/main/java/com/minecolonies/coremod/colony/managers/BuildingManager.java
@@ -230,7 +230,7 @@ public class BuildingManager implements IBuildingManager
             }
         }
 
-        if (removedBuildings.size() >= buildings.values().size())
+        if (!removedBuildings.isEmpty() && removedBuildings.size() >= buildings.values().size())
         {
             Log.getLogger().warn("Colony:"+colony.getID()+" is removing all buildings at once. Did you just load a backup? If not there is a chance that colony data got corrupted and you want to restore a backup.");
         }

--- a/src/main/java/com/minecolonies/coremod/colony/managers/BuildingManager.java
+++ b/src/main/java/com/minecolonies/coremod/colony/managers/BuildingManager.java
@@ -96,6 +96,7 @@ public class BuildingManager implements IBuildingManager
     @Override
     public void readFromNBT(@NotNull final NBTTagCompound compound)
     {
+        buildings.clear();
         //  Buildings
         final NBTTagList buildingTagList = compound.getTagList(TAG_BUILDINGS, Constants.NBT.TAG_COMPOUND);
         for (int i = 0; i < buildingTagList.tagCount(); ++i)
@@ -227,6 +228,11 @@ public class BuildingManager implements IBuildingManager
                     removeField(pos);
                 }
             }
+        }
+
+        if (removedBuildings.size() > 1)
+        {
+            Log.getLogger().warn("Colony:"+colony.getID()+" is removing more than one building at once. Did you just load a backup? If not there is a chance that colony data got corrupted and you want to restore a backup.");
         }
 
         removedBuildings.forEach(IBuilding::destroy);

--- a/src/main/java/com/minecolonies/coremod/colony/managers/BuildingManager.java
+++ b/src/main/java/com/minecolonies/coremod/colony/managers/BuildingManager.java
@@ -230,9 +230,9 @@ public class BuildingManager implements IBuildingManager
             }
         }
 
-        if (removedBuildings.size() > 1)
+        if (removedBuildings.size() >= buildings.values().size())
         {
-            Log.getLogger().warn("Colony:"+colony.getID()+" is removing more than one building at once. Did you just load a backup? If not there is a chance that colony data got corrupted and you want to restore a backup.");
+            Log.getLogger().warn("Colony:"+colony.getID()+" is removing all buildings at once. Did you just load a backup? If not there is a chance that colony data got corrupted and you want to restore a backup.");
         }
 
         removedBuildings.forEach(IBuilding::destroy);

--- a/src/main/java/com/minecolonies/coremod/colony/managers/CitizenManager.java
+++ b/src/main/java/com/minecolonies/coremod/colony/managers/CitizenManager.java
@@ -83,6 +83,7 @@ public class CitizenManager implements ICitizenManager
     {
         maxCitizens = compound.getInteger(TAG_MAX_CITIZENS);
 
+        citizens.clear();
         //  Citizens before Buildings, because Buildings track the Citizens
         citizens.putAll(NBTUtils.streamCompound(compound.getTagList(TAG_CITIZENS, Constants.NBT.TAG_COMPOUND))
                           .map(this::deserializeCitizen)

--- a/src/main/java/com/minecolonies/coremod/colony/managers/ProgressManager.java
+++ b/src/main/java/com/minecolonies/coremod/colony/managers/ProgressManager.java
@@ -188,6 +188,7 @@ public class ProgressManager implements IProgressManager
     @Override
     public void readFromNBT(@NotNull final NBTTagCompound compound)
     {
+        notifiedProgress.clear();
         final NBTTagCompound progressCompound = compound.getCompoundTag(TAG_PROGRESS_MANAGER);
         final NBTTagList progressTags = progressCompound.getTagList(TAG_PROGRESS_LIST, Constants.NBT.TAG_COMPOUND);
         notifiedProgress.addAll(NBTUtils.streamCompound(progressTags)

--- a/src/main/java/com/minecolonies/coremod/colony/managers/RaidManager.java
+++ b/src/main/java/com/minecolonies/coremod/colony/managers/RaidManager.java
@@ -303,6 +303,7 @@ public class RaidManager implements IRaiderManager
     {
         if (compound.hasKey(TAG_RAID_MANAGER))
         {
+            schematicMap.clear();
             final NBTTagCompound raiderCompound = compound.getCompoundTag(TAG_RAID_MANAGER);
             final NBTTagList raiderTags = raiderCompound.getTagList(TAG_SCHEMATIC_LIST, Constants.NBT.TAG_COMPOUND);
             schematicMap.putAll(NBTUtils.streamCompound(raiderTags)

--- a/src/main/java/com/minecolonies/coremod/colony/permissions/Permissions.java
+++ b/src/main/java/com/minecolonies/coremod/colony/permissions/Permissions.java
@@ -290,6 +290,8 @@ public class Permissions implements IPermissions
      */
     public void loadPermissions(@NotNull final NBTTagCompound compound)
     {
+        players.clear();
+        permissionMap.clear();
         //  Owners
         final NBTTagList ownerTagList = compound.getTagList(TAG_OWNERS, net.minecraftforge.common.util.Constants.NBT.TAG_COMPOUND);
         for (int i = 0; i < ownerTagList.tagCount(); ++i)

--- a/src/main/java/com/minecolonies/coremod/colony/workorders/WorkManager.java
+++ b/src/main/java/com/minecolonies/coremod/colony/workorders/WorkManager.java
@@ -200,6 +200,7 @@ public class WorkManager implements IWorkManager
     @Override
     public void readFromNBT(@NotNull final NBTTagCompound compound)
     {
+        workOrders.clear();
         //  Work Orders
         final NBTTagList list = compound.getTagList(TAG_WORK_ORDERS, NBT.TAG_COMPOUND);
         for (int i = 0; i < list.tagCount(); ++i)

--- a/src/main/java/com/minecolonies/coremod/util/BackUpHelper.java
+++ b/src/main/java/com/minecolonies/coremod/util/BackUpHelper.java
@@ -30,6 +30,8 @@ import static com.minecolonies.coremod.MineColonies.COLONY_MANAGER_CAP;
 
 public final class BackUpHelper
 {
+    private final static int MAX_COLONY_LOAD = 5000;
+
     /**
      * Private constructor to hide implicit one.
      */
@@ -102,7 +104,8 @@ public final class BackUpHelper
 
         for (int dim = 0; dim < FMLCommonHandler.instance().getMinecraftServerInstance().worlds.length; dim++)
         {
-            for (int i = 1; i <= IColonyManager.getInstance().getTopColonyId() + 1; i++)
+            int missingFilesInRow = 0;
+            for (int i = 1; i <= MAX_COLONY_LOAD && missingFilesInRow < 5; i++)
             {
                 // Check non-deleted files for colony id + dim
                 @NotNull final File file = new File(saveDir, String.format(FILENAME_COLONY, i, dim));
@@ -113,6 +116,10 @@ public final class BackUpHelper
                     {
                         loadColonyBackup(i, dim);
                     }
+                }
+                else
+                {
+                    missingFilesInRow++;
                 }
             }
         }

--- a/src/main/java/com/minecolonies/coremod/util/BackUpHelper.java
+++ b/src/main/java/com/minecolonies/coremod/util/BackUpHelper.java
@@ -114,6 +114,7 @@ public final class BackUpHelper
                 @NotNull final File file = new File(saveDir, String.format(FILENAME_COLONY, i, dim));
                 if (file.exists())
                 {
+                    missingFilesInRow = 0;
                     // Load colony if null
                     if (IColonyManager.getInstance().getColonyByDimension(i, dim) == null)
                     {

--- a/src/main/java/com/minecolonies/coremod/util/BackUpHelper.java
+++ b/src/main/java/com/minecolonies/coremod/util/BackUpHelper.java
@@ -30,6 +30,9 @@ import static com.minecolonies.coremod.MineColonies.COLONY_MANAGER_CAP;
 
 public final class BackUpHelper
 {
+    /**
+     * The maximum amount of colonies we're trying to load from a backup
+     */
     private final static int MAX_COLONY_LOAD = 5000;
 
     /**

--- a/src/main/java/com/minecolonies/coremod/util/BackUpHelper.java
+++ b/src/main/java/com/minecolonies/coremod/util/BackUpHelper.java
@@ -7,6 +7,7 @@ import com.minecolonies.api.colony.buildings.IBuilding;
 import com.minecolonies.api.configuration.Configurations;
 import com.minecolonies.api.util.Log;
 import com.minecolonies.coremod.colony.Colony;
+import com.minecolonies.coremod.colony.IColonyManagerCapability;
 import net.minecraft.nbt.CompressedStreamTools;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.world.World;
@@ -61,9 +62,9 @@ public final class BackUpHelper
                     if (file.exists())
                     {
                         // mark existing files
-                        if (IColonyManager.getInstance().getColonyByDimension(i,dim) == null)
+                        if (IColonyManager.getInstance().getColonyByDimension(i, dim) == null)
                         {
-                            markColonyDeleted(i,dim);
+                            markColonyDeleted(i, dim);
                             addToZipFile(String.format(FILENAME_COLONY_DELETED, i, dim), zos, saveDir);
                         }
                         else
@@ -93,8 +94,32 @@ public final class BackUpHelper
     }
 
     /**
-     * Get save location for Minecolonies backup data, from the world/save
-     * directory.
+     * Loads all colonies from backup files which the world cap is missing.
+     */
+    public static void loadMissingColonies()
+    {
+        @NotNull final File saveDir = new File(DimensionManager.getWorld(0).getSaveHandler().getWorldDirectory(), FILENAME_MINECOLONIES_PATH);
+
+        for (int dim = 0; dim < FMLCommonHandler.instance().getMinecraftServerInstance().worlds.length; dim++)
+        {
+            for (int i = 1; i <= IColonyManager.getInstance().getTopColonyId() + 1; i++)
+            {
+                // Check non-deleted files for colony id + dim
+                @NotNull final File file = new File(saveDir, String.format(FILENAME_COLONY, i, dim));
+                if (file.exists())
+                {
+                    // Load colony if null
+                    if (IColonyManager.getInstance().getColonyByDimension(i, dim) == null)
+                    {
+                        loadColonyBackup(i, dim);
+                    }
+                }
+            }
+        }
+    }
+
+    /**
+     * Get save location for Minecolonies backup data, from the world/save directory.
      *
      * @return Save file for minecolonies.
      */
@@ -142,8 +167,7 @@ public final class BackUpHelper
     }
 
     /**
-     * Save an NBTTagCompound to a file.  Does so in a safe manner using an
-     * intermediate tmp file.
+     * Save an NBTTagCompound to a file.  Does so in a safe manner using an intermediate tmp file.
      *
      * @param file     The destination file to write the data to.
      * @param compound The NBTTagCompound to write to the file.
@@ -249,7 +273,7 @@ public final class BackUpHelper
         }
         else
         {
-            Log.getLogger().warn("Colony is null, creating new colony!");
+            Log.getLogger().warn("Colony is missing, loading backup!");
             final World colonyWorld = FMLCommonHandler.instance().getMinecraftServerInstance().getWorld(dimension);
             colony = Colony.loadColony(compound, colonyWorld);
             colonyWorld.getCapability(COLONY_MANAGER_CAP, null).addColony(colony);


### PR DESCRIPTION
# Changes proposed in this pull request:
- fix colony readNbt not always resetting existing lists, which caused glitches when using the loadBackup command
- Add backup loading on worldload when the cap is missing a non-deleted colony

Review please
