### PR TITLE
Fix things getting lost potentially

### DIFF
--- a/src/api/java/com/minecolonies/api/crafting/ItemStorage.java
+++ b/src/api/java/com/minecolonies/api/crafting/ItemStorage.java
@@ -208,7 +208,7 @@ public class ItemStorage
                  && (this.shouldIgnoreDamageValue || that.getDamageValue() == this.getDamageValue())
                  && (this.shouldIgnoreNBTValue
                        || (that.getItemStack().getTag() == null && this.getItemStack().getTag() == null)
-                       || that.getItemStack().getTag().equals(this.getItemStack().getTag()));
+                       || (that.getItemStack().getTag() != null && that.getItemStack().getTag().equals(this.getItemStack().getTag())));
     }
 
     /**

--- a/src/api/java/com/minecolonies/api/tileentities/AbstractTileEntityColonyBuilding.java
+++ b/src/api/java/com/minecolonies/api/tileentities/AbstractTileEntityColonyBuilding.java
@@ -212,6 +212,7 @@ public abstract class AbstractTileEntityColonyBuilding extends TileEntityRack im
         readSchematicDataFromNBT(compound);
     }
 
+    @NotNull
     @Override
     public CompoundNBT write(@NotNull final CompoundNBT compound)
     {

--- a/src/api/java/com/minecolonies/api/tileentities/TileEntityColonyBuilding.java
+++ b/src/api/java/com/minecolonies/api/tileentities/TileEntityColonyBuilding.java
@@ -441,6 +441,7 @@ public class TileEntityColonyBuilding extends AbstractTileEntityColonyBuilding i
         combinedInv = null;
     }
 
+    @NotNull
     @Override
     public <T> LazyOptional<T> getCapability(@NotNull final Capability<T> capability, @Nullable final Direction side)
     {

--- a/src/api/java/com/minecolonies/api/tileentities/TileEntityRack.java
+++ b/src/api/java/com/minecolonies/api/tileentities/TileEntityRack.java
@@ -425,21 +425,6 @@ public class TileEntityRack extends AbstractTileEntityRack
             }
         }
 
-        if (compound.keySet().contains("Items"))
-        {
-            ListNBT nbttaglist = compound.getList("Items", 10);
-
-            for (int i = 0; i < nbttaglist.size(); ++i)
-            {
-                CompoundNBT nbttagcompound = nbttaglist.getCompound(i);
-                int j = nbttagcompound.getByte("Slot") & 255;
-                if (j >= 0 && j < inventory.getSlots())
-                {
-                    inventory.setStackInSlot(j, ItemStack.read(nbttagcompound));
-                }
-            }
-        }
-
         main = compound.getBoolean(TAG_MAIN);
         updateItemStorage();
 

--- a/src/main/java/com/minecolonies/coremod/network/messages/server/colony/building/TransferItemsRequestMessage.java
+++ b/src/main/java/com/minecolonies/coremod/network/messages/server/colony/building/TransferItemsRequestMessage.java
@@ -103,17 +103,29 @@ public class TransferItemsRequestMessage extends AbstractBuildingServerMessage<I
               stack -> ItemStackUtils.compareItemStacksIgnoreStackSize(stack, itemStack, true, true)));
         }
 
-        final ItemStack itemStackToTake = itemStack.copy();
-        itemStackToTake.setCount(amountToTake);
+        ItemStack remainingItemStack = ItemStack.EMPTY;
+        int tempAmount = amountToTake;
+        for (int i = 0; i < Math.max(1, Math.ceil((double) amountToTake/itemStack.getMaxStackSize())); i++)
+        {
+            final ItemStack itemStackToTake = itemStack.copy();
+            int insertAmount = Math.max(itemStack.getMaxStackSize(), tempAmount);
+            itemStackToTake.setCount(insertAmount);
+            tempAmount -= insertAmount;
 
-        ItemStack remainingItemStack = InventoryUtils.addItemStackToProviderWithResult(building.getTileEntity(), itemStackToTake);
-        if (ItemStackUtils.isEmpty(remainingItemStack) || ItemStackUtils.getSize(remainingItemStack) != ItemStackUtils.getSize(itemStackToTake))
+            remainingItemStack = InventoryUtils.addItemStackToProviderWithResult(building.getTileEntity(), itemStackToTake);
+            if (!remainingItemStack.isEmpty())
+            {
+                break;
+            }
+        }
+
+        if (ItemStackUtils.isEmpty(remainingItemStack) || ItemStackUtils.getSize(remainingItemStack) != amountToTake)
         {
             //Only doing this at the moment as the additional chest do not detect new content
             building.getTileEntity().markDirty();
         }
 
-        if (ItemStackUtils.isEmpty(remainingItemStack) || ItemStackUtils.getSize(remainingItemStack) != ItemStackUtils.getSize(itemStackToTake))
+        if (ItemStackUtils.isEmpty(remainingItemStack) || ItemStackUtils.getSize(remainingItemStack) != amountToTake)
         {
             if (!isCreative)
             {

--- a/src/main/java/com/minecolonies/coremod/network/messages/server/colony/building/TransferItemsRequestMessage.java
+++ b/src/main/java/com/minecolonies/coremod/network/messages/server/colony/building/TransferItemsRequestMessage.java
@@ -115,6 +115,7 @@ public class TransferItemsRequestMessage extends AbstractBuildingServerMessage<I
             remainingItemStack = InventoryUtils.addItemStackToProviderWithResult(building.getTileEntity(), itemStackToTake);
             if (!remainingItemStack.isEmpty())
             {
+                tempAmount += remainingItemStack.getCount();
                 break;
             }
         }
@@ -129,7 +130,7 @@ public class TransferItemsRequestMessage extends AbstractBuildingServerMessage<I
         {
             if (!isCreative)
             {
-                int amountToRemoveFromPlayer = amountToTake - ItemStackUtils.getSize(remainingItemStack);
+                int amountToRemoveFromPlayer = amountToTake - tempAmount;
                 while (amountToRemoveFromPlayer > 0)
                 {
                     final int slot =

--- a/src/main/java/com/minecolonies/coremod/network/messages/server/colony/building/TransferItemsRequestMessage.java
+++ b/src/main/java/com/minecolonies/coremod/network/messages/server/colony/building/TransferItemsRequestMessage.java
@@ -108,7 +108,7 @@ public class TransferItemsRequestMessage extends AbstractBuildingServerMessage<I
         for (int i = 0; i < Math.max(1, Math.ceil((double) amountToTake/itemStack.getMaxStackSize())); i++)
         {
             final ItemStack itemStackToTake = itemStack.copy();
-            int insertAmount = Math.max(itemStack.getMaxStackSize(), tempAmount);
+            int insertAmount = Math.min(itemStack.getMaxStackSize(), tempAmount);
             itemStackToTake.setCount(insertAmount);
             tempAmount -= insertAmount;
 


### PR DESCRIPTION
This should fix the issue with the builder losing things.
Basically, when the builder has a request for an item. And you fulfill it via page 2 of the builder hut, the button will insert ALL items in the inventory with 1 insert call (stack of > 64) the builder hence will pick up a stack > 64 since the request was fulfilled with this stack. This inventory just has to be reloaded from NBT to delete all those faulty stacks then. And tada you lost a lot of items.

# Changes proposed in this pull request:
- Also cleans up some backwards compat data from 1.12
-
-

Review please
