### PR TITLE
Fix/warehouse resolver

### DIFF
--- a/src/api/java/com/minecolonies/api/tileentities/AbstractTileEntityWareHouse.java
+++ b/src/api/java/com/minecolonies/api/tileentities/AbstractTileEntityWareHouse.java
@@ -1,8 +1,10 @@
 package com.minecolonies.api.tileentities;
 
 import com.minecolonies.api.inventory.InventoryCitizen;
+import com.minecolonies.api.util.Tuple;
 import net.minecraft.item.ItemStack;
 import net.minecraft.tileentity.TileEntityType;
+import net.minecraft.util.math.BlockPos;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.List;
@@ -39,7 +41,7 @@ public abstract class AbstractTileEntityWareHouse extends TileEntityColonyBuildi
      * @return True when the warehouse holds a stack, false when not.
      */
     @NotNull
-    public abstract List<ItemStack> getMatchingItemStacksInWarehouse(@NotNull Predicate<ItemStack> itemStackSelectionPredicate);
+    public abstract List<Tuple<ItemStack, BlockPos>> getMatchingItemStacksInWarehouse(@NotNull Predicate<ItemStack> itemStackSelectionPredicate);
 
     /**
      * Dump the inventory of a citizen into the warehouse. Go through all items and search the right chest to dump it in.

--- a/src/api/java/com/minecolonies/api/tileentities/TileEntityColonyBuilding.java
+++ b/src/api/java/com/minecolonies/api/tileentities/TileEntityColonyBuilding.java
@@ -39,6 +39,7 @@ import net.minecraftforge.items.IItemHandlerModifiable;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
+import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -200,17 +201,20 @@ public class TileEntityColonyBuilding extends AbstractTileEntityColonyBuilding i
 
         if (theBuilding != null)
         {
-            if (isInTileEntity(theBuilding.getTileEntity(), notEmptyPredicate))
-            {
-                return theBuilding.getPosition();
-            }
+            final List<BlockPos> containers = new ArrayList<>(theBuilding.getAdditionalCountainers());
+            containers.add(getBuilding().getPosition());
 
-            for (final BlockPos pos : theBuilding.getAdditionalCountainers())
+            for (final BlockPos pos : containers)
             {
                 final TileEntity entity = getWorld().getTileEntity(pos);
-                if ((entity instanceof AbstractTileEntityRack
-                       && ((AbstractTileEntityRack) entity).hasItemStack(notEmptyPredicate))
-                      || (isInTileEntity(entity, notEmptyPredicate)))
+                if (entity instanceof AbstractTileEntityRack)
+                {
+                    if (((AbstractTileEntityRack) entity).hasItemStack(notEmptyPredicate))
+                    {
+                        return pos;
+                    }
+                }
+                else if (isInTileEntity(entity, notEmptyPredicate))
                 {
                     return pos;
                 }

--- a/src/api/java/com/minecolonies/api/tileentities/TileEntityColonyBuilding.java
+++ b/src/api/java/com/minecolonies/api/tileentities/TileEntityColonyBuilding.java
@@ -9,7 +9,6 @@ import com.minecolonies.api.colony.buildings.views.IBuildingView;
 import com.minecolonies.api.colony.permissions.Action;
 import com.minecolonies.api.inventory.api.CombinedItemHandler;
 import com.minecolonies.api.inventory.container.ContainerBuildingInventory;
-import com.minecolonies.api.util.InventoryUtils;
 import com.minecolonies.api.util.ItemStackUtils;
 import com.minecolonies.api.util.WorldUtil;
 import io.netty.buffer.Unpooled;
@@ -31,7 +30,6 @@ import net.minecraft.util.text.ITextComponent;
 import net.minecraft.util.text.StringTextComponent;
 import net.minecraft.world.World;
 import net.minecraftforge.common.capabilities.Capability;
-import net.minecraftforge.common.capabilities.ICapabilityProvider;
 import net.minecraftforge.common.util.LazyOptional;
 import net.minecraftforge.items.CapabilityItemHandler;
 import net.minecraftforge.items.IItemHandler;
@@ -44,7 +42,6 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.function.Predicate;
-import java.util.stream.Collectors;
 
 import static com.minecolonies.api.util.constant.BuildingConstants.MIN_SLOTS_FOR_RECOGNITION;
 import static com.minecolonies.api.util.constant.NbtTagConstants.TAG_BUILDING_TYPE;
@@ -206,17 +203,20 @@ public class TileEntityColonyBuilding extends AbstractTileEntityColonyBuilding i
 
             for (final BlockPos pos : containers)
             {
-                final TileEntity entity = getWorld().getTileEntity(pos);
-                if (entity instanceof AbstractTileEntityRack)
+                if (WorldUtil.isBlockLoaded(world, pos))
                 {
-                    if (((AbstractTileEntityRack) entity).hasItemStack(notEmptyPredicate))
+                    final TileEntity entity = getWorld().getTileEntity(pos);
+                    if (entity instanceof AbstractTileEntityRack)
+                    {
+                        if (((AbstractTileEntityRack) entity).hasItemStack(notEmptyPredicate))
+                        {
+                            return pos;
+                        }
+                    }
+                    else if (isInTileEntity(entity, notEmptyPredicate))
                     {
                         return pos;
                     }
-                }
-                else if (isInTileEntity(entity, notEmptyPredicate))
-                {
-                    return pos;
                 }
             }
         }

--- a/src/main/java/com/minecolonies/coremod/colony/buildings/AbstractBuilding.java
+++ b/src/main/java/com/minecolonies/coremod/colony/buildings/AbstractBuilding.java
@@ -65,7 +65,6 @@ import net.minecraft.tileentity.ChestTileEntity;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.Tuple;
 import net.minecraft.util.math.BlockPos;
-import net.minecraft.util.math.ChunkPos;
 import net.minecraft.util.text.ITextComponent;
 import net.minecraft.util.text.StringTextComponent;
 import net.minecraft.util.text.TranslationTextComponent;
@@ -1541,11 +1540,14 @@ public abstract class AbstractBuilding extends AbstractBuildingContainer impleme
     public void onRequestedRequestComplete(@NotNull final IRequestManager manager, @NotNull final IRequest<?> request)
     {
         final Integer citizenThatRequested = getCitizensByRequest().remove(request.getId());
-        getOpenRequestsByCitizen().get(citizenThatRequested).remove(request.getId());
 
-        if (getOpenRequestsByCitizen().get(citizenThatRequested).isEmpty())
+        if (getOpenRequestsByCitizen().containsKey(citizenThatRequested))
         {
-            getOpenRequestsByCitizen().remove(citizenThatRequested);
+            getOpenRequestsByCitizen().get(citizenThatRequested).remove(request.getId());
+            if (getOpenRequestsByCitizen().get(citizenThatRequested).isEmpty())
+            {
+                getOpenRequestsByCitizen().remove(citizenThatRequested);
+            }
         }
 
         getOpenRequestsByRequestableType().get(TypeToken.of(request.getRequest().getClass())).remove(request.getId());

--- a/src/main/java/com/minecolonies/coremod/entity/ai/citizen/miner/Node.java
+++ b/src/main/java/com/minecolonies/coremod/entity/ai/citizen/miner/Node.java
@@ -1,5 +1,6 @@
 package com.minecolonies.coremod.entity.ai.citizen.miner;
 
+import com.minecolonies.api.util.Log;
 import com.minecolonies.api.util.Vec2i;
 import net.minecraft.nbt.CompoundNBT;
 import net.minecraft.util.math.MathHelper;
@@ -106,7 +107,17 @@ public class Node
             z = compound.getInt(TAG_Z);
         }
 
-        final NodeType style = NodeType.valueOf(compound.getString(TAG_STYLE));
+        final String nodeType = compound.getString(TAG_STYLE);
+        NodeType style;
+        try
+        {
+            style = NodeType.valueOf(nodeType);
+        }
+        catch (IllegalArgumentException ex)
+        {
+            style = NodeType.TUNNEL;
+            Log.getLogger().error("Miner node failed loading: " + nodeType + " . Please report this to the mod authors!", ex);
+        }
 
         final NodeStatus status = NodeStatus.valueOf(compound.getString(TAG_STATUS));
 

--- a/src/main/java/com/minecolonies/coremod/tileentities/TileEntityWareHouse.java
+++ b/src/main/java/com/minecolonies/coremod/tileentities/TileEntityWareHouse.java
@@ -9,6 +9,7 @@ import com.minecolonies.api.tileentities.TileEntityRack;
 import com.minecolonies.api.util.InventoryUtils;
 import com.minecolonies.api.util.ItemStackUtils;
 import com.minecolonies.api.util.Tuple;
+import com.minecolonies.api.util.WorldUtil;
 import net.minecraft.item.ItemStack;
 import net.minecraft.tileentity.ChestTileEntity;
 import net.minecraft.tileentity.TileEntity;
@@ -47,22 +48,26 @@ public class TileEntityWareHouse extends AbstractTileEntityWareHouse
         int totalCountFound = 0;
         for (@NotNull final BlockPos pos : getBuilding().getAdditionalCountainers())
         {
-            final TileEntity entity = getWorld().getTileEntity(pos);
-            if (entity instanceof TileEntityRack && !((AbstractTileEntityRack) entity).isEmpty())
+            if (WorldUtil.isBlockLoaded(world, pos))
             {
-                totalCountFound+= ((AbstractTileEntityRack) entity).getCount(itemStack, true);
-                if (totalCountFound >= count)
+                final TileEntity entity = getWorld().getTileEntity(pos);
+                if (entity instanceof TileEntityRack && !((AbstractTileEntityRack) entity).isEmpty())
                 {
-                    return true;
+                    totalCountFound += ((AbstractTileEntityRack) entity).getCount(itemStack, true);
+                    if (totalCountFound >= count)
+                    {
+                        return true;
+                    }
                 }
-            }
 
-            if (entity instanceof ChestTileEntity)
-            {
-                totalCountFound += InventoryUtils.getItemCountInItemHandler(entity.getCapability(ITEM_HANDLER_CAPABILITY, null).orElseGet(null), item -> item.isItemEqualIgnoreDurability(itemStack) && item.getCount() >= itemStack.getCount());
-                if (totalCountFound >= count)
+                if (entity instanceof ChestTileEntity)
                 {
-                    return true;
+                    totalCountFound += InventoryUtils.getItemCountInItemHandler(entity.getCapability(ITEM_HANDLER_CAPABILITY, null).orElseGet(null),
+                      item -> item.isItemEqualIgnoreDurability(itemStack) && item.getCount() >= itemStack.getCount());
+                    if (totalCountFound >= count)
+                    {
+                        return true;
+                    }
                 }
             }
         }


### PR DESCRIPTION
Closes #5529


# Changes proposed in this pull request:
- Fixes warehouse resolver to get the position with the stack directly without double querying.
- Don't query triple by even additionally asking the tileEntity every time when false
- Don't query quatruple by not additionally asking the building tileEntity that is connected to all
- Add some safeguards
- Adds logging to find out what is causing the weird miner issue.

Review please
