### PR TITLE
- Fix claiming on 1.14

### DIFF
--- a/src/main/java/com/minecolonies/coremod/colony/ColonyManager.java
+++ b/src/main/java/com/minecolonies/coremod/colony/ColonyManager.java
@@ -361,7 +361,7 @@ public final class ColonyManager implements IColonyManager
         {
             return true;
         }
-        final ChunkLoadStorage storage = worldCapability.getChunkStorage(centralChunk.getPos().getXStart(), centralChunk.getPos().getZStart());
+        final ChunkLoadStorage storage = worldCapability.getChunkStorage(centralChunk.getPos().x, centralChunk.getPos().z);
         if (storage != null)
         {
             storage.applyToCap(colonyCap);

--- a/src/main/java/com/minecolonies/coremod/util/ChunkDataHelper.java
+++ b/src/main/java/com/minecolonies/coremod/util/ChunkDataHelper.java
@@ -288,12 +288,6 @@ public final class ChunkDataHelper
       final World world,
       final BlockPos center)
     {
-        final Chunk centralChunk = world.getChunkAt(center);
-        loadChunkAndAddData(world, center, add, colonyId, center);
-
-        final int chunkX = centralChunk.getPos().x;
-        final int chunkZ = centralChunk.getPos().z;
-
         final IChunkmanagerCapability chunkManager = world.getCapability(CHUNK_STORAGE_UPDATE_CAP, null).orElseGet(null);
         if (chunkManager == null)
         {
@@ -307,6 +301,12 @@ public final class ChunkDataHelper
             return;
         }
 
+        final Chunk centralChunk = world.getChunkAt(center);
+        loadChunkAndAddData(world, center, add, colonyId, center, chunkManager);
+
+        final int chunkX = centralChunk.getPos().x;
+        final int chunkZ = centralChunk.getPos().z;
+
         int additionalChunksToLoad = 0;
         for (int i = chunkX - range; i <= chunkX + range; i++)
         {
@@ -317,7 +317,7 @@ public final class ChunkDataHelper
                 {
                     continue;
                 }
-                if (loadChunkAndAddData(world, pos, add, colonyId, center))
+                if (loadChunkAndAddData(world, pos, add, colonyId, center, chunkManager))
                 {
                     continue;
                 }
@@ -353,18 +353,18 @@ public final class ChunkDataHelper
       final int buffer,
       final World world)
     {
-        final Chunk centralChunk = world.getChunkAt(center);
-        loadChunkAndAddData(world, center, add, colonyId);
-
-        final int chunkX = centralChunk.getPos().x;
-        final int chunkZ = centralChunk.getPos().z;
-
         final IChunkmanagerCapability chunkManager = world.getCapability(CHUNK_STORAGE_UPDATE_CAP, null).orElseGet(null);
         if (chunkManager == null)
         {
             Log.getLogger().error(UNABLE_TO_FIND_WORLD_CAP_TEXT);
             return;
         }
+
+        final Chunk centralChunk = world.getChunkAt(center);
+        loadChunkAndAddData(world, center, add, colonyId, chunkManager);
+
+        final int chunkX = centralChunk.getPos().x;
+        final int chunkZ = centralChunk.getPos().z;
 
         final int maxRange = range * 2 + buffer;
         int additionalChunksToLoad = 0;
@@ -379,7 +379,7 @@ public final class ChunkDataHelper
 
                 if (i >= chunkX - DISTANCE_TO_LOAD_IMMEDIATELY && j >= chunkZ - DISTANCE_TO_LOAD_IMMEDIATELY && i <= chunkX + DISTANCE_TO_LOAD_IMMEDIATELY
                       && j <= chunkZ + DISTANCE_TO_LOAD_IMMEDIATELY
-                      && loadChunkAndAddData(world, new BlockPos(i * BLOCKS_PER_CHUNK, 0, j * BLOCKS_PER_CHUNK), add, colonyId))
+                      && loadChunkAndAddData(world, new BlockPos(i * BLOCKS_PER_CHUNK, 0, j * BLOCKS_PER_CHUNK), add, colonyId, chunkManager))
                 {
                     continue;
                 }
@@ -439,7 +439,7 @@ public final class ChunkDataHelper
      * @param id    the id.
      * @return true if successful.
      */
-    public static boolean loadChunkAndAddData(final World world, final BlockPos pos, final boolean add, final int id)
+    public static boolean loadChunkAndAddData(final World world, final BlockPos pos, final boolean add, final int id, final IChunkmanagerCapability chunkManager)
     {
         if (!world.isBlockLoaded(pos))
         {
@@ -456,6 +456,13 @@ public final class ChunkDataHelper
         if (cap == null)
         {
             return false;
+        }
+
+        // Before directly adding cap data, apply data from our cache.
+        final ChunkLoadStorage chunkLoadStorage = chunkManager.getChunkStorage(chunk.getPos().x, chunk.getPos().z);
+        if (chunkLoadStorage != null)
+        {
+            chunkLoadStorage.applyToCap(cap);
         }
 
         if (add)
@@ -490,7 +497,13 @@ public final class ChunkDataHelper
      * @param buildingPos the building pos.
      * @return true if successful.
      */
-    public static boolean loadChunkAndAddData(final World world, final BlockPos pos, final boolean add, final int id, final BlockPos buildingPos)
+    public static boolean loadChunkAndAddData(
+      final World world,
+      final BlockPos pos,
+      final boolean add,
+      final int id,
+      final BlockPos buildingPos,
+      final IChunkmanagerCapability chunkManager)
     {
         if (!world.isBlockLoaded(pos))
         {
@@ -502,6 +515,13 @@ public final class ChunkDataHelper
         if (cap == null)
         {
             return false;
+        }
+
+        // Before directly adding cap data, apply data from our cache.
+        final ChunkLoadStorage chunkLoadStorage = chunkManager.getChunkStorage(chunk.getPos().x, chunk.getPos().z);
+        if (chunkLoadStorage != null)
+        {
+            chunkLoadStorage.applyToCap(cap);
         }
 
         if (add)


### PR DESCRIPTION
# Changes proposed in this pull request:
- Fixes an issue with chunk claims, where the claim happens and later is overwritten by data from our ChunkLoadStorage cache. Now we apply the cache before modifying the final chunk data. Likely a cause of randomly unclaimed/orphaned chunks
- Added detection to double colonies which could happen because of this claim bug and cause accessibility issues with citizens/buildings and other glitches when two are present in the very same area/with the same owner. Those are logged as warning now, so that users can manually choose the right colony to keep/delete the other.

Review please
