### PR TITLE
improve state typing/add dynamic tick rates v1.14

### DIFF
--- a/src/api/java/com/minecolonies/api/entity/ai/statemachine/AIEventTarget.java
+++ b/src/api/java/com/minecolonies/api/entity/ai/statemachine/AIEventTarget.java
@@ -12,7 +12,7 @@ import java.util.function.Supplier;
  * Special AI Targets which are used for preState cecks and limits.
  * They are checked before normal AITargets always
  */
-public class AIEventTarget extends TickingEvent
+public class AIEventTarget extends TickingEvent<IAIState>
 {
     /**
      * Construct a special target.

--- a/src/api/java/com/minecolonies/api/entity/ai/statemachine/AIOneTimeEventTarget.java
+++ b/src/api/java/com/minecolonies/api/entity/ai/statemachine/AIOneTimeEventTarget.java
@@ -11,7 +11,7 @@ import java.util.function.Supplier;
 /**
  * One time usage AITarget, unregisters itself after usage
  */
-public class AIOneTimeEventTarget extends TickingOneTimeEvent
+public class AIOneTimeEventTarget extends TickingOneTimeEvent<IAIState>
 {
     /**
      * Event to trigger a one time transition.

--- a/src/api/java/com/minecolonies/api/entity/ai/statemachine/AITarget.java
+++ b/src/api/java/com/minecolonies/api/entity/ai/statemachine/AITarget.java
@@ -16,7 +16,7 @@ import java.util.function.Supplier;
  * to tell if execution is wanted.
  * And it can change state.
  */
-public class AITarget extends TickingTransition
+public class AITarget extends TickingTransition<IAIState>
 {
     /**
      * Construct a target.

--- a/src/api/java/com/minecolonies/api/entity/ai/statemachine/basestatemachine/BasicEvent.java
+++ b/src/api/java/com/minecolonies/api/entity/ai/statemachine/basestatemachine/BasicEvent.java
@@ -1,7 +1,7 @@
 package com.minecolonies.api.entity.ai.statemachine.basestatemachine;
 
-import com.minecolonies.api.entity.ai.statemachine.states.IAIEventType;
 import com.minecolonies.api.entity.ai.statemachine.states.IAIState;
+import com.minecolonies.api.entity.ai.statemachine.states.IStateEventType;
 import com.minecolonies.api.entity.ai.statemachine.transitions.IStateMachineEvent;
 import org.jetbrains.annotations.NotNull;
 
@@ -17,10 +17,10 @@ public class BasicEvent extends BasicTransition implements IStateMachineEvent
     /**
      * The event type of this event
      */
-    private final IAIEventType eventType;
+    private final IStateEventType eventType;
 
     public BasicEvent(
-      @NotNull final IAIEventType eventType,
+      @NotNull final IStateEventType eventType,
       @NotNull final BooleanSupplier condition,
       @NotNull final Supplier<IAIState> nextState)
     {
@@ -33,7 +33,7 @@ public class BasicEvent extends BasicTransition implements IStateMachineEvent
      *
      * @return IAIEventType
      */
-    public IAIEventType getEventType()
+    public IStateEventType getEventType()
     {
         return eventType;
     }

--- a/src/api/java/com/minecolonies/api/entity/ai/statemachine/basestatemachine/BasicStateMachine.java
+++ b/src/api/java/com/minecolonies/api/entity/ai/statemachine/basestatemachine/BasicStateMachine.java
@@ -1,7 +1,7 @@
 package com.minecolonies.api.entity.ai.statemachine.basestatemachine;
 
-import com.minecolonies.api.entity.ai.statemachine.states.IAIEventType;
-import com.minecolonies.api.entity.ai.statemachine.states.IAIState;
+import com.minecolonies.api.entity.ai.statemachine.states.IState;
+import com.minecolonies.api.entity.ai.statemachine.states.IStateEventType;
 import com.minecolonies.api.entity.ai.statemachine.transitions.IStateMachineEvent;
 import com.minecolonies.api.entity.ai.statemachine.transitions.IStateMachineOneTimeEvent;
 import com.minecolonies.api.entity.ai.statemachine.transitions.IStateMachineTransition;
@@ -17,27 +17,27 @@ import java.util.function.Consumer;
  * Basic statemachine class, can be used for any Transition typed which extends the transition interface.
  * It contains the current state and a hashmap for events and transitions, which are the minimal requirements to have a working statemachine.
  */
-public class BasicStateMachine<T extends IStateMachineTransition> implements IStateMachine<T>
+public class BasicStateMachine<T extends IStateMachineTransition<S>, S extends IState> implements IStateMachine<T, S>
 {
     /**
      * The lists of transitions and events
      */
     @NotNull
-    protected final Map<IAIState, ArrayList<T>>     transitionMap;
+    protected final Map<S, ArrayList<T>>               transitionMap;
     @NotNull
-    protected final Map<IAIEventType, ArrayList<T>> eventTransitionMap;
+    protected final Map<IStateEventType, ArrayList<T>> eventTransitionMap;
 
     /**
      * The current state we're in
      */
     @NotNull
-    private IAIState state;
+    private S state;
 
     /**
      * The state we started in
      */
     @NotNull
-    private final IAIState initState;
+    private final S initState;
 
     /**
      * The exception handler
@@ -48,7 +48,7 @@ public class BasicStateMachine<T extends IStateMachineTransition> implements ISt
     /**
      * Construct a new StateMachine
      */
-    protected BasicStateMachine(@NotNull final IAIState initialState, @NotNull final Consumer<RuntimeException> exceptionHandler)
+    protected BasicStateMachine(@NotNull final S initialState, @NotNull final Consumer<RuntimeException> exceptionHandler)
     {
         this.state = initialState;
         this.initState = initialState;
@@ -142,7 +142,7 @@ public class BasicStateMachine<T extends IStateMachineTransition> implements ISt
      */
     public boolean transitionToNext(@NotNull final T transition)
     {
-        final IAIState newState;
+        final S newState;
         try
         {
             newState = transition.getNextState();
@@ -181,7 +181,7 @@ public class BasicStateMachine<T extends IStateMachineTransition> implements ISt
      *
      * @return The current IAIState.
      */
-    public final IAIState getState()
+    public final S getState()
     {
         return state;
     }

--- a/src/api/java/com/minecolonies/api/entity/ai/statemachine/basestatemachine/BasicTransition.java
+++ b/src/api/java/com/minecolonies/api/entity/ai/statemachine/basestatemachine/BasicTransition.java
@@ -1,6 +1,6 @@
 package com.minecolonies.api.entity.ai.statemachine.basestatemachine;
 
-import com.minecolonies.api.entity.ai.statemachine.states.IAIState;
+import com.minecolonies.api.entity.ai.statemachine.states.IState;
 import com.minecolonies.api.entity.ai.statemachine.transitions.IStateMachineTransition;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -13,13 +13,13 @@ import java.util.function.Supplier;
  * Consists of a state the transition applies in, a statesupplier which determines its next state and
  * a condition which has to be true to transition into the next state.
  */
-public class BasicTransition implements IStateMachineTransition
+public class BasicTransition<S extends IState> implements IStateMachineTransition<S>
 {
     /**
      * The State we're starting in
      */
     @Nullable
-    private final IAIState state;
+    private final S state;
 
     /**
      * The condition which needs to be met to transition
@@ -31,7 +31,7 @@ public class BasicTransition implements IStateMachineTransition
      * The next state we transition into
      */
     @NotNull
-    private final Supplier<IAIState> nextState;
+    private final Supplier<S> nextState;
 
     /**
      * Creating a new transition from State A to B under condition C
@@ -40,7 +40,7 @@ public class BasicTransition implements IStateMachineTransition
      * @param condition Condition C
      * @param nextState State B
      */
-    public BasicTransition(@NotNull final IAIState state, @NotNull final BooleanSupplier condition, @NotNull final Supplier<IAIState> nextState)
+    public BasicTransition(@NotNull final S state, @NotNull final BooleanSupplier condition, @NotNull final Supplier<S> nextState)
     {
         this.state = state;
         this.condition = condition;
@@ -50,7 +50,7 @@ public class BasicTransition implements IStateMachineTransition
     /**
      * Protected Constructor to allow subclasses without a state
      */
-    protected BasicTransition(@NotNull final BooleanSupplier condition, @NotNull final Supplier<IAIState> nextState)
+    protected BasicTransition(@NotNull final BooleanSupplier condition, @NotNull final Supplier<S> nextState)
     {
         this.state = null;
         this.condition = condition;
@@ -62,7 +62,7 @@ public class BasicTransition implements IStateMachineTransition
      *
      * @return IAIState
      */
-    public IAIState getState()
+    public S getState()
     {
         return state;
     }
@@ -72,7 +72,7 @@ public class BasicTransition implements IStateMachineTransition
      *
      * @return next AI state
      */
-    public IAIState getNextState()
+    public S getNextState()
     {
         return nextState.get();
     }

--- a/src/api/java/com/minecolonies/api/entity/ai/statemachine/basestatemachine/IStateMachine.java
+++ b/src/api/java/com/minecolonies/api/entity/ai/statemachine/basestatemachine/IStateMachine.java
@@ -1,6 +1,6 @@
 package com.minecolonies.api.entity.ai.statemachine.basestatemachine;
 
-import com.minecolonies.api.entity.ai.statemachine.states.IAIState;
+import com.minecolonies.api.entity.ai.statemachine.states.IState;
 import com.minecolonies.api.entity.ai.statemachine.transitions.IStateMachineTransition;
 import org.jetbrains.annotations.NotNull;
 
@@ -9,7 +9,7 @@ import org.jetbrains.annotations.NotNull;
  * Contains all needed functions for a basic statemachine
  * @param <T>
  */
-public interface IStateMachine<T extends IStateMachineTransition>
+public interface IStateMachine<T extends IStateMachineTransition, S extends IState>
 {
     /**
      * Adds a transitions to the machine's transition table
@@ -39,7 +39,7 @@ public interface IStateMachine<T extends IStateMachineTransition>
     /**
      * Return the current state of the Statemachine
      */
-    IAIState getState();
+    S getState();
 
     /**
      * Reset the statemachine to the start

--- a/src/api/java/com/minecolonies/api/entity/ai/statemachine/states/AIBlockingEventType.java
+++ b/src/api/java/com/minecolonies/api/entity/ai/statemachine/states/AIBlockingEventType.java
@@ -3,7 +3,7 @@ package com.minecolonies.api.entity.ai.statemachine.states;
 /**
  * Event types used in statemachine events.
  */
-public enum AIBlockingEventType implements IAIEventType
+public enum AIBlockingEventType implements IStateEventType
 {
     /*###Priority NonStates###*/
     /**

--- a/src/api/java/com/minecolonies/api/entity/ai/statemachine/states/IAIState.java
+++ b/src/api/java/com/minecolonies/api/entity/ai/statemachine/states/IAIState.java
@@ -4,7 +4,7 @@ package com.minecolonies.api.entity.ai.statemachine.states;
  * Interface type for IAIState enums
  * Implement this interface to add new statetypes
  */
-public interface IAIState
+public interface IAIState extends IState
 {
     /**
      * Check whether we can interrupt the current state to eat

--- a/src/api/java/com/minecolonies/api/entity/ai/statemachine/states/IState.java
+++ b/src/api/java/com/minecolonies/api/entity/ai/statemachine/states/IState.java
@@ -1,0 +1,9 @@
+package com.minecolonies.api.entity.ai.statemachine.states;
+
+/**
+ * The basic state type for statemachine states. Implement this interface to add new statetypes
+ */
+public interface IState
+{
+
+}

--- a/src/api/java/com/minecolonies/api/entity/ai/statemachine/states/IStateEventType.java
+++ b/src/api/java/com/minecolonies/api/entity/ai/statemachine/states/IStateEventType.java
@@ -3,6 +3,6 @@ package com.minecolonies.api.entity.ai.statemachine.states;
 /**
  * Interface type for all statemachine Event types
  */
-public interface IAIEventType
+public interface IStateEventType
 {
 }

--- a/src/api/java/com/minecolonies/api/entity/ai/statemachine/tickratestatemachine/ITickRateStateMachine.java
+++ b/src/api/java/com/minecolonies/api/entity/ai/statemachine/tickratestatemachine/ITickRateStateMachine.java
@@ -1,9 +1,10 @@
 package com.minecolonies.api.entity.ai.statemachine.tickratestatemachine;
 
 import com.minecolonies.api.entity.ai.statemachine.basestatemachine.IStateMachine;
+import com.minecolonies.api.entity.ai.statemachine.states.IState;
 import org.jetbrains.annotations.NotNull;
 
-public interface ITickRateStateMachine extends IStateMachine<ITickingTransition>
+public interface ITickRateStateMachine<S extends IState> extends IStateMachine<ITickingTransition<S>, S>
 {
     /**
      * Tick the statemachine.
@@ -18,5 +19,19 @@ public interface ITickRateStateMachine extends IStateMachine<ITickingTransition>
      * @return true if this target worked and we should stop executing this tick
      */
     @Override
-    boolean checkTransition(@NotNull ITickingTransition transition);
+    boolean checkTransition(@NotNull ITickingTransition<S> transition);
+
+    /**
+     * Returns the current rate the statemachine is beeing ticked at.
+     *
+     * @return the tickrate
+     */
+    int getTickRate();
+
+    /**
+     * Returns the current rate the statemachine is beeing ticked at.
+     *
+     * @return the tickrate
+     */
+    void setTickRate(final int tickRate);
 }

--- a/src/api/java/com/minecolonies/api/entity/ai/statemachine/tickratestatemachine/ITickingTransition.java
+++ b/src/api/java/com/minecolonies/api/entity/ai/statemachine/tickratestatemachine/ITickingTransition.java
@@ -1,9 +1,10 @@
 package com.minecolonies.api.entity.ai.statemachine.tickratestatemachine;
 
+import com.minecolonies.api.entity.ai.statemachine.states.IState;
 import com.minecolonies.api.entity.ai.statemachine.transitions.IStateMachineTransition;
 import org.jetbrains.annotations.NotNull;
 
-public interface ITickingTransition extends IStateMachineTransition
+public interface ITickingTransition<S extends IState> extends IStateMachineTransition<S>
 {
     /**
      * Returns the intended tickRate of the AITarget

--- a/src/api/java/com/minecolonies/api/entity/ai/statemachine/tickratestatemachine/TickingEvent.java
+++ b/src/api/java/com/minecolonies/api/entity/ai/statemachine/tickratestatemachine/TickingEvent.java
@@ -1,7 +1,7 @@
 package com.minecolonies.api.entity.ai.statemachine.tickratestatemachine;
 
-import com.minecolonies.api.entity.ai.statemachine.states.IAIEventType;
-import com.minecolonies.api.entity.ai.statemachine.states.IAIState;
+import com.minecolonies.api.entity.ai.statemachine.states.IState;
+import com.minecolonies.api.entity.ai.statemachine.states.IStateEventType;
 import com.minecolonies.api.entity.ai.statemachine.transitions.IStateMachineEvent;
 import org.jetbrains.annotations.NotNull;
 
@@ -11,12 +11,12 @@ import java.util.function.Supplier;
 /**
  * Event with a tickrate for a statemachine using a tickrate.
  */
-public class TickingEvent extends TickingTransition implements IStateMachineEvent
+public class TickingEvent<S extends IState> extends TickingTransition<S> implements IStateMachineEvent<S>
 {
     /**
      * The type of this Event
      */
-    private final IAIEventType eventType;
+    private final IStateEventType eventType;
 
     /**
      * Creates a new TickingEvent
@@ -27,9 +27,9 @@ public class TickingEvent extends TickingTransition implements IStateMachineEven
      * @param tickRate  tickrate at which the event is checked
      */
     protected TickingEvent(
-      @NotNull final IAIEventType eventType,
+      @NotNull final IStateEventType eventType,
       @NotNull final BooleanSupplier condition,
-      @NotNull final Supplier<IAIState> nextState,
+      @NotNull final Supplier<S> nextState,
       @NotNull final int tickRate)
     {
         super(condition, nextState, tickRate);
@@ -40,7 +40,7 @@ public class TickingEvent extends TickingTransition implements IStateMachineEven
      * Get the type of this event
      */
     @Override
-    public IAIEventType getEventType()
+    public IStateEventType getEventType()
     {
         return eventType;
     }

--- a/src/api/java/com/minecolonies/api/entity/ai/statemachine/tickratestatemachine/TickingOneTimeEvent.java
+++ b/src/api/java/com/minecolonies/api/entity/ai/statemachine/tickratestatemachine/TickingOneTimeEvent.java
@@ -1,7 +1,7 @@
 package com.minecolonies.api.entity.ai.statemachine.tickratestatemachine;
 
-import com.minecolonies.api.entity.ai.statemachine.states.IAIEventType;
-import com.minecolonies.api.entity.ai.statemachine.states.IAIState;
+import com.minecolonies.api.entity.ai.statemachine.states.IState;
+import com.minecolonies.api.entity.ai.statemachine.states.IStateEventType;
 import com.minecolonies.api.entity.ai.statemachine.transitions.IStateMachineOneTimeEvent;
 import org.jetbrains.annotations.NotNull;
 
@@ -12,7 +12,7 @@ import java.util.function.Supplier;
  * One time event that can be checked at the given tickrate, one time events are removed after causing a state transition.
  * (Even when transitioning into the same state again)
  */
-public class TickingOneTimeEvent extends TickingEvent implements IStateMachineOneTimeEvent
+public class TickingOneTimeEvent<S extends IState> extends TickingEvent<S> implements IStateMachineOneTimeEvent<S>
 {
     /**
      * Creates a new TickingEvent
@@ -23,9 +23,9 @@ public class TickingOneTimeEvent extends TickingEvent implements IStateMachineOn
      * @param tickRate  tickrate at which the event is checked
      */
     protected TickingOneTimeEvent(
-      @NotNull final IAIEventType eventType,
+      @NotNull final IStateEventType eventType,
       @NotNull final BooleanSupplier condition,
-      @NotNull final Supplier<IAIState> nextState,
+      @NotNull final Supplier<S> nextState,
       @NotNull final int tickRate)
     {
         super(eventType, condition, nextState, tickRate);

--- a/src/api/java/com/minecolonies/api/entity/ai/statemachine/tickratestatemachine/TickingTransition.java
+++ b/src/api/java/com/minecolonies/api/entity/ai/statemachine/tickratestatemachine/TickingTransition.java
@@ -1,7 +1,7 @@
 package com.minecolonies.api.entity.ai.statemachine.tickratestatemachine;
 
 import com.minecolonies.api.entity.ai.statemachine.basestatemachine.BasicTransition;
-import com.minecolonies.api.entity.ai.statemachine.states.IAIState;
+import com.minecolonies.api.entity.ai.statemachine.states.IState;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.function.BooleanSupplier;
@@ -13,7 +13,7 @@ import static com.minecolonies.api.entity.ai.statemachine.tickratestatemachine.T
 /**
  * Transition with tickrate logic, allows to define an intended tickrate at which this transition will be checked.
  */
-public class TickingTransition extends BasicTransition implements ITickingTransition
+public class TickingTransition<S extends IState> extends BasicTransition<S> implements ITickingTransition<S>
 {
     /**
      * The tickrate at which the Target should be called, e.g. tickRate = 20 means call function every 20 Ticks
@@ -43,9 +43,9 @@ public class TickingTransition extends BasicTransition implements ITickingTransi
      * @param tickRate  The expected tickrate at which this transition should be checked.
      */
     public TickingTransition(
-      @NotNull final IAIState state,
+      @NotNull final S state,
       @NotNull final BooleanSupplier condition,
-      @NotNull final Supplier<IAIState> nextState,
+      @NotNull final Supplier<S> nextState,
       @NotNull final int tickRate)
     {
         super(state, condition, nextState);
@@ -73,7 +73,7 @@ public class TickingTransition extends BasicTransition implements ITickingTransi
      */
     protected TickingTransition(
       @NotNull final BooleanSupplier condition,
-      @NotNull final Supplier<IAIState> nextState,
+      @NotNull final Supplier<S> nextState,
       @NotNull final int tickRate)
     {
         super(condition, nextState);

--- a/src/api/java/com/minecolonies/api/entity/ai/statemachine/transitions/IStateMachineEvent.java
+++ b/src/api/java/com/minecolonies/api/entity/ai/statemachine/transitions/IStateMachineEvent.java
@@ -1,16 +1,17 @@
 package com.minecolonies.api.entity.ai.statemachine.transitions;
 
-import com.minecolonies.api.entity.ai.statemachine.states.IAIEventType;
+import com.minecolonies.api.entity.ai.statemachine.states.IState;
+import com.minecolonies.api.entity.ai.statemachine.states.IStateEventType;
 
 /**
  * Event transition type for Statemachines
  */
-public interface IStateMachineEvent extends IStateMachineTransition
+public interface IStateMachineEvent<S extends IState> extends IStateMachineTransition<S>
 {
     /**
      * Get the event type of the transition
      *
      * @return event type
      */
-    IAIEventType getEventType();
+    IStateEventType getEventType();
 }

--- a/src/api/java/com/minecolonies/api/entity/ai/statemachine/transitions/IStateMachineOneTimeEvent.java
+++ b/src/api/java/com/minecolonies/api/entity/ai/statemachine/transitions/IStateMachineOneTimeEvent.java
@@ -1,9 +1,11 @@
 package com.minecolonies.api.entity.ai.statemachine.transitions;
 
+import com.minecolonies.api.entity.ai.statemachine.states.IState;
+
 /**
  * Type for one time usage events
  */
-public interface IStateMachineOneTimeEvent extends IStateMachineEvent
+public interface IStateMachineOneTimeEvent<S extends IState> extends IStateMachineEvent<S>
 {
     /**
      * Check whether the one time Event is done

--- a/src/api/java/com/minecolonies/api/entity/ai/statemachine/transitions/IStateMachineTransition.java
+++ b/src/api/java/com/minecolonies/api/entity/ai/statemachine/transitions/IStateMachineTransition.java
@@ -1,23 +1,23 @@
 package com.minecolonies.api.entity.ai.statemachine.transitions;
 
-import com.minecolonies.api.entity.ai.statemachine.states.IAIState;
+import com.minecolonies.api.entity.ai.statemachine.states.IState;
 
 /**
  * Transition type for Statemachines
  */
-public interface IStateMachineTransition
+public interface IStateMachineTransition<S extends IState>
 {
     /**
      * Get the state of the transition
      *
      * @return state
      */
-    IAIState getState();
+    S getState();
 
     /**
      * Get the next state the Transition goes into
      */
-    IAIState getNextState();
+    S getNextState();
 
     /**
      * Check if the condition of the transition is fulfilled

--- a/src/main/java/com/minecolonies/coremod/colony/Colony.java
+++ b/src/main/java/com/minecolonies/coremod/colony/Colony.java
@@ -14,6 +14,7 @@ import com.minecolonies.api.colony.permissions.Rank;
 import com.minecolonies.api.colony.requestsystem.manager.IRequestManager;
 import com.minecolonies.api.colony.requestsystem.requester.IRequester;
 import com.minecolonies.api.colony.workorders.IWorkManager;
+import com.minecolonies.api.entity.ai.statemachine.states.IState;
 import com.minecolonies.api.entity.ai.statemachine.tickratestatemachine.ITickRateStateMachine;
 import com.minecolonies.api.entity.ai.statemachine.tickratestatemachine.TickRateStateMachine;
 import com.minecolonies.api.entity.ai.statemachine.tickratestatemachine.TickingTransition;
@@ -226,7 +227,7 @@ public class Colony implements IColony
     /**
      * The colonies state machine
      */
-    private final ITickRateStateMachine colonyStateMachine;
+    private final ITickRateStateMachine<IState> colonyStateMachine;
 
     /**
      * Mournign parameters.
@@ -318,18 +319,18 @@ public class Colony implements IColony
         }
 
 
-        colonyStateMachine = new TickRateStateMachine(INACTIVE, e -> {});
+        colonyStateMachine = new TickRateStateMachine<>(INACTIVE, e -> {});
 
-        colonyStateMachine.addTransition(new TickingTransition(INACTIVE, () -> true, this::updateState, UPDATE_STATE_INTERVAL));
-        colonyStateMachine.addTransition(new TickingTransition(UNLOADED, () -> true, this::updateState, UPDATE_STATE_INTERVAL));
-        colonyStateMachine.addTransition(new TickingTransition(ACTIVE, () -> true, this::updateState, UPDATE_STATE_INTERVAL));
+        colonyStateMachine.addTransition(new TickingTransition<>(INACTIVE, () -> true, this::updateState, UPDATE_STATE_INTERVAL));
+        colonyStateMachine.addTransition(new TickingTransition<>(UNLOADED, () -> true, this::updateState, UPDATE_STATE_INTERVAL));
+        colonyStateMachine.addTransition(new TickingTransition<>(ACTIVE, () -> true, this::updateState, UPDATE_STATE_INTERVAL));
 
-        colonyStateMachine.addTransition(new TickingTransition(ACTIVE, this::updateSubscribers, () -> ACTIVE, UPDATE_SUBSCRIBERS_INTERVAL));
-        colonyStateMachine.addTransition(new TickingTransition(ACTIVE, this::tickRequests, () -> ACTIVE, UPDATE_RS_INTERVAL));
-        colonyStateMachine.addTransition(new TickingTransition(ACTIVE, this::checkDayTime, () -> ACTIVE, UPDATE_DAYTIME_INTERVAL));
-        colonyStateMachine.addTransition(new TickingTransition(ACTIVE, this::updateWayPoints, () -> ACTIVE, CHECK_WAYPOINT_EVERY));
-        colonyStateMachine.addTransition(new TickingTransition(ACTIVE, this::worldTickSlow, () -> ACTIVE, MAX_TICKRATE));
-        colonyStateMachine.addTransition(new TickingTransition(UNLOADED, this::worldTickUnloaded, () -> UNLOADED, MAX_TICKRATE));
+        colonyStateMachine.addTransition(new TickingTransition<>(ACTIVE, this::updateSubscribers, () -> ACTIVE, UPDATE_SUBSCRIBERS_INTERVAL));
+        colonyStateMachine.addTransition(new TickingTransition<>(ACTIVE, this::tickRequests, () -> ACTIVE, UPDATE_RS_INTERVAL));
+        colonyStateMachine.addTransition(new TickingTransition<>(ACTIVE, this::checkDayTime, () -> ACTIVE, UPDATE_DAYTIME_INTERVAL));
+        colonyStateMachine.addTransition(new TickingTransition<>(ACTIVE, this::updateWayPoints, () -> ACTIVE, CHECK_WAYPOINT_EVERY));
+        colonyStateMachine.addTransition(new TickingTransition<>(ACTIVE, this::worldTickSlow, () -> ACTIVE, MAX_TICKRATE));
+        colonyStateMachine.addTransition(new TickingTransition<>(UNLOADED, this::worldTickUnloaded, () -> UNLOADED, MAX_TICKRATE));
     }
 
     /**

--- a/src/main/java/com/minecolonies/coremod/entity/ai/basic/AbstractAISkeleton.java
+++ b/src/main/java/com/minecolonies/coremod/entity/ai/basic/AbstractAISkeleton.java
@@ -19,7 +19,6 @@ import org.jetbrains.annotations.NotNull;
 
 import java.util.Arrays;
 import java.util.EnumSet;
-import java.util.Random;
 
 /**
  * Skeleton class for worker ai.
@@ -44,12 +43,7 @@ public abstract class AbstractAISkeleton<J extends IJob> extends Goal
      * The statemachine this AI uses
      */
     @NotNull
-    private final ITickRateStateMachine stateMachine;
-
-    /**
-     * Counter for updateTask ticks received
-     */
-    private int tickCounter = 0;
+    private final ITickRateStateMachine<IAIState> stateMachine;
 
     /**
      * Sets up some important skeleton stuff for every ai.
@@ -70,10 +64,8 @@ public abstract class AbstractAISkeleton<J extends IJob> extends Goal
         this.worker = this.job.getCitizen().getCitizenEntity().get();
         this.world = CompatibilityUtils.getWorldFromCitizen(this.worker);
         this.chatSpamFilter = new ChatSpamFilter(job.getCitizen());
-        stateMachine = new TickRateStateMachine(AIWorkerState.INIT, this::onException);
-
-        // Start at a random tickcounter to spread AI updates over all ticks
-        tickCounter = new Random().nextInt(MineColonies.getConfig().getCommon().updateRate.get()) + 1;
+        stateMachine = new TickRateStateMachine<>(AIWorkerState.INIT, this::onException);
+        stateMachine.setTickRate(MineColonies.getConfig().getCommon().updateRate.get());
     }
 
     /**
@@ -81,7 +73,7 @@ public abstract class AbstractAISkeleton<J extends IJob> extends Goal
      *
      * @param target the target to register.
      */
-    protected void registerTarget(final TickingTransition target)
+    protected void registerTarget(final TickingTransition<IAIState> target)
     {
         stateMachine.addTransition(target);
     }
@@ -142,15 +134,7 @@ public abstract class AbstractAISkeleton<J extends IJob> extends Goal
     @Override
     public final void tick()
     {
-        if (tickCounter < MineColonies.getConfig().getCommon().updateRate.get())
-        {
-            tickCounter++;
-        }
-        else
-        {
             stateMachine.tick();
-            tickCounter = 1;
-        }
     }
 
     protected void onException(final RuntimeException e)
@@ -178,6 +162,16 @@ public abstract class AbstractAISkeleton<J extends IJob> extends Goal
     public final IAIState getState()
     {
         return stateMachine.getState();
+    }
+
+    /**
+     * Gets the update rate of the worker's statemachine
+     *
+     * @return update rate
+     */
+    public int getTickRate()
+    {
+        return stateMachine.getTickRate();
     }
 
     /**

--- a/src/main/java/com/minecolonies/coremod/entity/ai/basic/AbstractEntityAIBasic.java
+++ b/src/main/java/com/minecolonies/coremod/entity/ai/basic/AbstractEntityAIBasic.java
@@ -469,7 +469,7 @@ public abstract class AbstractEntityAIBasic<J extends AbstractJob> extends Abstr
             {
                 worker.getCitizenItemHandler().hitBlockWithToolInHand(currentWorkingLocation);
             }
-            delay--;
+            delay -= getTickRate();
             return true;
         }
         clearWorkTarget();

--- a/src/main/java/com/minecolonies/coremod/entity/ai/minimal/EntityAICitizenAvoidEntity.java
+++ b/src/main/java/com/minecolonies/coremod/entity/ai/minimal/EntityAICitizenAvoidEntity.java
@@ -1,6 +1,8 @@
 package com.minecolonies.coremod.entity.ai.minimal;
 
 import com.minecolonies.api.entity.ai.statemachine.AITarget;
+import com.minecolonies.api.entity.ai.statemachine.states.IAIState;
+import com.minecolonies.api.entity.ai.statemachine.tickratestatemachine.ITickRateStateMachine;
 import com.minecolonies.api.entity.ai.statemachine.tickratestatemachine.TickRateStateMachine;
 import com.minecolonies.api.entity.pathfinding.PathResult;
 import com.minecolonies.api.util.CompatibilityUtils;
@@ -62,7 +64,7 @@ public class EntityAICitizenAvoidEntity extends Goal
     /**
      * This AI's state changer.
      */
-    private final TickRateStateMachine stateMachine;
+    private final ITickRateStateMachine<IAIState> stateMachine;
 
     /**
      * The blockpos from where the citizen started fleeing.
@@ -96,7 +98,7 @@ public class EntityAICitizenAvoidEntity extends Goal
         this.nearSpeed = nearSpeed;
         super.setMutexFlags(EnumSet.of(Flag.MOVE));
 
-        stateMachine = new TickRateStateMachine(SAFE, this::onException);
+        stateMachine = new TickRateStateMachine<>(SAFE, this::onException);
 
         stateMachine.addTransition(new AITarget(SAFE, this::isEntityClose, () -> RUNNING, 5));
         stateMachine.addTransition(new AITarget(RUNNING, this::updateMoving, () -> SAFE, 5));

--- a/src/main/java/com/minecolonies/coremod/entity/ai/minimal/EntityAICitizenChild.java
+++ b/src/main/java/com/minecolonies/coremod/entity/ai/minimal/EntityAICitizenChild.java
@@ -6,6 +6,7 @@ import com.minecolonies.api.entity.ai.statemachine.AIEventTarget;
 import com.minecolonies.api.entity.ai.statemachine.AITarget;
 import com.minecolonies.api.entity.ai.statemachine.states.AIBlockingEventType;
 import com.minecolonies.api.entity.ai.statemachine.states.IAIState;
+import com.minecolonies.api.entity.ai.statemachine.tickratestatemachine.ITickRateStateMachine;
 import com.minecolonies.api.entity.ai.statemachine.tickratestatemachine.TickRateStateMachine;
 import com.minecolonies.api.entity.pathfinding.PathResult;
 import com.minecolonies.api.util.CompatibilityUtils;
@@ -52,7 +53,7 @@ public class EntityAICitizenChild extends Goal
     protected final EntityCitizen child;
     private final   Random        rand = new Random();
 
-    private final TickRateStateMachine stateMachine;
+    private final ITickRateStateMachine<IAIState> stateMachine;
 
     /**
      * Timer for actions/between actions
@@ -109,7 +110,7 @@ public class EntityAICitizenChild extends Goal
         super();
         this.child = citizen;
         super.setMutexFlags(EnumSet.of(Goal.Flag.MOVE));
-        stateMachine = new TickRateStateMachine(State.IDLE, this::handleAIException);
+        stateMachine = new TickRateStateMachine<>(State.IDLE, this::handleAIException);
         stateMachine.addTransition(new AIEventTarget(AIBlockingEventType.STATE_BLOCKING, this::updateTimers, stateMachine::getState, 1));
         stateMachine.addTransition(new AIEventTarget(AIBlockingEventType.EVENT, this::tryGrowUp, () -> State.IDLE, 500));
 

--- a/src/main/java/com/minecolonies/coremod/entity/mobs/EntityMercenary.java
+++ b/src/main/java/com/minecolonies/coremod/entity/mobs/EntityMercenary.java
@@ -5,9 +5,8 @@ import com.minecolonies.api.colony.IColony;
 import com.minecolonies.api.colony.IColonyManager;
 import com.minecolonies.api.colony.IColonyRelated;
 import com.minecolonies.api.entity.ModEntities;
-import com.minecolonies.api.entity.ai.statemachine.basestatemachine.IStateMachine;
-import com.minecolonies.api.entity.ai.statemachine.states.IAIState;
-import com.minecolonies.api.entity.ai.statemachine.tickratestatemachine.ITickingTransition;
+import com.minecolonies.api.entity.ai.statemachine.states.IState;
+import com.minecolonies.api.entity.ai.statemachine.tickratestatemachine.ITickRateStateMachine;
 import com.minecolonies.api.entity.ai.statemachine.tickratestatemachine.TickRateStateMachine;
 import com.minecolonies.api.entity.ai.statemachine.tickratestatemachine.TickingTransition;
 import com.minecolonies.api.entity.pathfinding.AbstractAdvancedPathNavigate;
@@ -114,7 +113,7 @@ public class EntityMercenary extends CreatureEntity implements INPC, IColonyRela
     /**
      * This entities state machine
      */
-    private IStateMachine<ITickingTransition> stateMachine;
+    private ITickRateStateMachine<IState> stateMachine;
 
     /**
      * The entities name.
@@ -164,11 +163,11 @@ public class EntityMercenary extends CreatureEntity implements INPC, IColonyRela
         this.getAttribute(SharedMonsterAttributes.MAX_HEALTH).setBaseValue(60);
         this.setHealth(this.getMaxHealth());
 
-        stateMachine = new TickRateStateMachine(EntityMercenaryAI.State.INIT, this::handleStateException);
-        stateMachine.addTransition(new TickingTransition(EntityMercenaryAI.State.INIT, this::isInitialized, () -> EntityMercenaryAI.State.SPAWN_EVENT, 20));
-        stateMachine.addTransition(new TickingTransition(EntityMercenaryAI.State.SPAWN_EVENT, this::spawnEvent, () -> EntityMercenaryAI.State.ALIVE, 30));
-        stateMachine.addTransition(new TickingTransition(EntityMercenaryAI.State.ALIVE, this::shouldDespawn, () -> EntityMercenaryAI.State.DEAD, 100));
-        stateMachine.addTransition(new TickingTransition(EntityMercenaryAI.State.DEAD, () -> true, this::getState, 500));
+        stateMachine = new TickRateStateMachine<>(EntityMercenaryAI.State.INIT, this::handleStateException);
+        stateMachine.addTransition(new TickingTransition<>(EntityMercenaryAI.State.INIT, this::isInitialized, () -> EntityMercenaryAI.State.SPAWN_EVENT, 20));
+        stateMachine.addTransition(new TickingTransition<>(EntityMercenaryAI.State.SPAWN_EVENT, this::spawnEvent, () -> EntityMercenaryAI.State.ALIVE, 30));
+        stateMachine.addTransition(new TickingTransition<>(EntityMercenaryAI.State.ALIVE, this::shouldDespawn, () -> EntityMercenaryAI.State.DEAD, 100));
+        stateMachine.addTransition(new TickingTransition<>(EntityMercenaryAI.State.DEAD, () -> true, this::getState, 500));
     }
 
     /**
@@ -280,7 +279,7 @@ public class EntityMercenary extends CreatureEntity implements INPC, IColonyRela
      *
      * @return state
      */
-    public IAIState getState()
+    public IState getState()
     {
         return stateMachine.getState();
     }

--- a/src/main/java/com/minecolonies/coremod/entity/mobs/EntityMercenaryAI.java
+++ b/src/main/java/com/minecolonies/coremod/entity/mobs/EntityMercenaryAI.java
@@ -2,7 +2,8 @@ package com.minecolonies.coremod.entity.mobs;
 
 import com.ldtteam.structurize.util.LanguageHandler;
 import com.minecolonies.api.colony.buildings.IBuilding;
-import com.minecolonies.api.entity.ai.statemachine.states.IAIState;
+import com.minecolonies.api.entity.ai.statemachine.states.IState;
+import com.minecolonies.api.entity.ai.statemachine.tickratestatemachine.ITickRateStateMachine;
 import com.minecolonies.api.entity.ai.statemachine.tickratestatemachine.TickRateStateMachine;
 import com.minecolonies.api.entity.ai.statemachine.tickratestatemachine.TickingTransition;
 import com.minecolonies.api.entity.pathfinding.PathResult;
@@ -38,7 +39,7 @@ public class EntityMercenaryAI extends Goal
     /**
      * State machine for this AI
      */
-    private final TickRateStateMachine stateMachine;
+    private final ITickRateStateMachine<IState> stateMachine;
 
     /**
      * The entity for this AI.
@@ -92,7 +93,7 @@ public class EntityMercenaryAI extends Goal
 
     private final Random rand = new Random();
 
-    public enum State implements IAIState
+    public enum State implements IState
     {
         INIT,
         SPAWN_EVENT,
@@ -100,12 +101,6 @@ public class EntityMercenaryAI extends Goal
         FIGHTING,
         ALIVE,
         DEAD;
-
-        @Override
-        public boolean isOkayToEat()
-        {
-            return false;
-        }
     }
 
     public EntityMercenaryAI(final EntityMercenary entityMercenary)
@@ -113,11 +108,11 @@ public class EntityMercenaryAI extends Goal
         super();
         entity = entityMercenary;
         patrolPoints = new LinkedList<>();
-        stateMachine = new TickRateStateMachine(State.INIT, this::handleAIException);
-        stateMachine.addTransition(new TickingTransition(State.INIT, this::initialize, () -> State.PATROLLING, 10));
-        stateMachine.addTransition(new TickingTransition(State.PATROLLING, this::hasTarget, () -> State.FIGHTING, 5));
-        stateMachine.addTransition(new TickingTransition(State.PATROLLING, this::patrol, () -> State.PATROLLING, 10));
-        stateMachine.addTransition(new TickingTransition(State.FIGHTING, this::fighting, () -> State.PATROLLING, 5));
+        stateMachine = new TickRateStateMachine<>(State.INIT, this::handleAIException);
+        stateMachine.addTransition(new TickingTransition<>(State.INIT, this::initialize, () -> State.PATROLLING, 10));
+        stateMachine.addTransition(new TickingTransition<>(State.PATROLLING, this::hasTarget, () -> State.FIGHTING, 5));
+        stateMachine.addTransition(new TickingTransition<>(State.PATROLLING, this::patrol, () -> State.PATROLLING, 10));
+        stateMachine.addTransition(new TickingTransition<>(State.FIGHTING, this::fighting, () -> State.PATROLLING, 5));
     }
 
     /**


### PR DESCRIPTION
# Changes proposed in this pull request:
Added dynamic state types for the machines, so that they no longer rely on the AI-defined state interface, which forces you to implement AI specific stuff even when not beeing used in an AI environment. The generic type allows you to use custom state with matching return types nicely.

Dynamic ticking added to the statemachine gives them the ability to skip/throttle down the ticks they receive, which is currently used for an AI config which allows lower update rates.(was previously done outside the statemachine). Having this within the statemachine lets logic which uses tick as time measurement to adapt the timers accordingly so that despite the machine ticking less the actions work as intended, e.g. setDelay does -= getTickRate();

Changed the internal streams to loops as the lists the streams run on are very short and calls are quite frequent, so loops are better suited performance wise. (Also showed when doing a profiler test with the big server world(450+) colonies, resulting in about half the tick time needed). Also this should make debugging AI a bit better, as I think streams are harder to debug on.

Review please
