### PR TITLE
Fixed lumberjack crafting

### DIFF
--- a/src/main/java/com/minecolonies/coremod/colony/buildings/workerbuildings/BuildingLumberjack.java
+++ b/src/main/java/com/minecolonies/coremod/colony/buildings/workerbuildings/BuildingLumberjack.java
@@ -105,6 +105,27 @@ public class BuildingLumberjack extends AbstractFilterableListCrafter
         keepX.put(itemStack -> ItemStackUtils.hasToolLevel(itemStack, ToolType.AXE, TOOL_LEVEL_WOOD_OR_GOLD, getMaxToolLevel()), new Tuple<>(1, true));
     }
 
+    @Override
+    public void checkForWorkerSpecificRecipes()
+    {
+        if (recipes.isEmpty())
+        {
+            addStrippedWoodRecipe(Items.OAK_LOG, Items.STRIPPED_OAK_LOG);
+            addStrippedWoodRecipe(Items.SPRUCE_LOG, Items.STRIPPED_SPRUCE_LOG);
+            addStrippedWoodRecipe(Items.BIRCH_LOG, Items.STRIPPED_BIRCH_LOG);
+            addStrippedWoodRecipe(Items.JUNGLE_LOG, Items.STRIPPED_JUNGLE_LOG);
+            addStrippedWoodRecipe(Items.ACACIA_LOG, Items.STRIPPED_ACACIA_LOG);
+            addStrippedWoodRecipe(Items.DARK_OAK_LOG, Items.STRIPPED_DARK_OAK_LOG);
+            addStrippedWoodRecipe(Items.OAK_WOOD, Items.STRIPPED_OAK_WOOD);
+            addStrippedWoodRecipe(Items.SPRUCE_WOOD, Items.STRIPPED_SPRUCE_WOOD);
+            addStrippedWoodRecipe(Items.BIRCH_WOOD, Items.STRIPPED_BIRCH_WOOD);
+            addStrippedWoodRecipe(Items.JUNGLE_WOOD, Items.STRIPPED_JUNGLE_WOOD);
+            addStrippedWoodRecipe(Items.ACACIA_WOOD, Items.STRIPPED_ACACIA_WOOD);
+            addStrippedWoodRecipe(Items.DARK_OAK_WOOD, Items.STRIPPED_DARK_OAK_WOOD);
+            markDirty();
+        }
+    }
+
     public final void addStrippedWoodRecipe(final Item baseVariant, final Item strippedVariant)
     {
         final IRecipeStorage storage = StandardFactoryController.getInstance().getNewInstance(
@@ -114,7 +135,8 @@ public class BuildingLumberjack extends AbstractFilterableListCrafter
           1,
           new ItemStack(strippedVariant, 1),
           Blocks.AIR);
-        recipes.add(IColonyManager.getInstance().getRecipeManager().checkOrAddRecipe(storage));
+
+        addRecipeToList(IColonyManager.getInstance().getRecipeManager().checkOrAddRecipe(storage));
     }
 
     @Override
@@ -238,22 +260,6 @@ public class BuildingLumberjack extends AbstractFilterableListCrafter
         else
         {
             endRestriction = null;
-        }
-
-        if (recipes.isEmpty())
-        {
-            addStrippedWoodRecipe(Items.OAK_LOG, Items.STRIPPED_OAK_LOG);
-            addStrippedWoodRecipe(Items.SPRUCE_LOG, Items.STRIPPED_SPRUCE_LOG);
-            addStrippedWoodRecipe(Items.BIRCH_LOG, Items.STRIPPED_BIRCH_LOG);
-            addStrippedWoodRecipe(Items.JUNGLE_LOG, Items.STRIPPED_JUNGLE_LOG);
-            addStrippedWoodRecipe(Items.ACACIA_LOG, Items.STRIPPED_ACACIA_LOG);
-            addStrippedWoodRecipe(Items.DARK_OAK_LOG, Items.STRIPPED_DARK_OAK_LOG);
-            addStrippedWoodRecipe(Items.OAK_WOOD, Items.STRIPPED_OAK_WOOD);
-            addStrippedWoodRecipe(Items.SPRUCE_WOOD, Items.STRIPPED_SPRUCE_WOOD);
-            addStrippedWoodRecipe(Items.BIRCH_WOOD, Items.STRIPPED_BIRCH_WOOD);
-            addStrippedWoodRecipe(Items.JUNGLE_WOOD, Items.STRIPPED_JUNGLE_WOOD);
-            addStrippedWoodRecipe(Items.ACACIA_WOOD, Items.STRIPPED_ACACIA_WOOD);
-            addStrippedWoodRecipe(Items.DARK_OAK_WOOD, Items.STRIPPED_DARK_OAK_WOOD);
         }
     }
 

--- a/src/main/java/com/minecolonies/coremod/entity/ai/citizen/lumberjack/EntityAIWorkLumberjack.java
+++ b/src/main/java/com/minecolonies/coremod/entity/ai/citizen/lumberjack/EntityAIWorkLumberjack.java
@@ -188,10 +188,14 @@ public class EntityAIWorkLumberjack extends AbstractEntityAICrafting<JobLumberja
     @Override
     protected IAIState decide()
     {
+        if (checkIfStuck())
+        {
+            tryUnstuck();
+        }
 
         if (walkToBuilding())
         {
-            return LUMBERJACK_START_WORKING;
+            return START_WORKING;
         }
 
         if (job.getActionsDone() >= getActionsDoneUntilDumping())
@@ -257,7 +261,7 @@ public class EntityAIWorkLumberjack extends AbstractEntityAICrafting<JobLumberja
         if (checkForToolOrWeapon(ToolType.AXE))
         {
             // Reset everything, maybe there are new crafting requests
-            return LUMBERJACK_START_WORKING;
+            return START_WORKING;
         }
         return LUMBERJACK_SEARCHING_TREE;
     }
@@ -275,7 +279,7 @@ public class EntityAIWorkLumberjack extends AbstractEntityAICrafting<JobLumberja
         }
 
         // Reset everything, maybe there are new crafting requests
-        return LUMBERJACK_START_WORKING;
+        return START_WORKING;
     }
 
     /**
@@ -551,7 +555,7 @@ public class EntityAIWorkLumberjack extends AbstractEntityAICrafting<JobLumberja
     {
         if (!worker.getNavigator().noPath())
         {
-            Path path = worker.getNavigator().getPath();
+            final Path path = worker.getNavigator().getPath();
             if (path != null)
             {
                 if (path.getCurrentPathLength() > path.getCurrentPathIndex())
@@ -576,14 +580,19 @@ public class EntityAIWorkLumberjack extends AbstractEntityAICrafting<JobLumberja
      */
     private void tryUnstuck()
     {
+        if (worker.getCurrentPosition() == null)
+        {
+            return;
+        }
+
         if (!worker.getNavigator().noPath())
         {
             Path path = worker.getNavigator().getPath();
             if (path != null)
             {
                 // Unstuck with path
-                ArrayList<BlockPos> checkPositions = new ArrayList<>();
-                PathPoint next = path.getPathPointFromIndex(path.getCurrentPathIndex());
+                final List<BlockPos> checkPositions = new ArrayList<>();
+                final PathPoint next = path.getPathPointFromIndex(path.getCurrentPathIndex());
 
                 // Blocks in front of the worker
                 for (int i = 0; i <= 2; i++)


### PR DESCRIPTION
- Fixes missing craft-request check, introduced by dc4e169.
- Calls tryUnstuck as the first step in the AI's decision-making process, to make sure it tries to free itself as often and early as possible.
- Migrated recipe-registration of LJ to new `checkForWorkerSpecificRecipes()` mechanism.
- Fixed a possible nptr exception (happened once on a testing world) during unstucking.