### PR TITLE
Fix stone tools - additional rules take precedence

### DIFF
--- a/src/main/java/com/minecolonies/coremod/colony/buildings/workerbuildings/BuildingBlacksmith.java
+++ b/src/main/java/com/minecolonies/coremod/colony/buildings/workerbuildings/BuildingBlacksmith.java
@@ -119,7 +119,7 @@ public class BuildingBlacksmith extends AbstractBuildingCrafter
         if (isRecipeAllowed.isPresent())
         {
             return matchOverride || isRecipeAllowed.get();
-        } 
+        }
         else
         {
             return matchOverride;

--- a/src/main/java/com/minecolonies/coremod/colony/buildings/workerbuildings/BuildingBlacksmith.java
+++ b/src/main/java/com/minecolonies/coremod/colony/buildings/workerbuildings/BuildingBlacksmith.java
@@ -99,26 +99,30 @@ public class BuildingBlacksmith extends AbstractBuildingCrafter
             return false;
         }
 
+        // Additional recipe rules
+
+        final IRecipeStorage storage = IColonyManager.getInstance().getRecipeManager().getRecipes().get(token);
+
+        final ItemStack output = storage.getPrimaryOutput();
+
+        boolean matchOverride;
+        matchOverride= output.getItem() instanceof ToolItem ||
+                    output.getItem() instanceof SwordItem ||
+                    output.getItem() instanceof ArmorItem ||
+                    output.getItem() instanceof HoeItem ||
+                    output.getItem() instanceof ShieldItem ||
+                    Compatibility.isTinkersWeapon(output);
+
+        // End Additional recipe rules
+
         isRecipeAllowed = super.canRecipeBeAddedBasedOnTags(token);
         if (isRecipeAllowed.isPresent())
         {
-            return isRecipeAllowed.get();
-        }
+            return matchOverride || isRecipeAllowed.get();
+        } 
         else
         {
-            // Additional recipe rules
-
-            final IRecipeStorage storage = IColonyManager.getInstance().getRecipeManager().getRecipes().get(token);
-
-            final ItemStack output = storage.getPrimaryOutput();
-            return output.getItem() instanceof ToolItem ||
-                     output.getItem() instanceof SwordItem ||
-                     output.getItem() instanceof ArmorItem ||
-                     output.getItem() instanceof HoeItem ||
-                     output.getItem() instanceof ShieldItem ||
-                     Compatibility.isTinkersWeapon(output);
-
-            // End Additional recipe rules
+            return matchOverride;
         }
     }
 


### PR DESCRIPTION
# Changes proposed in this pull request:
- Force additional rules if true to take precedence over tags, which lets the blacksmith make stone tools/weapons

Thank you @PowerSchill for catching it. 

Review please
