### PR TITLE
Improve Back loading 114

### DIFF
--- a/src/api/java/com/minecolonies/api/colony/HappinessData.java
+++ b/src/api/java/com/minecolonies/api/colony/HappinessData.java
@@ -1,8 +1,8 @@
 package com.minecolonies.api.colony;
 
-import net.minecraft.network.PacketBuffer;
 import net.minecraft.nbt.CompoundNBT;
 import net.minecraft.nbt.ListNBT;
+import net.minecraft.network.PacketBuffer;
 import net.minecraftforge.common.util.Constants;
 import net.minecraftforge.common.util.Constants.NBT;
 import org.jetbrains.annotations.NotNull;
@@ -212,6 +212,7 @@ public class HappinessData
 
         final int numDeaths = tagCompound.getInt(TAG_TOTAL_DEATH_MODIFIER);
         final ListNBT deathTagList = tagCompound.getList(TAG_DEATH_MODIFIER, Constants.NBT.TAG_COMPOUND);
+        deathModifier.clear();
         for (int i = 0; i < numDeaths; ++i)
         {
             final CompoundNBT deathCompound = deathTagList.getCompound(i);

--- a/src/api/java/com/minecolonies/api/util/constant/ColonyConstants.java
+++ b/src/api/java/com/minecolonies/api/util/constant/ColonyConstants.java
@@ -53,7 +53,7 @@ public final class ColonyConstants
     /**
      * How often the subscribers get updated in ticks.
      */
-    public static final int UPDATE_SUBSCRIBERS_INTERVAL = 100;
+    public static final int UPDATE_SUBSCRIBERS_INTERVAL = 20;
 
     /**
      * How often the colony state gets updated in ticks.

--- a/src/main/java/com/minecolonies/coremod/colony/Colony.java
+++ b/src/main/java/com/minecolonies/coremod/colony/Colony.java
@@ -621,6 +621,7 @@ public class Colony implements IColony
         //  Workload
         workManager.read(compound.getCompound(TAG_WORK));
 
+        wayPoints.clear();
         // Waypoints
         final ListNBT wayPointTagList = compound.getList(TAG_WAYPOINT, NBT.TAG_COMPOUND);
         for (int i = 0; i < wayPointTagList.size(); ++i)
@@ -631,6 +632,7 @@ public class Colony implements IColony
             wayPoints.put(pos, state);
         }
 
+        freeBlocks.clear();
         // Free blocks
         final ListNBT freeBlockTagList = compound.getList(TAG_FREE_BLOCKS, NBT.TAG_STRING);
         for (int i = 0; i < freeBlockTagList.size(); ++i)
@@ -638,6 +640,7 @@ public class Colony implements IColony
             freeBlocks.add(ForgeRegistries.BLOCKS.getValue(new ResourceLocation(freeBlockTagList.getString(i))));
         }
 
+        freePositions.clear();
         // Free positions
         final ListNBT freePositionTagList = compound.getList(TAG_FREE_POSITIONS, NBT.TAG_COMPOUND);
         for (int i = 0; i < freePositionTagList.size(); ++i)

--- a/src/main/java/com/minecolonies/coremod/colony/Colony.java
+++ b/src/main/java/com/minecolonies/coremod/colony/Colony.java
@@ -343,7 +343,7 @@ public class Colony implements IColony
         }
         packageManager.updateAwayTime();
 
-        if (loadedChunks.size() > 40 && (!packageManager.getCloseSubscribers().isEmpty() || !packageManager.getImportantColonyPlayers().isEmpty()))
+        if (!packageManager.getCloseSubscribers().isEmpty() || (loadedChunks.size() > 40 && !packageManager.getImportantColonyPlayers().isEmpty()))
         {
             isActive = true;
             return ACTIVE;

--- a/src/main/java/com/minecolonies/coremod/colony/ColonyManager.java
+++ b/src/main/java/com/minecolonies/coremod/colony/ColonyManager.java
@@ -885,6 +885,7 @@ public final class ColonyManager implements IColonyManager
                     Log.getLogger().info(String.format("Server UUID %s", serverUUID));
                 }
                 loaded = true;
+                BackUpHelper.loadMissingColonies();
             }
 
             for (@NotNull final IColony c : getColonies(world))

--- a/src/main/java/com/minecolonies/coremod/colony/managers/BuildingManager.java
+++ b/src/main/java/com/minecolonies/coremod/colony/managers/BuildingManager.java
@@ -93,6 +93,7 @@ public class BuildingManager implements IBuildingManager
     @Override
     public void read(@NotNull final CompoundNBT compound)
     {
+        buildings.clear();
         //  Buildings
         final ListNBT buildingTagList = compound.getList(TAG_BUILDINGS, Constants.NBT.TAG_COMPOUND);
         for (int i = 0; i < buildingTagList.size(); ++i)
@@ -225,6 +226,13 @@ public class BuildingManager implements IBuildingManager
                     removeField(pos);
                 }
             }
+        }
+
+        if (!removedBuildings.isEmpty() && removedBuildings.size() >= buildings.values().size())
+        {
+            Log.getLogger()
+              .warn("Colony:" + colony.getID()
+                      + " is removing all buildings at once. Did you just load a backup? If not there is a chance that colony data got corrupted and you want to restore a backup.");
         }
 
         removedBuildings.forEach(IBuilding::destroy);

--- a/src/main/java/com/minecolonies/coremod/colony/managers/CitizenManager.java
+++ b/src/main/java/com/minecolonies/coremod/colony/managers/CitizenManager.java
@@ -90,6 +90,7 @@ public class CitizenManager implements ICitizenManager
     {
         maxCitizens = compound.getInt(TAG_MAX_CITIZENS);
 
+        citizens.clear();
         //  Citizens before Buildings, because Buildings track the Citizens
         citizens.putAll(NBTUtils.streamCompound(compound.getList(TAG_CITIZENS, Constants.NBT.TAG_COMPOUND))
                           .map(this::deserializeCitizen)

--- a/src/main/java/com/minecolonies/coremod/colony/managers/ProgressManager.java
+++ b/src/main/java/com/minecolonies/coremod/colony/managers/ProgressManager.java
@@ -1,8 +1,8 @@
 package com.minecolonies.coremod.colony.managers;
 
+import com.ldtteam.structurize.util.LanguageHandler;
 import com.minecolonies.api.blocks.ModBlocks;
 import com.minecolonies.api.colony.ColonyProgressType;
-import com.ldtteam.structurize.util.LanguageHandler;
 import com.minecolonies.api.colony.buildings.IBuilding;
 import com.minecolonies.api.colony.managers.interfaces.IProgressManager;
 import com.minecolonies.api.colony.workorders.IWorkOrder;
@@ -188,6 +188,7 @@ public class ProgressManager implements IProgressManager
     @Override
     public void read(@NotNull final CompoundNBT compound)
     {
+        notifiedProgress.clear();
         final CompoundNBT progressCompound = compound.getCompound(TAG_PROGRESS_MANAGER);
         final ListNBT progressTags = progressCompound.getList(TAG_PROGRESS_LIST, Constants.NBT.TAG_COMPOUND);
         notifiedProgress.addAll(NBTUtils.streamCompound(progressTags)

--- a/src/main/java/com/minecolonies/coremod/colony/managers/RaidManager.java
+++ b/src/main/java/com/minecolonies/coremod/colony/managers/RaidManager.java
@@ -305,6 +305,7 @@ public class RaidManager implements IRaiderManager
     @Override
     public void read(@NotNull final CompoundNBT compound)
     {
+        schematicMap.clear();
         if (compound.keySet().contains(TAG_RAID_MANAGER))
         {
             final CompoundNBT raiderCompound = compound.getCompound(TAG_RAID_MANAGER);

--- a/src/main/java/com/minecolonies/coremod/colony/permissions/Permissions.java
+++ b/src/main/java/com/minecolonies/coremod/colony/permissions/Permissions.java
@@ -288,6 +288,8 @@ public class Permissions implements IPermissions
      */
     public void loadPermissions(@NotNull final CompoundNBT compound)
     {
+        players.clear();
+        permissionMap.clear();
         //  Owners
         final ListNBT ownerTagList = compound.getList(TAG_OWNERS, net.minecraftforge.common.util.Constants.NBT.TAG_COMPOUND);
         for (int i = 0; i < ownerTagList.size(); ++i)

--- a/src/main/java/com/minecolonies/coremod/colony/workorders/WorkManager.java
+++ b/src/main/java/com/minecolonies/coremod/colony/workorders/WorkManager.java
@@ -194,6 +194,7 @@ public class WorkManager implements IWorkManager
     @Override
     public void read(@NotNull final CompoundNBT compound)
     {
+        workOrders.clear();
         //  Work Orders
         final ListNBT list = compound.getList(TAG_WORK_ORDERS, NBT.TAG_COMPOUND);
         for (int i = 0; i < list.size(); ++i)


### PR DESCRIPTION
# Changes proposed in this pull request:
- fix colony readNbt not always resetting existing lists, which caused glitches when using the loadBackup command
- Add backup loading on worldload when the cap is missing a non-deleted colony

Review please
