### PR TITLE
Fix citizen limit calculation (#4228)

### DIFF
--- a/src/api/java/com/minecolonies/api/tileentities/TileEntityRack.java
+++ b/src/api/java/com/minecolonies/api/tileentities/TileEntityRack.java
@@ -340,15 +340,7 @@ public class TileEntityRack extends AbstractTileEntityRack
             size = compound.getInt(TAG_SIZE);
             if (size > 0)
             {
-                inventory = new RackInventory(DEFAULT_SIZE + size * SLOT_PER_LINE)
-                {
-                    @Override
-                    protected void onContentsChanged(final int slot)
-                    {
-                        updateItemStorage();
-                        super.onContentsChanged(slot);
-                    }
-                };
+                inventory = new RackInventory(DEFAULT_SIZE + size * SLOT_PER_LINE);
             }
         }
 

--- a/src/api/java/com/minecolonies/api/util/constant/NbtTagConstants.java
+++ b/src/api/java/com/minecolonies/api/util/constant/NbtTagConstants.java
@@ -9,8 +9,6 @@ public final class NbtTagConstants
     public static final String TAG_NAME                   = "name";
     public static final String TAG_DIMENSION              = "dimension";
     public static final String TAG_CENTER                 = "center";
-    public static final String TAG_MAX_CITIZENS           = "maxCitizens";
-    public static final String TAG_POTENTIAL_MAX_CITIZENS = "potentialMaxCitizens";
     public static final String TAG_BUILDINGS              = "buildings";
     public static final String TAG_BUILDING               = "building";
     public static final String TAG_BUILDINGS_CLAIM        = "buildingsClaim";

--- a/src/api/java/com/minecolonies/api/util/constant/WindowConstants.java
+++ b/src/api/java/com/minecolonies/api/util/constant/WindowConstants.java
@@ -33,7 +33,7 @@ public final class WindowConstants
     /**
      * Id of the info button in the GUI.
      */
-    public static final String BUTTON_INFO = "townhall_info_page";
+    public static final String BUTTON_INFO = "info";
 
     /**
      * Id of the info button in the GUI.

--- a/src/api/java/com/minecolonies/api/util/constant/WindowConstants.java
+++ b/src/api/java/com/minecolonies/api/util/constant/WindowConstants.java
@@ -33,7 +33,7 @@ public final class WindowConstants
     /**
      * Id of the info button in the GUI.
      */
-    public static final String BUTTON_INFO = "info";
+    public static final String BUTTON_INFO = "townhall_info_page";
 
     /**
      * Id of the info button in the GUI.

--- a/src/main/java/com/minecolonies/coremod/client/gui/WindowTownHall.java
+++ b/src/main/java/com/minecolonies/coremod/client/gui/WindowTownHall.java
@@ -6,7 +6,9 @@ import com.ldtteam.blockout.views.DropDownList;
 import com.ldtteam.blockout.views.ScrollingList;
 import com.ldtteam.blockout.views.SwitchView;
 import com.ldtteam.structurize.util.LanguageHandler;
-import com.minecolonies.api.colony.*;
+import com.minecolonies.api.colony.CompactColonyReference;
+import com.minecolonies.api.colony.HappinessData;
+import com.minecolonies.api.colony.ICitizenDataView;
 import com.minecolonies.api.colony.buildings.views.IBuildingView;
 import com.minecolonies.api.colony.buildings.workerbuildings.ITownHallView;
 import com.minecolonies.api.colony.permissions.Action;
@@ -19,11 +21,11 @@ import com.minecolonies.api.util.Log;
 import com.minecolonies.api.util.constant.Constants;
 import com.minecolonies.coremod.MineColonies;
 import com.minecolonies.coremod.Network;
+import com.minecolonies.coremod.colony.buildings.AbstractBuildingGuards;
+import com.minecolonies.coremod.colony.buildings.AbstractBuildingWorker;
 import com.minecolonies.coremod.colony.buildings.views.AbstractBuildingBuilderView;
 import com.minecolonies.coremod.colony.buildings.workerbuildings.BuildingTownHall;
 import com.minecolonies.coremod.commands.ClickEventWithExecutable;
-import com.minecolonies.coremod.colony.buildings.AbstractBuildingWorker;
-import com.minecolonies.coremod.colony.buildings.AbstractBuildingGuards;
 import com.minecolonies.coremod.network.messages.*;
 import net.minecraft.block.Block;
 import net.minecraft.client.Minecraft;
@@ -587,7 +589,7 @@ public class WindowTownHall extends AbstractWindowBuilding<ITownHallView>
         final Map<String, Integer> jobMaxCountMap = new HashMap<>();
         for (@NotNull final IBuildingView building : townHall.getColony().getBuildings())
         {
-            if (building.getBuildingLevel() > 0 && building instanceof AbstractBuildingWorker.View)
+            if (building instanceof AbstractBuildingWorker.View)
             {
                 String jobName = LanguageHandler.format(((AbstractBuildingWorker.View) building).getJobName()).toLowerCase(Locale.ENGLISH);
                 if (building instanceof AbstractBuildingGuards.View)

--- a/src/main/java/com/minecolonies/coremod/colony/Colony.java
+++ b/src/main/java/com/minecolonies/coremod/colony/Colony.java
@@ -608,6 +608,9 @@ public class Colony implements IColony
             buildingManager.read(compound);
         }
 
+        // Recalculate max after citizens and buildings are loaded.
+        citizenManager.calculateMaxCitizens();
+
         if (compound.keySet().contains(TAG_PROGRESS_MANAGER))
         {
             progressManager.read(compound);
@@ -1282,6 +1285,7 @@ public class Colony implements IColony
         if (building != null)
         {
             building.onUpgradeComplete(level);
+            citizenManager.calculateMaxCitizens();
             this.markDirty();
         }
     }

--- a/src/main/java/com/minecolonies/coremod/colony/buildings/AbstractBuildingGuards.java
+++ b/src/main/java/com/minecolonies/coremod/colony/buildings/AbstractBuildingGuards.java
@@ -209,7 +209,6 @@ public abstract class AbstractBuildingGuards extends AbstractBuildingWorker impl
                 AttributeModifierUtils.addHealthModifier(citizenEntity, healthModBuildingHP);
                 AttributeModifierUtils.addHealthModifier(citizenEntity, healthModConfig);
             }
-            colony.getCitizenManager().calculateMaxCitizens();
 
             // Set new home, since guards are housed at their workerbuilding.
             final IBuilding building = citizen.getHomeBuilding();
@@ -324,7 +323,6 @@ public abstract class AbstractBuildingGuards extends AbstractBuildingWorker impl
             }
         }
         super.removeCitizen(citizen);
-        colony.getCitizenManager().calculateMaxCitizens();
     }
 
     @Override

--- a/src/main/java/com/minecolonies/coremod/colony/buildings/AbstractCitizenAssignable.java
+++ b/src/main/java/com/minecolonies/coremod/colony/buildings/AbstractCitizenAssignable.java
@@ -135,6 +135,7 @@ public abstract class AbstractCitizenAssignable extends AbstractSchematicProvide
         if (isCitizenAssigned(citizen))
         {
             assignedCitizen.remove(citizen);
+            colony.getCitizenManager().calculateMaxCitizens();
             markDirty();
         }
     }
@@ -208,6 +209,7 @@ public abstract class AbstractCitizenAssignable extends AbstractSchematicProvide
             assignedCitizen.add(citizen);
         }
 
+        colony.getCitizenManager().calculateMaxCitizens();
         markDirty();
         return true;
     }

--- a/src/main/java/com/minecolonies/coremod/colony/managers/CitizenManager.java
+++ b/src/main/java/com/minecolonies/coremod/colony/managers/CitizenManager.java
@@ -39,7 +39,7 @@ import java.util.stream.Collectors;
 import static com.minecolonies.api.util.constant.ColonyConstants.HAPPINESS_FACTOR;
 import static com.minecolonies.api.util.constant.ColonyConstants.WELL_SATURATED_LIMIT;
 import static com.minecolonies.api.util.constant.Constants.*;
-import static com.minecolonies.api.util.constant.NbtTagConstants.*;
+import static com.minecolonies.api.util.constant.NbtTagConstants.TAG_CITIZENS;
 
 public class CitizenManager implements ICitizenManager
 {
@@ -97,9 +97,6 @@ public class CitizenManager implements ICitizenManager
     @Override
     public void read(@NotNull final CompoundNBT compound)
     {
-        maxCitizens = compound.getInt(TAG_MAX_CITIZENS);
-        potentialMaxCitizens = compound.getInt(TAG_POTENTIAL_MAX_CITIZENS);
-
         citizens.clear();
         //  Citizens before Buildings, because Buildings track the Citizens
         citizens.putAll(NBTUtils.streamCompound(compound.getList(TAG_CITIZENS, Constants.NBT.TAG_COMPOUND))
@@ -120,9 +117,6 @@ public class CitizenManager implements ICitizenManager
     @Override
     public void write(@NotNull final CompoundNBT compound)
     {
-        compound.putInt(TAG_MAX_CITIZENS, maxCitizens);
-        compound.putInt(TAG_POTENTIAL_MAX_CITIZENS, potentialMaxCitizens);
-
         @NotNull final ListNBT citizenTagList = citizens.values().stream().map(citizen -> citizen.serializeNBT()).collect(NBTUtils.toListNBT());
         compound.put(TAG_CITIZENS, citizenTagList);
     }
@@ -298,7 +292,7 @@ public class CitizenManager implements ICitizenManager
                 {
                     newMaxCitizens += b.getMaxInhabitants();
                 }
-                else if (b instanceof AbstractBuildingGuards)
+                else if (b instanceof AbstractBuildingGuards && b.getBuildingLevel() > 0)
                 {
                     if (b.getAssignedCitizen().size() != 0)
                     {

--- a/src/main/java/com/minecolonies/coremod/network/messages/BuyCitizenMessage.java
+++ b/src/main/java/com/minecolonies/coremod/network/messages/BuyCitizenMessage.java
@@ -131,7 +131,7 @@ public class BuyCitizenMessage implements IMessage
         final PlayerEntity player = ctxIn.getSender();
 
         // Check if we spawn a new citizen
-        if (colony.getCitizenManager().getCurrentCitizenCount() < colony.getCitizenManager().getMaxCitizens())
+        if (colony.getCitizenManager().getCurrentCitizenCount() < colony.getCitizenManager().getPotentialMaxCitizens())
         {
             // Get item chosen by player
             final BuyCitizenType buyCitizenType = BuyCitizenType.getFromIndex(buyItemIndex);


### PR DESCRIPTION
Lost commit from 1.14

* Fix citizen limit calculation.
Now Calculates on building upgrade/destruction.
Recalculates after colony load, instead of reading old values.
Recruitment of additional guards over the citizen hut limit now works.
Level 0 guard-buildings no longer count towards the limit.

* Add missing calculation case & make it global for future use.