### PR TITLE
#4517

### DIFF
--- a/src/api/java/com/minecolonies/api/entity/citizen/AbstractEntityCitizen.java
+++ b/src/api/java/com/minecolonies/api/entity/citizen/AbstractEntityCitizen.java
@@ -201,7 +201,7 @@ public abstract class AbstractEntityCitizen extends AgeableEntity implements ICa
 
         final String textureBase = "textures/entity/" + model.getTextureBase() + (female ? "female" : "male");
         final int moddedTextureId = (textureId % model.getNumTextures()) + 1;
-        texture = new ResourceLocation(Constants.MOD_ID, textureBase + moddedTextureId + renderMetadata + ".png");
+        texture = new ResourceLocation(Constants.MOD_ID, textureBase + moddedTextureId + ".png");
     }
 
     /**
@@ -340,6 +340,7 @@ public abstract class AbstractEntityCitizen extends AgeableEntity implements ICa
     public void setTextureId(final int textureId)
     {
         this.textureId = textureId;
+        dataManager.set(DATA_TEXTURE, textureId);
     }
 
     /**

--- a/src/api/java/com/minecolonies/api/entity/citizen/AbstractEntityCitizen.java
+++ b/src/api/java/com/minecolonies/api/entity/citizen/AbstractEntityCitizen.java
@@ -201,7 +201,7 @@ public abstract class AbstractEntityCitizen extends AgeableEntity implements ICa
 
         final String textureBase = "textures/entity/" + model.getTextureBase() + (female ? "female" : "male");
         final int moddedTextureId = (textureId % model.getNumTextures()) + 1;
-        texture = new ResourceLocation(Constants.MOD_ID, textureBase + moddedTextureId + ".png");
+        texture = new ResourceLocation(Constants.MOD_ID, textureBase + moddedTextureId + renderMetadata + ".png");
     }
 
     /**

--- a/src/main/java/com/minecolonies/coremod/colony/CitizenData.java
+++ b/src/main/java/com/minecolonies/coremod/colony/CitizenData.java
@@ -323,6 +323,7 @@ public class CitizenData implements ICitizenData
         female = rand.nextBoolean();
         paused = false;
         name = generateName(rand);
+        textureId = rand.nextInt(255);
 
         saturation = MAX_SATURATION;
         final int levelCap = (int) colony.getOverallHappiness();


### PR DESCRIPTION


Closes #4517 
# Changes proposed in this pull request:
- Assigns a random textureId to a citizen in CitizenData::initForNewCitizen() (same place as name and gender)
- Removes renderMetadata from the creation of the resourcelocation in AbstractEntityCitizen::setTexture()

Review please! 
