### PR TITLE
Fix miner building first platform one block to close to the top

### DIFF
--- a/src/main/java/com/minecolonies/coremod/entity/ai/citizen/miner/EntityAIStructureMiner.java
+++ b/src/main/java/com/minecolonies/coremod/entity/ai/citizen/miner/EntityAIStructureMiner.java
@@ -473,7 +473,7 @@ public class EntityAIStructureMiner extends AbstractEntityAIStructureWithWorkOrd
 
         if (getOwnBuilding().getStartingLevelShaft() == 0)
         {
-            getOwnBuilding().setStartingLevelShaft(nextCobble.getY() - 3);
+            getOwnBuilding().setStartingLevelShaft(nextCobble.getY() - 4);
         }
 
         if (nextCobble.getY() < getOwnBuilding().getStartingLevelShaft())


### PR DESCRIPTION
# Changes proposed in this pull request:
- Move mine platforms one block down to not break the miners hut.
- Huge PR, i know.
- Tested with Acacia, Asia and Wooden.

Review please
