### PR TITLE
Fixed issue #5062

### DIFF
--- a/src/api/java/com/minecolonies/api/util/constant/TranslationConstants.java
+++ b/src/api/java/com/minecolonies/api/util/constant/TranslationConstants.java
@@ -330,6 +330,8 @@ public final class TranslationConstants
     @NonNls
     public static final String TOO_MANY_FILTERED_FLORIST = "com.minecolonies.gui.workerhuts.florist.toomany";
     @NonNls
+    public static final String TOO_MANY_FILTERED_BELOW_LVL4_FLORIST = "com.minecolonies.gui.workerhuts.florist.toomanybelow";
+    @NonNls
     public static final String FLORIST_BUILDING_NAME = "com.minecolonies.coremod.gui.workerhuts.florist";
     @NonNls
     public static final String ENCHANTER_BUILDING_NAME = "com.minecolonies.coremod.gui.workerhuts.enchanter";

--- a/src/main/java/com/minecolonies/coremod/client/gui/WindowHutFlorist.java
+++ b/src/main/java/com/minecolonies/coremod/client/gui/WindowHutFlorist.java
@@ -76,7 +76,7 @@ public class WindowHutFlorist extends AbstractHutFilterableLists
 
             if (ownBuilding.getBuildingLevel() <= MAX_LEVEL_BEFORE_SORTING && button.getLabel().equals(ON) && building.getSize(PAGE_ITEMS_VIEW) >= 1)
             {
-                LanguageHandler.sendPlayerMessage(Minecraft.getInstance().player, TOO_MANY_FILTERED_FLORIST);
+                LanguageHandler.sendPlayerMessage(Minecraft.getInstance().player, TOO_MANY_FILTERED_BELOW_LVL4_FLORIST);
                 return;
             }
 

--- a/src/main/resources/assets/minecolonies/lang/en_us.json
+++ b/src/main/resources/assets/minecolonies/lang/en_us.json
@@ -1153,6 +1153,7 @@
   "com.minecolonies.gui.workerhuts.florist.flowers": "Plantables",
   "com.minecolonies.gui.workerhuts.florist.toolow": "The florist currently randomly generates the flowers in the list, upgrade to level 4 or above to select them manually!",
   "com.minecolonies.gui.workerhuts.florist.toomany": "You can deactivate max 5 options. Upgrade to level 5 to restrict it further!",
+  "com.minecolonies.gui.workerhuts.florist.toomanybelow": "You can deactivate max 1 option. Upgrade to level 4 to restrict it further!",
   "com.minecolonies.coremod.gui.townHall.population.florists": "Florists: %d/%d",
   "com.minecolonies.coremod.gui.townHall.population.bakerys": "Bakeries: %d/%d",
   "com.minecolonies.coremod.gui.townHall.population.universitys": "Universities: %d/%d",


### PR DESCRIPTION
Closes #5062 

# Changes proposed in this pull request:
- Added new `TOO_MANY_FILTERED_BELOW_LVL4_FLORIST` to `TranslationConstants.java` that handels the case of the Florist being below level 4 and therefor can just deactivate 1 plantable.

- Changed the function `onButtonClicked` in `WindowHutFloist.java` to display the right message.

- Added the message to "en_US.json"


Review please
