### PR TITLE
Rework citizen entity handling, should avoid fake citizens.

### DIFF
--- a/src/api/java/com/minecolonies/api/colony/ICitizen.java
+++ b/src/api/java/com/minecolonies/api/colony/ICitizen.java
@@ -78,20 +78,6 @@ public interface ICitizen
     double getSaturation();
 
     /**
-     * Health getter.
-     *
-     * @return citizen Dexterity value
-     */
-    double getHealth();
-
-    /**
-     * Max health getter.
-     *
-     * @return citizen Dexterity value.
-     */
-    double getMaxHealth();
-
-    /**
      * Check if the entity is a child
      *
      * @return true if child

--- a/src/api/java/com/minecolonies/api/colony/ICitizenData.java
+++ b/src/api/java/com/minecolonies/api/colony/ICitizenData.java
@@ -8,9 +8,9 @@ import com.minecolonies.api.colony.requestsystem.requestable.IRequestable;
 import com.minecolonies.api.colony.requestsystem.token.IToken;
 import com.minecolonies.api.entity.citizen.AbstractEntityCitizen;
 import com.minecolonies.api.entity.citizen.citizenhandlers.ICitizenHappinessHandler;
-import net.minecraft.network.PacketBuffer;
 import net.minecraft.entity.player.ServerPlayerEntity;
 import net.minecraft.nbt.CompoundNBT;
+import net.minecraft.network.PacketBuffer;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.text.ITextComponent;
 import net.minecraft.world.World;
@@ -60,6 +60,11 @@ public interface ICitizenData extends ICitizen, INBTSerializable<CompoundNBT>
      * Initializes a new citizen, when not read from nbt
      */
     void initForNewCitizen();
+
+    /**
+     * Initializes the entities values from citizen data.
+     */
+    void initEntityValues();
 
     /**
      * Sets wether this citizen is female.

--- a/src/api/java/com/minecolonies/api/colony/ICitizenDataView.java
+++ b/src/api/java/com/minecolonies/api/colony/ICitizenDataView.java
@@ -86,6 +86,16 @@ public interface ICitizenDataView extends ICitizen
     double getHealthmodifier();
 
     /**
+     * @return current health.
+     */
+    double getHealth();
+
+    /**
+     * @return max health.
+     */
+    double getMaxHealth();
+
+    /**
      * @return returns the current modifier related to damage.
      */
     double getDamageModifier();

--- a/src/api/java/com/minecolonies/api/colony/managers/interfaces/ICitizenManager.java
+++ b/src/api/java/com/minecolonies/api/colony/managers/interfaces/ICitizenManager.java
@@ -2,6 +2,7 @@ package com.minecolonies.api.colony.managers.interfaces;
 
 import com.minecolonies.api.colony.ICitizenData;
 import com.minecolonies.api.colony.IColony;
+import com.minecolonies.api.entity.citizen.AbstractEntityCitizen;
 import net.minecraft.entity.player.ServerPlayerEntity;
 import net.minecraft.nbt.CompoundNBT;
 import net.minecraft.util.math.BlockPos;
@@ -15,6 +16,20 @@ import java.util.Set;
 
 public interface ICitizenManager
 {
+    /**
+     * Register a citizen entity with the colony
+     *
+     * @param citizen citizen to register
+     */
+    void registerCitizen(final AbstractEntityCitizen citizen);
+
+    /**
+     * Unregiters a citizen with the colony
+     *
+     * @param citizen citizen to unregister
+     */
+    void unregisterCitizen(final AbstractEntityCitizen citizen);
+
     /**
      * Read the citizens from nbt.
      * @param compound the compound to read it from.

--- a/src/api/java/com/minecolonies/api/entity/citizen/citizenhandlers/ICitizenColonyHandler.java
+++ b/src/api/java/com/minecolonies/api/entity/citizen/citizenhandlers/ICitizenColonyHandler.java
@@ -1,6 +1,5 @@
 package com.minecolonies.api.entity.citizen.citizenhandlers;
 
-import com.minecolonies.api.colony.ICitizenData;
 import com.minecolonies.api.colony.IColony;
 import com.minecolonies.api.colony.buildings.IBuilding;
 import com.minecolonies.api.colony.buildings.IBuildingWorker;
@@ -16,21 +15,15 @@ public interface ICitizenColonyHandler
     @Nullable
     IBuildingWorker getWorkBuilding();
 
-    /**
-     * Assigns a citizen to a colony.
-     *
-     * @param c    the colony.
-     * @param data the data of the new citizen.
-     */
-    void initEntityCitizenValues(@Nullable IColony c, @Nullable ICitizenData data);
-
     @Nullable
     IBuilding getHomeBuilding();
 
     /**
      * Server-specific update for the EntityCitizen.
+     * @param colonyID
+     * @param citizenID
      */
-    void updateColonyServer();
+    void registerWithColony(final int colonyID, final int citizenID);
 
     /**
      * Update the client side of the citizen entity.
@@ -63,9 +56,9 @@ public interface ICitizenColonyHandler
     void setColonyId(int colonyId);
 
     /**
-     * Clears the colony of the citizen.
+     * Actions when the entity is removed.
      */
-    void clearColony();
+    void onCitizenRemoved();
 
     /**
      * Check if a citizen is at home.

--- a/src/api/java/com/minecolonies/api/inventory/api/CombinedItemHandler.java
+++ b/src/api/java/com/minecolonies/api/inventory/api/CombinedItemHandler.java
@@ -14,7 +14,6 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import javax.annotation.Nonnull;
-import java.util.Arrays;
 
 import static com.minecolonies.api.util.constant.Suppression.RAWTYPES;
 import static com.minecolonies.api.util.constant.Suppression.UNCHECKED;
@@ -179,7 +178,16 @@ public class CombinedItemHandler implements IItemHandlerModifiable, INBTSerializ
     @Override
     public int getSlots()
     {
-        return Arrays.stream(handlers).mapToInt(IItemHandler::getSlots).sum();
+        int sum = 0;
+        for (final IItemHandler handler : handlers)
+        {
+            if (handler != null)
+            {
+                sum += handler.getSlots();
+            }
+        }
+
+        return sum;
     }
 
     /**

--- a/src/api/java/com/minecolonies/api/util/InstantStructurePlacer.java
+++ b/src/api/java/com/minecolonies/api/util/InstantStructurePlacer.java
@@ -64,9 +64,9 @@ public final class InstantStructurePlacer extends com.ldtteam.structurize.util.I
             structureWrapper.structure.setPlacementSettings(new PlacementSettings(mirror, BlockPosUtil.getRotationFromRotations(rotations)));
             structureWrapper.placeStructure(pos.subtract(structureWrapper.structure.getOffset()), complete);
         }
-        catch (final IllegalStateException e)
+        catch (final Exception e)
         {
-            Log.getLogger().warn("Could not load structure!", e);
+            Log.getLogger().warn("Could not load structure:" + name, e);
         }
     }
 

--- a/src/api/java/com/minecolonies/api/util/InventoryUtils.java
+++ b/src/api/java/com/minecolonies/api/util/InventoryUtils.java
@@ -1599,44 +1599,11 @@ public class InventoryUtils
             return true;
         }
 
-        sourceStack = targetHandler.insertItem(sourceIndex,sourceStack,true);
-
-        if(ItemStackUtils.isEmpty(sourceStack))
+        if (addItemStackToItemHandler(targetHandler, sourceStack))
         {
-            sourceStack = sourceHandler.extractItem(sourceIndex, Integer.MAX_VALUE, false);
-            sourceStack = targetHandler.insertItem(sourceIndex,sourceStack,false);
-            sourceHandler.insertItem(sourceIndex,sourceStack,false);
+            sourceHandler.extractItem(sourceIndex, Integer.MAX_VALUE, false);
             return true;
         }
-
-        boolean success = false;
-        for (int i = 0; i < targetHandler.getSlots(); i++)
-        {
-            sourceStack = targetHandler.insertItem(i, sourceStack, true);
-            if (ItemStackUtils.isEmpty(sourceStack))
-            {
-                success = true;
-                break;
-            }
-        }
-
-        if (!success)
-        {
-            return false;
-        }
-
-        sourceStack = targetHandler.insertItem(sourceIndex,sourceStack,false);
-
-        for (int i = 0; i < targetHandler.getSlots(); i++)
-        {
-            sourceStack = targetHandler.insertItem(i, sourceStack, false);
-            if (ItemStackUtils.isEmpty(sourceStack))
-            {
-                return true;
-            }
-        }
-
-        sourceHandler.insertItem(sourceIndex,sourceStack,false);
         return false;
     }
 

--- a/src/api/java/com/minecolonies/api/util/constant/NameConstants.java
+++ b/src/api/java/com/minecolonies/api/util/constant/NameConstants.java
@@ -469,7 +469,6 @@ public final class NameConstants
       "Cheverell",
       "Cheyne",
       "Chichester",
-      "Child",
       "Chilton",
       "Chowne",
       "Chudderley",

--- a/src/main/java/com/minecolonies/coremod/colony/managers/EventStructureManager.java
+++ b/src/main/java/com/minecolonies/coremod/colony/managers/EventStructureManager.java
@@ -41,7 +41,7 @@ public class EventStructureManager implements IEventStructureManager
     /**
      * Backup schematics folder name.
      */
-    public static final String STRUCTURE_BACKUP_FOLDER = "structBackup";
+    public static final String STRUCTURE_BACKUP_FOLDER = "structbackup";
 
     /**
      * The map which holds the backup schematics to load. pos,event id

--- a/src/main/java/com/minecolonies/coremod/entity/ai/basic/AbstractEntityAIBasic.java
+++ b/src/main/java/com/minecolonies/coremod/entity/ai/basic/AbstractEntityAIBasic.java
@@ -89,12 +89,6 @@ public abstract class AbstractEntityAIBasic<J extends AbstractJob> extends Abstr
     protected BlockPos currentWorkingLocation = null;
 
     /**
-     * The block the ai is currently standing at or wants to stand.
-     */
-    @Nullable
-    protected BlockPos currentStandingLocation = null;
-
-    /**
      * The time in ticks until the next action is made.
      */
     private int delay = 0;
@@ -468,27 +462,26 @@ public abstract class AbstractEntityAIBasic<J extends AbstractJob> extends Abstr
      * The worker will move and animate correctly while he waits.
      *
      * @return true if we have to wait for something
-     *
-     * @see #currentStandingLocation @see #currentWorkingLocation
      */
     private boolean waitingForSomething()
     {
         if (delay > 0)
         {
-            if (currentStandingLocation != null
-                  && (!worker.getNavigator().noPath() || !worker.isWorkerAtSiteWithMove(currentStandingLocation, DEFAULT_RANGE_FOR_DELAY)))
-            {
-                //Don't decrease delay as we are just walking...
-                return true;
-            }
-            if (delay % HIT_EVERY_X_TICKS == 0)
+            if (delay % HIT_EVERY_X_TICKS == 0 && currentWorkingLocation != null && EntityUtils.isLivingAtSite(worker,
+              currentWorkingLocation.getX(),
+              currentWorkingLocation.getY(),
+              currentWorkingLocation.getZ(),
+              DEFAULT_RANGE_FOR_DELAY))
             {
                 worker.getCitizenItemHandler().hitBlockWithToolInHand(currentWorkingLocation);
             }
             delay -= getTickRate();
+            if (delay <= 0)
+            {
+                clearWorkTarget();
+            }
             return true;
         }
-        clearWorkTarget();
         return false;
     }
 
@@ -497,7 +490,6 @@ public abstract class AbstractEntityAIBasic<J extends AbstractJob> extends Abstr
      */
     private void clearWorkTarget()
     {
-        this.currentStandingLocation = null;
         this.currentWorkingLocation = null;
         this.delay = 0;
     }
@@ -766,7 +758,7 @@ public abstract class AbstractEntityAIBasic<J extends AbstractJob> extends Abstr
         }
         if (!proxy.walkToBlock(stand, range))
         {
-            workOnBlock(null, stand, DELAY_RECHECK);
+            workOnBlock(null, DELAY_RECHECK);
             return true;
         }
         return false;
@@ -775,15 +767,12 @@ public abstract class AbstractEntityAIBasic<J extends AbstractJob> extends Abstr
     /**
      * Sets the block the AI is currently working on.
      * This block will receive animation hits on delay.
-     *
-     * @param target  the block that will be hit
-     * @param stand   the block the worker will walk to
+     *  @param target  the block that will be hit
      * @param timeout the time in ticks to hit the block
      */
-    private void workOnBlock(@Nullable final BlockPos target, @Nullable final BlockPos stand, final int timeout)
+    private void workOnBlock(@Nullable final BlockPos target, final int timeout)
     {
         this.currentWorkingLocation = target;
-        this.currentStandingLocation = stand;
         this.delay = timeout;
     }
 

--- a/src/main/java/com/minecolonies/coremod/entity/ai/basic/AbstractEntityAIInteract.java
+++ b/src/main/java/com/minecolonies/coremod/entity/ai/basic/AbstractEntityAIInteract.java
@@ -254,7 +254,6 @@ public abstract class AbstractEntityAIInteract<J extends AbstractJob> extends Ab
             return true;
         }
         currentWorkingLocation = blockToMine;
-        currentStandingLocation = safeStand;
 
 
         return hasNotDelayed(getBlockMiningDelay(curBlock, blockToMine));

--- a/src/main/java/com/minecolonies/coremod/entity/ai/minimal/EntityAISickTask.java
+++ b/src/main/java/com/minecolonies/coremod/entity/ai/minimal/EntityAISickTask.java
@@ -324,7 +324,7 @@ public class EntityAISickTask extends Goal
         citizenData.getCitizenHappinessHandler().setHealthModifier(true);
         citizenData.markDirty();
         citizen.getCitizenDiseaseHandler().cure();
-        citizen.setHealth((float) citizenData.getMaxHealth());
+        citizen.setHealth(citizen.getMaxHealth());
         reset();
     }
 

--- a/src/main/java/com/minecolonies/coremod/entity/citizen/EntityCitizen.java
+++ b/src/main/java/com/minecolonies/coremod/entity/citizen/EntityCitizen.java
@@ -559,6 +559,7 @@ public class EntityCitizen extends AbstractEntityCitizen
      * @return the data.
      */
     @Override
+    @NotNull
     public ICitizenData getCitizenData()
     {
         return citizenData;

--- a/src/main/java/com/minecolonies/coremod/entity/citizen/EntityCitizen.java
+++ b/src/main/java/com/minecolonies/coremod/entity/citizen/EntityCitizen.java
@@ -559,17 +559,8 @@ public class EntityCitizen extends AbstractEntityCitizen
      * @return the data.
      */
     @Override
-    @Nullable
     public ICitizenData getCitizenData()
     {
-        if (citizenData == null && citizenColonyHandler != null && citizenColonyHandler.getColony() != null)
-        {
-            final ICitizenData data = citizenColonyHandler.getColony().getCitizenManager().getCitizen(citizenId);
-            if (data != null)
-            {
-                citizenData = data;
-            }
-        }
         return citizenData;
     }
 
@@ -1094,7 +1085,7 @@ public class EntityCitizen extends AbstractEntityCitizen
 
         if (isServerWorld())
         {
-            citizenColonyHandler.updateColonyServer();
+            citizenColonyHandler.registerWithColony(citizenColonyHandler.getColonyId(), citizenId);
         }
 
         isDay = compound.getBoolean(TAG_DAY);
@@ -1324,7 +1315,11 @@ public class EntityCitizen extends AbstractEntityCitizen
     @Override
     public void setCitizenData(@Nullable final ICitizenData data)
     {
-        this.citizenData = data;
+        if (data != null)
+        {
+            this.citizenData = data;
+            data.initEntityValues();
+        }
     }
 
     /**
@@ -1438,7 +1433,7 @@ public class EntityCitizen extends AbstractEntityCitizen
 
         this.setCustomNameVisible(MineColonies.getConfig().getCommon().alwaysRenderNameTag.get());
         citizenItemHandler.pickupItems();
-        citizenColonyHandler.updateColonyServer();
+        citizenColonyHandler.registerWithColony(citizenColonyHandler.getColonyId(), citizenId);
 
         if (citizenData != null)
         {
@@ -1619,14 +1614,13 @@ public class EntityCitizen extends AbstractEntityCitizen
         return new ContainerCitizenInventory(id, inv, buffer);
     }
 
+    /**
+     * Removes the entity from world.
+     */
     @Override
     public void remove()
     {
-        if (citizenData != null)
-        {
-            citizenData.setLastPosition(getCurrentPosition());
-            citizenData.setCitizenEntity(null);
-        }
+        citizenColonyHandler.onCitizenRemoved();
         super.remove();
     }
 

--- a/src/main/java/com/minecolonies/coremod/entity/citizen/citizenhandlers/CitizenColonyHandler.java
+++ b/src/main/java/com/minecolonies/coremod/entity/citizen/citizenhandlers/CitizenColonyHandler.java
@@ -1,26 +1,19 @@
 package com.minecolonies.coremod.entity.citizen.citizenhandlers;
 
 import com.minecolonies.api.client.render.modeltype.BipedModelType;
-import com.minecolonies.api.colony.ICitizenData;
 import com.minecolonies.api.colony.IColony;
 import com.minecolonies.api.colony.IColonyManager;
 import com.minecolonies.api.colony.buildings.IBuilding;
 import com.minecolonies.api.colony.buildings.IBuildingWorker;
-import com.minecolonies.api.entity.citizen.AbstractEntityCitizen;
 import com.minecolonies.api.entity.citizen.citizenhandlers.ICitizenColonyHandler;
 import com.minecolonies.api.util.Log;
 import com.minecolonies.coremod.colony.buildings.workerbuildings.BuildingHome;
 import com.minecolonies.coremod.entity.citizen.EntityCitizen;
-import net.minecraft.entity.SharedMonsterAttributes;
 import net.minecraft.util.Tuple;
 import net.minecraft.util.math.AxisAlignedBB;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.math.Vec3d;
-import net.minecraft.util.text.StringTextComponent;
-import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
-
-import java.util.Optional;
 
 import static com.minecolonies.api.entity.citizen.AbstractEntityCitizen.*;
 import static com.minecolonies.api.util.constant.CitizenConstants.RANGE_TO_BE_HOME;
@@ -48,6 +41,11 @@ public class CitizenColonyHandler implements ICitizenColonyHandler
     private IColony colony;
 
     /**
+     * Whether the entity is registered to the colony yet.
+     */
+    private boolean registered = false;
+
+    /**
      * Constructor for the experience handler.
      * @param citizen the citizen owning the handler.
      */
@@ -68,55 +66,6 @@ public class CitizenColonyHandler implements ICitizenColonyHandler
         return (citizen.getCitizenData() == null) ? null : citizen.getCitizenData().getWorkBuilding();
     }
 
-    /**
-     * Assigns a citizen to a colony.
-     *
-     * @param c    the colony.
-     * @param data the data of the new citizen.
-     */
-    @Override
-    public void initEntityCitizenValues(@Nullable final IColony c, @Nullable final ICitizenData data)
-    {
-        if (c == null)
-        {
-            colony = null;
-            colonyId = 0;
-            citizen.setCitizenId(0);
-            citizen.setCitizenData(null);
-            citizen.remove();
-            return;
-        }
-
-        colony = c;
-        colonyId = colony.getID();
-        citizen.setCitizenId(data.getId());
-        citizen.setCitizenData(data);
-        data.setCitizenEntity(citizen);
-
-        citizen.setIsChild(data.isChild());
-        citizen.setCustomName(new StringTextComponent(citizen.getCitizenData().getName()));
-
-        citizen.getAttribute(SharedMonsterAttributes.MAX_HEALTH).setBaseValue(data.getMaxHealth());
-        citizen.setHealth((float) data.getHealth());
-
-        citizen.setFemale(citizen.getCitizenData().isFemale());
-        citizen.setTextureId(citizen.getCitizenData().getTextureId());
-
-        citizen.getDataManager().set(DATA_COLONY_ID, colonyId);
-        citizen.getDataManager().set(DATA_CITIZEN_ID, citizen.getCitizenId());
-        citizen.getDataManager().set(DATA_IS_FEMALE, citizen.isFemale() ? 1 : 0);
-        citizen.getDataManager().set(DATA_TEXTURE, citizen.getTextureId());
-        citizen.getDataManager().set(DATA_IS_ASLEEP, citizen.getCitizenData().isAsleep());
-        citizen.getDataManager().set(DATA_IS_CHILD, citizen.getCitizenData().isChild());
-        citizen.getDataManager().set(DATA_BED_POS, citizen.getCitizenData().getBedPos());
-
-        citizen.getCitizenExperienceHandler().updateLevel();
-
-        data.setLastPosition(citizen.getPosition());
-
-        citizen.getCitizenJobHandler().onJobChanged(citizen.getCitizenJobHandler().getColonyJob());
-    }
-
     @Override
     @Nullable
     public IBuilding getHomeBuilding()
@@ -126,79 +75,38 @@ public class CitizenColonyHandler implements ICitizenColonyHandler
 
     /**
      * Server-specific update for the EntityCitizen.
+     * @param colonyID
+     * @param citizenID
      */
     @Override
-    public void updateColonyServer()
+    public void registerWithColony(final int colonyID, final int citizenID)
     {
-        if (colonyId == 0)
+        if (registered)
         {
-            final IColony colony = IColonyManager.getInstance().getColonyByPosFromWorld(citizen.getEntityWorld(), citizen.getPosition());
-            if (colony == null)
-            {
-                citizen.remove();
-            }
-            else
-            {
-                this.colonyId = colony.getID();
-                handleNullColony();
-            }
             return;
         }
 
-        if (colony == null)
+        this.colonyId = colonyID;
+        citizen.setCitizenId(citizenID);
+
+        if (colonyId == 0 || citizen.getCitizenId() == 0)
         {
-            handleNullColony();
+            citizen.remove();
+            return;
         }
-    }
 
-    /**
-     * Handles extreme cases like colony or citizen is null.
-     */
-    private void handleNullColony()
-    {
-        final IColony c = IColonyManager.getInstance().getColonyByWorld(colonyId, citizen.world);
+        final IColony colony = IColonyManager.getInstance().getColonyByWorld(colonyId, citizen.world);
 
-        if (c == null)
+        if (colony == null)
         {
             Log.getLogger().warn(String.format("EntityCitizen '%s' unable to find Colony #%d", citizen.getUniqueID(), colonyId));
             citizen.remove();
             return;
         }
 
-        final ICitizenData data = c.getCitizenManager().getCitizen(citizen.getCitizenId());
-        if (data == null)
-        {
-            //  Citizen does not exist in the Colony
-            Log.getLogger().warn(String.format("EntityCitizen '%s' attempting to register with Colony #%d as Citizen %d, but not known to colony",
-              citizen.getUniqueID(),
-              colonyId,
-              citizen.getCitizenId()));
-            citizen.remove();
-            return;
-        }
-
-        final Optional<AbstractEntityCitizen> entityCitizenOptional = data.getCitizenEntity();
-        entityCitizenOptional.filter(entityCitizen -> !citizen.getUniqueID().equals(entityCitizen.getUniqueID()))
-          .ifPresent(entityCitizen -> handleExistingCitizen(data, entityCitizen));
-
-        initEntityCitizenValues(c, data);
-    }
-
-    private void handleExistingCitizen(@NotNull final ICitizenData data, @NotNull final AbstractEntityCitizen existingCitizen)
-    {
-        Log.getLogger().warn(String.format("EntityCitizen '%s' attempting to register with Colony #%d as Citizen #%d, but already have a citizen ('%s')",
-          citizen.getUniqueID(),
-          colonyId,
-          citizen.getCitizenId(),
-          existingCitizen.getUniqueID()));
-        if (existingCitizen.getUniqueID().equals(citizen.getUniqueID()))
-        {
-            data.setCitizenEntity(citizen);
-        }
-        else
-        {
-            citizen.remove();
-        }
+        this.colony = colony;
+        colony.getCitizenManager().registerCitizen(citizen);
+        registered = true;
     }
 
     /**
@@ -273,13 +181,14 @@ public class CitizenColonyHandler implements ICitizenColonyHandler
         this.colonyId = colonyId;
     }
 
-    /**
-     * Clears the colony of the citizen.
-     */
     @Override
-    public void clearColony()
+    public void onCitizenRemoved()
     {
-        initEntityCitizenValues(null, null);
+        if (citizen.getCitizenData() != null && registered && colony != null)
+        {
+            colony.getCitizenManager().unregisterCitizen(citizen);
+            citizen.getCitizenData().setLastPosition(citizen.getCurrentPosition());
+        }
     }
 
     /**

--- a/src/main/java/com/minecolonies/coremod/entity/pathfinding/ChunkCache.java
+++ b/src/main/java/com/minecolonies/coremod/entity/pathfinding/ChunkCache.java
@@ -1,7 +1,5 @@
 package com.minecolonies.coremod.entity.pathfinding;
 
-import javax.annotation.Nullable;
-
 import net.minecraft.block.BlockState;
 import net.minecraft.block.Blocks;
 import net.minecraft.entity.Entity;
@@ -10,7 +8,8 @@ import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.Direction;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.math.shapes.VoxelShape;
-import net.minecraft.world.*;
+import net.minecraft.world.IWorldReader;
+import net.minecraft.world.World;
 import net.minecraft.world.biome.Biome;
 import net.minecraft.world.biome.BiomeManager;
 import net.minecraft.world.biome.Biomes;
@@ -24,6 +23,8 @@ import net.minecraft.world.lighting.WorldLightManager;
 import net.minecraftforge.api.distmarker.Dist;
 import net.minecraftforge.api.distmarker.OnlyIn;
 import org.jetbrains.annotations.NotNull;
+
+import javax.annotation.Nullable;
 
 public class ChunkCache implements IWorldReader
 {
@@ -50,19 +51,6 @@ public class ChunkCache implements IWorldReader
             for (int l = this.chunkZ; l <= j; ++l)
             {
                 this.chunkArray[k - this.chunkX][l - this.chunkZ] = worldIn.getChunk(k, l);
-            }
-        }
-
-        for (int i1 = posFromIn.getX() >> 4; i1 <= posToIn.getX() >> 4; ++i1)
-        {
-            for (int j1 = posFromIn.getZ() >> 4; j1 <= posToIn.getZ() >> 4; ++j1)
-            {
-                Chunk chunk = this.chunkArray[i1 - this.chunkX][j1 - this.chunkZ];
-
-                if (chunk != null && !chunk.isEmptyBetween(posFromIn.getY(), posToIn.getY()))
-                {
-                    this.empty = false;
-                }
             }
         }
     }

--- a/src/main/java/com/minecolonies/coremod/event/EventHandler.java
+++ b/src/main/java/com/minecolonies/coremod/event/EventHandler.java
@@ -8,7 +8,6 @@ import com.minecolonies.api.blocks.ModBlocks;
 import com.minecolonies.api.colony.*;
 import com.minecolonies.api.colony.buildings.IGuardBuilding;
 import com.minecolonies.api.colony.permissions.Action;
-import com.minecolonies.api.entity.citizen.AbstractEntityCitizen;
 import com.minecolonies.api.util.BlockPosUtil;
 import com.minecolonies.api.util.Log;
 import com.minecolonies.api.util.constant.Constants;
@@ -101,11 +100,7 @@ public class EventHandler
     {
         if (!event.getWorld().isRemote)
         {
-            if (event.getEntity() instanceof EntityCitizen)
-            {
-                ((AbstractEntityCitizen) event.getEntity()).getCitizenColonyHandler().updateColonyServer();
-            }
-            else if (MineColonies.getConfig().getCommon().mobAttackCitizens.get() && (event.getEntity() instanceof IMob) && !(event.getEntity() instanceof LlamaEntity))
+            if (MineColonies.getConfig().getCommon().mobAttackCitizens.get() && (event.getEntity() instanceof IMob) && !(event.getEntity() instanceof LlamaEntity))
             {
                 ((MobEntity) event.getEntity()).targetSelector.addGoal(6, new NearestAttackableTargetGoal<>((MobEntity) event.getEntity(), EntityCitizen.class, true));
                 ((MobEntity) event.getEntity()).targetSelector.addGoal(7, new NearestAttackableTargetGoal((MobEntity) event.getEntity(), EntityMercenary.class, true));

--- a/src/main/java/com/minecolonies/coremod/placementhandlers/MinecoloniesPlacementHandlers.java
+++ b/src/main/java/com/minecolonies/coremod/placementhandlers/MinecoloniesPlacementHandlers.java
@@ -26,8 +26,8 @@ import net.minecraft.block.Blocks;
 import net.minecraft.item.BlockItem;
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.CompoundNBT;
-import net.minecraft.tileentity.TileEntity;
 import net.minecraft.tileentity.ChestTileEntity;
+import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.Direction;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.World;
@@ -155,8 +155,11 @@ public final class MinecoloniesPlacementHandlers
                 {
                     handleTileEntityPlacement(tileEntityData, world, pos);
                 }
-                final BlockState newState =  BlockMinecoloniesRack.getPlacementState(blockState, world.getTileEntity(pos), pos);
-                world.setBlockState(pos, newState);
+                if (entity instanceof TileEntityRack)
+                {
+                    final BlockState newState = BlockMinecoloniesRack.getPlacementState(blockState, world.getTileEntity(pos), pos);
+                    world.setBlockState(pos, newState);
+                }
             }
             return blockState;
         }


### PR DESCRIPTION
# Changes proposed in this pull request:
Citizens now register themselves to a colony, and are removed if that fails. 
They register with their citizen id and colony id, and get assigned their citizen data and colony when successfull. 

CitizenData's hash and equals no longer unnecessarily use other values than their id.
Fixed a bug where the inv utils tried to access a nonexistant index.
Removed health from citizen data, as we are not using it and vanilla entities store it already with all modifiers.

Review please
