### PR TITLE
Hotfix packets and netty memory leak

### DIFF
--- a/src/main/java/com/minecolonies/coremod/colony/managers/BuildingManager.java
+++ b/src/main/java/com/minecolonies/coremod/colony/managers/BuildingManager.java
@@ -501,7 +501,7 @@ public class BuildingManager implements IBuildingManager
             {
                 if (building.isDirty() || !newSubscribers.isEmpty())
                 {
-                    ColonyUtils.sendToAll(players, new ColonyViewBuildingViewMessage(building));
+                    players.forEach(player -> MineColonies.getNetwork().sendTo(new ColonyViewBuildingViewMessage(building), player));
                 }
             }
         }
@@ -519,7 +519,7 @@ public class BuildingManager implements IBuildingManager
             {
                 if (building instanceof BuildingFarmer)
                 {
-                    ColonyUtils.sendToAll(players, new ColonyViewBuildingViewMessage(building));
+                    players.forEach(player -> MineColonies.getNetwork().sendTo(new ColonyViewBuildingViewMessage(building), player));
                 }
             }
         }

--- a/src/main/java/com/minecolonies/coremod/colony/managers/CitizenManager.java
+++ b/src/main/java/com/minecolonies/coremod/colony/managers/CitizenManager.java
@@ -21,7 +21,6 @@ import com.minecolonies.coremod.entity.citizen.EntityCitizen;
 import com.minecolonies.coremod.network.messages.ColonyViewCitizenViewMessage;
 import com.minecolonies.coremod.network.messages.ColonyViewRemoveCitizenMessage;
 import com.minecolonies.coremod.network.messages.HappinessDataMessage;
-import com.minecolonies.coremod.util.ColonyUtils;
 import net.minecraft.entity.player.EntityPlayerMP;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.nbt.NBTTagList;
@@ -136,7 +135,7 @@ public class CitizenManager implements ICitizenManager
                 {
                     if (citizen.isDirty() || !newSubscribers.isEmpty())
                     {
-                        ColonyUtils.sendToAll(players, new ColonyViewCitizenViewMessage(colony, citizen));
+                        players.forEach(player -> MineColonies.getNetwork().sendTo(new ColonyViewCitizenViewMessage(colony, citizen), player));
                     }
                 }
             }

--- a/src/main/java/com/minecolonies/coremod/colony/managers/ColonyPackageManager.java
+++ b/src/main/java/com/minecolonies/coremod/colony/managers/ColonyPackageManager.java
@@ -13,7 +13,6 @@ import com.minecolonies.coremod.network.messages.ColonyStylesMessage;
 import com.minecolonies.coremod.network.messages.ColonyViewMessage;
 import com.minecolonies.coremod.network.messages.ColonyViewWorkOrderMessage;
 import com.minecolonies.coremod.network.messages.PermissionsMessage;
-import com.minecolonies.coremod.util.ColonyUtils;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
 import net.minecraft.entity.player.EntityPlayerMP;
@@ -198,7 +197,7 @@ public class ColonyPackageManager implements IColonyPackageManager
             {
                 if (!(workOrder instanceof WorkOrderBuildMiner))
                 {
-                    ColonyUtils.sendToAll(players, new ColonyViewWorkOrderMessage(colony, workOrder));
+                    players.forEach(player -> MineColonies.getNetwork().sendTo(new ColonyViewWorkOrderMessage(colony, workOrder), player));
                 }
             }
             workManager.setDirty(false);
@@ -211,7 +210,7 @@ public class ColonyPackageManager implements IColonyPackageManager
         if (Structures.isDirty() || !newSubscribers.isEmpty())
         {
             final Set<EntityPlayerMP> players = Structures.isDirty() ? closeSubscribers : newSubscribers;
-            ColonyUtils.sendToAll(players, new ColonyStylesMessage());
+            players.forEach(player -> MineColonies.getNetwork().sendTo(new ColonyStylesMessage(), player));
         }
         Structures.clearDirty();
     }

--- a/src/main/java/com/minecolonies/coremod/network/messages/ColonyViewCitizenViewMessage.java
+++ b/src/main/java/com/minecolonies/coremod/network/messages/ColonyViewCitizenViewMessage.java
@@ -69,5 +69,6 @@ public class ColonyViewCitizenViewMessage extends AbstractMessage<ColonyViewCiti
     protected void messageOnClientThread(final ColonyViewCitizenViewMessage message, final MessageContext ctx)
     {
         IColonyManager.getInstance().handleColonyViewCitizensMessage(message.colonyId, message.citizenId, message.citizenBuffer, message.dimension);
+        message.citizenBuffer.release();
     }
 }

--- a/src/main/java/com/minecolonies/coremod/network/messages/ColonyViewMessage.java
+++ b/src/main/java/com/minecolonies/coremod/network/messages/ColonyViewMessage.java
@@ -81,6 +81,7 @@ public class ColonyViewMessage extends AbstractMessage<ColonyViewMessage, IMessa
         if (MineColonies.proxy.getWorldFromMessage(ctx) != null)
         {
             IColonyManager.getInstance().handleColonyViewMessage(message.colonyId, message.colonyBuffer, MineColonies.proxy.getWorldFromMessage(ctx), message.isNewSubscription, message.dim);
+            message.colonyBuffer.release();
         }
     }
 }

--- a/src/main/java/com/minecolonies/coremod/network/messages/ColonyViewWorkOrderMessage.java
+++ b/src/main/java/com/minecolonies/coremod/network/messages/ColonyViewWorkOrderMessage.java
@@ -63,6 +63,7 @@ public class ColonyViewWorkOrderMessage extends AbstractMessage<ColonyViewWorkOr
     protected void messageOnClientThread(final ColonyViewWorkOrderMessage message, final MessageContext ctx)
     {
         IColonyManager.getInstance().handleColonyViewWorkOrderMessage(message.colonyId, message.workOrderBuffer, Minecraft.getMinecraft().world.provider.getDimension());
+        message.workOrderBuffer.release();
     }
 }
 

--- a/src/main/java/com/minecolonies/coremod/network/messages/PermissionsMessage.java
+++ b/src/main/java/com/minecolonies/coremod/network/messages/PermissionsMessage.java
@@ -89,6 +89,7 @@ public class PermissionsMessage
         protected void messageOnClientThread(final View message, final MessageContext ctx)
         {
             IColonyManager.getInstance().handlePermissionsViewMessage(message.colonyID, message.data, message.dimension);
+            message.data.release();
         }
 
         @Override

--- a/src/main/java/com/minecolonies/coremod/util/ColonyUtils.java
+++ b/src/main/java/com/minecolonies/coremod/util/ColonyUtils.java
@@ -2,16 +2,10 @@ package com.minecolonies.coremod.util;
 
 import com.ldtteam.structures.helpers.Structure;
 import com.minecolonies.api.util.BlockPosUtil;
-import com.minecolonies.coremod.MineColonies;
-import net.minecraft.entity.player.EntityPlayer;
-import net.minecraft.entity.player.EntityPlayerMP;
 import net.minecraft.util.Mirror;
 import net.minecraft.util.Tuple;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.World;
-import net.minecraftforge.fml.common.network.simpleimpl.IMessage;
-
-import java.util.Set;
 
 /**
  * Contains colony specific utility.
@@ -54,19 +48,5 @@ public final class ColonyUtils
         final int z2 = wrapper.getPosition().getZ() + (wrapper.getLength() - wrapper.getOffset().getZ());
 
         return new Tuple<>(new Tuple<>(x1, x2), new Tuple<>(z1, z2));
-    }
-
-    /**
-     * Sends a message to all given players.
-     *
-     * @param players the list of players
-     * @param message the message to send
-     */
-    public static void sendToAll(Set<EntityPlayerMP> players, IMessage message)
-    {
-        for (final EntityPlayer player : players)
-        {
-            MineColonies.getNetwork().sendTo(message, (EntityPlayerMP) player);
-        }
     }
 }


### PR DESCRIPTION
Closes #4050

# Changes proposed in this pull request:
- hotfix packets and netty memory leak

Packets were re-using a buffer, causing index overflows. Netty memory leak was caused by not properly releasing buffers.

Review please
