### PR TITLE
Better optimize fuel handling

### DIFF
--- a/src/main/java/com/minecolonies/coremod/colony/buildings/AbstractBuildingSmelterCrafter.java
+++ b/src/main/java/com/minecolonies/coremod/colony/buildings/AbstractBuildingSmelterCrafter.java
@@ -196,6 +196,10 @@ public abstract class AbstractBuildingSmelterCrafter extends AbstractFilterableL
      */
     public List<ItemStack> getAllowedFuel()
     {
+        if (!getCopyOfAllowedItems().containsKey(FUEL_LIST))
+        {
+            return new ArrayList<ItemStack>();
+        }
         return getCopyOfAllowedItems().get(FUEL_LIST).stream().map(ItemStorage::getItemStack).peek(stack -> stack.setCount(stack.getMaxStackSize())).collect(Collectors.toList());
     }
 

--- a/src/main/java/com/minecolonies/coremod/entity/ai/basic/AbstractEntityAIRequestSmelter.java
+++ b/src/main/java/com/minecolonies/coremod/entity/ai/basic/AbstractEntityAIRequestSmelter.java
@@ -328,7 +328,7 @@ public abstract class AbstractEntityAIRequestSmelter<J extends AbstractJobCrafte
                         new InvWrapper(furnace), SMELTABLE_SLOT);
                     }
                 }
-                else if (currentRecipeStorage.getIntermediate() == Blocks.FURNACE)
+                else if (currentRecipeStorage.getIntermediate() == Blocks.FURNACE && currentRequest != null)
                 {
                     needsCurrently = new Tuple<>(smeltable, currentRequest.getRequest().getCount());
                     return GATHERING_REQUIRED_MATERIALS;
@@ -364,12 +364,7 @@ public abstract class AbstractEntityAIRequestSmelter<J extends AbstractJobCrafte
         if (currentRecipeStorage == null)
         {
             IAIState newState = checkIfAbleToSmelt(amountOfFuelInBuilding + amountOfFuelInInv, false);
-            if(newState == CRAFT)
-            {
-                setDelay(TICKS_20);
-                return START_WORKING;
-            }
-            else
+            if(newState != CRAFT)
             {
                 return newState;
             }

--- a/src/main/java/com/minecolonies/coremod/entity/ai/basic/AbstractEntityAIRequestSmelter.java
+++ b/src/main/java/com/minecolonies/coremod/entity/ai/basic/AbstractEntityAIRequestSmelter.java
@@ -61,6 +61,13 @@ public abstract class AbstractEntityAIRequestSmelter<J extends AbstractJobCrafte
           new AITarget(RETRIEVING_END_PRODUCT_FROM_FURNACE, this::retrieveSmeltableFromFurnace, 1));
     }
 
+    @NotNull
+    @Override
+    protected List<ItemStack> itemsNiceToHave()
+    {
+        return getOwnBuilding().getAllowedFuel();
+    }
+
     @Override
     protected IAIState getRecipe()
     {
@@ -321,7 +328,7 @@ public abstract class AbstractEntityAIRequestSmelter<J extends AbstractJobCrafte
                         new InvWrapper(furnace), SMELTABLE_SLOT);
                     }
                 }
-                else
+                else if (currentRecipeStorage.getIntermediate() == Blocks.FURNACE)
                 {
                     needsCurrently = new Tuple<>(smeltable, currentRequest.getRequest().getCount());
                     return GATHERING_REQUIRED_MATERIALS;
@@ -352,12 +359,6 @@ public abstract class AbstractEntityAIRequestSmelter<J extends AbstractJobCrafte
         if (amountOfFuelInBuilding + amountOfFuelInInv <= 0 && !getOwnBuilding().hasWorkerOpenRequestsOfType(worker.getCitizenData(), TypeToken.of(StackList.class)))
         {
             worker.getCitizenData().createRequestAsync(new StackList(possibleFuels, COM_MINECOLONIES_REQUESTS_BURNABLE, STACKSIZE, 1));
-        }
-
-        if (amountOfFuelInBuilding > 0 && amountOfFuelInInv == 0)
-        {
-            needsCurrently = new Tuple<>(item -> FurnaceTileEntity.isFuel(item) && possibleFuels.stream().anyMatch(candidate -> item.isItemEqual(candidate)), STACKSIZE);
-            return GATHERING_REQUIRED_MATERIALS;
         }
 
         if (currentRecipeStorage == null)
@@ -412,6 +413,12 @@ public abstract class AbstractEntityAIRequestSmelter<J extends AbstractJobCrafte
             walkTo = posOfOven;
             worker.getCitizenStatusHandler().setLatestStatus(new TranslationTextComponent("com.minecolonies.coremod.status.retrieving"));
             return RETRIEVING_END_PRODUCT_FROM_FURNACE;
+        }
+
+        if (amountOfFuelInBuilding > 0 && amountOfFuelInInv == 0)
+        {
+            needsCurrently = new Tuple<>(item -> FurnaceTileEntity.isFuel(item) && possibleFuels.stream().anyMatch(candidate -> item.isItemEqual(candidate)), STACKSIZE);
+            return GATHERING_REQUIRED_MATERIALS;
         }
 
         return checkIfAbleToSmelt(amountOfFuelInBuilding + amountOfFuelInInv, true);

--- a/src/main/java/com/minecolonies/coremod/entity/ai/basic/AbstractEntityAIRequestSmelter.java
+++ b/src/main/java/com/minecolonies/coremod/entity/ai/basic/AbstractEntityAIRequestSmelter.java
@@ -211,7 +211,11 @@ public abstract class AbstractEntityAIRequestSmelter<J extends AbstractJobCrafte
             currentRequest.addDelivery(stack);
 
             incrementActionsDoneAndDecSaturation();
-            job.finishRequest(true);
+            job.setCraftCounter(job.getCraftCounter() + resultCount);
+            if(job.getCraftCounter() >= job.getMaxCraftingCount())
+            {
+                job.finishRequest(true);
+            }
         }
 
         setDelay(STANDARD_DELAY);


### PR DESCRIPTION
# Changes proposed in this pull request:
- move fuel grabbing a little later in the process, to speed smelting/crafting behavior
- make sure that we don't hit a case where the crafter decides to do nothing but play with fuel
- make smeltercrafter hold on to fuel in inventory better, to compensate for the later grab. 

Review please
