### PR TITLE
Fix command op restrictions

### DIFF
--- a/src/api/java/com/minecolonies/api/configuration/CommonConfiguration.java
+++ b/src/api/java/com/minecolonies/api/configuration/CommonConfiguration.java
@@ -63,8 +63,6 @@ public class CommonConfiguration extends AbstractConfiguration
     public final ForgeConfigSpec.BooleanValue canPlayerUseColonyTPCommand;
     public final ForgeConfigSpec.BooleanValue canPlayerUseAllyTHTeleport;
     public final ForgeConfigSpec.BooleanValue canPlayerUseHomeTPCommand;
-    public final ForgeConfigSpec.BooleanValue canPlayerUseCitizenInfoCommand;
-    public final ForgeConfigSpec.BooleanValue canPlayerUseListCitizensCommand;
     public final ForgeConfigSpec.BooleanValue canPlayerUseShowColonyInfoCommand;
     public final ForgeConfigSpec.BooleanValue canPlayerUseKillCitizensCommand;
     public final ForgeConfigSpec.BooleanValue canPlayerUseAddOfficerCommand;
@@ -212,8 +210,6 @@ public class CommonConfiguration extends AbstractConfiguration
         canPlayerUseColonyTPCommand = defineBoolean(builder, "canplayerusecolonytpcommand", false);
         canPlayerUseAllyTHTeleport = defineBoolean(builder, "canplayeruseallytownhallteleport", true);
         canPlayerUseHomeTPCommand = defineBoolean(builder, "canplayerusehometpcommand", true);
-        canPlayerUseCitizenInfoCommand = defineBoolean(builder, "canplayerusecitizeninfocommand", true);
-        canPlayerUseListCitizensCommand = defineBoolean(builder, "canplayeruselistcitizenscommand", true);
         canPlayerUseShowColonyInfoCommand = defineBoolean(builder, "canplayeruseshowcolonyinfocommand", true);
         canPlayerUseKillCitizensCommand = defineBoolean(builder, "canplayerusekillcitizenscommand", true);
         canPlayerUseAddOfficerCommand = defineBoolean(builder, "canplayeruseaddofficercommand", true);

--- a/src/main/java/com/minecolonies/coremod/commands/citizencommands/CommandCitizenInfo.java
+++ b/src/main/java/com/minecolonies/coremod/commands/citizencommands/CommandCitizenInfo.java
@@ -5,7 +5,6 @@ import com.minecolonies.api.colony.ICitizenData;
 import com.minecolonies.api.colony.IColony;
 import com.minecolonies.api.colony.IColonyManager;
 import com.minecolonies.api.entity.citizen.AbstractEntityCitizen;
-import com.minecolonies.coremod.MineColonies;
 import com.minecolonies.coremod.commands.commandTypes.IMCColonyOfficerCommand;
 import com.minecolonies.coremod.commands.commandTypes.IMCCommand;
 import com.mojang.brigadier.arguments.IntegerArgumentType;
@@ -43,12 +42,6 @@ public class CommandCitizenInfo implements IMCColonyOfficerCommand
         if (colony == null)
         {
             LanguageHandler.sendPlayerMessage((PlayerEntity) sender, "com.minecolonies.command.colonyidnotfound", colonyID);
-            return 0;
-        }
-
-        if (!MineColonies.getConfig().getCommon().canPlayerUseCitizenInfoCommand.get())
-        {
-            LanguageHandler.sendPlayerMessage((PlayerEntity) sender, "com.minecolonies.command.notenabledinconfig");
             return 0;
         }
 

--- a/src/main/java/com/minecolonies/coremod/commands/citizencommands/CommandCitizenKill.java
+++ b/src/main/java/com/minecolonies/coremod/commands/citizencommands/CommandCitizenKill.java
@@ -52,7 +52,7 @@ public class CommandCitizenKill implements IMCColonyOfficerCommand
             return 0;
         }
 
-        if (!MineColonies.getConfig().getCommon().canPlayerUseKillCitizensCommand.get())
+        if (!IMCCommand.isPlayerOped((PlayerEntity) sender) && !MineColonies.getConfig().getCommon().canPlayerUseKillCitizensCommand.get())
         {
             LanguageHandler.sendPlayerMessage((PlayerEntity) sender, "com.minecolonies.command.notenabledinconfig");
             return 0;

--- a/src/main/java/com/minecolonies/coremod/commands/citizencommands/CommandCitizenList.java
+++ b/src/main/java/com/minecolonies/coremod/commands/citizencommands/CommandCitizenList.java
@@ -4,7 +4,6 @@ import com.ldtteam.structurize.util.LanguageHandler;
 import com.minecolonies.api.colony.ICitizenData;
 import com.minecolonies.api.colony.IColony;
 import com.minecolonies.api.colony.IColonyManager;
-import com.minecolonies.coremod.MineColonies;
 import com.minecolonies.coremod.commands.commandTypes.IMCColonyOfficerCommand;
 import com.minecolonies.coremod.commands.commandTypes.IMCCommand;
 import com.mojang.brigadier.arguments.IntegerArgumentType;
@@ -68,12 +67,6 @@ public class CommandCitizenList implements IMCColonyOfficerCommand
         if (colony == null)
         {
             LanguageHandler.sendPlayerMessage((PlayerEntity) sender, "com.minecolonies.command.colonyidnotfound", colonyID);
-            return 0;
-        }
-
-        if (!MineColonies.getConfig().getCommon().canPlayerUseListCitizensCommand.get())
-        {
-            LanguageHandler.sendPlayerMessage((PlayerEntity) sender, "com.minecolonies.command.notenabledinconfig");
             return 0;
         }
 

--- a/src/main/java/com/minecolonies/coremod/commands/colonycommands/CommandAddOfficer.java
+++ b/src/main/java/com/minecolonies/coremod/commands/colonycommands/CommandAddOfficer.java
@@ -32,7 +32,7 @@ public class CommandAddOfficer implements IMCColonyOfficerCommand
     {
         final Entity sender = context.getSource().getEntity();
 
-        if (!MineColonies.getConfig().getCommon().canPlayerUseAddOfficerCommand.get())
+        if (!IMCCommand.isPlayerOped((PlayerEntity) sender) && !MineColonies.getConfig().getCommon().canPlayerUseAddOfficerCommand.get())
         {
             LanguageHandler.sendPlayerMessage((PlayerEntity) sender, "com.minecolonies.command.notenabledinconfig");
             return 0;

--- a/src/main/java/com/minecolonies/coremod/commands/colonycommands/CommandDeleteColony.java
+++ b/src/main/java/com/minecolonies/coremod/commands/colonycommands/CommandDeleteColony.java
@@ -38,7 +38,7 @@ public class CommandDeleteColony implements IMCColonyOfficerCommand
     {
         final Entity sender = context.getSource().getEntity();
 
-        if (!MineColonies.getConfig().getCommon().canPlayerUseDeleteColonyCommand.get())
+        if (!IMCCommand.isPlayerOped((PlayerEntity) sender) && !MineColonies.getConfig().getCommon().canPlayerUseDeleteColonyCommand.get())
         {
             LanguageHandler.sendPlayerMessage((PlayerEntity) sender, "com.minecolonies.command.notenabledinconfig");
             return 0;

--- a/src/main/java/com/minecolonies/coremod/commands/colonycommands/CommandTeleport.java
+++ b/src/main/java/com/minecolonies/coremod/commands/colonycommands/CommandTeleport.java
@@ -32,7 +32,7 @@ public class CommandTeleport implements IMCColonyOfficerCommand
     {
         final Entity sender = context.getSource().getEntity();
 
-        if (!MineColonies.getConfig().getCommon().canPlayerUseColonyTPCommand.get())
+        if (!IMCCommand.isPlayerOped((PlayerEntity) sender) && !MineColonies.getConfig().getCommon().canPlayerUseColonyTPCommand.get())
         {
             LanguageHandler.sendPlayerMessage((PlayerEntity) sender, "com.minecolonies.command.notenabledinconfig");
             return 0;


### PR DESCRIPTION
# Changes proposed in this pull request:
Commands which are disabled in the config no longer prevent OPs from using them.
Removed config restriction on informational commands like citizen and and citizen list, they're now always available for colony officers.

Review please
