### PR TITLE
Some small fixes

### DIFF
--- a/src/api/java/com/minecolonies/api/entity/pathfinding/PathingStuckHandler.java
+++ b/src/api/java/com/minecolonies/api/entity/pathfinding/PathingStuckHandler.java
@@ -126,6 +126,7 @@ public class PathingStuckHandler implements IStuckHandler
     {
         if (navigator.getDesiredPos() == null || navigator.getDesiredPos().equals(BlockPos.ZERO))
         {
+            resetGlobalStuckTimers();
             return;
         }
 

--- a/src/api/java/com/minecolonies/api/inventory/InventoryCitizen.java
+++ b/src/api/java/com/minecolonies/api/inventory/InventoryCitizen.java
@@ -254,17 +254,18 @@ public class InventoryCitizen implements IItemHandlerModifiable, INameable
     public ItemStack insertItem(final int slot, @Nonnull final ItemStack stack, final boolean simulate)
     {
         markDirty();
+        final ItemStack copy = stack.copy();
         final ItemStack inSlot = mainInventory.get(slot);
-        if (inSlot.getCount() >= inSlot.getMaxStackSize() || (!inSlot.isEmpty() && !inSlot.isItemEqual(stack)))
+        if (inSlot.getCount() >= inSlot.getMaxStackSize() || (!inSlot.isEmpty() && !inSlot.isItemEqual(copy)))
         {
-            return stack;
+            return copy;
         }
 
         if (inSlot.isEmpty())
         {
             if (!simulate)
             {
-                mainInventory.set(slot, stack);
+                mainInventory.set(slot, copy);
                 return ItemStack.EMPTY;
             }
             else
@@ -274,11 +275,11 @@ public class InventoryCitizen implements IItemHandlerModifiable, INameable
         }
 
         final int avail = inSlot.getMaxStackSize() - inSlot.getCount();
-        if (avail >= stack.getCount())
+        if (avail >= copy.getCount())
         {
             if (!simulate)
             {
-                inSlot.setCount(inSlot.getCount() + stack.getCount());
+                inSlot.setCount(inSlot.getCount() + copy.getCount());
             }
             return ItemStack.EMPTY;
         }
@@ -288,8 +289,8 @@ public class InventoryCitizen implements IItemHandlerModifiable, INameable
             {
                 inSlot.setCount(inSlot.getCount() + avail);
             }
-            stack.setCount(stack.getCount() - avail);
-            return stack;
+            copy.setCount(copy.getCount() - avail);
+            return copy;
         }
     }
 

--- a/src/api/java/com/minecolonies/api/tileentities/TileEntityRack.java
+++ b/src/api/java/com/minecolonies/api/tileentities/TileEntityRack.java
@@ -9,7 +9,6 @@ import com.minecolonies.api.util.ItemStackUtils;
 import com.minecolonies.api.util.WorldUtil;
 import io.netty.buffer.Unpooled;
 import net.minecraft.block.BlockState;
-import net.minecraft.block.Blocks;
 import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.entity.player.PlayerInventory;
 import net.minecraft.inventory.container.Container;
@@ -325,11 +324,7 @@ public class TileEntityRack extends AbstractTileEntityRack
         for (int i = 0; i < inventoryTagList.size(); ++i)
         {
             final CompoundNBT inventoryCompound = inventoryTagList.getCompound(i);
-            if (inventoryCompound.contains(TAG_EMPTY))
-            {
-                inventory.setStackInSlot(i, ItemStackUtils.EMPTY);
-            }
-            else
+            if (!inventoryCompound.contains(TAG_EMPTY))
             {
                 final ItemStack stack = ItemStack.read(inventoryCompound);
                 inventory.setStackInSlot(i, stack);

--- a/src/api/java/com/minecolonies/api/tileentities/TileEntityRack.java
+++ b/src/api/java/com/minecolonies/api/tileentities/TileEntityRack.java
@@ -395,6 +395,12 @@ public class TileEntityRack extends AbstractTileEntityRack
     }
 
     @Override
+    public void handleUpdateTag(final CompoundNBT tag)
+    {
+        this.read(tag);
+    }
+
+    @Override
     public void rotate(final Rotation rotationIn)
     {
         super.rotate(rotationIn);
@@ -402,12 +408,6 @@ public class TileEntityRack extends AbstractTileEntityRack
         {
             relativeNeighbor = relativeNeighbor.rotate(rotationIn);
         }
-    }
-
-    @Override
-    public void handleUpdateTag(final CompoundNBT tag)
-    {
-        this.read(tag);
     }
 
     @Nonnull

--- a/src/api/java/com/minecolonies/api/util/InventoryUtils.java
+++ b/src/api/java/com/minecolonies/api/util/InventoryUtils.java
@@ -14,7 +14,6 @@ import net.minecraft.item.ItemStack;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.Direction;
 import net.minecraft.util.math.BlockPos;
-import net.minecraft.util.math.ChunkPos;
 import net.minecraft.world.World;
 import net.minecraftforge.common.capabilities.ICapabilityProvider;
 import net.minecraftforge.items.IItemHandler;
@@ -973,7 +972,7 @@ public class InventoryUtils
 
                 if (slot >= 0)
                 {
-                    itemHandler.insertItem(slot, itemStack, false);
+                    itemHandler.insertItem(slot, itemStack.copy(), false);
                     return ItemStackUtils.EMPTY;
                 }
                 else
@@ -987,7 +986,7 @@ public class InventoryUtils
                 slot = itemHandler.getSlots() == 0 ? -1 : 0;
                 while (!ItemStackUtils.isEmpty(leftOver) && slot != -1 && slot != itemHandler.getSlots())
                 {
-                    leftOver = itemHandler.insertItem(slot, leftOver, false);
+                    leftOver = itemHandler.insertItem(slot, leftOver.copy(), false);
                     if (!ItemStackUtils.isEmpty(leftOver))
                     {
                         slot++;

--- a/src/api/java/com/minecolonies/api/util/WorldUtil.java
+++ b/src/api/java/com/minecolonies/api/util/WorldUtil.java
@@ -1,11 +1,11 @@
 package com.minecolonies.api.util;
 
+import net.minecraft.block.BlockState;
 import net.minecraft.util.math.AxisAlignedBB;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.math.ChunkPos;
 import net.minecraft.world.IWorld;
 import net.minecraft.world.World;
-import net.minecraft.world.chunk.Chunk;
 import net.minecraft.world.chunk.ChunkStatus;
 
 /**
@@ -43,11 +43,13 @@ public class WorldUtil
      * @param world the world to mark it dirty in.
      * @param pos the position within the chunk.
      */
-    public static void markChunkDirty(final IWorld world, final BlockPos pos)
+    public static void markChunkDirty(final World world, final BlockPos pos)
     {
         if (WorldUtil.isBlockLoaded(world, pos))
         {
-            ((Chunk) world.getChunk(pos)).markDirty();
+            world.getChunk(pos.getX() >> 4, pos.getZ() >> 4).markDirty();
+            final BlockState state = world.getBlockState(pos);
+            world.notifyBlockUpdate(pos, state, state, 3);
         }
     }
 

--- a/src/main/java/com/minecolonies/coremod/colony/buildings/AbstractBuilding.java
+++ b/src/main/java/com/minecolonies/coremod/colony/buildings/AbstractBuilding.java
@@ -1215,10 +1215,13 @@ public abstract class AbstractBuilding extends AbstractBuildingContainer impleme
         {
             for (final IToken<?> req : reqs)
             {
-                final IRequestResolver<?> resolver = colony.getRequestManager().getResolverForRequest(req);
-                if (resolver instanceof IPlayerRequestResolver || resolver instanceof IRetryingRequestResolver)
+                if (colony.getRequestManager().getRequestForToken(req).getState() == RequestState.IN_PROGRESS)
                 {
-                    colony.getRequestManager().reassignRequest(req, Collections.emptyList());
+                    final IRequestResolver<?> resolver = colony.getRequestManager().getResolverForRequest(req);
+                    if (resolver instanceof IPlayerRequestResolver || resolver instanceof IRetryingRequestResolver)
+                    {
+                        colony.getRequestManager().reassignRequest(req, Collections.emptyList());
+                    }
                 }
             }
             return false;

--- a/src/main/java/com/minecolonies/coremod/entity/ai/citizen/guard/AbstractEntityAIGuard.java
+++ b/src/main/java/com/minecolonies/coremod/entity/ai/citizen/guard/AbstractEntityAIGuard.java
@@ -400,42 +400,44 @@ public abstract class AbstractEntityAIGuard<J extends AbstractJobGuard<J>, B ext
      */
     private IAIState checkAndAttackTarget()
     {
-        if (getState() == GUARD_SLEEP || getState() == GUARD_REGEN)
+        if (getState() == GUARD_SLEEP || getState() == GUARD_REGEN || getState() == GUARD_ATTACK_PROTECT || getState() == GUARD_ATTACK_PHYSICAL
+              || getState() == GUARD_ATTACK_RANGED)
         {
             return null;
         }
 
         if (checkForTarget())
         {
-            if (hasTool())
+            if (!hasTool())
             {
-                for (final ICitizenData citizen : getOwnBuilding().getAssignedCitizen())
-                {
-                    if (citizen.getEntity().isPresent() && citizen.getEntity().get().getRevengeTarget() == null)
-                    {
-                        citizen.getEntity().get().setRevengeTarget(target);
-                    }
-                }
-
-                if (target instanceof AbstractEntityMinecoloniesMob)
-                {
-                    for (final Map.Entry<BlockPos, IBuilding> entry : worker.getCitizenColonyHandler().getColony().getBuildingManager().getBuildings().entrySet())
-                    {
-                        if (entry.getValue() instanceof AbstractBuildingGuards &&
-                              worker.getPosition().distanceSq(entry.getKey()) < PATROL_DEVIATION_RAID_POINT)
-                        {
-                            final AbstractBuildingGuards building = (AbstractBuildingGuards) entry.getValue();
-                            building.setTempNextPatrolPoint(target.getPosition());
-                        }
-                    }
-                }
-
-                fighttimer = 30;
-                equipInventoryArmor();
-                worker.getNavigator().clearPath();
-                return getAttackState();
+                return START_WORKING;
             }
-            return START_WORKING;
+
+            for (final ICitizenData citizen : getOwnBuilding().getAssignedCitizen())
+            {
+                if (citizen.getEntity().isPresent() && citizen.getEntity().get().getRevengeTarget() == null)
+                {
+                    citizen.getEntity().get().setRevengeTarget(target);
+                }
+            }
+
+            if (target instanceof AbstractEntityMinecoloniesMob)
+            {
+                for (final Map.Entry<BlockPos, IBuilding> entry : worker.getCitizenColonyHandler().getColony().getBuildingManager().getBuildings().entrySet())
+                {
+                    if (entry.getValue() instanceof AbstractBuildingGuards &&
+                          worker.getPosition().distanceSq(entry.getKey()) < PATROL_DEVIATION_RAID_POINT)
+                    {
+                        final AbstractBuildingGuards building = (AbstractBuildingGuards) entry.getValue();
+                        building.setTempNextPatrolPoint(target.getPosition());
+                    }
+                }
+            }
+
+            fighttimer = 30;
+            equipInventoryArmor();
+            moveInAttackPosition();
+            return getAttackState();
         }
 
         if (fighttimer > 0)
@@ -666,9 +668,7 @@ public abstract class AbstractEntityAIGuard<J extends AbstractJobGuard<J>, B ext
         if (worker.getEntitySenses().canSee(target) && isWithinPersecutionDistance(target.getPosition()))
         {
             target.setRevengeTarget(worker);
-            fighttimer = 30;
-            worker.getNavigator().clearPath();
-            return getAttackState();
+            return checkAndAttackTarget();
         }
 
         // Move towards the target
@@ -757,15 +757,6 @@ public abstract class AbstractEntityAIGuard<J extends AbstractJobGuard<J>, B ext
             {
                 resetTarget();
                 return false;
-            }
-
-            // Move into range
-            if (!isInAttackDistance(target.getPosition()))
-            {
-                if (worker.getNavigator().noPath())
-                {
-                    moveInAttackPosition();
-                }
             }
 
             return true;

--- a/src/main/java/com/minecolonies/coremod/entity/ai/citizen/guard/AbstractEntityAIGuard.java
+++ b/src/main/java/com/minecolonies/coremod/entity/ai/citizen/guard/AbstractEntityAIGuard.java
@@ -432,6 +432,7 @@ public abstract class AbstractEntityAIGuard<J extends AbstractJobGuard<J>, B ext
 
                 fighttimer = 30;
                 equipInventoryArmor();
+                worker.getNavigator().clearPath();
                 return getAttackState();
             }
             return START_WORKING;
@@ -666,6 +667,7 @@ public abstract class AbstractEntityAIGuard<J extends AbstractJobGuard<J>, B ext
         {
             target.setRevengeTarget(worker);
             fighttimer = 30;
+            worker.getNavigator().clearPath();
             return getAttackState();
         }
 

--- a/src/main/java/com/minecolonies/coremod/entity/ai/citizen/guard/EntityAIRanger.java
+++ b/src/main/java/com/minecolonies/coremod/entity/ai/citizen/guard/EntityAIRanger.java
@@ -458,15 +458,22 @@ public class EntityAIRanger extends AbstractEntityAIGuard<JobRanger, AbstractBui
     {
         super.atBuildingActions();
 
-        // Pickup arrows and request arrows
-        InventoryUtils.transferXOfFirstSlotInProviderWithIntoNextFreeSlotInItemHandler(getOwnBuilding(),
-          item -> item.getItem() instanceof ArrowItem,
-          64,
-          worker.getInventoryCitizen());
 
-        if (InventoryUtils.getItemCountInItemHandler(worker.getInventoryCitizen(), item -> item.getItem() instanceof ArrowItem) < 16)
+        final UnlockAbilityResearchEffect arrowItemEffect =
+          worker.getCitizenColonyHandler().getColony().getResearchManager().getResearchEffects().getEffect(ARROW_ITEMS, UnlockAbilityResearchEffect.class);
+
+        if (arrowItemEffect != null && arrowItemEffect.getEffect())
         {
-            checkIfRequestForItemExistOrCreateAsynch(new ItemStack(Items.ARROW), 64, 16);
+            // Pickup arrows and request arrows
+            InventoryUtils.transferXOfFirstSlotInProviderWithIntoNextFreeSlotInItemHandler(getOwnBuilding(),
+              item -> item.getItem() instanceof ArrowItem,
+              64,
+              worker.getInventoryCitizen());
+
+            if (InventoryUtils.getItemCountInItemHandler(worker.getInventoryCitizen(), item -> item.getItem() instanceof ArrowItem) < 16)
+            {
+                checkIfRequestForItemExistOrCreateAsynch(new ItemStack(Items.ARROW), 64, 16);
+            }
         }
     }
 

--- a/src/main/java/com/minecolonies/coremod/entity/pathfinding/ChunkCache.java
+++ b/src/main/java/com/minecolonies/coremod/entity/pathfinding/ChunkCache.java
@@ -56,7 +56,7 @@ public class ChunkCache implements IWorldReader
         {
             for (int l = this.chunkZ; l <= j; ++l)
             {
-                if (WorldUtil.isChunkLoaded(world, new ChunkPos(k, l)))
+                if (WorldUtil.isEntityChunkLoaded(world, new ChunkPos(k, l)))
                 {
                     this.chunkArray[k - this.chunkX][l - this.chunkZ] = worldIn.getChunk(k, l);
                 }

--- a/src/main/java/com/minecolonies/coremod/network/messages/client/UpdateChunkRangeCapabilityMessage.java
+++ b/src/main/java/com/minecolonies/coremod/network/messages/client/UpdateChunkRangeCapabilityMessage.java
@@ -56,7 +56,7 @@ public class UpdateChunkRangeCapabilityMessage implements IMessage
             {
                 final int chunkX = xC + x;
                 final int chunkZ = zC + z;
-                if (!checkLoaded || WorldUtil.isChunkLoaded(world, chunkX, chunkZ))
+                if (!checkLoaded || WorldUtil.isEntityChunkLoaded(world, chunkX, chunkZ))
                 {
                     final Chunk chunk = world.getChunk(chunkX, chunkZ);
                     final IColonyTagCapability cap = chunk.getCapability(CLOSE_COLONY_CAP, null).orElseGet(null);

--- a/src/main/java/com/minecolonies/coremod/network/messages/server/colony/citizen/TransferItemsToCitizenRequestMessage.java
+++ b/src/main/java/com/minecolonies/coremod/network/messages/server/colony/citizen/TransferItemsToCitizenRequestMessage.java
@@ -150,7 +150,6 @@ public class TransferItemsToCitizenRequestMessage extends AbstractColonyServerMe
             final ItemStack remainingItemStack = InventoryUtils.addItemStackToItemHandlerWithResult(citizen.getInventoryCitizen(), insertStack);
             if (!ItemStackUtils.isEmpty(remainingItemStack))
             {
-                insertStack.setCount(remainingItemStack.getCount());
                 tempAmount += (insertStack.getCount() - remainingItemStack.getCount());
                 break;
             }


### PR DESCRIPTION
Closes #5511
Closes #5491
Closes #5477

# Changes proposed in this pull request:
Copy item on insert to avoid issues.
Fix guards not stopping their current path when finding a target.
Fix possible chunk loading for path creation and colony cap messages
Fix TransferItemsToCitizenRequestMessage modifying the inserted stack and miscalculating the remove count sometimes
Fix stuckhandler not always resetting timers properly
Fix rangers requesting arrows before they can use them
Fix  guard AI not always moving to their attack target on start
Fix guard AI overriding their targets mid combat

Review please
