### PR TITLE
Fix citizen limit calculation

### DIFF
--- a/src/api/java/com/minecolonies/api/tileentities/TileEntityRack.java
+++ b/src/api/java/com/minecolonies/api/tileentities/TileEntityRack.java
@@ -340,15 +340,7 @@ public class TileEntityRack extends AbstractTileEntityRack
             size = compound.getInt(TAG_SIZE);
             if (size > 0)
             {
-                inventory = new RackInventory(DEFAULT_SIZE + size * SLOT_PER_LINE)
-                {
-                    @Override
-                    protected void onContentsChanged(final int slot)
-                    {
-                        updateItemStorage();
-                        super.onContentsChanged(slot);
-                    }
-                };
+                inventory = new RackInventory(DEFAULT_SIZE + size * SLOT_PER_LINE);
             }
         }
 

--- a/src/api/java/com/minecolonies/api/util/constant/NbtTagConstants.java
+++ b/src/api/java/com/minecolonies/api/util/constant/NbtTagConstants.java
@@ -9,8 +9,6 @@ public final class NbtTagConstants
     public static final String TAG_NAME                   = "name";
     public static final String TAG_DIMENSION              = "dimension";
     public static final String TAG_CENTER                 = "center";
-    public static final String TAG_MAX_CITIZENS           = "maxCitizens";
-    public static final String TAG_POTENTIAL_MAX_CITIZENS = "potentialMaxCitizens";
     public static final String TAG_BUILDINGS              = "buildings";
     public static final String TAG_BUILDING               = "building";
     public static final String TAG_BUILDINGS_CLAIM        = "buildingsClaim";

--- a/src/api/java/com/minecolonies/api/util/constant/WindowConstants.java
+++ b/src/api/java/com/minecolonies/api/util/constant/WindowConstants.java
@@ -13,7 +13,7 @@ public final class WindowConstants
     /**
      * Id of the info button in the GUI.
      */
-    public static final String BUTTON_INFO = "info";
+    public static final String BUTTON_INFO = "townhall_info_page";
 
     /**
      * Id of the action button in the GUI.

--- a/src/main/java/com/minecolonies/coremod/client/gui/WindowTownHall.java
+++ b/src/main/java/com/minecolonies/coremod/client/gui/WindowTownHall.java
@@ -6,7 +6,9 @@ import com.ldtteam.blockout.views.DropDownList;
 import com.ldtteam.blockout.views.ScrollingList;
 import com.ldtteam.blockout.views.SwitchView;
 import com.ldtteam.structurize.util.LanguageHandler;
-import com.minecolonies.api.colony.*;
+import com.minecolonies.api.colony.CompactColonyReference;
+import com.minecolonies.api.colony.HappinessData;
+import com.minecolonies.api.colony.ICitizenDataView;
 import com.minecolonies.api.colony.buildings.views.IBuildingView;
 import com.minecolonies.api.colony.buildings.workerbuildings.ITownHallView;
 import com.minecolonies.api.colony.permissions.Action;
@@ -19,11 +21,11 @@ import com.minecolonies.api.util.Log;
 import com.minecolonies.api.util.constant.Constants;
 import com.minecolonies.coremod.MineColonies;
 import com.minecolonies.coremod.Network;
+import com.minecolonies.coremod.colony.buildings.AbstractBuildingGuards;
+import com.minecolonies.coremod.colony.buildings.AbstractBuildingWorker;
 import com.minecolonies.coremod.colony.buildings.views.AbstractBuildingBuilderView;
 import com.minecolonies.coremod.colony.buildings.workerbuildings.BuildingTownHall;
 import com.minecolonies.coremod.commands.ClickEventWithExecutable;
-import com.minecolonies.coremod.colony.buildings.AbstractBuildingWorker;
-import com.minecolonies.coremod.colony.buildings.AbstractBuildingGuards;
 import com.minecolonies.coremod.network.messages.*;
 import net.minecraft.block.Block;
 import net.minecraft.client.Minecraft;
@@ -587,7 +589,7 @@ public class WindowTownHall extends AbstractWindowBuilding<ITownHallView>
         final Map<String, Integer> jobMaxCountMap = new HashMap<>();
         for (@NotNull final IBuildingView building : townHall.getColony().getBuildings())
         {
-            if (building.getBuildingLevel() > 0 && building instanceof AbstractBuildingWorker.View)
+            if (building instanceof AbstractBuildingWorker.View)
             {
                 String jobName = ((AbstractBuildingWorker.View) building).getJobName().toLowerCase(Locale.ENGLISH);
                 if (building instanceof AbstractBuildingGuards.View)

--- a/src/main/java/com/minecolonies/coremod/colony/Colony.java
+++ b/src/main/java/com/minecolonies/coremod/colony/Colony.java
@@ -1279,6 +1279,7 @@ public class Colony implements IColony
         if (building != null)
         {
             building.onUpgradeComplete(level);
+            citizenManager.calculateMaxCitizens();
             this.markDirty();
         }
     }

--- a/src/main/java/com/minecolonies/coremod/colony/Colony.java
+++ b/src/main/java/com/minecolonies/coremod/colony/Colony.java
@@ -602,6 +602,9 @@ public class Colony implements IColony
             //Compatability with old version!
             buildingManager.read(compound);
         }
+        
+        // Recalculate max after citizens and buildings are loaded.
+        citizenManager.calculateMaxCitizens();
 
         if (compound.keySet().contains(TAG_PROGRESS_MANAGER))
         {

--- a/src/main/java/com/minecolonies/coremod/colony/buildings/AbstractBuildingGuards.java
+++ b/src/main/java/com/minecolonies/coremod/colony/buildings/AbstractBuildingGuards.java
@@ -193,6 +193,14 @@ public abstract class AbstractBuildingGuards extends AbstractBuildingWorker impl
         }
 
         super.onUpgradeComplete(newLevel);
+        colony.getCitizenManager().calculateMaxCitizens();
+    }
+
+    @Override
+    public void onDestroyed()
+    {
+        super.onDestroyed();
+        colony.getCitizenManager().calculateMaxCitizens();
     }
 
     @Override

--- a/src/main/java/com/minecolonies/coremod/colony/buildings/AbstractBuildingGuards.java
+++ b/src/main/java/com/minecolonies/coremod/colony/buildings/AbstractBuildingGuards.java
@@ -193,14 +193,6 @@ public abstract class AbstractBuildingGuards extends AbstractBuildingWorker impl
         }
 
         super.onUpgradeComplete(newLevel);
-        colony.getCitizenManager().calculateMaxCitizens();
-    }
-
-    @Override
-    public void onDestroyed()
-    {
-        super.onDestroyed();
-        colony.getCitizenManager().calculateMaxCitizens();
     }
 
     @Override
@@ -217,7 +209,6 @@ public abstract class AbstractBuildingGuards extends AbstractBuildingWorker impl
                 AttributeModifierUtils.addHealthModifier(citizenEntity, healthModBuildingHP);
                 AttributeModifierUtils.addHealthModifier(citizenEntity, healthModConfig);
             }
-            colony.getCitizenManager().calculateMaxCitizens();
 
             // Set new home, since guards are housed at their workerbuilding.
             final IBuilding building = citizen.getHomeBuilding();
@@ -332,7 +323,6 @@ public abstract class AbstractBuildingGuards extends AbstractBuildingWorker impl
             }
         }
         super.removeCitizen(citizen);
-        colony.getCitizenManager().calculateMaxCitizens();
     }
 
     @Override

--- a/src/main/java/com/minecolonies/coremod/colony/buildings/AbstractCitizenAssignable.java
+++ b/src/main/java/com/minecolonies/coremod/colony/buildings/AbstractCitizenAssignable.java
@@ -135,6 +135,7 @@ public abstract class AbstractCitizenAssignable extends AbstractSchematicProvide
         if (isCitizenAssigned(citizen))
         {
             assignedCitizen.remove(citizen);
+            colony.getCitizenManager().calculateMaxCitizens();
             markDirty();
         }
     }
@@ -208,6 +209,7 @@ public abstract class AbstractCitizenAssignable extends AbstractSchematicProvide
             assignedCitizen.add(citizen);
         }
 
+        colony.getCitizenManager().calculateMaxCitizens();
         markDirty();
         return true;
     }

--- a/src/main/java/com/minecolonies/coremod/colony/managers/CitizenManager.java
+++ b/src/main/java/com/minecolonies/coremod/colony/managers/CitizenManager.java
@@ -39,7 +39,7 @@ import java.util.stream.Collectors;
 import static com.minecolonies.api.util.constant.ColonyConstants.HAPPINESS_FACTOR;
 import static com.minecolonies.api.util.constant.ColonyConstants.WELL_SATURATED_LIMIT;
 import static com.minecolonies.api.util.constant.Constants.*;
-import static com.minecolonies.api.util.constant.NbtTagConstants.*;
+import static com.minecolonies.api.util.constant.NbtTagConstants.TAG_CITIZENS;
 
 public class CitizenManager implements ICitizenManager
 {
@@ -92,9 +92,6 @@ public class CitizenManager implements ICitizenManager
     @Override
     public void read(@NotNull final CompoundNBT compound)
     {
-        maxCitizens = compound.getInt(TAG_MAX_CITIZENS);
-        potentialMaxCitizens = compound.getInt(TAG_POTENTIAL_MAX_CITIZENS);
-
         citizens.clear();
         //  Citizens before Buildings, because Buildings track the Citizens
         citizens.putAll(NBTUtils.streamCompound(compound.getList(TAG_CITIZENS, Constants.NBT.TAG_COMPOUND))
@@ -115,9 +112,6 @@ public class CitizenManager implements ICitizenManager
     @Override
     public void write(@NotNull final CompoundNBT compound)
     {
-        compound.putInt(TAG_MAX_CITIZENS, maxCitizens);
-        compound.putInt(TAG_POTENTIAL_MAX_CITIZENS, potentialMaxCitizens);
-
         @NotNull final ListNBT citizenTagList = citizens.values().stream().map(citizen -> citizen.serializeNBT()).collect(NBTUtils.toListNBT());
         compound.put(TAG_CITIZENS, citizenTagList);
     }
@@ -289,7 +283,7 @@ public class CitizenManager implements ICitizenManager
                 {
                     newMaxCitizens += b.getMaxInhabitants();
                 }
-                else if (b instanceof AbstractBuildingGuards)
+                else if (b instanceof AbstractBuildingGuards && b.getBuildingLevel() > 0)
                 {
                     if (b.getAssignedCitizen().size() != 0)
                     {

--- a/src/main/java/com/minecolonies/coremod/network/messages/BuyCitizenMessage.java
+++ b/src/main/java/com/minecolonies/coremod/network/messages/BuyCitizenMessage.java
@@ -1,15 +1,14 @@
 package com.minecolonies.coremod.network.messages;
 
+import com.ldtteam.structurize.util.LanguageHandler;
 import com.minecolonies.api.colony.ICitizenData;
 import com.minecolonies.api.colony.IColony;
 import com.minecolonies.api.colony.IColonyManager;
 import com.minecolonies.api.network.IMessage;
 import com.minecolonies.api.util.InventoryUtils;
-import com.ldtteam.structurize.util.LanguageHandler;
 import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
-
 import net.minecraft.item.Items;
 import net.minecraft.network.PacketBuffer;
 import net.minecraftforge.fml.LogicalSide;
@@ -131,7 +130,7 @@ public class BuyCitizenMessage implements IMessage
         final PlayerEntity player = ctxIn.getSender();
 
         // Check if we spawn a new citizen
-        if (colony.getCitizenManager().getCurrentCitizenCount() < colony.getCitizenManager().getMaxCitizens())
+        if (colony.getCitizenManager().getCurrentCitizenCount() < colony.getCitizenManager().getPotentialMaxCitizens())
         {
             // Get item chosen by player
             final BuyCitizenType buyCitizenType = BuyCitizenType.getFromIndex(buyItemIndex);

--- a/src/main/resources/assets/minecolonies/gui/townhall/windowtownhall.xml
+++ b/src/main/resources/assets/minecolonies/gui/townhall/windowtownhall.xml
@@ -2,8 +2,8 @@
         xsi:noNamespaceSchemaLocation="file:../../../../java/com/minecolonies/blockout/blockOut.xsd">
 
     <image source="minecolonies:textures/gui/townhall_book.png" pos="75 0" size="374 243" />
-    
-    <image id="info0" pos="56 73" size="31 14" source="minecolonies:textures/gui/bookmark_short_ribbon_01.png"/>
+
+    <image id="townhall_info_page0" pos="56 73" size="31 14" source="minecolonies:textures/gui/bookmark_short_ribbon_01.png"/>
     <image id="actions0" pos="56 97" size="31 14" source="minecolonies:textures/gui/bookmark_short_ribbon_02.png"/>
     <image id="permissions0" pos="56 121" size="31 15" source="minecolonies:textures/gui/bookmark_short_ribbon_03.png"/>
     <image id="citizens0" pos="56 145" size="31 14" source="minecolonies:textures/gui/bookmark_short_ribbon_04.png"/>
@@ -11,9 +11,9 @@
     <image id="workOrder0" pos="56 193" size="31 14" source="minecolonies:textures/gui/bookmark_short_ribbon_06.png"/>
     <image id="happiness0" pos="56 217" size="31 14" source="minecolonies:textures/gui/bookmark_short_ribbon_01.png"/>
 
-    <buttonimage id="info1" size="204 17" pos="58 43" source="minecolonies:textures/gui/bookmark_ribbon_01.png" visible="false"
-                label="$(com.minecolonies.coremod.gui.workerhuts.information)"
-                textalign="MIDDLE_LEFT" textoffset="35 2" textcolor="White" textdisabledcolor="DarkGray"/>
+    <buttonimage id="townhall_info_page1" size="204 17" pos="58 43" source="minecolonies:textures/gui/bookmark_ribbon_01.png" visible="false"
+                 label="$(com.minecolonies.coremod.gui.workerhuts.information)"
+                 textalign="MIDDLE_LEFT" textoffset="35 2" textcolor="White" textdisabledcolor="DarkGray"/>
     <buttonimage id="actions1" size="204 17" pos="58 43" source="minecolonies:textures/gui/bookmark_ribbon_02.png" visible="false"
                 label="$(com.minecolonies.coremod.gui.townHall.actions)"
                 textalign="MIDDLE_LEFT" textoffset="35 2" textcolor="White" textdisabledcolor="DarkGray"/>
@@ -56,7 +56,7 @@
                 textalign="MIDDLE_LEFT" textcolor="White" textoffset="8 1" enabled="false"/>
 
     <!-- onHoverId="infoExt" onHoverId="actionsExt" onHoverId="permissionsExt" onHoverId="citizensExt" onHoverId="settingsExt" onHoverId="workOrderExt" onHoverId="happinessExt" -->
-    <buttonimage id="info" size="17 17" pos="62 71"
+    <buttonimage id="townhall_info_page" size="17 17" pos="62 71"
                  source="minecolonies:textures/gui/red_wax_information.png"/>
     <buttonimage id="actions" size="17 17" pos="62 95"
                  source="minecolonies:textures/gui/red_wax_actions.png"/>


### PR DESCRIPTION
Closes #4191
Closes #3463

# Changes proposed in this pull request:
Now Calculates on building upgrade/destruction.
Recalculates after colony load, instead of reading old values.
Recruitment of additional guards over the citizen hut limit now works.
Level 0 guard-buildings no longer count towards the limit.

**Update**: Fixed another case and changed it to global instead. So that in the future you only need to adjust the maxCitizenCalc for new buildings/other stuff that houses.
The max citizens are now recalculated on:
- Assign and removal from a building
- Upgrade and destruction from a building
- removal of a citizen
- Colony load


Review please
