### PR TITLE
Fixed typo in the stone smeltery research name

### DIFF
--- a/src/main/java/com/minecolonies/coremod/colony/buildings/workerbuildings/BuildingStoneSmeltery.java
+++ b/src/main/java/com/minecolonies/coremod/colony/buildings/workerbuildings/BuildingStoneSmeltery.java
@@ -150,7 +150,7 @@ public class BuildingStoneSmeltery extends AbstractBuildingSmelterCrafter
     @Override
     public void requestUpgrade(final PlayerEntity player, final BlockPos builder)
     {
-        final UnlockBuildingResearchEffect effect = colony.getResearchManager().getResearchEffects().getEffect("Stonesmelter", UnlockBuildingResearchEffect.class);
+        final UnlockBuildingResearchEffect effect = colony.getResearchManager().getResearchEffects().getEffect("Stonesmeltery", UnlockBuildingResearchEffect.class);
         if (effect == null)
         {
             player.sendMessage(new TranslationTextComponent("com.minecolonies.coremod.research.havetounlock"));


### PR DESCRIPTION
Stone Smeltery Build+Upgrade didn't work because the requirement had a different name than the research.

# Changes proposed in this pull request:
- Aligned the requirement name with the research name

Review please
