### PR TITLE
Added textual feedback to the sort-button in the warehouse

### DIFF
--- a/src/api/java/com/minecolonies/api/util/constant/TranslationConstants.java
+++ b/src/api/java/com/minecolonies/api/util/constant/TranslationConstants.java
@@ -379,6 +379,8 @@ public final class TranslationConstants
     public static final String NO = "com.minecolonies.coremod.entity.citizen.no.";
     @NonNls
     public static final String DEMANDS = "com.minecolonies.coremod.entity.citizen.demands.";
+    @NonNls
+    public static final String WAREHOUSE_SORTED = "com.minecolonies.coremod.gui.warehouse.sorted";
 
     private TranslationConstants()
     {

--- a/src/main/java/com/minecolonies/coremod/client/gui/WindowHutWareHouse.java
+++ b/src/main/java/com/minecolonies/coremod/client/gui/WindowHutWareHouse.java
@@ -19,6 +19,7 @@ import com.minecolonies.coremod.network.messages.server.colony.building.RemoveMi
 import com.minecolonies.coremod.network.messages.server.colony.building.warehouse.SortWarehouseMessage;
 import com.minecolonies.coremod.network.messages.server.colony.building.warehouse.UpgradeWarehouseMessage;
 import net.minecraft.block.Blocks;
+import net.minecraft.client.Minecraft;
 import net.minecraft.entity.player.PlayerInventory;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.ResourceLocation;
@@ -28,6 +29,7 @@ import org.jetbrains.annotations.NotNull;
 import java.util.ArrayList;
 import java.util.List;
 
+import static com.minecolonies.api.util.constant.TranslationConstants.*;
 import static com.minecolonies.api.util.constant.WindowConstants.*;
 import static com.minecolonies.coremod.client.gui.WindowHutBuilder.*;
 
@@ -271,7 +273,9 @@ public class WindowHutWareHouse extends AbstractWindowBuilding<BuildingWareHouse
      */
     private void sortWarehouse()
     {
+
         Network.getNetwork().sendToServer(new SortWarehouseMessage(this.building));
+        LanguageHandler.sendPlayerMessage(Minecraft.getInstance().player, WAREHOUSE_SORTED);
     }
 
     /**

--- a/src/main/resources/assets/minecolonies/lang/en_us.json
+++ b/src/main/resources/assets/minecolonies/lang/en_us.json
@@ -1372,6 +1372,7 @@
   "com.minecolonies.coremod.gui.scan.select.stack": "Stack(s)",
   "com.minecolonies.coremod.gui.scan.select.title": "Stack Selection GUI",
   "com.minecolonies.coremod.gui.warehouse.limitreached": "Limit Reached",
+  "com.minecolonies.coremod.gui.warehouse.sorted": "Warehouse stock sorted!",
   "com.minecolonies.coremod.university.researchconcluded.0": "Your researchers just successfully concluded: %s",
   "com.minecolonies.coremod.university.researchconcluded.1": "The researchers in your colony just unravelled the mystery of: %s",
   "com.minecolonies.coremod.university.researchconcluded.2": "The Research about %s was successfully demystified by your researchers",


### PR DESCRIPTION
Players will now get a message when they sort the warehouse as suggested by a user.

# Changes proposed in this pull request:
- Added a new `TranslationConstant` called `WAREHOUSE_SORTED`
- Added it into the `sortWarehouse`-function in `WindowHutWareHouse.java`
- Added a line for it in `en_us.json`

Closes #5099 

Review please
