### PR TITLE
Fix Inventory text being in the wrong position in upgraded double racks.

### DIFF
--- a/src/main/java/com/minecolonies/coremod/client/gui/containers/WindowRack.java
+++ b/src/main/java/com/minecolonies/coremod/client/gui/containers/WindowRack.java
@@ -120,7 +120,7 @@ public class WindowRack extends ContainerScreen<ContainerRack>
     protected void drawGuiContainerForegroundLayer(int mouseX, int mouseY)
     {
         this.font.drawString(this.title.getFormattedText(), 8.0F, 6.0F, 4210752);
-        this.font.drawString(this.playerInventory.getDisplayName().getFormattedText(), 8.0F, (float)(this.ySize - 96 + 2), 4210752);
+        this.font.drawString(this.playerInventory.getDisplayName().getFormattedText(), 8.0F, (float)(this.ySize - (inventoryRows > 6 ? 110 : 94)), 4210752);
     }
 
     /**


### PR DESCRIPTION
# Changes proposed in this pull request:
- Fix Inventory text being in the wrong position in upgraded double racks.
-
-

Review please
