### PR TITLE
Fix dimension change

### DIFF
--- a/src/main/java/com/minecolonies/coremod/colony/Colony.java
+++ b/src/main/java/com/minecolonies/coremod/colony/Colony.java
@@ -825,7 +825,7 @@ public class Colony implements IColony
     @Override
     public void onWorldUnload(@NotNull final World w)
     {
-        if (!w.equals(world))
+        if (w != world)
         {
             /**
              * If the event world is not the colony world ignore. This might happen in interactions with other mods.

--- a/src/main/java/com/minecolonies/coremod/entity/citizen/EntityCitizen.java
+++ b/src/main/java/com/minecolonies/coremod/entity/citizen/EntityCitizen.java
@@ -948,7 +948,10 @@ public class EntityCitizen extends AbstractEntityCitizen
             }
 
             heal((float) healAmount);
-            citizenData.markDirty();
+            if (healAmount > 0.1D)
+            {
+                citizenData.markDirty();
+            }
         }
     }
 

--- a/src/main/java/com/minecolonies/coremod/event/EventHandler.java
+++ b/src/main/java/com/minecolonies/coremod/event/EventHandler.java
@@ -8,6 +8,7 @@ import com.minecolonies.api.blocks.interfaces.IRSComponentBlock;
 import com.minecolonies.api.colony.*;
 import com.minecolonies.api.colony.buildings.IGuardBuilding;
 import com.minecolonies.api.colony.permissions.Action;
+import com.minecolonies.api.util.Log;
 import com.minecolonies.api.util.constant.Constants;
 import com.minecolonies.coremod.MineColonies;
 import com.minecolonies.coremod.Network;
@@ -735,6 +736,11 @@ public class EventHandler
         if (!event.getWorld().isRemote() && event.getWorld() instanceof World)
         {
             IColonyManager.getInstance().onWorldUnload((World) event.getWorld());
+        }
+        if (event.getWorld().isRemote())
+        {
+            IColonyManager.getInstance().resetColonyViews();
+            Log.getLogger().info("Removed all colony views");
         }
     }
 }

--- a/src/main/java/com/minecolonies/coremod/event/EventHandler.java
+++ b/src/main/java/com/minecolonies/coremod/event/EventHandler.java
@@ -223,14 +223,18 @@ public class EventHandler
             final ServerPlayerEntity player = (ServerPlayerEntity) event.getEntity();
             final Chunk oldChunk = player.world.getChunk(player.chunkCoordX, player.chunkCoordZ);
             final IColonyTagCapability oldCloseColonies = oldChunk.getCapability(CLOSE_COLONY_CAP, null).orElse(null);
-            // Remove visiting/subscriber from old colony
-            if (oldCloseColonies.getOwningColony() != 0)
+
+            if (oldCloseColonies != null)
             {
-                final IColony oldColony = IColonyManager.getInstance().getColonyByWorld(oldCloseColonies.getOwningColony(), player.world);
-                if (oldColony != null)
+                // Remove visiting/subscriber from old colony
+                if (oldCloseColonies.getOwningColony() != 0)
                 {
-                    oldColony.removeVisitingPlayer(player);
-                    oldColony.getPackageManager().removeCloseSubscriber(player);
+                    final IColony oldColony = IColonyManager.getInstance().getColonyByWorld(oldCloseColonies.getOwningColony(), player.world);
+                    if (oldColony != null)
+                    {
+                        oldColony.removeVisitingPlayer(player);
+                        oldColony.getPackageManager().removeCloseSubscriber(player);
+                    }
                 }
             }
         }
@@ -250,13 +254,16 @@ public class EventHandler
 
             final Chunk newChunk = player.world.getChunk(player.chunkCoordX, player.chunkCoordZ);
             final IColonyTagCapability newCloseColonies = newChunk.getCapability(CLOSE_COLONY_CAP, null).orElse(null);
-
-            // Add visiting/subscriber to new colony
-            final IColony newColony = IColonyManager.getInstance().getColonyByWorld(newCloseColonies.getOwningColony(), player.world);
-            if (newColony != null)
+            
+            if (newCloseColonies != null)
             {
-                newColony.addVisitingPlayer(player);
-                newColony.getPackageManager().addCloseSubscriber(player);
+                // Add visiting/subscriber to new colony
+                final IColony newColony = IColonyManager.getInstance().getColonyByWorld(newCloseColonies.getOwningColony(), player.world);
+                if (newColony != null)
+                {
+                    newColony.addVisitingPlayer(player);
+                    newColony.getPackageManager().addCloseSubscriber(player);
+                }
             }
         }
     }

--- a/src/main/java/com/minecolonies/coremod/event/FMLEventHandler.java
+++ b/src/main/java/com/minecolonies/coremod/event/FMLEventHandler.java
@@ -1,6 +1,7 @@
 package com.minecolonies.coremod.event;
 
 import com.minecolonies.api.colony.IColonyManager;
+import com.minecolonies.api.util.Log;
 import com.minecolonies.coremod.Network;
 import com.minecolonies.coremod.commands.EntryPoint;
 import com.minecolonies.coremod.entity.pathfinding.Pathfinding;
@@ -60,6 +61,12 @@ public class FMLEventHandler
     @SubscribeEvent
     public static void onServerStopped(final FMLServerStoppingEvent event)
     {
+        if (!event.getServer().isDedicatedServer())
+        {
+            IColonyManager.getInstance().resetColonyViews();
+            Log.getLogger().info("Removed all colony views");
+        }
+
         Pathfinding.shutdown();
     }
 

--- a/src/main/java/com/minecolonies/coremod/event/FMLEventHandler.java
+++ b/src/main/java/com/minecolonies/coremod/event/FMLEventHandler.java
@@ -1,7 +1,6 @@
 package com.minecolonies.coremod.event;
 
 import com.minecolonies.api.colony.IColonyManager;
-import com.minecolonies.api.util.Log;
 import com.minecolonies.coremod.Network;
 import com.minecolonies.coremod.commands.EntryPoint;
 import com.minecolonies.coremod.entity.pathfinding.Pathfinding;
@@ -61,12 +60,6 @@ public class FMLEventHandler
     @SubscribeEvent
     public static void onServerStopped(final FMLServerStoppingEvent event)
     {
-        if (!event.getServer().isDedicatedServer())
-        {
-            IColonyManager.getInstance().resetColonyViews();
-            Log.getLogger().info("Removed all colony views");
-        }
-
         Pathfinding.shutdown();
     }
 

--- a/src/main/java/com/minecolonies/coremod/network/messages/UpdateChunkRangeCapabilityMessage.java
+++ b/src/main/java/com/minecolonies/coremod/network/messages/UpdateChunkRangeCapabilityMessage.java
@@ -7,7 +7,6 @@ import com.minecolonies.coremod.util.ChunkClientDataHelper;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.world.ClientWorld;
 import net.minecraft.network.PacketBuffer;
-import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.math.ChunkPos;
 import net.minecraft.world.World;
 import net.minecraft.world.chunk.Chunk;
@@ -19,7 +18,6 @@ import org.jetbrains.annotations.Nullable;
 import java.util.ArrayList;
 import java.util.List;
 
-import static com.minecolonies.api.util.constant.Constants.BLOCKS_PER_CHUNK;
 import static com.minecolonies.coremod.MineColonies.CLOSE_COLONY_CAP;
 
 /**
@@ -57,7 +55,7 @@ public class UpdateChunkRangeCapabilityMessage implements IMessage
             {
                 final int chunkX = xC + x;
                 final int chunkZ = zC + z;
-                if (!checkLoaded || world.isBlockPresent(new BlockPos(chunkX * BLOCKS_PER_CHUNK, 0, chunkZ * BLOCKS_PER_CHUNK)))
+                if (!checkLoaded || world.getChunkProvider().isChunkLoaded(new ChunkPos(chunkX, chunkZ)))
                 {
                     final Chunk chunk = world.getChunk(chunkX, chunkZ);
                     final IColonyTagCapability cap = chunk.getCapability(CLOSE_COLONY_CAP, null).orElseGet(null);


### PR DESCRIPTION
Closes #4787

# Changes proposed in this pull request:
Fix dimension change subscribers add/removal, our usual onChunkEnter fails since it is coord based on the entities current world obj so it can't compare the right chunk objects from two different worlds.


Review please
