### PR TITLE
Allow certain requests to have a minimum count

### DIFF
--- a/src/api/java/com/minecolonies/api/colony/buildings/IBuilding.java
+++ b/src/api/java/com/minecolonies/api/colony/buildings/IBuilding.java
@@ -303,12 +303,6 @@ public interface IBuilding extends ISchematicProvider, ICitizenAssignable, IBuil
     BuildingEntry getBuildingRegistryEntry();
 
     /**
-     * Check if the building requires always all items to continue working or if a partial quantity would also solve it.
-     * @return true if so.
-     */
-    boolean requiresCompleteRequestFulfillment();
-
-    /**
      * Remove the minimum stock.
      * @param itemStack the stack to remove.
      */

--- a/src/api/java/com/minecolonies/api/colony/requestsystem/requestable/Burnable.java
+++ b/src/api/java/com/minecolonies/api/colony/requestsystem/requestable/Burnable.java
@@ -76,6 +76,12 @@ public class Burnable implements IDeliverable
         return count;
     }
 
+    @Override
+    public int getMinimumCount()
+    {
+        return 1;
+    }
+
     @NotNull
     @Override
     public ItemStack getResult()

--- a/src/api/java/com/minecolonies/api/colony/requestsystem/requestable/Food.java
+++ b/src/api/java/com/minecolonies/api/colony/requestsystem/requestable/Food.java
@@ -76,6 +76,12 @@ public class Food implements IDeliverable
         return count;
     }
 
+    @Override
+    public int getMinimumCount()
+    {
+        return 1;
+    }
+
     @NotNull
     @Override
     public ItemStack getResult()

--- a/src/api/java/com/minecolonies/api/colony/requestsystem/requestable/IDeliverable.java
+++ b/src/api/java/com/minecolonies/api/colony/requestsystem/requestable/IDeliverable.java
@@ -8,7 +8,6 @@ import org.jetbrains.annotations.NotNull;
  */
 public interface IDeliverable extends IRetryable
 {
-
     /**
      * Method called to check if a given stack matches this deliverable.
      * The first stack that returns true from this method is returned as a Deliverable.
@@ -21,9 +20,16 @@ public interface IDeliverable extends IRetryable
     /**
      * Method called to get the amount of items that need to be in the stack.
      *
-     * @return The amount of items that
+     * @return The amount of items.
      */
     int getCount();
+
+    /**
+     * Method called to get the minimum amount required to fulfill this request.
+     *
+     * @return the minimum amount.
+     */
+    int getMinimumCount();
 
     /**
      * Method to get the result of the delivery.

--- a/src/api/java/com/minecolonies/api/colony/requestsystem/requestable/Tool.java
+++ b/src/api/java/com/minecolonies/api/colony/requestsystem/requestable/Tool.java
@@ -232,6 +232,12 @@ public class Tool implements IDeliverable
     }
 
     @Override
+    public int getMinimumCount()
+    {
+        return 1;
+    }
+
+    @Override
     public void setResult(@NotNull final ItemStack result)
     {
         this.result = result;

--- a/src/api/java/com/minecolonies/api/colony/requestsystem/requestable/crafting/AbstractCrafting.java
+++ b/src/api/java/com/minecolonies/api/colony/requestsystem/requestable/crafting/AbstractCrafting.java
@@ -7,28 +7,44 @@ import org.jetbrains.annotations.NotNull;
 
 import java.util.Objects;
 
+/**
+ * Abstract crafting request.
+ */
 public abstract class AbstractCrafting implements IRequestable
 {
-
     ////// --------------------------- NBTConstants --------------------------- \\\\\\
     protected static final String NBT_STACK       = "Stack";
     protected static final String NBT_COUNT       = "Count";
+    protected static final String NBT_MIN_COUNT       = "Count";
     ////// --------------------------- NBTConstants --------------------------- \\\\\\
 
+    /**
+     * The stack.
+     */
     @NotNull
     private final ItemStack theStack;
 
+    /**
+     * The count.
+     */
     private final int count;
+
+    /**
+     * The minimum count.
+     */
+    private final int minCount;
 
     /**
      * Create a Stack deliverable.
      * @param stack the required stack.
      * @param count the crafting count.
+     * @param minCount the min crafting count.
      */
-    public AbstractCrafting(@NotNull final ItemStack stack, final int count)
+    public AbstractCrafting(@NotNull final ItemStack stack, final int count, final int minCount)
     {
         this.theStack = stack.copy();
         this.count = count;
+        this.minCount = minCount;
 
         if (ItemStackUtils.isEmpty(stack))
         {
@@ -44,9 +60,22 @@ public abstract class AbstractCrafting implements IRequestable
         return theStack;
     }
 
+    /**
+     * Get the count to fulfill.
+     * @return the count.
+     */
     public int getCount()
     {
         return count;
+    }
+
+    /**
+     * Get the min count to fulfill.
+     * @return the min count.
+     */
+    public int getMinCount()
+    {
+        return minCount;
     }
 
     @Override
@@ -61,13 +90,12 @@ public abstract class AbstractCrafting implements IRequestable
             return false;
         }
         final AbstractCrafting that = (AbstractCrafting) o;
-        return getCount() == that.getCount() &&
-                 theStack.equals(that.theStack);
+        return getCount() == that.getCount() && getMinCount() == that.getMinCount() && theStack.equals(that.theStack);
     }
 
     @Override
     public int hashCode()
     {
-        return Objects.hash(theStack, getCount());
+        return Objects.hash(theStack, getCount(), getMinCount());
     }
 }

--- a/src/api/java/com/minecolonies/api/colony/requestsystem/requestable/crafting/PrivateCrafting.java
+++ b/src/api/java/com/minecolonies/api/colony/requestsystem/requestable/crafting/PrivateCrafting.java
@@ -13,10 +13,11 @@ public class PrivateCrafting extends AbstractCrafting
      *
      * @param stack the required stack.
      * @param count the crafting count.
+     * @param minCount the min count.
      */
-    public PrivateCrafting(@NotNull final ItemStack stack, final int count)
+    public PrivateCrafting(@NotNull final ItemStack stack, final int count, final int minCount)
     {
-        super(stack, count);
+        super(stack, count, minCount);
     }
 
     /**
@@ -31,6 +32,7 @@ public class PrivateCrafting extends AbstractCrafting
         final CompoundNBT compound = new CompoundNBT();
         compound.put(NBT_STACK, input.getStack().serializeNBT());
         compound.putInt(NBT_COUNT, input.getCount());
+        compound.putInt(NBT_MIN_COUNT, input.getCount());
 
         return compound;
     }
@@ -46,7 +48,8 @@ public class PrivateCrafting extends AbstractCrafting
     {
         final ItemStack stack = ItemStackUtils.deserializeFromNBT(compound.getCompound(NBT_STACK));
         final int count = compound.getInt(NBT_COUNT);
+        final int minCount = compound.getInt(NBT_MIN_COUNT);
 
-        return new PrivateCrafting(stack, count);
+        return new PrivateCrafting(stack, count, minCount == 0 ? count : minCount);
     }
 }

--- a/src/api/java/com/minecolonies/api/colony/requestsystem/requestable/crafting/PublicCrafting.java
+++ b/src/api/java/com/minecolonies/api/colony/requestsystem/requestable/crafting/PublicCrafting.java
@@ -13,11 +13,10 @@ public class PublicCrafting extends AbstractCrafting
      *
      * @param stack the required stack.
      * @param count the crafting count.
-     * @param minCount the min count.
      */
-    public PublicCrafting(@NotNull final ItemStack stack, final int count, final int minCount)
+    public PublicCrafting(@NotNull final ItemStack stack, final int count)
     {
-        super(stack, count, minCount);
+        super(stack, count, count);
     }
 
     /**
@@ -32,7 +31,6 @@ public class PublicCrafting extends AbstractCrafting
         final CompoundNBT compound = new CompoundNBT();
         compound.put(NBT_STACK, input.getStack().serializeNBT());
         compound.putInt(NBT_COUNT, input.getCount());
-        compound.putInt(NBT_MIN_COUNT, input.getCount());
 
         return compound;
     }
@@ -48,8 +46,7 @@ public class PublicCrafting extends AbstractCrafting
     {
         final ItemStack stack = ItemStackUtils.deserializeFromNBT(compound.getCompound(NBT_STACK));
         final int count = compound.getInt(NBT_COUNT);
-        final int minCount = compound.getInt(NBT_MIN_COUNT);
 
-        return new PublicCrafting(stack, count, minCount == 0 ? count : minCount);
+        return new PublicCrafting(stack, count);
     }
 }

--- a/src/api/java/com/minecolonies/api/colony/requestsystem/requestable/crafting/PublicCrafting.java
+++ b/src/api/java/com/minecolonies/api/colony/requestsystem/requestable/crafting/PublicCrafting.java
@@ -13,10 +13,11 @@ public class PublicCrafting extends AbstractCrafting
      *
      * @param stack the required stack.
      * @param count the crafting count.
+     * @param minCount the min count.
      */
-    public PublicCrafting(@NotNull final ItemStack stack, final int count)
+    public PublicCrafting(@NotNull final ItemStack stack, final int count, final int minCount)
     {
-        super(stack, count);
+        super(stack, count, minCount);
     }
 
     /**
@@ -31,6 +32,7 @@ public class PublicCrafting extends AbstractCrafting
         final CompoundNBT compound = new CompoundNBT();
         compound.put(NBT_STACK, input.getStack().serializeNBT());
         compound.putInt(NBT_COUNT, input.getCount());
+        compound.putInt(NBT_MIN_COUNT, input.getCount());
 
         return compound;
     }
@@ -46,7 +48,8 @@ public class PublicCrafting extends AbstractCrafting
     {
         final ItemStack stack = ItemStackUtils.deserializeFromNBT(compound.getCompound(NBT_STACK));
         final int count = compound.getInt(NBT_COUNT);
+        final int minCount = compound.getInt(NBT_MIN_COUNT);
 
-        return new PublicCrafting(stack, count);
+        return new PublicCrafting(stack, count, minCount == 0 ? count : minCount);
     }
 }

--- a/src/main/java/com/minecolonies/coremod/colony/buildings/AbstractBuilding.java
+++ b/src/main/java/com/minecolonies/coremod/colony/buildings/AbstractBuilding.java
@@ -1509,12 +1509,6 @@ public abstract class AbstractBuilding extends AbstractBuildingContainer impleme
         return Optional.of(getColony().getCitizenManager().getCitizen(citizenID));
     }
 
-    @Override
-    public boolean requiresCompleteRequestFulfillment()
-    {
-        return true;
-    }
-
     //------------------------- !END! RequestSystem handling for minecolonies buildings -------------------------//
 
     @Override

--- a/src/main/java/com/minecolonies/coremod/colony/buildings/AbstractBuildingStructureBuilder.java
+++ b/src/main/java/com/minecolonies/coremod/colony/buildings/AbstractBuildingStructureBuilder.java
@@ -423,12 +423,6 @@ public abstract class AbstractBuildingStructureBuilder extends AbstractBuildingW
         return new Tuple<>(this.progressPos, this.progressStage);
     }
 
-    @Override
-    public boolean requiresCompleteRequestFulfillment()
-    {
-        return false;
-    }
-
     /**
      * Getter for the blocks to be removed in fluids_remove.
      * @return the blocks to be removed in fluids_remove.

--- a/src/main/java/com/minecolonies/coremod/colony/buildings/workerbuildings/PostBox.java
+++ b/src/main/java/com/minecolonies/coremod/colony/buildings/workerbuildings/PostBox.java
@@ -11,6 +11,7 @@ import com.minecolonies.api.colony.buildings.registry.BuildingEntry;
 import com.minecolonies.api.colony.requestsystem.manager.IRequestManager;
 import com.minecolonies.api.colony.requestsystem.request.IRequest;
 import com.minecolonies.api.colony.requestsystem.request.RequestState;
+import com.minecolonies.api.colony.requestsystem.requestable.IDeliverable;
 import com.minecolonies.api.colony.requestsystem.requestable.Stack;
 import com.minecolonies.api.colony.requestsystem.resolver.IRequestResolver;
 import com.minecolonies.coremod.client.gui.WindowPostBox;
@@ -79,8 +80,7 @@ public class PostBox extends AbstractBuilding implements IRSComponent
         super.onRequestedRequestCancelled(manager, request);
         if (request.getState() == RequestState.FAILED && request.getRequest() instanceof Stack)
         {
-            final Stack req = new Stack(((Stack) request.getRequest()).getStack());
-            req.setCount(((Stack) request.getRequest()).getCount());
+            final IDeliverable req = ((Stack) request.getRequest()).copyWithCount(((Stack) request.getRequest()).getCount());
             createRequest(req, false);
         }
     }

--- a/src/main/java/com/minecolonies/coremod/colony/requestable/SmeltableOre.java
+++ b/src/main/java/com/minecolonies/coremod/colony/requestable/SmeltableOre.java
@@ -59,8 +59,7 @@ public class SmeltableOre implements IDeliverable
     @Override
     public boolean matches(@NotNull final ItemStack stack)
     {
-        return ItemStackUtils.IS_SMELTABLE.and(
-            itemStack -> IColonyManager.getInstance().getCompatibilityManager().isOre(itemStack)).test(stack);
+        return ItemStackUtils.IS_SMELTABLE.and(itemStack -> IColonyManager.getInstance().getCompatibilityManager().isOre(itemStack)).test(stack);
     }
 
     @Override
@@ -70,7 +69,7 @@ public class SmeltableOre implements IDeliverable
     }
 
     @Override
-    public IDeliverable copyWithCount(@NotNull final int newCount)
+    public IDeliverable copyWithCount(final int newCount)
     {
         return new SmeltableOre(newCount);
     }
@@ -79,6 +78,12 @@ public class SmeltableOre implements IDeliverable
     public int getCount()
     {
         return count;
+    }
+
+    @Override
+    public int getMinimumCount()
+    {
+        return 1;
     }
 
     @NotNull

--- a/src/main/java/com/minecolonies/coremod/colony/requestsystem/resolvers/PrivateWorkerCraftingProductionResolver.java
+++ b/src/main/java/com/minecolonies/coremod/colony/requestsystem/resolvers/PrivateWorkerCraftingProductionResolver.java
@@ -63,12 +63,6 @@ public class PrivateWorkerCraftingProductionResolver extends AbstractCraftingPro
     @Override
     public void resolveForBuilding(@NotNull final IRequestManager manager, @NotNull final IRequest<? extends PrivateCrafting> request, @NotNull final AbstractBuilding building)
     {
-        if (building.requiresCompleteRequestFulfillment())
-        {
-            super.resolveForBuilding(manager, request, building);
-            return;
-        }
-
         manager.updateRequestState(request.getId(), RequestState.FINALIZING);
 
         final AbstractBuildingWorker buildingWorker = (AbstractBuildingWorker) building;

--- a/src/main/java/com/minecolonies/coremod/colony/requestsystem/resolvers/PrivateWorkerCraftingRequestResolver.java
+++ b/src/main/java/com/minecolonies/coremod/colony/requestsystem/resolvers/PrivateWorkerCraftingRequestResolver.java
@@ -42,7 +42,6 @@ public class PrivateWorkerCraftingRequestResolver extends AbstractCraftingReques
         return null;
     }
 
-    @Nullable
     @Override
     public void onAssignedRequestBeingCancelled(@NotNull final IRequestManager manager, @NotNull final IRequest<? extends IDeliverable> request)
     {
@@ -50,13 +49,11 @@ public class PrivateWorkerCraftingRequestResolver extends AbstractCraftingReques
     }
 
     @Override
-    public void onAssignedRequestCancelled(
-      @NotNull final IRequestManager manager, @NotNull final IRequest<? extends IDeliverable> request)
+    public void onAssignedRequestCancelled(@NotNull final IRequestManager manager, @NotNull final IRequest<? extends IDeliverable> request)
     {
 
     }
 
-    @NotNull
     @Override
     public void onRequestedRequestCancelled(@NotNull final IRequestManager manager, @NotNull final IRequest<?> request)
     {
@@ -101,8 +98,8 @@ public class PrivateWorkerCraftingRequestResolver extends AbstractCraftingReques
     }
 
     @Override
-    protected IRequestable createNewRequestableForStack(final ItemStack stack, final int count)
+    protected IRequestable createNewRequestableForStack(final ItemStack stack, final int count, final int minCount)
     {
-        return new PrivateCrafting(stack, count);
+        return new PrivateCrafting(stack, count, minCount);
     }
 }

--- a/src/main/java/com/minecolonies/coremod/colony/requestsystem/resolvers/PublicWorkerCraftingRequestResolver.java
+++ b/src/main/java/com/minecolonies/coremod/colony/requestsystem/resolvers/PublicWorkerCraftingRequestResolver.java
@@ -91,6 +91,6 @@ public class PublicWorkerCraftingRequestResolver extends AbstractCraftingRequest
     @Override
     protected IRequestable createNewRequestableForStack(final ItemStack stack, final int count, final int minCount)
     {
-        return new PublicCrafting(stack, count, minCount);
+        return new PublicCrafting(stack, count);
     }
 }

--- a/src/main/java/com/minecolonies/coremod/colony/requestsystem/resolvers/PublicWorkerCraftingRequestResolver.java
+++ b/src/main/java/com/minecolonies/coremod/colony/requestsystem/resolvers/PublicWorkerCraftingRequestResolver.java
@@ -89,8 +89,8 @@ public class PublicWorkerCraftingRequestResolver extends AbstractCraftingRequest
     }
 
     @Override
-    protected IRequestable createNewRequestableForStack(final ItemStack stack, final int count)
+    protected IRequestable createNewRequestableForStack(final ItemStack stack, final int count, final int minCount)
     {
-        return new PublicCrafting(stack, count);
+        return new PublicCrafting(stack, count, minCount);
     }
 }

--- a/src/main/java/com/minecolonies/coremod/colony/requestsystem/resolvers/core/AbstractBuildingDependentRequestResolver.java
+++ b/src/main/java/com/minecolonies/coremod/colony/requestsystem/resolvers/core/AbstractBuildingDependentRequestResolver.java
@@ -19,17 +19,13 @@ import java.util.Optional;
  */
 public abstract class AbstractBuildingDependentRequestResolver<R extends IRequestable> extends AbstractRequestResolver<R> implements IBuildingBasedRequester
 {
-
-    public AbstractBuildingDependentRequestResolver(
-      @NotNull final ILocation location,
-      @NotNull final IToken<?> token)
+    public AbstractBuildingDependentRequestResolver(@NotNull final ILocation location, @NotNull final IToken<?> token)
     {
         super(location, token);
     }
 
     @Override
-    public boolean canResolveRequest(
-      @NotNull final IRequestManager manager, final IRequest<? extends R> requestToCheck)
+    public boolean canResolveRequest(@NotNull final IRequestManager manager, final IRequest<? extends R> requestToCheck)
     {
         if (!manager.getColony().getWorld().isRemote)
         {
@@ -40,7 +36,6 @@ public abstract class AbstractBuildingDependentRequestResolver<R extends IReques
                 return building.map(b -> canResolveForBuilding(manager, requestToCheck, b)).orElse(false);
             }
         }
-
         return false;
     }
 
@@ -48,25 +43,21 @@ public abstract class AbstractBuildingDependentRequestResolver<R extends IReques
 
     @Nullable
     @Override
-    public List<IToken<?>> attemptResolveRequest(
-      @NotNull final IRequestManager manager, @NotNull final IRequest<? extends R> request)
+    public List<IToken<?>> attemptResolveRequest(@NotNull final IRequestManager manager, @NotNull final IRequest<? extends R> request)
     {
         final AbstractBuilding building = getBuilding(manager, request.getId()).map(r -> (AbstractBuilding) r).get();
         return attemptResolveForBuilding(manager, request, building);
     }
 
     @Nullable
-    public abstract List<IToken<?>> attemptResolveForBuilding(
-      @NotNull final IRequestManager manager, @NotNull final IRequest<? extends R> request, @NotNull final AbstractBuilding building);
+    public abstract List<IToken<?>> attemptResolveForBuilding(@NotNull final IRequestManager manager, @NotNull final IRequest<? extends R> request, @NotNull final AbstractBuilding building);
 
     @Override
-    public void resolveRequest(
-      @NotNull final IRequestManager manager, @NotNull final IRequest<? extends R> request)
+    public void resolveRequest(@NotNull final IRequestManager manager, @NotNull final IRequest<? extends R> request)
     {
         final AbstractBuilding building = getBuilding(manager, request.getId()).map(r -> (AbstractBuilding) r).get();
         resolveForBuilding(manager, request, building);
     }
 
-    public abstract void resolveForBuilding(
-      @NotNull final IRequestManager manager, @NotNull final IRequest<? extends R> request, @NotNull final AbstractBuilding building);
+    public abstract void resolveForBuilding(@NotNull final IRequestManager manager, @NotNull final IRequest<? extends R> request, @NotNull final AbstractBuilding building);
 }

--- a/src/main/java/com/minecolonies/coremod/entity/ai/basic/AbstractEntityAIRequestSmelter.java
+++ b/src/main/java/com/minecolonies/coremod/entity/ai/basic/AbstractEntityAIRequestSmelter.java
@@ -12,6 +12,7 @@ import com.minecolonies.api.entity.ai.statemachine.AITarget;
 import com.minecolonies.api.entity.ai.statemachine.states.IAIState;
 import com.minecolonies.api.util.InventoryUtils;
 import com.minecolonies.api.util.ItemStackUtils;
+import com.minecolonies.api.util.constant.Constants;
 import com.minecolonies.coremod.colony.buildings.AbstractBuildingSmelterCrafter;
 import com.minecolonies.coremod.colony.interactionhandling.StandardInteractionResponseHandler;
 import com.minecolonies.coremod.colony.jobs.AbstractJobCrafter;
@@ -394,7 +395,7 @@ public abstract class AbstractEntityAIRequestSmelter<J extends AbstractJobCrafte
 
         if (amountOfFuelInBuilding + amountOfFuelInInv <= 0 && !getOwnBuilding().hasWorkerOpenRequestsOfType(worker.getCitizenData(), TypeToken.of(StackList.class)))
         {
-            worker.getCitizenData().createRequestAsync(new StackList(getOwnBuilding(AbstractBuildingSmelterCrafter.class).getAllowedFuel(), COM_MINECOLONIES_REQUESTS_BURNABLE));
+            worker.getCitizenData().createRequestAsync(new StackList(getOwnBuilding(AbstractBuildingSmelterCrafter.class).getAllowedFuel(), COM_MINECOLONIES_REQUESTS_BURNABLE, STACKSIZE, 1));
         }
 
         if (amountOfFuelInBuilding > 0 && amountOfFuelInInv == 0)

--- a/src/main/java/com/minecolonies/coremod/entity/ai/basic/AbstractEntityAIStructure.java
+++ b/src/main/java/com/minecolonies/coremod/entity/ai/basic/AbstractEntityAIStructure.java
@@ -589,8 +589,7 @@ public abstract class AbstractEntityAIStructure<J extends AbstractJobStructure> 
                     (IRequest<? extends IDeliverable> r) -> r.getRequest().matches(placedStack.getKey().getItemStack()))
                   .isEmpty())
             {
-                final Stack stackRequest = new Stack(placedStack.getKey().getItemStack());
-                stackRequest.setCount(placedStack.getValue());
+                final Stack stackRequest = new Stack(placedStack.getKey().getItemStack(), placedStack.getValue(), 1);
                 placer.getWorker().getCitizenData().createRequest(stackRequest);
                 placer.registerBlockAsNeeded(placedStack.getKey().getItemStack());
                 return true;

--- a/src/main/java/com/minecolonies/coremod/entity/ai/basic/AbstractEntityAIUsesFurnace.java
+++ b/src/main/java/com/minecolonies/coremod/entity/ai/basic/AbstractEntityAIUsesFurnace.java
@@ -8,6 +8,7 @@ import com.minecolonies.api.entity.ai.statemachine.AITarget;
 import com.minecolonies.api.entity.ai.statemachine.states.IAIState;
 import com.minecolonies.api.util.InventoryUtils;
 import com.minecolonies.api.util.ItemStackUtils;
+import com.minecolonies.api.util.constant.Constants;
 import com.minecolonies.coremod.colony.buildings.AbstractBuildingFurnaceUser;
 import com.minecolonies.coremod.colony.interactionhandling.StandardInteractionResponseHandler;
 import com.minecolonies.coremod.colony.jobs.AbstractJob;
@@ -186,7 +187,7 @@ public abstract class AbstractEntityAIUsesFurnace<J extends AbstractJob> extends
           req -> req.getShortDisplayString().getString().equals(
             LanguageHandler.format(COM_MINECOLONIES_REQUESTS_BURNABLE))))
         {
-            worker.getCitizenData().createRequestAsync(new StackList(getOwnBuilding(AbstractBuildingFurnaceUser.class).getAllowedFuel(), COM_MINECOLONIES_REQUESTS_BURNABLE));
+            worker.getCitizenData().createRequestAsync(new StackList(getOwnBuilding(AbstractBuildingFurnaceUser.class).getAllowedFuel(), COM_MINECOLONIES_REQUESTS_BURNABLE, STACKSIZE, 1));
         }
 
         if (amountOfSmeltableInBuilding > 0 && amountOfSmeltableInInv == 0)

--- a/src/main/java/com/minecolonies/coremod/entity/ai/citizen/composter/EntityAIWorkComposter.java
+++ b/src/main/java/com/minecolonies/coremod/entity/ai/citizen/composter/EntityAIWorkComposter.java
@@ -6,6 +6,7 @@ import com.minecolonies.api.entity.ai.statemachine.AITarget;
 import com.minecolonies.api.entity.ai.statemachine.states.IAIState;
 import com.minecolonies.api.util.InventoryUtils;
 import com.minecolonies.api.util.ItemStackUtils;
+import com.minecolonies.api.util.constant.Constants;
 import com.minecolonies.coremod.MineColonies;
 import com.minecolonies.coremod.colony.buildings.workerbuildings.BuildingComposter;
 import com.minecolonies.coremod.colony.jobs.JobComposter;
@@ -131,7 +132,7 @@ public class EntityAIWorkComposter extends AbstractEntityAIInteract<JobComposter
             }
             if (!itemList.isEmpty())
             {
-                worker.getCitizenData().createRequestAsync(new StackList(itemList, COM_MINECOLONIES_REQUESTS_COMPOSTABLE));
+                worker.getCitizenData().createRequestAsync(new StackList(itemList, COM_MINECOLONIES_REQUESTS_COMPOSTABLE, Constants.STACKSIZE, 1));
             }
         }
 

--- a/src/main/java/com/minecolonies/coremod/entity/ai/citizen/farmer/EntityAIWorkFarmer.java
+++ b/src/main/java/com/minecolonies/coremod/entity/ai/citizen/farmer/EntityAIWorkFarmer.java
@@ -46,6 +46,7 @@ import org.jetbrains.annotations.Nullable;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 import java.util.function.Predicate;
 
 import static com.minecolonies.api.entity.ai.statemachine.states.AIWorkerState.*;
@@ -169,12 +170,12 @@ public class EntityAIWorkFarmer extends AbstractEntityAIInteract<JobFarmer>
 
         if (amountOfCompostInBuilding + amountOfCompostInInv <= 0)
         {
-            if (!getOwnBuilding().hasWorkerOpenRequestsOfType(worker.getCitizenData(), TypeToken.of(StackList.class)))
+            if (!getOwnBuilding().hasWorkerOpenRequestsOfType(Objects.requireNonNull(worker.getCitizenData()), TypeToken.of(StackList.class)))
             {
                 final List<ItemStack> compostAbleItems = new ArrayList<>();
-                compostAbleItems.add(new ItemStack(ModItems.compost));
+                compostAbleItems.add(new ItemStack(ModItems.compost, 1));
                 compostAbleItems.add(new ItemStack(Items.BONE_MEAL, 1));
-                worker.getCitizenData().createRequestAsync(new StackList(compostAbleItems, FERTLIZER));
+                worker.getCitizenData().createRequestAsync(new StackList(compostAbleItems, FERTLIZER, STACKSIZE, 1));
             }
         }
         else if (amountOfCompostInInv <= 0 && amountOfCompostInBuilding > 0)

--- a/src/main/java/com/minecolonies/coremod/entity/ai/citizen/smelter/EntityAIWorkSmelter.java
+++ b/src/main/java/com/minecolonies/coremod/entity/ai/citizen/smelter/EntityAIWorkSmelter.java
@@ -11,6 +11,7 @@ import com.minecolonies.api.entity.ai.statemachine.AITarget;
 import com.minecolonies.api.entity.ai.statemachine.states.IAIState;
 import com.minecolonies.api.util.InventoryUtils;
 import com.minecolonies.api.util.ItemStackUtils;
+import com.minecolonies.api.util.constant.Constants;
 import com.minecolonies.coremod.colony.buildings.AbstractBuildingFurnaceUser;
 import com.minecolonies.coremod.colony.buildings.workerbuildings.BuildingSmeltery;
 import com.minecolonies.coremod.colony.interactionhandling.StandardInteractionResponseHandler;
@@ -351,7 +352,7 @@ public class EntityAIWorkSmelter extends AbstractEntityAIUsesFurnace<JobSmelter>
                 }
                 else
                 {
-                    worker.getCitizenData().createRequestAsync(new StackList(requests, COM_MINECOLONIES_REQUESTS_SMELTABLE_ORE));
+                    worker.getCitizenData().createRequestAsync(new StackList(requests, COM_MINECOLONIES_REQUESTS_SMELTABLE_ORE, STACKSIZE, 1));
                 }
             }
             else

--- a/src/main/resources/data/minecolonies/recipes/blockpostbox.json
+++ b/src/main/resources/data/minecolonies/recipes/blockpostbox.json
@@ -10,7 +10,7 @@
       "tag": "minecraft:planks"
     },
     "I": {
-      "item": "forge:chests"
+      "tag": "forge:chests"
     },
     "S": {
       "item": "structurize:sceptergold"

--- a/src/main/resources/data/minecolonies/recipes/blockstash.json
+++ b/src/main/resources/data/minecolonies/recipes/blockstash.json
@@ -10,7 +10,7 @@
       "tag": "minecraft:planks"
     },
     "I": {
-      "item": "forge:chests"
+      "tag": "forge:chests"
     },
     "S": {
       "item": "structurize:sceptergold"


### PR DESCRIPTION
This PR basically replaces the previous handling where specific workers were able to make requests that were partially fulfilled with a request specific handling. Thus worker can request something with a count and a min count, where the RS will try to fulfill the count and if this is not possible but the system has a bit less it will try to match the minCount.

I also removed some of the heavy streams with quicker for loops.

Review please
