### PR TITLE
Make smeltercrafters more aggressive about fuel

### DIFF
--- a/src/main/java/com/minecolonies/coremod/entity/ai/basic/AbstractEntityAIRequestSmelter.java
+++ b/src/main/java/com/minecolonies/coremod/entity/ai/basic/AbstractEntityAIRequestSmelter.java
@@ -231,7 +231,7 @@ public abstract class AbstractEntityAIRequestSmelter<J extends AbstractJobCrafte
      * @param amountOfFuel the total amount of fuel.
      * @return START_USING_FURNACE if enough, else check for additional worker specific jobs.
      */
-    private IAIState checkIfAbleToSmelt(final int amountOfFuel)
+    private IAIState checkIfAbleToSmelt(final int amountOfFuel, final boolean checkSmeltables)
     {
         for (final BlockPos pos : getOwnBuilding().getFurnaces())
         {
@@ -242,8 +242,9 @@ public abstract class AbstractEntityAIRequestSmelter<J extends AbstractJobCrafte
                 if (!((FurnaceTileEntity) entity).isBurning())
                 {
                     final FurnaceTileEntity furnace = (FurnaceTileEntity) entity;
+                    
                     if ((amountOfFuel > 0 && hasSmeltableInFurnaceAndNoFuel(furnace))
-                          || (hasFuelInFurnaceAndNoSmeltable(furnace))
+                          || (hasFuelInFurnaceAndNoSmeltable(furnace) && checkSmeltables)
                           || (amountOfFuel > 0 && hasNeitherFuelNorSmeltAble(furnace)))
                     {
                         walkTo = pos;
@@ -298,30 +299,34 @@ public abstract class AbstractEntityAIRequestSmelter<J extends AbstractJobCrafte
         if (entity instanceof FurnaceTileEntity)
         {
             final FurnaceTileEntity furnace = (FurnaceTileEntity) entity;
+            final List<ItemStack> possibleFuels = getOwnBuilding().getAllowedFuel();
 
-            final Predicate<ItemStack> smeltable = stack -> currentRecipeStorage.getCleanedInput().get(0).getItemStack().isItemEqual(stack);
-            if (InventoryUtils.hasItemInItemHandler(worker.getInventoryCitizen(), smeltable))
-            {
-                if (hasFuelInFurnaceAndNoSmeltable(furnace) || hasNeitherFuelNorSmeltAble(furnace))
-                {
-                    InventoryUtils.transferXOfFirstSlotInItemHandlerWithIntoInItemHandler(
-                      worker.getInventoryCitizen(), smeltable, STACKSIZE,
-                      new InvWrapper(furnace), SMELTABLE_SLOT);
-                }
-            }
-            else
-            {
-                needsCurrently = new Tuple<>(smeltable, currentRequest.getRequest().getCount());
-                return GATHERING_REQUIRED_MATERIALS;
-            }
-
-            if (InventoryUtils.hasItemInItemHandler(worker.getInventoryCitizen(), FurnaceTileEntity::isFuel)
+            if (InventoryUtils.hasItemInItemHandler(worker.getInventoryCitizen(), item -> FurnaceTileEntity.isFuel(item) && possibleFuels.stream().anyMatch(candidate -> item.isItemEqual(candidate)))
                   && (hasSmeltableInFurnaceAndNoFuel(furnace) || hasNeitherFuelNorSmeltAble(furnace)))
             {
                 InventoryUtils.transferXOfFirstSlotInItemHandlerWithIntoInItemHandler(
-                  worker.getInventoryCitizen(), FurnaceTileEntity::isFuel, STACKSIZE,
+                  worker.getInventoryCitizen(), item -> FurnaceTileEntity.isFuel(item) && possibleFuels.stream().anyMatch(candidate -> item.isItemEqual(candidate)), STACKSIZE,
                   new InvWrapper(furnace), FUEL_SLOT);
             }
+
+            if(currentRecipeStorage != null)
+            {
+                final Predicate<ItemStack> smeltable = stack -> currentRecipeStorage.getCleanedInput().get(0).getItemStack().isItemEqual(stack);
+                if (InventoryUtils.hasItemInItemHandler(worker.getInventoryCitizen(), smeltable))
+                {
+                    if (hasFuelInFurnaceAndNoSmeltable(furnace) || hasNeitherFuelNorSmeltAble(furnace))
+                    {
+                        InventoryUtils.transferXOfFirstSlotInItemHandlerWithIntoInItemHandler(
+                        worker.getInventoryCitizen(), smeltable, STACKSIZE,
+                        new InvWrapper(furnace), SMELTABLE_SLOT);
+                    }
+                }
+                else
+                {
+                    needsCurrently = new Tuple<>(smeltable, currentRequest.getRequest().getCount());
+                    return GATHERING_REQUIRED_MATERIALS;
+                }
+            }   
         }
         else
         {
@@ -338,10 +343,35 @@ public abstract class AbstractEntityAIRequestSmelter<J extends AbstractJobCrafte
     @Override
     protected IAIState craft()
     {
+
+        final List<ItemStack> possibleFuels = getOwnBuilding().getAllowedFuel();
+
+        final int amountOfFuelInBuilding = InventoryUtils.getItemCountInProvider(getOwnBuilding(), item -> FurnaceTileEntity.isFuel(item) && possibleFuels.stream().anyMatch(candidate -> item.isItemEqual(candidate)));
+        final int amountOfFuelInInv = InventoryUtils.getItemCountInItemHandler(worker.getInventoryCitizen(), item -> FurnaceTileEntity.isFuel(item) && possibleFuels.stream().anyMatch(candidate -> item.isItemEqual(candidate)));
+
+        if (amountOfFuelInBuilding + amountOfFuelInInv <= 0 && !getOwnBuilding().hasWorkerOpenRequestsOfType(worker.getCitizenData(), TypeToken.of(StackList.class)))
+        {
+            worker.getCitizenData().createRequestAsync(new StackList(possibleFuels, COM_MINECOLONIES_REQUESTS_BURNABLE, STACKSIZE, 1));
+        }
+
+        if (amountOfFuelInBuilding > 0 && amountOfFuelInInv == 0)
+        {
+            needsCurrently = new Tuple<>(item -> FurnaceTileEntity.isFuel(item) && possibleFuels.stream().anyMatch(candidate -> item.isItemEqual(candidate)), STACKSIZE);
+            return GATHERING_REQUIRED_MATERIALS;
+        }
+
         if (currentRecipeStorage == null)
         {
-            setDelay(TICKS_20);
-            return START_WORKING;
+            IAIState newState = checkIfAbleToSmelt(amountOfFuelInBuilding + amountOfFuelInInv, false);
+            if(newState == CRAFT)
+            {
+                setDelay(TICKS_20);
+                return START_WORKING;
+            }
+            else
+            {
+                return newState;
+            }
         }
 
         if (walkToBuilding())
@@ -384,20 +414,6 @@ public abstract class AbstractEntityAIRequestSmelter<J extends AbstractJobCrafte
             return RETRIEVING_END_PRODUCT_FROM_FURNACE;
         }
 
-        final int amountOfFuelInBuilding = InventoryUtils.getItemCountInProvider(getOwnBuilding(), FurnaceTileEntity::isFuel);
-        final int amountOfFuelInInv = InventoryUtils.getItemCountInItemHandler(worker.getInventoryCitizen(), FurnaceTileEntity::isFuel);
-
-        if (amountOfFuelInBuilding + amountOfFuelInInv <= 0 && !getOwnBuilding().hasWorkerOpenRequestsOfType(worker.getCitizenData(), TypeToken.of(StackList.class)))
-        {
-            worker.getCitizenData().createRequestAsync(new StackList(getOwnBuilding().getAllowedFuel(), COM_MINECOLONIES_REQUESTS_BURNABLE, STACKSIZE, 1));
-        }
-
-        if (amountOfFuelInBuilding > 0 && amountOfFuelInInv == 0)
-        {
-            needsCurrently = new Tuple<>(FurnaceTileEntity::isFuel, STACKSIZE);
-            return GATHERING_REQUIRED_MATERIALS;
-        }
-
-        return checkIfAbleToSmelt(amountOfFuelInBuilding + amountOfFuelInInv);
+        return checkIfAbleToSmelt(amountOfFuelInBuilding + amountOfFuelInInv, true);
     }
 }


### PR DESCRIPTION
# Changes proposed in this pull request:
- SmelterCrafters checks fuel status far more often, and before crafting. 
- SmelterCrafters properly limit fuel decisions to allowable fuels

Review please
