### PR TITLE
Slightly better handling of pickup requests

### DIFF
--- a/src/api/java/com/minecolonies/api/colony/buildings/IBuilding.java
+++ b/src/api/java/com/minecolonies/api/colony/buildings/IBuilding.java
@@ -307,10 +307,10 @@ public interface IBuilding extends ISchematicProvider, ICitizenAssignable, IBuil
      * The call will return false if a pickup request already exists, or if the priority is not within
      * the proper range, or if the pickup priority is set to NEVER (0).
      *
-     * @param priority The priority of the pickup request.
+     * @param scaledPriority The priority of the pickup request. This value is considered already scaled!
      * @return true if a pickup request could be created, false if not.
      */
-    boolean createPickupRequest(final int priority);
+    boolean createPickupRequest(final int scaledPriority);
 
     @Override
     ImmutableCollection<IRequestResolver<?>> getResolvers();

--- a/src/api/java/com/minecolonies/api/colony/requestsystem/requestable/deliveryman/AbstractDeliverymanRequestable.java
+++ b/src/api/java/com/minecolonies/api/colony/requestsystem/requestable/deliveryman/AbstractDeliverymanRequestable.java
@@ -1,20 +1,89 @@
 package com.minecolonies.api.colony.requestsystem.requestable.deliveryman;
 
+/**
+ * Abstract class for all deliveryman-requests
+ */
 public abstract class AbstractDeliverymanRequestable implements IDeliverymanRequestable
 {
     ////// --------------------------- NBTConstants --------------------------- \\\\\\
     protected static final String NBT_PRIORITY = "Priority";
     ////// --------------------------- NBTConstants --------------------------- \\\\\\
 
-    public static final int MAX_DELIVERYMAN_STANDARD_PRIORITY = 10;
-    public static final int MAX_DELIVERYMAN_AGING_PRIORITY    = 11;
-    public static final int MAX_DELIVERYMAN_PLAYER_PRIORITY   = 12;
+    private static final int MAX_BUILDING_PRIORITY     = 10;
+    private static final int DEFAULT_DELIVERY_PRIORITY = 11;
+    private static final int MAX_AGING_PRIORITY        = 12;
+    private static final int PLAYER_ACTION_PRIORITY    = 13;
 
     protected int priority = 0;
 
+    /**
+     * Constructor for deliveryman requestables
+     *
+     * @param priority The priority of the request. Higher priority -> Earlier delivery/pickup
+     */
     protected AbstractDeliverymanRequestable(final int priority)
     {
         this.priority = priority;
+    }
+
+    /**
+     * Scales the priority to the desired internal value.
+     * This is used so that the actual priorities are not just 1-10, but i.e. 1-100 (x^2)
+     * This will effectively make the aging-algorithm, which always increments by 1, slower.
+     * The function can be anything - a linear scaler, quadratic, exponential, whatever.
+     * Adapt over time to find the best solution.
+     */
+    public static int scaledPriority(final int priority)
+    {
+        return (int) Math.pow(priority, 2);
+    }
+
+    /**
+     * Gets the maximum priority allowed to be set in the building GUI.
+     * This is the "normal" setting available to players.
+     *
+     * @param returnScaled true if the value should be returned scaled
+     * @return the scaled/unscaled priority
+     */
+    public static int getMaxBuildingPriority(final boolean returnScaled)
+    {
+        return returnScaled ? scaledPriority(MAX_BUILDING_PRIORITY) : MAX_BUILDING_PRIORITY;
+    }
+
+    /**
+     * Gets the priority given to deliveries.
+     * This affects follow-up deliveries from crafters, and deliveries from the warehouse.
+     *
+     * @param returnScaled true if the value should be returned scaled
+     * @return the scaled/unscaled priority
+     */
+    public static int getDefaultDeliveryPriority(final boolean returnScaled)
+    {
+        return returnScaled ? scaledPriority(DEFAULT_DELIVERY_PRIORITY) : DEFAULT_DELIVERY_PRIORITY;
+    }
+
+    /**
+     * Gets the maximum priority the aging mechanism can assign.
+     * After that, priorities can not naturally increase.
+     *
+     * @param returnScaled true if the value should be returned scaled
+     * @return the scaled/unscaled priority
+     */
+    public static int getMaxAgingPriority(final boolean returnScaled)
+    {
+        return returnScaled ? scaledPriority(MAX_AGING_PRIORITY) : MAX_AGING_PRIORITY;
+    }
+
+    /**
+     * Gets the priority given to the Request-Pickup-Now-feature
+     * TODO: Eventually, this should also affect the Postbox.
+     *
+     * @param returnScaled true if the value should be returned scaled
+     * @return the scaled/unscaled priority
+     */
+    public static int getPlayerActionPriority(final boolean returnScaled)
+    {
+        return returnScaled ? scaledPriority(PLAYER_ACTION_PRIORITY) : PLAYER_ACTION_PRIORITY;
     }
 
     @Override
@@ -28,7 +97,7 @@ public abstract class AbstractDeliverymanRequestable implements IDeliverymanRequ
     {
         // The priority set by by the aging mechanism can actually exceed the maximum priority that requesters can choose.
         // Worst case, the priority queue turns into a FIFO queue for really old requests, with new maximum-priority requests having to wait.
-        priority = Math.min(MAX_DELIVERYMAN_AGING_PRIORITY, priority + 1);
+        priority = Math.min(getMaxAgingPriority(true), priority + 1);
     }
 
     @Override

--- a/src/api/java/com/minecolonies/api/colony/requestsystem/requestable/deliveryman/AbstractDeliverymanRequestable.java
+++ b/src/api/java/com/minecolonies/api/colony/requestsystem/requestable/deliveryman/AbstractDeliverymanRequestable.java
@@ -10,9 +10,9 @@ public abstract class AbstractDeliverymanRequestable implements IDeliverymanRequ
     ////// --------------------------- NBTConstants --------------------------- \\\\\\
 
     private static final int MAX_BUILDING_PRIORITY     = 10;
-    private static final int DEFAULT_DELIVERY_PRIORITY = 11;
-    private static final int MAX_AGING_PRIORITY        = 12;
-    private static final int PLAYER_ACTION_PRIORITY    = 13;
+    private static final int DEFAULT_DELIVERY_PRIORITY = 13;
+    private static final int MAX_AGING_PRIORITY        = 14;
+    private static final int PLAYER_ACTION_PRIORITY    = 15;
 
     protected int priority = 0;
 
@@ -35,7 +35,10 @@ public abstract class AbstractDeliverymanRequestable implements IDeliverymanRequ
      */
     public static int scaledPriority(final int priority)
     {
-        return (int) Math.pow(priority, 2);
+        // This version makes the increase quadratic
+        // return (int) Math.pow(priority, 2);
+
+        return priority;
     }
 
     /**

--- a/src/api/java/com/minecolonies/api/colony/requestsystem/requestable/deliveryman/Delivery.java
+++ b/src/api/java/com/minecolonies/api/colony/requestsystem/requestable/deliveryman/Delivery.java
@@ -27,6 +27,14 @@ public class Delivery extends AbstractDeliverymanRequestable
     @NotNull
     private final ItemStack stack;
 
+    /**
+     * Constructor for Delivery requests
+     *
+     * @param start    The location of the source inventory
+     * @param target   The location of the target inventory
+     * @param stack    The stack to be delivered
+     * @param priority The priority of the request
+     */
     public Delivery(@NotNull final ILocation start, @NotNull final ILocation target, @NotNull final ItemStack stack, final int priority)
     {
         super(priority);

--- a/src/api/java/com/minecolonies/api/colony/requestsystem/requestable/deliveryman/Pickup.java
+++ b/src/api/java/com/minecolonies/api/colony/requestsystem/requestable/deliveryman/Pickup.java
@@ -10,6 +10,12 @@ import org.jetbrains.annotations.NotNull;
  */
 public class Pickup extends AbstractDeliverymanRequestable
 {
+
+    /**
+     * Constructor for Delivery requests
+     *
+     * @param priority The priority of the request.
+     */
     public Pickup(final int priority)
     {
         super(priority);

--- a/src/api/java/com/minecolonies/api/tileentities/TileEntityStash.java
+++ b/src/api/java/com/minecolonies/api/tileentities/TileEntityStash.java
@@ -6,22 +6,29 @@ import com.minecolonies.api.colony.buildings.IBuilding;
 import net.minecraft.tileentity.TileEntityType;
 import net.minecraftforge.items.ItemStackHandler;
 
-import static com.minecolonies.api.colony.requestsystem.requestable.deliveryman.AbstractDeliverymanRequestable.MAX_DELIVERYMAN_STANDARD_PRIORITY;
+import static com.minecolonies.api.colony.requestsystem.requestable.deliveryman.AbstractDeliverymanRequestable.getMaxBuildingPriority;
 import static com.minecolonies.api.util.constant.Constants.DEFAULT_SIZE;
 
 /**
  * Class which handles the tileEntity for the Stash block.
  */
-
 public class TileEntityStash extends TileEntityColonyBuilding
 {
 
+    /**
+     * Constructor of the stash based on a tile entity type
+     *
+     * @param type tile entity type
+     */
     public TileEntityStash(final TileEntityType type)
     {
         super(type);
         inventory = new NotifyingRackInventory(DEFAULT_SIZE);
     }
 
+    /**
+     * Default constructor of the stash
+     */
     public TileEntityStash()
     {
         super(MinecoloniesTileEntities.STASH);
@@ -52,7 +59,7 @@ public class TileEntityStash extends TileEntityColonyBuilding
                     if (!freeStacks())
                     {
                         // Note that createPickupRequest will make sure to only create on request per building.
-                        building.createPickupRequest(MAX_DELIVERYMAN_STANDARD_PRIORITY);
+                        building.createPickupRequest(getMaxBuildingPriority(true));
                     }
                 }
             }

--- a/src/api/java/com/minecolonies/api/util/constant/TranslationConstants.java
+++ b/src/api/java/com/minecolonies/api/util/constant/TranslationConstants.java
@@ -32,6 +32,8 @@ public final class TranslationConstants
     @NonNls
     public static final String COM_MINECOLONIES_COREMOD_ENTITY_DELIVERYMAN_FORCEPICKUP_FAILED      = "entity.deliveryman.forcepickupfailed";
     @NonNls
+    public static final String COM_MINECOLONIES_COREMOD_ENTITY_DELIVERYMAN_PRIORITY                = "com.minecolonies.coremod.gui.workerhuts.buildprio";
+    @NonNls
     public static final String COM_MINECOLONIES_COREMOD_ENTITY_WORKER_INVENTORYFULLCHEST           = "entity.worker.inventoryfullchestfull";
     @NonNls
     public static final String COM_MINECOLONIES_COREMOD_ENTITY_WORKER_PICKAXEREQUEST               = "entity.worker.pickaxerequest";

--- a/src/api/java/com/minecolonies/api/util/constant/TranslationConstants.java
+++ b/src/api/java/com/minecolonies/api/util/constant/TranslationConstants.java
@@ -32,7 +32,7 @@ public final class TranslationConstants
     @NonNls
     public static final String COM_MINECOLONIES_COREMOD_ENTITY_DELIVERYMAN_FORCEPICKUP_FAILED      = "entity.deliveryman.forcepickupfailed";
     @NonNls
-    public static final String COM_MINECOLONIES_COREMOD_ENTITY_DELIVERYMAN_PRIORITY                = "com.minecolonies.coremod.gui.workerhuts.buildprio";
+    public static final String COM_MINECOLONIES_COREMOD_ENTITY_DELIVERYMAN_PRIORITY                = "com.minecolonies.coremod.gui.workerhuts.deliveryman.priority";
     @NonNls
     public static final String COM_MINECOLONIES_COREMOD_ENTITY_WORKER_INVENTORYFULLCHEST           = "entity.worker.inventoryfullchestfull";
     @NonNls

--- a/src/api/java/com/minecolonies/api/util/constant/WindowConstants.java
+++ b/src/api/java/com/minecolonies/api/util/constant/WindowConstants.java
@@ -956,6 +956,11 @@ public final class WindowConstants
     public static final String REQUEST_SHORT_DETAIL = "shortDetail";
 
     /**
+     * Id of the short detail label.
+     */
+    public static final String REQUEST_PRIORITY = "priority";
+
+    /**
      * Id of the requester label.
      */
     public static final String REQUESTER = "requester";

--- a/src/main/java/com/minecolonies/coremod/client/gui/WindowHutDeliveryman.java
+++ b/src/main/java/com/minecolonies/coremod/client/gui/WindowHutDeliveryman.java
@@ -10,7 +10,6 @@ import com.minecolonies.api.colony.requestsystem.requestable.deliveryman.IDelive
 import com.minecolonies.api.util.constant.Constants;
 import com.minecolonies.coremod.colony.buildings.workerbuildings.BuildingDeliveryman;
 import com.minecolonies.coremod.colony.buildings.workerbuildings.BuildingFarmer;
-import net.minecraft.util.text.TranslationTextComponent;
 import org.jetbrains.annotations.NotNull;
 
 import static com.minecolonies.api.util.constant.TranslationConstants.COM_MINECOLONIES_COREMOD_ENTITY_DELIVERYMAN_PRIORITY;
@@ -80,8 +79,12 @@ public class WindowHutDeliveryman extends AbstractWindowWorkerBuilding<BuildingD
                 rowPane.findPaneOfTypeByID(REQUEST_SHORT_DETAIL, Label.class)
                   .setLabelText(request.getShortDisplayString().getFormattedText().replace("§f", ""));
 
-                rowPane.findPaneOfTypeByID(REQUEST_PRIORITY, Label.class)
-                  .setLabelText(LanguageHandler.format(COM_MINECOLONIES_COREMOD_ENTITY_DELIVERYMAN_PRIORITY) + ((IDeliverymanRequestable)(request.getRequest())).getPriority());
+                if (request.getRequest() instanceof IDeliverymanRequestable)
+                {
+                    rowPane.findPaneOfTypeByID(REQUEST_PRIORITY, Label.class)
+                      .setLabelText(
+                        LanguageHandler.format(COM_MINECOLONIES_COREMOD_ENTITY_DELIVERYMAN_PRIORITY) + ((IDeliverymanRequestable) (request.getRequest())).getPriority());
+                }
 
                 final Image logo = rowPane.findPaneOfTypeByID(DELIVERY_IMAGE, Image.class);
                 logo.setImage(request.getDisplayIcon());

--- a/src/main/java/com/minecolonies/coremod/client/gui/WindowHutDeliveryman.java
+++ b/src/main/java/com/minecolonies/coremod/client/gui/WindowHutDeliveryman.java
@@ -4,12 +4,16 @@ import com.ldtteam.blockout.Pane;
 import com.ldtteam.blockout.controls.Image;
 import com.ldtteam.blockout.controls.Label;
 import com.ldtteam.blockout.views.ScrollingList;
+import com.ldtteam.structurize.util.LanguageHandler;
 import com.minecolonies.api.colony.requestsystem.request.IRequest;
+import com.minecolonies.api.colony.requestsystem.requestable.deliveryman.IDeliverymanRequestable;
 import com.minecolonies.api.util.constant.Constants;
 import com.minecolonies.coremod.colony.buildings.workerbuildings.BuildingDeliveryman;
 import com.minecolonies.coremod.colony.buildings.workerbuildings.BuildingFarmer;
+import net.minecraft.util.text.TranslationTextComponent;
 import org.jetbrains.annotations.NotNull;
 
+import static com.minecolonies.api.util.constant.TranslationConstants.COM_MINECOLONIES_COREMOD_ENTITY_DELIVERYMAN_PRIORITY;
 import static com.minecolonies.api.util.constant.WindowConstants.*;
 
 /**
@@ -75,6 +79,9 @@ public class WindowHutDeliveryman extends AbstractWindowWorkerBuilding<BuildingD
 
                 rowPane.findPaneOfTypeByID(REQUEST_SHORT_DETAIL, Label.class)
                   .setLabelText(request.getShortDisplayString().getFormattedText().replace("§f", ""));
+
+                rowPane.findPaneOfTypeByID(REQUEST_PRIORITY, Label.class)
+                  .setLabelText(LanguageHandler.format(COM_MINECOLONIES_COREMOD_ENTITY_DELIVERYMAN_PRIORITY) + ((IDeliverymanRequestable)(request.getRequest())).getPriority());
 
                 final Image logo = rowPane.findPaneOfTypeByID(DELIVERY_IMAGE, Image.class);
                 logo.setImage(request.getDisplayIcon());

--- a/src/main/java/com/minecolonies/coremod/colony/buildings/AbstractBuilding.java
+++ b/src/main/java/com/minecolonies/coremod/colony/buildings/AbstractBuilding.java
@@ -73,7 +73,7 @@ import java.util.*;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
-import static com.minecolonies.api.colony.requestsystem.requestable.deliveryman.AbstractDeliverymanRequestable.MAX_DELIVERYMAN_PLAYER_PRIORITY;
+import static com.minecolonies.api.colony.requestsystem.requestable.deliveryman.AbstractDeliverymanRequestable.getPlayerActionPriority;
 import static com.minecolonies.api.research.util.ResearchConstants.MINIMUM_STOCK;
 import static com.minecolonies.api.util.constant.BuildingConstants.NO_WORK_ORDER;
 import static com.minecolonies.api.util.constant.NbtTagConstants.*;
@@ -1115,9 +1115,9 @@ public abstract class AbstractBuilding extends AbstractBuildingContainer impleme
     }
 
     @Override
-    public boolean createPickupRequest(final int priority)
+    public boolean createPickupRequest(final int scaledPriority)
     {
-        if (priority < 0 || priority > MAX_DELIVERYMAN_PLAYER_PRIORITY)
+        if (scaledPriority < 0 || scaledPriority > getPlayerActionPriority(true))
         {
             return false;
         }
@@ -1127,7 +1127,7 @@ public abstract class AbstractBuilding extends AbstractBuildingContainer impleme
             return false;
         }
 
-        createRequest(new Pickup(priority), true);
+        createRequest(new Pickup(scaledPriority), true);
         return true;
     }
 

--- a/src/main/java/com/minecolonies/coremod/colony/buildings/AbstractBuildingContainer.java
+++ b/src/main/java/com/minecolonies/coremod/colony/buildings/AbstractBuildingContainer.java
@@ -2,6 +2,7 @@ package com.minecolonies.coremod.colony.buildings;
 
 import com.minecolonies.api.colony.IColony;
 import com.minecolonies.api.colony.buildings.IBuildingContainer;
+import com.minecolonies.api.colony.requestsystem.requestable.deliveryman.AbstractDeliverymanRequestable;
 import com.minecolonies.api.tileentities.AbstractTileEntityColonyBuilding;
 import com.minecolonies.api.tileentities.TileEntityRack;
 import com.minecolonies.coremod.blocks.BlockMinecoloniesRack;
@@ -32,7 +33,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.function.Predicate;
 
-import static com.minecolonies.api.colony.requestsystem.requestable.deliveryman.AbstractDeliverymanRequestable.MAX_DELIVERYMAN_STANDARD_PRIORITY;
+import static com.minecolonies.api.colony.requestsystem.requestable.deliveryman.AbstractDeliverymanRequestable.getMaxBuildingPriority;
 import static com.minecolonies.api.util.constant.NbtTagConstants.*;
 
 /**
@@ -57,9 +58,9 @@ public abstract class AbstractBuildingContainer extends AbstractCitizenAssignabl
     protected AbstractTileEntityColonyBuilding tileEntity;
 
     /**
-     * Priority of the building in the pickUpList.
+     * Priority of the building in the pickUpList. This is the unscaled value (mainly for a more intuitive GUI).
      */
-    private int pickUpPriority = 1;
+    private int unscaledPickUpPriority = 1;
 
     /**
      * The constructor for the building container.
@@ -85,14 +86,14 @@ public abstract class AbstractBuildingContainer extends AbstractCitizenAssignabl
         }
         if (compound.keySet().contains(TAG_PRIO))
         {
-            this.pickUpPriority = compound.getInt(TAG_PRIO);
+            this.unscaledPickUpPriority = compound.getInt(TAG_PRIO);
         }
         if (compound.keySet().contains(TAG_PRIO_STATE))
         {
             // This was the old int representation of Pickup:Never
             if (compound.getInt(TAG_PRIO_STATE) == 0)
             {
-                this.pickUpPriority = 0;
+                this.unscaledPickUpPriority = 0;
             }
         }
     }
@@ -108,7 +109,7 @@ public abstract class AbstractBuildingContainer extends AbstractCitizenAssignabl
             containerTagList.add(NBTUtil.writeBlockPos(pos));
         }
         compound.put(TAG_CONTAINERS, containerTagList);
-        compound.putInt(TAG_PRIO, this.pickUpPriority);
+        compound.putInt(TAG_PRIO, this.unscaledPickUpPriority);
 
         return compound;
     }
@@ -116,13 +117,13 @@ public abstract class AbstractBuildingContainer extends AbstractCitizenAssignabl
     @Override
     public int getPickUpPriority()
     {
-        return this.pickUpPriority;
+        return this.unscaledPickUpPriority;
     }
 
     @Override
     public void alterPickUpPriority(final int value)
     {
-        this.pickUpPriority = MathHelper.clamp(this.pickUpPriority + value, 0, MAX_DELIVERYMAN_STANDARD_PRIORITY);
+        this.unscaledPickUpPriority = MathHelper.clamp(this.unscaledPickUpPriority + value, 0, getMaxBuildingPriority(false));
     }
 
     @Override

--- a/src/main/java/com/minecolonies/coremod/colony/jobs/JobDeliveryman.java
+++ b/src/main/java/com/minecolonies/coremod/colony/jobs/JobDeliveryman.java
@@ -10,6 +10,7 @@ import com.minecolonies.api.colony.requestsystem.data.IRequestSystemDeliveryManJ
 import com.minecolonies.api.colony.requestsystem.manager.IRequestManager;
 import com.minecolonies.api.colony.requestsystem.request.IRequest;
 import com.minecolonies.api.colony.requestsystem.request.RequestState;
+import com.minecolonies.api.colony.requestsystem.requestable.deliveryman.AbstractDeliverymanRequestable;
 import com.minecolonies.api.colony.requestsystem.requestable.deliveryman.IDeliverymanRequestable;
 import com.minecolonies.api.colony.requestsystem.token.IToken;
 import com.minecolonies.api.entity.citizen.AbstractEntityCitizen;
@@ -27,7 +28,7 @@ import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
 
-import static com.minecolonies.api.colony.requestsystem.requestable.deliveryman.AbstractDeliverymanRequestable.MAX_DELIVERYMAN_PLAYER_PRIORITY;
+import static com.minecolonies.api.colony.requestsystem.requestable.deliveryman.AbstractDeliverymanRequestable.getPlayerActionPriority;
 import static com.minecolonies.api.util.constant.BuildingConstants.TAG_ACTIVE;
 import static com.minecolonies.api.util.constant.CitizenConstants.BASE_MOVEMENT_SPEED;
 import static com.minecolonies.api.util.constant.Suppression.UNCHECKED;
@@ -199,7 +200,7 @@ public class JobDeliveryman extends AbstractJob
         }
         getTaskQueueFromDataStore().add(Math.max(0, insertionIndex), token);
 
-        if (newRequest instanceof StandardRequests.PickupRequest && newRequest.getRequest().getPriority() == MAX_DELIVERYMAN_PLAYER_PRIORITY)
+        if (newRequest instanceof StandardRequests.PickupRequest && newRequest.getRequest().getPriority() == getPlayerActionPriority(true))
         {
             getCitizen().getCitizenEntity()
               .get()

--- a/src/main/java/com/minecolonies/coremod/colony/requestsystem/resolvers/PublicWorkerCraftingProductionResolver.java
+++ b/src/main/java/com/minecolonies/coremod/colony/requestsystem/resolvers/PublicWorkerCraftingProductionResolver.java
@@ -22,7 +22,7 @@ import org.jetbrains.annotations.Nullable;
 import java.util.Comparator;
 import java.util.List;
 
-import static com.minecolonies.api.colony.requestsystem.requestable.deliveryman.AbstractDeliverymanRequestable.MAX_DELIVERYMAN_STANDARD_PRIORITY;
+import static com.minecolonies.api.colony.requestsystem.requestable.deliveryman.AbstractDeliverymanRequestable.getDefaultDeliveryPriority;
 
 public class PublicWorkerCraftingProductionResolver extends AbstractCraftingProductionResolver<PublicCrafting>
 {
@@ -80,8 +80,7 @@ public class PublicWorkerCraftingProductionResolver extends AbstractCraftingProd
 
             completedRequest.getDeliveries().forEach(parentRequest::addDelivery);
             completedRequest.getDeliveries().forEach(itemStack -> {
-                // Followup-Deliveries for crafting requests have the highest possible priority. They are important after all!
-                final Delivery delivery = new Delivery(getLocation(), parentRequestRequester.getLocation(), itemStack, MAX_DELIVERYMAN_STANDARD_PRIORITY);
+                final Delivery delivery = new Delivery(getLocation(), parentRequestRequester.getLocation(), itemStack, getDefaultDeliveryPriority(true));
 
                 final IToken<?> requestToken =
                   manager.createRequest(this,

--- a/src/main/java/com/minecolonies/coremod/colony/requestsystem/resolvers/WarehouseRequestResolver.java
+++ b/src/main/java/com/minecolonies/coremod/colony/requestsystem/resolvers/WarehouseRequestResolver.java
@@ -32,7 +32,7 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 
-import static com.minecolonies.api.colony.requestsystem.requestable.deliveryman.AbstractDeliverymanRequestable.MAX_DELIVERYMAN_STANDARD_PRIORITY;
+import static com.minecolonies.api.colony.requestsystem.requestable.deliveryman.AbstractDeliverymanRequestable.getDefaultDeliveryPriority;
 import static com.minecolonies.api.util.RSConstants.CONST_WAREHOUSE_RESOLVER_PRIORITY;
 
 /**
@@ -204,8 +204,7 @@ public class WarehouseRequestResolver extends AbstractRequestResolver<IDeliverab
                 final ILocation itemStackLocation =
                   manager.getFactoryController().getNewInstance(TypeConstants.ILOCATION, itemStackPos, wareHouse.getWorld().getDimension().getType().getId());
 
-                // Deliveries from the warehouse to some location requesting stuff from the warehouse always have MAX_DELIVERYMAN_STANDARD_PRIORITY.
-                final Delivery delivery = new Delivery(itemStackLocation, completedRequest.getRequester().getLocation(), deliveryStack.copy(), MAX_DELIVERYMAN_STANDARD_PRIORITY);
+                final Delivery delivery = new Delivery(itemStackLocation, completedRequest.getRequester().getLocation(), deliveryStack.copy(), getDefaultDeliveryPriority(true));
 
                 final IToken<?> requestToken =
                   manager.createRequest(new WarehouseRequestResolver(completedRequest.getRequester().getLocation(), completedRequest.getId()), delivery);

--- a/src/main/java/com/minecolonies/coremod/entity/ai/basic/AbstractEntityAIBasic.java
+++ b/src/main/java/com/minecolonies/coremod/entity/ai/basic/AbstractEntityAIBasic.java
@@ -58,7 +58,7 @@ import java.util.Collection;
 import java.util.List;
 import java.util.function.Predicate;
 
-import static com.minecolonies.api.colony.requestsystem.requestable.deliveryman.AbstractDeliverymanRequestable.MAX_DELIVERYMAN_STANDARD_PRIORITY;
+import static com.minecolonies.api.colony.requestsystem.requestable.deliveryman.AbstractDeliverymanRequestable.*;
 import static com.minecolonies.api.entity.ai.statemachine.states.AIWorkerState.*;
 import static com.minecolonies.api.util.constant.CitizenConstants.*;
 import static com.minecolonies.api.util.constant.Constants.*;
@@ -1022,7 +1022,7 @@ public abstract class AbstractEntityAIBasic<J extends AbstractJob> extends Abstr
             // Note that this will not create a pickup request when another request is already in progress.
             if (building.getPickUpPriority() > 0)
             {
-                building.createPickupRequest(MAX_DELIVERYMAN_STANDARD_PRIORITY);
+                building.createPickupRequest(getMaxBuildingPriority(true));
             }
             alreadyKept.clear();
             slotAt = 0;
@@ -1042,7 +1042,7 @@ public abstract class AbstractEntityAIBasic<J extends AbstractJob> extends Abstr
         {
             // Worker is not currently crafting, pickup is allowed.
             // Note that this will not create a pickup request when another request is already in progress.
-            building.createPickupRequest(building.getPickUpPriority());
+            building.createPickupRequest(scaledPriority(building.getPickUpPriority()));
         }
         return afterDump();
     }

--- a/src/main/java/com/minecolonies/coremod/entity/ai/basic/AbstractEntityAIBasic.java
+++ b/src/main/java/com/minecolonies/coremod/entity/ai/basic/AbstractEntityAIBasic.java
@@ -58,7 +58,8 @@ import java.util.Collection;
 import java.util.List;
 import java.util.function.Predicate;
 
-import static com.minecolonies.api.colony.requestsystem.requestable.deliveryman.AbstractDeliverymanRequestable.*;
+import static com.minecolonies.api.colony.requestsystem.requestable.deliveryman.AbstractDeliverymanRequestable.getMaxBuildingPriority;
+import static com.minecolonies.api.colony.requestsystem.requestable.deliveryman.AbstractDeliverymanRequestable.scaledPriority;
 import static com.minecolonies.api.entity.ai.statemachine.states.AIWorkerState.*;
 import static com.minecolonies.api.util.constant.CitizenConstants.*;
 import static com.minecolonies.api.util.constant.Constants.*;

--- a/src/main/java/com/minecolonies/coremod/entity/ai/basic/AbstractEntityAIBasic.java
+++ b/src/main/java/com/minecolonies/coremod/entity/ai/basic/AbstractEntityAIBasic.java
@@ -116,6 +116,11 @@ public abstract class AbstractEntityAIBasic<J extends AbstractJob> extends Abstr
     private int slotAt = 0;
 
     /**
+     * Indicator if something has actually been dumped.
+     */
+    private boolean hasDumpedItems = false;
+
+    /**
      * Delay for walking.
      */
     protected static final int WALK_DELAY = 20;
@@ -1023,6 +1028,7 @@ public abstract class AbstractEntityAIBasic<J extends AbstractJob> extends Abstr
             if (building.getPickUpPriority() > 0)
             {
                 building.createPickupRequest(getMaxBuildingPriority(true));
+                hasDumpedItems = false;
             }
             alreadyKept.clear();
             slotAt = 0;
@@ -1038,11 +1044,12 @@ public abstract class AbstractEntityAIBasic<J extends AbstractJob> extends Abstr
         slotAt = 0;
         this.clearActionsDone();
 
-        if (isAfterDumpPickupAllowed() && building.getPickUpPriority() > 0)
+        if (isAfterDumpPickupAllowed() && building.getPickUpPriority() > 0 && hasDumpedItems)
         {
             // Worker is not currently crafting, pickup is allowed.
             // Note that this will not create a pickup request when another request is already in progress.
             building.createPickupRequest(scaledPriority(building.getPickUpPriority()));
+            hasDumpedItems = false;
         }
         return afterDump();
     }
@@ -1115,6 +1122,7 @@ public abstract class AbstractEntityAIBasic<J extends AbstractJob> extends Abstr
             {
                 final ItemStack activeStack = getInventory().extractItem(slotAt, amount, false);
                 InventoryUtils.transferItemStackIntoNextBestSlotInItemHandler(activeStack, buildingWorker.getCapability(ITEM_HANDLER_CAPABILITY, null).orElseGet(null));
+                hasDumpedItems = true;
             }
         }
         slotAt++;

--- a/src/main/java/com/minecolonies/coremod/network/messages/server/colony/building/ForcePickupMessage.java
+++ b/src/main/java/com/minecolonies/coremod/network/messages/server/colony/building/ForcePickupMessage.java
@@ -10,7 +10,7 @@ import net.minecraft.network.PacketBuffer;
 import net.minecraftforge.fml.network.NetworkEvent;
 import org.jetbrains.annotations.NotNull;
 
-import static com.minecolonies.api.colony.requestsystem.requestable.deliveryman.AbstractDeliverymanRequestable.MAX_DELIVERYMAN_PLAYER_PRIORITY;
+import static com.minecolonies.api.colony.requestsystem.requestable.deliveryman.AbstractDeliverymanRequestable.getPlayerActionPriority;
 import static com.minecolonies.api.util.constant.TranslationConstants.COM_MINECOLONIES_COREMOD_ENTITY_DELIVERYMAN_FORCEPICKUP_FAILED;
 
 /**
@@ -51,7 +51,7 @@ public class ForcePickupMessage extends AbstractBuildingServerMessage<IBuilding>
     @Override
     protected void onExecute(final NetworkEvent.Context ctxIn, final boolean isLogicalServer, final IColony colony, final IBuilding building)
     {
-        if (building.createPickupRequest(MAX_DELIVERYMAN_PLAYER_PRIORITY))
+        if (building.createPickupRequest(getPlayerActionPriority(true)))
         {
             building.markDirty();
         }

--- a/src/main/resources/assets/minecolonies/gui/windowhutdeliveryman.xml
+++ b/src/main/resources/assets/minecolonies/gui/windowhutdeliveryman.xml
@@ -11,13 +11,14 @@
                 label="$(com.minecolonies.coremod.gui.workerhuts.deliveryman.deliveries):"/>
 
             <list id="deliveries" size="164 185" pos="13 29">
-                <box size="100% 40" linewidth="2">
+                <box size="100% 52" linewidth="2">
                     <image id="deliveryImage" source="minecraft:textures/misc/shadow.png" size="16 16" pos="1 3"/>
 
 
                     <label id="shortDetail" size="50 12" pos="20 1" color="black"/>
                     <label id="requester" size="50 12" pos="20 13" color="black"/>
                     <label id="parent" size="50 12" pos="20 25" color="black"/>
+                    <label id="priority" size="50 12" pos="20 37" color="black"/>
                 </box>
             </list>
         </view>

--- a/src/main/resources/assets/minecolonies/lang/en_us.json
+++ b/src/main/resources/assets/minecolonies/lang/en_us.json
@@ -1415,6 +1415,7 @@
   "block.minecolonies.blockhutdyer.name": "Dyer",
   "block.minecolonies.blockhutdyer": "Dyer",
   "com.minecolonies.coremod.gui.workerhuts.deliveryman.deliveries": "Deliveries",
+  "com.minecolonies.coremod.gui.workerhuts.deliveryman.priority": "Priority: ",
 
   "entity.mummy": "Mummy",
   "entity.archermummy": "Mummy Archer",


### PR DESCRIPTION
1. Pickup Requests are now only triggered if the worker has actually dumped items. This should reduce the frequency of "empty" runs (happens when the worker dumps without actually having transferred items into the inventory)
2. A mechanism was added to allow arbitrary scaling of pickup priorities. For example, by setting this to a quadratic function, a priority of 1 would still be 1, but a priority of 2 would internally be handled as 4, 3 as 9 etc. This effectively slows down the aging mechanism. **In this PR, the scaling is set to the identity function, because this seems to make most sense after all.** Reason being that in a quadratic function, a prio-1 request would have to be set back 169 times by delivery requests to reach a prio of 170 (and thus be "immune" against deliveries). This seems excessive. Currently, deliveries default to priority 13, so a prio-1 request can be set back 13 times in theory. That sounds enough.
3. The pickup priority is now visible in the deliveryman's hut. This may or may not be good to add to the production version, but it sure helps with debugging issues / bottlenecks for deliverymen.