### PR TITLE
Fix Crafter Recipes

### DIFF
--- a/src/main/java/com/minecolonies/coremod/colony/buildings/AbstractBuildingWorker.java
+++ b/src/main/java/com/minecolonies/coremod/colony/buildings/AbstractBuildingWorker.java
@@ -238,6 +238,12 @@ public abstract class AbstractBuildingWorker extends AbstractBuilding implements
             return Optional.of(false);
         }
 
+        // Check against allowed products
+        if (ItemTags.getCollection().getOrCreate(products).contains(storage.getPrimaryOutput().getItem()))
+        {
+            return Optional.of(true);
+        }
+
         // Check against excluded ingredients
         for (final ItemStack stack : storage.getInput())
         {
@@ -245,12 +251,6 @@ public abstract class AbstractBuildingWorker extends AbstractBuilding implements
             {
                 return Optional.of(false);
             }
-        }
-
-        // Check against allowed products
-        if (ItemTags.getCollection().getOrCreate(products).contains(storage.getPrimaryOutput().getItem()))
-        {
-            return Optional.of(true);
         }
 
         // Check against allowed ingredients

--- a/src/main/java/com/minecolonies/coremod/colony/buildings/workerbuildings/BuildingStoneSmeltery.java
+++ b/src/main/java/com/minecolonies/coremod/colony/buildings/workerbuildings/BuildingStoneSmeltery.java
@@ -133,6 +133,7 @@ public class BuildingStoneSmeltery extends AbstractBuildingSmelterCrafter
                   block == Blocks.STONE ||
                   block == Blocks.STONE_BRICKS ||
                   block == Blocks.SMOOTH_STONE ||
+                  block == Blocks.TERRACOTTA ||
                   block instanceof GlazedTerracottaBlock)
             {
 

--- a/src/main/resources/data/minecolonies/tags/items/blacksmith_product_excluded.json
+++ b/src/main/resources/data/minecolonies/tags/items/blacksmith_product_excluded.json
@@ -1,8 +1,9 @@
 {
   "replace": false,
   "values": [
-    "#minecolonies:mechanic_product",
     "#minecolonies:dyer_product",
+    "#minecolonies:mechanic_product",
+    "#minecolonies:sawmill_product",
     "minecraft:firework_star"
   ]
 }


### PR DESCRIPTION
Reorder Tag evaluations to be product and then ingredient, rather than exclude and then include
Add Terracotta to Stonesmelter
Add sawmill products to blacksmith exclusions

Closes #5340
Closes #

# Changes proposed in this pull request:
-
-
-

Review please
