### PR TITLE
Builder fixes

### DIFF
--- a/src/main/java/com/minecolonies/coremod/colony/buildings/AbstractBuildingStructureBuilder.java
+++ b/src/main/java/com/minecolonies/coremod/colony/buildings/AbstractBuildingStructureBuilder.java
@@ -2,7 +2,7 @@ package com.minecolonies.coremod.colony.buildings;
 
 import com.minecolonies.api.colony.ICitizenData;
 import com.minecolonies.api.colony.IColony;
-import com.minecolonies.api.entity.ai.util.StructureIterator;
+import com.minecolonies.coremod.entity.ai.util.StructureIterator;
 import com.minecolonies.api.inventory.InventoryCitizen;
 import com.minecolonies.api.util.BlockPosUtil;
 import com.minecolonies.api.util.InventoryUtils;

--- a/src/main/java/com/minecolonies/coremod/entity/ai/basic/AbstractEntityAIStructure.java
+++ b/src/main/java/com/minecolonies/coremod/entity/ai/basic/AbstractEntityAIStructure.java
@@ -446,7 +446,8 @@ public abstract class AbstractEntityAIStructure<J extends AbstractJobStructure> 
 
                 final BlockState worldState = world.getBlockState(coords);
 
-                if (worldState.getMaterial() != Material.AIR
+                if (!sameInWorld
+                      && worldState.getMaterial() != Material.AIR
                       && !(worldState.getBlock() instanceof DoublePlantBlock && worldState.get(DoublePlantBlock.HALF).equals(DoubleBlockHalf.UPPER)))
                 {
                     handleBuildingOverBlock(coords);

--- a/src/main/java/com/minecolonies/coremod/entity/ai/basic/AbstractEntityAIStructure.java
+++ b/src/main/java/com/minecolonies/coremod/entity/ai/basic/AbstractEntityAIStructure.java
@@ -16,7 +16,7 @@ import com.minecolonies.api.entity.ai.statemachine.AIEventTarget;
 import com.minecolonies.api.entity.ai.statemachine.AITarget;
 import com.minecolonies.api.entity.ai.statemachine.states.AIBlockingEventType;
 import com.minecolonies.api.entity.ai.statemachine.states.IAIState;
-import com.minecolonies.api.entity.ai.util.StructureIterator;
+import com.minecolonies.coremod.entity.ai.util.StructureIterator;
 import com.minecolonies.api.entity.citizen.AbstractEntityCitizen;
 import com.minecolonies.api.util.*;
 import com.minecolonies.api.util.constant.TypeConstants;
@@ -202,7 +202,7 @@ public abstract class AbstractEntityAIStructure<J extends AbstractJobStructure> 
         //do not replace with method reference, this one stays the same on changing reference for currentStructure
         //URGENT: DO NOT REPLACE FOR ANY MEANS THIS WILL CRASH THE GAME.
         @NotNull final Supplier<StructureIterator.StructureBlock> getCurrentBlock = () -> currentStructure.getCurrentBlock();
-        @NotNull final Supplier<StructureIterator.Result> advanceBlock = () -> currentStructure.advanceBlock();
+        @NotNull final Supplier<StructureIterator.Result> advanceBlock = () -> currentStructure.advanceBlock(this);
 
         return () ->
         {
@@ -421,9 +421,15 @@ public abstract class AbstractEntityAIStructure<J extends AbstractJobStructure> 
         {
             if (handlers.canHandle(world, coords, blockState))
             {
-                if (!MineColonies.getConfig().getCommon().builderInfiniteResources.get())
+                boolean sameInWorld = false;
+                if (world.getBlockState(coords).getBlock() == blockState.getBlock())
                 {
-                    final List<ItemStack> requiredItems = handlers.getRequiredItems(world, coords, blockState, job.getStructure().getTileEntityData(job.getStructure().getLocalPosition()), false);
+                    sameInWorld = true;
+                }
+                if (!sameInWorld && !MineColonies.getConfig().getCommon().builderInfiniteResources.get())
+                {
+                    final List<ItemStack> requiredItems =
+                      handlers.getRequiredItems(world, coords, blockState, job.getStructure().getTileEntityData(job.getStructure().getLocalPosition()), false);
 
                     final List<ItemStack> itemList = new ArrayList<>();
                     for (final ItemStack stack : requiredItems)
@@ -436,6 +442,7 @@ public abstract class AbstractEntityAIStructure<J extends AbstractJobStructure> 
                         return false;
                     }
                 }
+
 
                 final BlockState worldState = world.getBlockState(coords);
 
@@ -464,7 +471,10 @@ public abstract class AbstractEntityAIStructure<J extends AbstractJobStructure> 
                 if (result instanceof BlockState)
                 {
                     decrease = (BlockState) result;
-                    decreaseInventory(coords, decrease.getBlock(), decrease);
+                    if (!sameInWorld)
+                    {
+                        decreaseInventory(coords, decrease.getBlock(), decrease);
+                    }
                     connectBlockToBuildingIfNecessary(decrease, coords);
                     worker.swingArm(worker.getActiveHand());
                     worker.getCitizenExperienceHandler().addExperience(XP_EACH_BLOCK);

--- a/src/main/java/com/minecolonies/coremod/entity/ai/basic/AbstractEntityAIStructureWithWorkOrder.java
+++ b/src/main/java/com/minecolonies/coremod/entity/ai/basic/AbstractEntityAIStructureWithWorkOrder.java
@@ -1,6 +1,5 @@
 package com.minecolonies.coremod.entity.ai.basic;
 
-import com.ldtteam.structurize.blocks.schematic.BlockSolidSubstitution;
 import com.ldtteam.structurize.placementhandlers.IPlacementHandler;
 import com.ldtteam.structurize.placementhandlers.PlacementHandlers;
 import com.ldtteam.structurize.util.BlockInfo;
@@ -10,8 +9,7 @@ import com.minecolonies.api.blocks.AbstractBlockHut;
 import com.minecolonies.api.colony.buildings.IBuilding;
 import com.minecolonies.api.compatibility.candb.ChiselAndBitsCheck;
 import com.minecolonies.api.crafting.ItemStorage;
-import com.minecolonies.api.entity.ai.util.StructureIterator;
-import com.minecolonies.api.util.BlockPosUtil;
+import com.minecolonies.coremod.entity.ai.util.StructureIterator;
 import com.minecolonies.api.util.ItemStackUtils;
 import com.minecolonies.api.util.Log;
 import com.minecolonies.coremod.MineColonies;
@@ -30,7 +28,6 @@ import net.minecraft.state.properties.DoubleBlockHalf;
 import net.minecraft.tags.BlockTags;
 import net.minecraft.util.Tuple;
 import net.minecraft.util.math.BlockPos;
-import net.minecraft.world.chunk.ChunkStatus;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 

--- a/src/main/java/com/minecolonies/coremod/entity/ai/citizen/builder/EntityAIStructureBuilder.java
+++ b/src/main/java/com/minecolonies/coremod/entity/ai/citizen/builder/EntityAIStructureBuilder.java
@@ -5,7 +5,7 @@ import com.minecolonies.api.blocks.ModBlocks;
 import com.minecolonies.api.colony.buildings.IBuilding;
 import com.minecolonies.api.entity.ai.statemachine.AITarget;
 import com.minecolonies.api.entity.ai.statemachine.states.IAIState;
-import com.minecolonies.api.entity.ai.util.StructureIterator;
+import com.minecolonies.coremod.entity.ai.util.StructureIterator;
 import com.minecolonies.api.util.*;
 import com.minecolonies.coremod.MineColonies;
 import com.minecolonies.coremod.colony.buildings.AbstractBuildingStructureBuilder;

--- a/src/main/java/com/minecolonies/coremod/entity/ai/util/StructureIterator.java
+++ b/src/main/java/com/minecolonies/coremod/entity/ai/util/StructureIterator.java
@@ -1,4 +1,4 @@
-package com.minecolonies.api.entity.ai.util;
+package com.minecolonies.coremod.entity.ai.util;
 
 import com.ldtteam.structures.helpers.Structure;
 import com.ldtteam.structurize.util.PlacementSettings;
@@ -6,6 +6,7 @@ import com.minecolonies.api.MinecoloniesAPIProxy;
 import com.minecolonies.api.blocks.AbstractBlockMinecoloniesRack;
 import com.minecolonies.api.colony.IColonyManager;
 import com.minecolonies.api.util.BlockPosUtil;
+import com.minecolonies.coremod.entity.ai.basic.AbstractEntityAIStructure;
 import net.minecraft.block.*;
 import net.minecraft.block.Blocks;
 import net.minecraft.item.Item;
@@ -211,7 +212,7 @@ public class StructureIterator
      * @return a Result enum specifying the result
      */
     @NotNull
-    public Result advanceBlock()
+    public Result advanceBlock(final AbstractEntityAIStructure abstractEntityAIStructure)
     {
         switch (this.stage)
         {
@@ -220,7 +221,7 @@ public class StructureIterator
                   structureBlock -> structureBlock.doesStructureBlockEqualWorldBlock()
                                       || structureBlock.worldBlock == Blocks.AIR);
             case BUILD:
-                return advanceBlocks(this.theStructure::incrementBlock, structureBlock -> structureBlock.doesStructureBlockEqualWorldBlock()
+                return advanceBlocks(this.theStructure::incrementBlock, structureBlock -> doesStructureBlockEqualWorldBlock(structureBlock, abstractEntityAIStructure)
                                                                                          || structureBlock.block == Blocks.AIR
                                                                                          || !structureBlock.metadata.getMaterial().isSolid());
             case SPAWN:
@@ -228,7 +229,7 @@ public class StructureIterator
                                                                           structureBlock.entity == null || structureBlock.entity.length <= 0);
             case DECORATE:
                 return advanceBlocks(this.theStructure::incrementBlock, structureBlock ->
-                                                                       structureBlock.doesStructureBlockEqualWorldBlock()
+                                                                          doesStructureBlockEqualWorldBlock(structureBlock, abstractEntityAIStructure)
                                                                          || structureBlock.metadata.getMaterial().isSolid());
             case REMOVE:
                 return advanceBlocks(this.theStructure::decrementBlock,
@@ -236,6 +237,22 @@ public class StructureIterator
             default:
                 return Result.NEW_BLOCK;
         }
+    }
+
+    /**
+     * Check if the block equals the world block and connect with the building if necessary.
+     * @param block the structure block.
+     * @param entityAIStructure the AI instance.
+     * @return true if so.
+     */
+    private boolean doesStructureBlockEqualWorldBlock(final StructureBlock block, final AbstractEntityAIStructure entityAIStructure)
+    {
+        if (block.doesStructureBlockEqualWorldBlock())
+        {
+            entityAIStructure.connectBlockToBuildingIfNecessary(block.metadata, block.blockPosition);
+            return true;
+        }
+        return false;
     }
 
     /**


### PR DESCRIPTION
This PR aims to improve some builder handling:

1) Always call the connectBlockToBuilding even if we already have it. This allows to re-register things if they failed earlier.

2) Some blocks like glasspains might get lost in an upgrade only because the new glasspane got a different blockstate. We should avoid this.

Review please
