### PR TITLE
Bring skill effects into alignment with plan for crafters

### DIFF
--- a/src/api/java/com/minecolonies/api/colony/buildings/IBuildingWorker.java
+++ b/src/api/java/com/minecolonies/api/colony/buildings/IBuildingWorker.java
@@ -208,13 +208,6 @@ public interface IBuildingWorker extends IBuilding
     Skill getSecondarySkill();
 
     /**
-     * Crafting Speed skill
-     * @return the crafting speed skill
-     */
-    @NotNull
-    Skill getCraftSpeedSkill();
-
-    /**
      *  Recipe Improvement skill getter
      * @return the recipe improvement skill
      */

--- a/src/api/java/com/minecolonies/api/colony/buildings/IBuildingWorker.java
+++ b/src/api/java/com/minecolonies/api/colony/buildings/IBuildingWorker.java
@@ -208,6 +208,20 @@ public interface IBuildingWorker extends IBuilding
     Skill getSecondarySkill();
 
     /**
+     * Crafting Speed skill
+     * @return the crafting speed skill
+     */
+    @NotNull
+    Skill getCraftSpeedSkill();
+
+    /**
+     *  Recipe Improvement skill getter
+     * @return the recipe improvement skill
+     */
+    @NotNull
+    Skill getRecipeImprovementSkill();
+
+    /**
      * Check if the worker is allowed to eat the following stack.
      *
      * @param stack the stack to test.

--- a/src/main/java/com/minecolonies/coremod/colony/buildings/AbstractBuildingCrafter.java
+++ b/src/main/java/com/minecolonies/coremod/colony/buildings/AbstractBuildingCrafter.java
@@ -11,6 +11,7 @@ import com.minecolonies.api.colony.requestsystem.resolver.IRequestResolver;
 import com.minecolonies.api.colony.requestsystem.token.IToken;
 import com.minecolonies.api.crafting.IRecipeStorage;
 import com.minecolonies.api.crafting.ItemStorage;
+import com.minecolonies.api.entity.citizen.Skill;
 import com.minecolonies.api.util.constant.TypeConstants;
 import com.minecolonies.coremod.colony.jobs.AbstractJobCrafter;
 import com.minecolonies.coremod.colony.requestsystem.resolvers.PrivateWorkerCraftingProductionResolver;
@@ -183,5 +184,20 @@ public abstract class AbstractBuildingCrafter extends AbstractBuildingWorker
     protected Optional<Boolean> canRecipeBeAddedBasedOnTags(final IToken token)
     {
         return super.canRecipeBeAddedBasedOnTags(token);
+    }
+
+    /**
+     * Crafting Speed skill
+     * @return the crafting speed skill
+     */
+    public Skill getCraftSpeedSkill()
+    {
+        return getSecondarySkill();
+    }
+
+    @Override
+    public Skill getRecipeImprovementSkill()
+    {
+        return getPrimarySkill();
     }
 }

--- a/src/main/java/com/minecolonies/coremod/colony/buildings/AbstractBuildingWorker.java
+++ b/src/main/java/com/minecolonies/coremod/colony/buildings/AbstractBuildingWorker.java
@@ -391,16 +391,9 @@ public abstract class AbstractBuildingWorker extends AbstractBuilding implements
 
     @Override
     @NotNull
-    public Skill getCraftSpeedSkill()
-    {
-        return getSecondarySkill();
-    }
-
-    @Override
-    @NotNull
     public Skill getRecipeImprovementSkill()
     {
-        return getPrimarySkill();
+        return getSecondarySkill();
     }
 
     @Override

--- a/src/main/java/com/minecolonies/coremod/colony/buildings/AbstractBuildingWorker.java
+++ b/src/main/java/com/minecolonies/coremod/colony/buildings/AbstractBuildingWorker.java
@@ -310,7 +310,7 @@ public abstract class AbstractBuildingWorker extends AbstractBuilding implements
         final ResourceLocation reducableProductExclusions = new ResourceLocation(MOD_ID, REDUCEABLE.concat(PRODUCT_EXCLUDED));
         final List<ItemStorage> inputs = recipe.getCleanedInput().stream().sorted(Comparator.comparingInt(ItemStorage::getAmount).reversed()).collect(Collectors.toList());
 
-        final double actualChance = Math.min(5.0, (BASE_CHANCE * count) + (BASE_CHANCE * citizen.getCitizenSkillHandler().getLevel(getPrimarySkill())));
+        final double actualChance = Math.min(5.0, (BASE_CHANCE * count) + (BASE_CHANCE * citizen.getCitizenSkillHandler().getLevel(getRecipeImprovementSkill())));
         final double roll = citizen.getRandom().nextDouble() * 100;
 
         if(roll <= actualChance && !ItemTags.getCollection().getOrCreate(reducableProductExclusions).contains(recipe.getPrimaryOutput().getItem()))
@@ -345,6 +345,20 @@ public abstract class AbstractBuildingWorker extends AbstractBuilding implements
                 replaceRecipe(recipe.getToken(), IColonyManager.getInstance().getRecipeManager().checkOrAddRecipe(storage));
             }
         }
+    }
+
+    @Override
+    @NotNull
+    public Skill getCraftSpeedSkill()
+    {
+        return getSecondarySkill();
+    }
+
+    @Override
+    @NotNull
+    public Skill getRecipeImprovementSkill()
+    {
+        return getPrimarySkill();
     }
 
     @Override

--- a/src/main/java/com/minecolonies/coremod/colony/buildings/workerbuildings/BuildingBlacksmith.java
+++ b/src/main/java/com/minecolonies/coremod/colony/buildings/workerbuildings/BuildingBlacksmith.java
@@ -89,6 +89,20 @@ public class BuildingBlacksmith extends AbstractBuildingCrafter
     }
 
     @Override
+    @NotNull
+    public Skill getCraftSpeedSkill()
+    {
+        return getPrimarySkill();
+    }
+
+    @Override
+    @NotNull
+    public Skill getRecipeImprovementSkill()
+    {
+        return getSecondarySkill();
+    }
+
+    @Override
     public boolean canRecipeBeAdded(final IToken<?> token)
     {
 

--- a/src/main/java/com/minecolonies/coremod/colony/buildings/workerbuildings/BuildingCrusher.java
+++ b/src/main/java/com/minecolonies/coremod/colony/buildings/workerbuildings/BuildingCrusher.java
@@ -127,20 +127,29 @@ public class BuildingCrusher extends AbstractBuildingCrafter
         }
     }
 
+    @Override
+    public void checkForWorkerSpecificRecipes()
+    {
+        loadCurrentRecipes();
+    }
+
     /**
      * Reload all of the current crusher recipes
      */
     private void loadCurrentRecipes()
     {
-        if(!super.recipes.isEmpty())
-        {
-            super.recipes.clear();
-        }
-
         for (final IRecipeStorage recipe : crusherRecipes.values())
         {
             final IToken<?> token = IColonyManager.getInstance().getRecipeManager().checkOrAddRecipe(recipe);
-            addRecipe(token);
+            final IRecipeStorage oldRecipe = getFirstRecipe(recipe.getPrimaryOutput());
+            if(oldRecipe != null && !oldRecipe.getToken().equals(token))
+            {
+                replaceRecipe(oldRecipe.getToken(), token);
+            }
+            else
+            {
+                addRecipe(token);
+            }
         }
 
         final IRecipeStorage clayballStorage = StandardFactoryController.getInstance().getNewInstance(
@@ -151,7 +160,7 @@ public class BuildingCrusher extends AbstractBuildingCrafter
             new ItemStack(Items.CLAY_BALL, 4),
             Blocks.AIR);
   
-        addRecipeToList(IColonyManager.getInstance().getRecipeManager().checkOrAddRecipe(clayballStorage));    
+        addRecipe(IColonyManager.getInstance().getRecipeManager().checkOrAddRecipe(clayballStorage));    
     }
 
     /**
@@ -342,36 +351,6 @@ public class BuildingCrusher extends AbstractBuildingCrafter
         {
             buf.writeItemStack(storage.getItemStack());
         }
-    }
-
-    @Override
-    public IRecipeStorage getFirstRecipe(final Predicate<ItemStack> stackPredicate)
-    {
-        for (final IRecipeStorage storage : crusherRecipes.values())
-        {
-            if (storage != null && stackPredicate.test(storage.getPrimaryOutput()))
-            {
-                return storage;
-            }
-        }
-        return null;
-    }
-
-    @Override
-    public IRecipeStorage getFirstFullFillableRecipe(final Predicate<ItemStack> stackPredicate, final int count)
-    {
-        for (final IRecipeStorage storage : crusherRecipes.values())
-        {
-            if (storage != null && stackPredicate.test(storage.getPrimaryOutput()))
-            {
-                final List<IItemHandler> handlers = getHandlers();
-                if (storage.canFullFillRecipe(count, handlers.toArray(new IItemHandler[0])))
-                {
-                    return storage;
-                }
-            }
-        }
-        return null;
     }
 
     @Override

--- a/src/main/java/com/minecolonies/coremod/colony/buildings/workerbuildings/BuildingDyer.java
+++ b/src/main/java/com/minecolonies/coremod/colony/buildings/workerbuildings/BuildingDyer.java
@@ -215,28 +215,29 @@ public class BuildingDyer extends AbstractBuildingSmelterCrafter
 
         if(recipe == null && stackPredicate.test(new ItemStack(Items.WHITE_WOOL)))
         {
-            final Set<IBuilding> wareHouses = colony.getBuildingManager().getBuildings().values().stream()
-            .filter(building -> building instanceof BuildingWareHouse)
-            .collect(Collectors.toSet());
-            
             final ResourceLocation wool = new ResourceLocation("minecraft", "wool");
-            final List<ItemStorage> woolItems = ItemTags.getCollection().getOrCreate(wool).getAllElements().stream()
-                                                .filter(item -> !item.equals(Items.WHITE_WOOL))
-                                                .map(i -> new ItemStorage(new ItemStack(i))).collect(Collectors.toList());
             final HashMap<ItemStorage, Integer> inventoryCounts = new HashMap<>();
+
+            final Set<IBuilding> wareHouses = colony.getBuildingManager().getBuildings().values().stream()
+                                                    .filter(building -> building instanceof BuildingWareHouse)
+                                                    .collect(Collectors.toSet());
+            
+            final List<ItemStorage> woolItems = ItemTags.getCollection().getOrCreate(wool).getAllElements().stream()
+                                                        .filter(item -> !item.equals(Items.WHITE_WOOL))
+                                                        .map(i -> new ItemStorage(new ItemStack(i))).collect(Collectors.toList());
 
             for(ItemStorage color : woolItems)
             {
                 for(IBuilding wareHouse: wareHouses)
                 {
                     final int colorCount = InventoryUtils.hasBuildingEnoughElseCount(wareHouse, color, 1);
-                    inventoryCounts.put(color, inventoryCounts.getOrDefault(color, 0) + colorCount);
+                    inventoryCounts.replace(color, inventoryCounts.getOrDefault(color, 0) + colorCount);
                 }
             }
 
             ItemStorage woolToUse = inventoryCounts.entrySet().stream()
-                .sorted(Comparator.comparing(itemEntry -> itemEntry.getValue(), Comparator.reverseOrder()))
-                .findFirst().get().getKey();
+                                                .sorted(Comparator.comparing(itemEntry -> itemEntry.getValue(), Comparator.reverseOrder()))
+                                                .findFirst().get().getKey();
 
             recipe = StandardFactoryController.getInstance().getNewInstance(
                 TypeConstants.RECIPE,

--- a/src/main/java/com/minecolonies/coremod/colony/buildings/workerbuildings/BuildingDyer.java
+++ b/src/main/java/com/minecolonies/coremod/colony/buildings/workerbuildings/BuildingDyer.java
@@ -6,14 +6,17 @@ import com.minecolonies.api.colony.ICitizenData;
 import com.minecolonies.api.colony.IColony;
 import com.minecolonies.api.colony.IColonyManager;
 import com.minecolonies.api.colony.IColonyView;
+import com.minecolonies.api.colony.buildings.IBuilding;
 import com.minecolonies.api.colony.buildings.ModBuildings;
 import com.minecolonies.api.colony.buildings.registry.BuildingEntry;
 import com.minecolonies.api.colony.jobs.IJob;
 import com.minecolonies.api.colony.requestsystem.StandardFactoryController;
 import com.minecolonies.api.colony.requestsystem.token.IToken;
 import com.minecolonies.api.crafting.IRecipeStorage;
+import com.minecolonies.api.crafting.ItemStorage;
 import com.minecolonies.api.entity.citizen.Skill;
 import com.minecolonies.api.inventory.container.ContainerCrafting;
+import com.minecolonies.api.util.InventoryUtils;
 import com.minecolonies.api.util.constant.TypeConstants;
 import com.minecolonies.coremod.client.gui.WindowHutDyer;
 import com.minecolonies.coremod.colony.buildings.AbstractBuildingSmelterCrafter;
@@ -29,14 +32,23 @@ import net.minecraft.inventory.container.INamedContainerProvider;
 import net.minecraft.item.ItemStack;
 import net.minecraft.item.Items;
 import net.minecraft.network.PacketBuffer;
+import net.minecraft.tags.ItemTags;
+import net.minecraft.util.ResourceLocation;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.text.ITextComponent;
 import net.minecraft.util.text.StringTextComponent;
 import net.minecraft.util.text.TranslationTextComponent;
 import net.minecraftforge.fml.network.NetworkHooks;
+import net.minecraftforge.items.IItemHandler;
 import org.jetbrains.annotations.NotNull;
 
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.List;
 import java.util.Optional;
+import java.util.Set;
+import java.util.function.Predicate;
+import java.util.stream.Collectors;
 
 import static com.minecolonies.api.util.constant.BuildingConstants.CONST_DEFAULT_MAX_BUILDING_LEVEL;
 
@@ -194,6 +206,67 @@ public class BuildingDyer extends AbstractBuildingSmelterCrafter
             return;
         }
         super.requestUpgrade(player, builder);
+    }
+
+    @Override
+    public IRecipeStorage getFirstRecipe(Predicate<ItemStack> stackPredicate)
+    {
+        IRecipeStorage recipe = super.getFirstRecipe(stackPredicate);
+
+        if(recipe == null && stackPredicate.test(new ItemStack(Items.WHITE_WOOL)))
+        {
+            final Set<IBuilding> wareHouses = colony.getBuildingManager().getBuildings().values().stream()
+            .filter(building -> building instanceof BuildingWareHouse)
+            .collect(Collectors.toSet());
+            
+            final ResourceLocation wool = new ResourceLocation("minecraft", "wool");
+            final List<ItemStorage> woolItems = ItemTags.getCollection().getOrCreate(wool).getAllElements().stream()
+                                                .filter(item -> !item.equals(Items.WHITE_WOOL))
+                                                .map(i -> new ItemStorage(new ItemStack(i))).collect(Collectors.toList());
+            final HashMap<ItemStorage, Integer> inventoryCounts = new HashMap<>();
+
+            for(ItemStorage color : woolItems)
+            {
+                for(IBuilding wareHouse: wareHouses)
+                {
+                    final int colorCount = InventoryUtils.hasBuildingEnoughElseCount(wareHouse, color, 1);
+                    inventoryCounts.put(color, inventoryCounts.getOrDefault(color, 0) + colorCount);
+                }
+            }
+
+            ItemStorage woolToUse = inventoryCounts.entrySet().stream()
+                .sorted(Comparator.comparing(itemEntry -> itemEntry.getValue(), Comparator.reverseOrder()))
+                .findFirst().get().getKey();
+
+            recipe = StandardFactoryController.getInstance().getNewInstance(
+                TypeConstants.RECIPE,
+                StandardFactoryController.getInstance().getNewInstance(TypeConstants.ITOKEN),
+                ImmutableList.of(woolToUse.getItemStack(), new ItemStack(Items.WHITE_DYE, 1)),
+                1,
+                new ItemStack(Items.WHITE_WOOL, 1),
+                Blocks.AIR);
+        }
+        return recipe;
+    }
+
+    @Override
+    public IRecipeStorage getFirstFullFillableRecipe(Predicate<ItemStack> stackPredicate, int count)
+    {
+        IRecipeStorage recipe =  super.getFirstFullFillableRecipe(stackPredicate, count);
+
+        if(recipe == null)
+        {
+            final IRecipeStorage storage = getFirstRecipe(stackPredicate);
+            if (storage != null && stackPredicate.test(storage.getPrimaryOutput()))
+            {
+                final List<IItemHandler> handlers = getHandlers();
+                if (storage.canFullFillRecipe(count, handlers.toArray(new IItemHandler[0])))
+                {
+                    return storage;
+                }
+            }
+        }
+        return null;        
     }
 
     /**

--- a/src/main/java/com/minecolonies/coremod/colony/buildings/workerbuildings/BuildingFletcher.java
+++ b/src/main/java/com/minecolonies/coremod/colony/buildings/workerbuildings/BuildingFletcher.java
@@ -92,6 +92,20 @@ public class BuildingFletcher extends AbstractBuildingCrafter
     }
 
     @Override
+    @NotNull
+    public Skill getCraftSpeedSkill()
+    {
+        return getPrimarySkill();
+    }
+
+    @Override
+    @NotNull
+    public Skill getRecipeImprovementSkill()
+    {
+        return getSecondarySkill();
+    }
+    
+    @Override
     public boolean canRecipeBeAdded(final IToken<?> token)
     {
         Optional<Boolean> isRecipeAllowed;

--- a/src/main/java/com/minecolonies/coremod/entity/ai/basic/AbstractEntityAICrafting.java
+++ b/src/main/java/com/minecolonies/coremod/entity/ai/basic/AbstractEntityAICrafting.java
@@ -14,6 +14,7 @@ import com.minecolonies.api.util.InventoryUtils;
 import com.minecolonies.api.util.ItemStackUtils;
 import com.minecolonies.api.util.Tuple;
 import com.minecolonies.coremod.colony.buildings.AbstractBuildingWorker;
+import com.minecolonies.coremod.colony.buildings.AbstractBuildingCrafter;
 import com.minecolonies.coremod.colony.jobs.AbstractJobCrafter;
 
 import net.minecraft.block.Blocks;
@@ -379,7 +380,7 @@ public abstract class AbstractEntityAICrafting<J extends AbstractJobCrafter<?, J
      */
     private int getRequiredProgressForMakingRawMaterial()
     {
-        final int jobModifier = worker.getCitizenData().getCitizenSkillHandler().getLevel(getOwnBuilding().getCraftSpeedSkill()) / 2;
+        final int jobModifier = worker.getCitizenData().getCitizenSkillHandler().getLevel(((AbstractBuildingCrafter) getOwnBuilding()).getCraftSpeedSkill()) / 2;
         return PROGRESS_MULTIPLIER / Math.min(jobModifier + 1, MAX_LEVEL) * HITTING_TIME;
     }
 

--- a/src/main/java/com/minecolonies/coremod/entity/ai/basic/AbstractEntityAICrafting.java
+++ b/src/main/java/com/minecolonies/coremod/entity/ai/basic/AbstractEntityAICrafting.java
@@ -379,7 +379,8 @@ public abstract class AbstractEntityAICrafting<J extends AbstractJobCrafter<?, J
      */
     private int getRequiredProgressForMakingRawMaterial()
     {
-        return PROGRESS_MULTIPLIER / Math.min(worker.getCitizenData().getJobModifier() + 1, MAX_LEVEL) * HITTING_TIME;
+        final int jobModifier = worker.getCitizenData().getCitizenSkillHandler().getLevel(getOwnBuilding().getCraftSpeedSkill()) / 2;
+        return PROGRESS_MULTIPLIER / Math.min(jobModifier + 1, MAX_LEVEL) * HITTING_TIME;
     }
 
     @Override

--- a/src/main/java/com/minecolonies/coremod/entity/ai/basic/AbstractEntityAIUsesFurnace.java
+++ b/src/main/java/com/minecolonies/coremod/entity/ai/basic/AbstractEntityAIUsesFurnace.java
@@ -4,12 +4,15 @@ import com.ldtteam.structurize.util.LanguageHandler;
 import com.minecolonies.api.colony.interactionhandling.ChatPriority;
 import com.minecolonies.api.colony.requestsystem.requestable.IRequestable;
 import com.minecolonies.api.colony.requestsystem.requestable.StackList;
+import com.minecolonies.api.entity.ai.statemachine.AIEventTarget;
 import com.minecolonies.api.entity.ai.statemachine.AITarget;
+import com.minecolonies.api.entity.ai.statemachine.states.AIBlockingEventType;
 import com.minecolonies.api.entity.ai.statemachine.states.IAIState;
 import com.minecolonies.api.entity.citizen.VisibleCitizenStatus;
 import com.minecolonies.api.util.InventoryUtils;
 import com.minecolonies.api.util.ItemStackUtils;
 import com.minecolonies.api.util.Tuple;
+import com.minecolonies.api.util.WorldUtil;
 import com.minecolonies.coremod.colony.buildings.AbstractBuildingFurnaceUser;
 import com.minecolonies.coremod.colony.interactionhandling.StandardInteraction;
 import com.minecolonies.coremod.colony.jobs.AbstractJob;
@@ -20,6 +23,7 @@ import net.minecraft.tileentity.FurnaceTileEntity;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.text.TranslationTextComponent;
+import net.minecraft.world.World;
 import net.minecraftforge.items.wrapper.InvWrapper;
 import org.jetbrains.annotations.NotNull;
 
@@ -62,6 +66,7 @@ public abstract class AbstractEntityAIUsesFurnace<J extends AbstractJob<?, J>, B
           new AITarget(IDLE, START_WORKING, STANDARD_DELAY),
           new AITarget(START_WORKING, this::startWorking, TICKS_SECOND),
           new AITarget(START_USING_FURNACE, this::fillUpFurnace, STANDARD_DELAY),
+          new AIEventTarget(AIBlockingEventType.AI_BLOCKING, this::accelerateFurnaces, TICKS_SECOND),
           new AITarget(RETRIEVING_END_PRODUCT_FROM_FURNACE, this::retrieveSmeltableFromFurnace, STANDARD_DELAY));
     }
 
@@ -199,6 +204,34 @@ public abstract class AbstractEntityAIUsesFurnace<J extends AbstractJob<?, J>, B
         }
 
         return checkIfAbleToSmelt(amountOfFuelInBuilding + amountOfFuelInInv, amountOfSmeltableInBuilding + amountOfSmeltableInInv);
+    }
+
+    /**
+     * Actually accelerate the furnaces
+     */
+    private IAIState accelerateFurnaces()
+    {
+        final int accelerationTicks = (worker.getCitizenData().getCitizenSkillHandler().getLevel(getOwnBuilding().getPrimarySkill()) / 10) * 2;
+        final World world = getOwnBuilding().getColony().getWorld();
+        for (final BlockPos pos : getOwnBuilding().getFurnaces())
+        {
+            if (WorldUtil.isBlockLoaded(world, pos))
+            {
+                final TileEntity entity = world.getTileEntity(pos);
+                if (entity instanceof FurnaceTileEntity)
+                {
+                    final FurnaceTileEntity furnace = (FurnaceTileEntity) entity;
+                    for(int i = 0; i < accelerationTicks; i++)
+                    {
+                        if (furnace.isBurning()) 
+                        {
+                            furnace.tick();
+                        }
+                    }
+                }
+            }
+        }
+        return getState();
     }
 
     /**

--- a/src/main/resources/data/minecolonies/tags/items/farmer_product.json
+++ b/src/main/resources/data/minecolonies/tags/items/farmer_product.json
@@ -3,6 +3,8 @@
   "values": [
     "minecraft:hay_block",
     "#forge:seeds",
-    "minecolonies:composted_dirt"
+    "minecolonies:composted_dirt",
+    "minecraft:melon",
+    "minecraft:coarse_dirt"
   ]
 }


### PR DESCRIPTION
# Changes proposed in this pull request:
- Set most crafters to have primary skill improve recipes and secondary skill effect speed
- Blacksmith and Fletcher are the reverse
- Make furnace burn faster for Smelter based on skill
- Fix crusher to actually resolve clay balls by removing old code
- Add Melon and coarse dirt to Farmer 
- Add new auto-resolve recipe for colored wool to white wool
    - This will pick the colored wool with the most stock in the warehouse to dye white
- Resolve multiple recipes with the same output at the same crafter
    - This will pick the recipe by figuring out what the majority ingredient is, and choosing the one with the most stock at the warehouse for that ingredient

Review please
