### PR TITLE
Added worker name to Resource-Scroll.

### DIFF
--- a/src/api/java/com/minecolonies/api/util/constant/WindowConstants.java
+++ b/src/api/java/com/minecolonies/api/util/constant/WindowConstants.java
@@ -629,6 +629,7 @@ public final class WindowConstants
     public static final String LABEL_CONSTRUCTION_NAME =  "constructionName";
     public static final String LABEL_CONSTRUCTION_POS =  "constructionPos";
     public static final String LABEL_PROGRESS =  "progress";
+    public static final String LABEL_WORKERNAME = "workerName";
 
     public static final String LABEL_PAGE_NUMBER = "pageNum";
 

--- a/src/main/java/com/minecolonies/coremod/client/gui/WindowResourceList.java
+++ b/src/main/java/com/minecolonies/coremod/client/gui/WindowResourceList.java
@@ -139,6 +139,7 @@ public class WindowResourceList extends AbstractWindowSkeleton
         //Make sure we have a fresh view
         Network.getNetwork().sendToServer(new MarkBuildingDirtyMessage(this.builder));
 
+        findPaneOfTypeByID(LABEL_WORKERNAME, Label.class).setLabelText(this.builder.getWorkerName());
         findPaneOfTypeByID(LABEL_CONSTRUCTION_NAME, Label.class).setLabelText(builder.getConstructionName());
     }
 

--- a/src/main/resources/assets/minecolonies/gui/windowresourcescroll.xml
+++ b/src/main/resources/assets/minecolonies/gui/windowresourcescroll.xml
@@ -5,12 +5,17 @@
     <image source="minecolonies:textures/gui/builderhut/builder_papper_sketch.png" size="100% 100%"/>
     <image source="minecolonies:textures/gui/builderhut/builder_charcoal_chalk.png" size="19 59" pos="175 180"/>
 
-    <label size="164 11" pos="0 13" color="black" textalign="MIDDLE"
+    <label size="100% 11" pos="0 11" color="black" textalign="MIDDLE"
            label="$(com.minecolonies.coremod.gui.workerhuts.resourceList)"/>
 
-    <label size="164 11" pos="0 24" id="constructionName" label="" color="black" textalign="MIDDLE"/>
+    <image source="minecolonies:textures/gui/builderhut/builder_sketch_left.png" size="6 15" pos="24 22"/>
+    <image source="minecolonies:textures/gui/builderhut/builder_sketch_center.png" size="130 15" pos="30 22"/>
+    <image source="minecolonies:textures/gui/builderhut/builder_sketch_right.png" size="6 15" pos="160 22"/>
+    <label id="workerName" size="90 11" pos="50 24" textalign="MIDDLE" color="blue"/>
 
-    <list id="resources" size="164 75%" pos="13 40">
+    <label size="100% 11" pos="0 38" id="constructionName" label="" color="black" textalign="MIDDLE"/>
+
+    <list id="resources" size="164 75%" pos="13 51">
         <box size="100% 30" linewidth="2">
             <itemicon id="resourceIcon" size="16 16" pos="1 1"/>
             <label id="resourceName" size="100 12" pos="20 3" textalign="MIDDLE_LEFT" color="black"/>


### PR DESCRIPTION
Closes #4805

# Changes proposed in this pull request:
- Worker name is added to the Resource-Scroll

Before and After image:
![image](https://user-images.githubusercontent.com/64359621/80768570-0a4f5200-8b4b-11ea-8ae4-81cfaf8ee707.png)


Review please
