### PR TITLE
Fixed typo in the stone smeltery research name

### DIFF
--- a/src/main/java/com/minecolonies/coremod/colony/buildings/workerbuildings/BuildingStoneSmeltery.java
+++ b/src/main/java/com/minecolonies/coremod/colony/buildings/workerbuildings/BuildingStoneSmeltery.java
@@ -150,7 +150,7 @@ public class BuildingStoneSmeltery extends AbstractBuildingSmelterCrafter
     @Override
     public void requestUpgrade(final PlayerEntity player, final BlockPos builder)
     {
-        final UnlockBuildingResearchEffect effect = colony.getResearchManager().getResearchEffects().getEffect("Stonesmelter", UnlockBuildingResearchEffect.class);
+        final UnlockBuildingResearchEffect effect = colony.getResearchManager().getResearchEffects().getEffect("Stonesmeltery", UnlockBuildingResearchEffect.class);
         if (effect == null)
         {
             player.sendMessage(new TranslationTextComponent("com.minecolonies.coremod.research.havetounlock"));


### PR DESCRIPTION
Fixed typo in the name of the UnlockBuildingResearchEffect of the stone smeltery.

# Changes proposed in this pull request:
- StoneSmeltery requirement and stone smeltery research name didn't align.
- This PR aligns the name, which reenables building and upgrading of the stone smeltery

Review please
