### PR TITLE
Fix citizen limit calculation v1.12

### DIFF
--- a/src/api/java/com/minecolonies/api/tileentities/TileEntityRack.java
+++ b/src/api/java/com/minecolonies/api/tileentities/TileEntityRack.java
@@ -330,15 +330,7 @@ public class TileEntityRack extends AbstractTileEntityRack
             size = compound.getInteger(TAG_SIZE);
             if (size > 0)
             {
-                inventory = new ItemStackHandler(DEFAULT_SIZE + size * SLOT_PER_LINE)
-                {
-                    @Override
-                    protected void onContentsChanged(final int slot)
-                    {
-                        updateItemStorage();
-                        super.onContentsChanged(slot);
-                    }
-                };
+                inventory = new RackInventory(DEFAULT_SIZE + size * SLOT_PER_LINE);
             }
         }
 

--- a/src/api/java/com/minecolonies/api/tileentities/TileEntityRack.java
+++ b/src/api/java/com/minecolonies/api/tileentities/TileEntityRack.java
@@ -20,7 +20,6 @@ import net.minecraft.world.World;
 import net.minecraftforge.common.capabilities.Capability;
 import net.minecraftforge.items.CapabilityItemHandler;
 import net.minecraftforge.items.IItemHandlerModifiable;
-import net.minecraftforge.items.ItemStackHandler;
 import net.minecraftforge.items.wrapper.CombinedInvWrapper;
 import org.jetbrains.annotations.NotNull;
 
@@ -156,15 +155,7 @@ public class TileEntityRack extends AbstractTileEntityRack
     public void upgradeItemStorage()
     {
         ++size;
-        final IItemHandlerModifiable tempInventory = new ItemStackHandler(DEFAULT_SIZE + size * SLOT_PER_LINE)
-        {
-            @Override
-            protected void onContentsChanged(final int slot)
-            {
-                updateItemStorage();
-                super.onContentsChanged(slot);
-            }
-        };
+        final IItemHandlerModifiable tempInventory = new RackInventory(DEFAULT_SIZE + size * SLOT_PER_LINE);
 
         for (int slot = 0; slot < inventory.getSlots(); slot++)
         {

--- a/src/api/java/com/minecolonies/api/util/constant/NbtTagConstants.java
+++ b/src/api/java/com/minecolonies/api/util/constant/NbtTagConstants.java
@@ -9,8 +9,6 @@ public final class NbtTagConstants
     public static final String TAG_NAME                   = "name";
     public static final String TAG_DIMENSION              = "dimension";
     public static final String TAG_CENTER                 = "center";
-    public static final String TAG_MAX_CITIZENS           = "maxCitizens";
-    public static final String TAG_POTENTIAL_MAX_CITIZENS = "potentialMaxCitizens";
     public static final String TAG_BUILDINGS              = "buildings";
     public static final String TAG_BUILDING               = "building";
     public static final String TAG_BUILDINGS_CLAIM        = "buildingsClaim";

--- a/src/api/java/com/minecolonies/api/util/constant/WindowConstants.java
+++ b/src/api/java/com/minecolonies/api/util/constant/WindowConstants.java
@@ -33,7 +33,7 @@ public final class WindowConstants
     /**
      * Id of the info button in the GUI.
      */
-    public static final String BUTTON_INFO = "info";
+    public static final String BUTTON_INFO = "townhall_info_page";
 
     /**
      * Id of the action button in the GUI.

--- a/src/main/java/com/minecolonies/coremod/client/gui/AbstractWindowBuilding.java
+++ b/src/main/java/com/minecolonies/coremod/client/gui/AbstractWindowBuilding.java
@@ -24,6 +24,11 @@ import static com.minecolonies.api.util.constant.WindowConstants.*;
 public abstract class AbstractWindowBuilding<B extends IBuildingView> extends AbstractWindowSkeleton
 {
     /**
+     * The info button ID for huts
+     */
+    public static final String BUTTON_INFO_HUTS = "hut_info_button";
+
+    /**
      * Type B is a class that extends {@link com.minecolonies.coremod.colony.buildings.AbstractBuildingWorker.View}.
      */
     protected final B          building;
@@ -42,15 +47,18 @@ public abstract class AbstractWindowBuilding<B extends IBuildingView> extends Ab
 
         this.building = building;
         registerButton(BUTTON_BUILD, this::buildClicked);
-        registerButton(BUTTON_INFO, this::infoClicked);
+        registerButton(BUTTON_INFO_HUTS, this::infoClicked);
         registerButton(BUTTON_INVENTORY, this::inventoryClicked);
         registerButton(BUTTON_EDIT_NAME, this::editName);
 
         title = findPaneOfTypeByID(LABEL_BUILDING_NAME, Label.class);
         buttonBuild = findPaneOfTypeByID(BUTTON_BUILD, Button.class);
-        Button buttonInfo = findPaneOfTypeByID(BUTTON_INFO, Button.class);
+        final Button buttonInfo = findPaneOfTypeByID(BUTTON_INFO_HUTS, Button.class);
 
-        buttonInfo.setVisible(I18n.hasKey(COM_MINECOLONIES_INFO_PREFIX + building.getSchematicName() + ".0"));
+        if (buttonInfo != null)
+        {
+            buttonInfo.setVisible(I18n.hasKey(COM_MINECOLONIES_INFO_PREFIX + building.getSchematicName() + ".0"));
+        }
     }
 
     /**

--- a/src/main/java/com/minecolonies/coremod/client/gui/WindowTownHall.java
+++ b/src/main/java/com/minecolonies/coremod/client/gui/WindowTownHall.java
@@ -1,6 +1,8 @@
 package com.minecolonies.coremod.client.gui;
 
-import com.minecolonies.api.colony.*;
+import com.minecolonies.api.colony.CompactColonyReference;
+import com.minecolonies.api.colony.HappinessData;
+import com.minecolonies.api.colony.ICitizenDataView;
 import com.minecolonies.api.colony.buildings.views.IBuildingView;
 import com.minecolonies.api.colony.buildings.workerbuildings.ITownHallView;
 import com.minecolonies.api.colony.permissions.Action;
@@ -19,10 +21,10 @@ import com.minecolonies.blockout.views.DropDownList;
 import com.minecolonies.blockout.views.ScrollingList;
 import com.minecolonies.blockout.views.SwitchView;
 import com.minecolonies.coremod.MineColonies;
+import com.minecolonies.coremod.colony.buildings.AbstractBuildingGuards;
+import com.minecolonies.coremod.colony.buildings.AbstractBuildingWorker;
 import com.minecolonies.coremod.colony.buildings.views.AbstractBuildingBuilderView;
 import com.minecolonies.coremod.colony.buildings.workerbuildings.BuildingTownHall;
-import com.minecolonies.coremod.colony.buildings.AbstractBuildingWorker;
-import com.minecolonies.coremod.colony.buildings.AbstractBuildingGuards;
 import com.minecolonies.coremod.network.messages.*;
 import net.minecraft.block.Block;
 import net.minecraft.client.Minecraft;
@@ -574,7 +576,7 @@ public class WindowTownHall extends AbstractWindowBuilding<ITownHallView>
         final Map<String, Integer> jobMaxCountMap = new HashMap<>();
         for (@NotNull final IBuildingView building : townHall.getColony().getBuildings())
         {
-            if (building.getBuildingLevel() > 0 && building instanceof AbstractBuildingWorker.View)
+            if (building instanceof AbstractBuildingWorker.View)
             {
                 String jobName = ((AbstractBuildingWorker.View) building).getJobName().toLowerCase(Locale.ENGLISH);
                 if (building instanceof AbstractBuildingGuards.View)

--- a/src/main/java/com/minecolonies/coremod/colony/Colony.java
+++ b/src/main/java/com/minecolonies/coremod/colony/Colony.java
@@ -1303,6 +1303,7 @@ public class Colony implements IColony
         if (building != null)
         {
             building.onUpgradeComplete(level);
+            getCitizenManager().calculateMaxCitizens();
             this.markDirty();
         }
     }

--- a/src/main/java/com/minecolonies/coremod/colony/Colony.java
+++ b/src/main/java/com/minecolonies/coremod/colony/Colony.java
@@ -606,6 +606,9 @@ public class Colony implements IColony
             buildingManager.readFromNBT(compound);
         }
 
+        // Recalculate max after citizens and buildings are loaded.
+        citizenManager.calculateMaxCitizens();
+
         if (compound.hasKey(TAG_STATS_MANAGER))
         {
             statsManager.readFromNBT(compound.getCompoundTag(TAG_STATS_MANAGER));

--- a/src/main/java/com/minecolonies/coremod/colony/buildings/AbstractBuildingGuards.java
+++ b/src/main/java/com/minecolonies/coremod/colony/buildings/AbstractBuildingGuards.java
@@ -192,7 +192,6 @@ public abstract class AbstractBuildingGuards extends AbstractBuildingWorker impl
         }
 
         super.onUpgradeComplete(newLevel);
-        colony.getCitizenManager().calculateMaxCitizens();
 
         if (newLevel == ACHIEVEMENT_LEVEL)
         {
@@ -202,13 +201,6 @@ public abstract class AbstractBuildingGuards extends AbstractBuildingWorker impl
         {
             this.getColony().getStatsManager().triggerAchievement(ModAchievements.achievementUpgradeGuardMax);
         }
-    }
-
-    @Override
-    public void onDestroyed()
-    {
-        super.onDestroyed();
-        colony.getCitizenManager().calculateMaxCitizens();
     }
 
     @Override
@@ -226,7 +218,6 @@ public abstract class AbstractBuildingGuards extends AbstractBuildingWorker impl
                 final AttributeModifier healthModConfig = new AttributeModifier(GUARD_HEALTH_MOD_CONFIG_NAME, Configurations.gameplay.guardHealthMult - 1, 1);
                 AttributeModifierUtils.addHealthModifier(citizenEntity, healthModConfig);
             }
-            colony.getCitizenManager().calculateMaxCitizens();
 
             // Set new home, since guards are housed at their workerbuilding.
             final IBuilding building = citizen.getHomeBuilding();
@@ -341,7 +332,6 @@ public abstract class AbstractBuildingGuards extends AbstractBuildingWorker impl
             }
         }
         super.removeCitizen(citizen);
-        colony.getCitizenManager().calculateMaxCitizens();
     }
 
     @Override

--- a/src/main/java/com/minecolonies/coremod/colony/buildings/AbstractBuildingGuards.java
+++ b/src/main/java/com/minecolonies/coremod/colony/buildings/AbstractBuildingGuards.java
@@ -192,6 +192,7 @@ public abstract class AbstractBuildingGuards extends AbstractBuildingWorker impl
         }
 
         super.onUpgradeComplete(newLevel);
+        colony.getCitizenManager().calculateMaxCitizens();
 
         if (newLevel == ACHIEVEMENT_LEVEL)
         {
@@ -201,6 +202,13 @@ public abstract class AbstractBuildingGuards extends AbstractBuildingWorker impl
         {
             this.getColony().getStatsManager().triggerAchievement(ModAchievements.achievementUpgradeGuardMax);
         }
+    }
+
+    @Override
+    public void onDestroyed()
+    {
+        super.onDestroyed();
+        colony.getCitizenManager().calculateMaxCitizens();
     }
 
     @Override

--- a/src/main/java/com/minecolonies/coremod/colony/buildings/AbstractCitizenAssignable.java
+++ b/src/main/java/com/minecolonies/coremod/colony/buildings/AbstractCitizenAssignable.java
@@ -135,6 +135,7 @@ public abstract class AbstractCitizenAssignable extends AbstractSchematicProvide
         if (isCitizenAssigned(citizen))
         {
             assignedCitizen.remove(citizen);
+            colony.getCitizenManager().calculateMaxCitizens();
             markDirty();
         }
     }
@@ -208,6 +209,7 @@ public abstract class AbstractCitizenAssignable extends AbstractSchematicProvide
             assignedCitizen.add(citizen);
         }
 
+        colony.getCitizenManager().calculateMaxCitizens();
         markDirty();
         return true;
     }

--- a/src/main/java/com/minecolonies/coremod/colony/managers/CitizenManager.java
+++ b/src/main/java/com/minecolonies/coremod/colony/managers/CitizenManager.java
@@ -38,7 +38,7 @@ import java.util.stream.Collectors;
 import static com.minecolonies.api.util.constant.ColonyConstants.HAPPINESS_FACTOR;
 import static com.minecolonies.api.util.constant.ColonyConstants.WELL_SATURATED_LIMIT;
 import static com.minecolonies.api.util.constant.Constants.*;
-import static com.minecolonies.api.util.constant.NbtTagConstants.*;
+import static com.minecolonies.api.util.constant.NbtTagConstants.TAG_CITIZENS;
 
 public class CitizenManager implements ICitizenManager
 {
@@ -91,9 +91,6 @@ public class CitizenManager implements ICitizenManager
     @Override
     public void readFromNBT(@NotNull final NBTTagCompound compound)
     {
-        maxCitizens = compound.getInteger(TAG_MAX_CITIZENS);
-        potentialMaxCitizens = compound.getInteger(TAG_POTENTIAL_MAX_CITIZENS);
-
         citizens.clear();
         //  Citizens before Buildings, because Buildings track the Citizens
         citizens.putAll(NBTUtils.streamCompound(compound.getTagList(TAG_CITIZENS, Constants.NBT.TAG_COMPOUND))
@@ -114,9 +111,6 @@ public class CitizenManager implements ICitizenManager
     @Override
     public void writeToNBT(@NotNull final NBTTagCompound compound)
     {
-        compound.setInteger(TAG_MAX_CITIZENS, maxCitizens);
-        compound.setInteger(TAG_POTENTIAL_MAX_CITIZENS, potentialMaxCitizens);
-
         @NotNull final NBTTagList citizenTagList = citizens.values().stream().map(INBTSerializable::serializeNBT).collect(NBTUtils.toNBTTagList());
         compound.setTag(TAG_CITIZENS, citizenTagList);
     }
@@ -288,7 +282,7 @@ public class CitizenManager implements ICitizenManager
                 {
                     newMaxCitizens += b.getMaxInhabitants();
                 }
-                else if (b instanceof AbstractBuildingGuards)
+                else if (b instanceof AbstractBuildingGuards && b.getBuildingLevel() > 0)
                 {
                     if (b.getAssignedCitizen().size() != 0)
                     {

--- a/src/main/java/com/minecolonies/coremod/network/messages/BuyCitizenMessage.java
+++ b/src/main/java/com/minecolonies/coremod/network/messages/BuyCitizenMessage.java
@@ -120,7 +120,7 @@ public class BuyCitizenMessage extends AbstractMessage<BuyCitizenMessage, IMessa
         }
 
         // Check if we spawn a new citizen
-        if (colony.getCitizenManager().getCurrentCitizenCount() < colony.getCitizenManager().getMaxCitizens())
+        if (colony.getCitizenManager().getCurrentCitizenCount() < colony.getCitizenManager().getPotentialMaxCitizens())
         {
             // Get item chosen by player
             final BuyCitizenType buyCitizenType = BuyCitizenType.getFromIndex(message.buyItemIndex);

--- a/src/main/resources/assets/minecolonies/gui/townhall/windowtownhall.xml
+++ b/src/main/resources/assets/minecolonies/gui/townhall/windowtownhall.xml
@@ -2,8 +2,8 @@
         xsi:noNamespaceSchemaLocation="file:../../../../java/com/minecolonies/blockout/blockOut.xsd">
 
     <image source="minecolonies:textures/gui/townhall_book.png" pos="75 0" size="374 243" />
-    
-    <image id="info0" pos="56 73" size="31 14" source="minecolonies:textures/gui/bookmark_short_ribbon_01.png"/>
+
+    <image id="townhall_info_page0" pos="56 73" size="31 14" source="minecolonies:textures/gui/bookmark_short_ribbon_01.png"/>
     <image id="actions0" pos="56 97" size="31 14" source="minecolonies:textures/gui/bookmark_short_ribbon_02.png"/>
     <image id="permissions0" pos="56 121" size="31 15" source="minecolonies:textures/gui/bookmark_short_ribbon_03.png"/>
     <image id="citizens0" pos="56 145" size="31 14" source="minecolonies:textures/gui/bookmark_short_ribbon_04.png"/>
@@ -11,9 +11,9 @@
     <image id="workOrder0" pos="56 193" size="31 14" source="minecolonies:textures/gui/bookmark_short_ribbon_06.png"/>
     <image id="happiness0" pos="56 217" size="31 14" source="minecolonies:textures/gui/bookmark_short_ribbon_01.png"/>
 
-    <buttonimage id="info1" size="204 17" pos="58 43" source="minecolonies:textures/gui/bookmark_ribbon_01.png" visible="false"
-                label="$(com.minecolonies.coremod.gui.workerHuts.information)"
-                textalign="MIDDLE_LEFT" textoffset="35 2" textcolor="White" textdisabledcolor="DarkGray"/>
+    <buttonimage id="townhall_info_page1" size="204 17" pos="58 43" source="minecolonies:textures/gui/bookmark_ribbon_01.png" visible="false"
+                 label="$(com.minecolonies.coremod.gui.workerHuts.information)"
+                 textalign="MIDDLE_LEFT" textoffset="35 2" textcolor="White" textdisabledcolor="DarkGray"/>
     <buttonimage id="actions1" size="204 17" pos="58 43" source="minecolonies:textures/gui/bookmark_ribbon_02.png" visible="false"
                 label="$(com.minecolonies.coremod.gui.townHall.actions)"
                 textalign="MIDDLE_LEFT" textoffset="35 2" textcolor="White" textdisabledcolor="DarkGray"/>
@@ -56,7 +56,7 @@
                 textalign="MIDDLE_LEFT" textcolor="White" textoffset="8 1" enabled="false"/>
 
     <!-- onHoverId="infoExt" onHoverId="actionsExt" onHoverId="permissionsExt" onHoverId="citizensExt" onHoverId="settingsExt" onHoverId="workOrderExt" onHoverId="happinessExt" -->
-    <buttonimage id="info" size="17 17" pos="62 71"
+    <buttonimage id="townhall_info_page" size="17 17" pos="62 71"
                  source="minecolonies:textures/gui/red_wax_information.png"/>
     <buttonimage id="actions" size="17 17" pos="62 95"
                  source="minecolonies:textures/gui/red_wax_actions.png"/>

--- a/src/main/resources/assets/minecolonies/gui/windowinfo.xml
+++ b/src/main/resources/assets/minecolonies/gui/windowinfo.xml
@@ -8,7 +8,7 @@
     <image source="minecolonies:textures/gui/builderhut/builder_sketch_right.png" size="6 15" pos="140 12"/>
     <label id="name" size="90 11" pos="50 14" textalign="MIDDLE" color="red"/>
 
-    <label id="info" size="150 180" pos="20 30" textalign="TOP_LEFT" label="" color="black" wrap="true"/>
+    <label id="hut_info_button" size="150 180" pos="20 30" textalign="TOP_LEFT" label="" color="black" wrap="true"/>
 
     <buttonimage id="infoPrevPage" size="18 10" pos="13 222" source="minecolonies:textures/gui/builderhut/turn_page_left.png"/>
     <label id="pageNum" size="20 11" pos="85 222" textalign="MIDDLE" label="" color="black"/>


### PR DESCRIPTION
Closes #4191
Closes #3463

# Changes proposed in this pull request:
Now Calculates on building upgrade/destruction.
Recalculates after colony load, instead of reading old values.
Recruitment of additional guards over the citizen hut limit now works.
Level 0 guard-buildings no longer count towards the limit.

**Update**: Fixed another case and changed it to global instead. So that in the future you only need to adjust the maxCitizenCalc for new buildings/other stuff that houses.
The max citizens are now recalculated on:
- Assign and removal from a building
- Upgrade and destruction from a building
- removal of a citizen
- Colony load


**1.12 only:**
Backported the RackInventory class from 1.14, as on 1.12 we're atm overwriting our setStackinSlot  hook needed for our warehouse and RS

Fixed an ID issue, causing the Townhalls info page to be hidden.

Review please
