### PR TITLE
Fix hasItemStack in racks

### DIFF
--- a/src/api/java/com/minecolonies/api/tileentities/TileEntityRack.java
+++ b/src/api/java/com/minecolonies/api/tileentities/TileEntityRack.java
@@ -133,7 +133,8 @@ public class TileEntityRack extends AbstractTileEntityRack
     @Override
     public boolean hasItemStack(final ItemStack stack, final boolean ignoreDamageValue)
     {
-        return content.get(new ItemStorage(stack, ignoreDamageValue)) != null;
+        final ItemStorage checkItem = new ItemStorage(stack, ignoreDamageValue);
+        return content.containsKey(checkItem) && content.get(checkItem) >= stack.getCount(); 
     }
 
     /**


### PR DESCRIPTION
# Changes proposed in this pull request:
- Fix TileEntityRack::hasItemStack to compare not just key, but quanity
- Without this, the request system has all sorts of weird behavior, and stuck requests

Review please
