### PR TITLE
Fix citizen request fulfilling sometimes messing up nbt

### DIFF
--- a/src/main/java/com/minecolonies/coremod/client/gui/WindowCitizen.java
+++ b/src/main/java/com/minecolonies/coremod/client/gui/WindowCitizen.java
@@ -287,43 +287,6 @@ public class WindowCitizen extends AbstractWindowRequestTree
 
     /**
      * Creates an Happiness bar according to the citizen maxHappiness and currentHappiness.
-     * <p>
-     * currently unused.
-     *
-     * @param citizen the citizen to create a create a happiness bar for.
-     * @param view    the view to add the happiness bar to.
-     */
-    /*
-    private static void createHappinessBar(final ICitizenDataView citizen, final View view)
-    {
-        final double experienceRatio = (citizen.getHappiness() / HappinessConstants.MAX_HAPPINESS) * XP_BAR_WIDTH;
-        view.findPaneOfTypeByID(WINDOW_ID_HAPPINESS_BAR, View.class).setAlignment(Alignment.MIDDLE_RIGHT);
-        view.findPaneOfTypeByID(WINDOW_ID_HAPPINESS, Label.class).setLabelText(Integer.toString((int) citizen.getHappiness()));
-
-
-        @NotNull final Image xpBar = new Image();
-        xpBar.setImage(Screen.GUI_ICONS_LOCATION, XP_BAR_ICON_COLUMN, HAPPINESS_BAR_EMPTY_ROW, XP_BAR_WIDTH, XP_HEIGHT, false);
-        xpBar.setPosition(LEFT_BORDER_X, LEFT_BORDER_Y);
-
-        @NotNull final Image xpBar2 = new Image();
-        xpBar2.setImage(Screen.GUI_ICONS_LOCATION, XP_BAR_ICON_COLUMN_END, HAPPINESS_BAR_EMPTY_ROW, XP_BAR_ICON_COLUMN_END_WIDTH, XP_HEIGHT, false);
-        xpBar2.setPosition(XP_BAR_ICON_END_OFFSET + LEFT_BORDER_X, LEFT_BORDER_Y);
-
-        view.findPaneOfTypeByID(WINDOW_ID_HAPPINESS_BAR, View.class).addChild(xpBar);
-        view.findPaneOfTypeByID(WINDOW_ID_HAPPINESS_BAR, View.class).addChild(xpBar2);
-
-        if (experienceRatio > 0)
-        {
-            @NotNull final Image xpBarFull = new Image();
-            xpBarFull.setImage(Screen.GUI_ICONS_LOCATION, XP_BAR_ICON_COLUMN, HAPPINESS_BAR_FULL_ROW, (int) experienceRatio, XP_HEIGHT, false);
-            xpBarFull.setPosition(LEFT_BORDER_X, LEFT_BORDER_Y);
-            view.findPaneOfTypeByID(WINDOW_ID_HAPPINESS_BAR, View.class).addChild(xpBarFull);
-        }
-    }
-    */
-
-    /**
-     * Creates an Happiness bar according to the citizen maxHappiness and currentHappiness.
      *
      * @param citizen pointer to the citizen data view
      * @param window  pointer to the current window

--- a/src/main/java/com/minecolonies/coremod/network/messages/server/colony/citizen/TransferItemsToCitizenRequestMessage.java
+++ b/src/main/java/com/minecolonies/coremod/network/messages/server/colony/citizen/TransferItemsToCitizenRequestMessage.java
@@ -126,7 +126,7 @@ public class TransferItemsToCitizenRequestMessage extends AbstractColonyServerMe
             int amountToRemoveFromPlayer = amountToTake - ItemStackUtils.getSize(remainingItemStack);
             while (amountToRemoveFromPlayer > 0)
             {
-                final int slot = InventoryUtils.findFirstSlotInItemHandlerWith(new InvWrapper(player.inventory), stack -> stack.isItemEqual(itemStack));
+                final int slot = InventoryUtils.findFirstSlotInItemHandlerWith(new InvWrapper(player.inventory), stack -> stack.isItemEqual(itemStack) && ItemStack.areItemStackTagsEqual(stack, itemStack));
                 final ItemStack itemsTaken = player.inventory.decrStackSize(slot, amountToRemoveFromPlayer);
                 amountToRemoveFromPlayer -= ItemStackUtils.getSize(itemsTaken);
             }

--- a/src/main/java/com/minecolonies/coremod/network/messages/server/colony/citizen/TransferItemsToCitizenRequestMessage.java
+++ b/src/main/java/com/minecolonies/coremod/network/messages/server/colony/citizen/TransferItemsToCitizenRequestMessage.java
@@ -126,7 +126,7 @@ public class TransferItemsToCitizenRequestMessage extends AbstractColonyServerMe
             int amountToRemoveFromPlayer = amountToTake - ItemStackUtils.getSize(remainingItemStack);
             while (amountToRemoveFromPlayer > 0)
             {
-                final int slot = InventoryUtils.findFirstSlotInItemHandlerWith(new InvWrapper(player.inventory), stack -> stack.isItemEqual(itemStack) && ItemStack.areItemStackTagsEqual(stack, itemStack));
+                final int slot = InventoryUtils.findFirstSlotInItemHandlerWith(new InvWrapper(player.inventory), stack -> ItemStackUtils.compareItemStacksIgnoreStackSize(stack, itemStack));
                 final ItemStack itemsTaken = player.inventory.decrStackSize(slot, amountToRemoveFromPlayer);
                 amountToRemoveFromPlayer -= ItemStackUtils.getSize(itemsTaken);
             }

--- a/src/main/resources/META-INF/mods.toml
+++ b/src/main/resources/META-INF/mods.toml
@@ -38,7 +38,7 @@ MineColonies is a Colony/Town Simulator that adds many structures and NPC worker
     # Does this dependency have to exist - if not, ordering below must be specified
     mandatory=true #mandatory
     # The version range of the dependency
-    versionRange="[31.2.0,)" #mandatory
+    versionRange="[31.2.8,)" #mandatory
     # An ordering relationship for the dependency - BEFORE or AFTER required if the relationship is not mandatory
     ordering="NONE"
     # Side this dependency is applied on - BOTH, CLIENT or SERVER


### PR DESCRIPTION
Closes #5264
Closes #
Closes #

# Changes proposed in this pull request:
- Actually check the item nbt of the item to move to the citizen to prevent it from getting changed during the transfer.
- Also remove a completely commented out method, because i thought its in that class, and that made it easier to look around.
- Bump Forge requirement to 31.2.8

Review please
