### PR TITLE
Disable crusher and sifter from learning recipes

### DIFF
--- a/src/main/java/com/minecolonies/coremod/colony/buildings/workerbuildings/BuildingCrusher.java
+++ b/src/main/java/com/minecolonies/coremod/colony/buildings/workerbuildings/BuildingCrusher.java
@@ -149,6 +149,12 @@ public class BuildingCrusher extends AbstractBuildingCrafter
         return false;
     }
 
+    @Override
+    public boolean canRecipeBeAdded(final IToken token)
+    {
+        return false;
+    }
+
     /**
      * The the current crusher mode with a certain quantity.
      *

--- a/src/main/java/com/minecolonies/coremod/colony/buildings/workerbuildings/BuildingSifter.java
+++ b/src/main/java/com/minecolonies/coremod/colony/buildings/workerbuildings/BuildingSifter.java
@@ -7,6 +7,7 @@ import com.minecolonies.api.colony.IColonyView;
 import com.minecolonies.api.colony.buildings.ModBuildings;
 import com.minecolonies.api.colony.buildings.registry.BuildingEntry;
 import com.minecolonies.api.colony.jobs.IJob;
+import com.minecolonies.api.colony.requestsystem.token.IToken;
 import com.minecolonies.api.crafting.ItemStorage;
 import com.minecolonies.blockout.views.Window;
 import com.minecolonies.coremod.MineColonies;
@@ -192,6 +193,12 @@ public class BuildingSifter extends AbstractBuildingWorker
         {
             this.sifterMesh = IColonyManager.getInstance().getCompatibilityManager().getMeshes().get(0);
         }
+    }
+
+    @Override
+    public boolean canRecipeBeAdded(final IToken token)
+    {
+        return false;
     }
 
     /**


### PR DESCRIPTION
Closes #4041

# Changes proposed in this pull request:
- Stop crusher and sifter from learning and thus also fulfilling recipes outside of their profession.
-
-

Review please
