### PR TITLE
Sleeping changes (#5593)

### DIFF
--- a/src/api/java/com/minecolonies/api/colony/ICitizenData.java
+++ b/src/api/java/com/minecolonies/api/colony/ICitizenData.java
@@ -233,4 +233,9 @@ public interface ICitizenData extends ICivilianData
      * @return the random.
      */
     Random getRandom();
+
+    /**
+     * Applies the effects of research to the data's entity
+     */
+    void applyResearchEffects();
 }

--- a/src/api/java/com/minecolonies/api/colony/interactionhandling/ModInteractionResponseHandlers.java
+++ b/src/api/java/com/minecolonies/api/colony/interactionhandling/ModInteractionResponseHandlers.java
@@ -12,15 +12,17 @@ public final class ModInteractionResponseHandlers
     /**
      * List of IDs.
      */
-    public static final ResourceLocation STANDARD    = new ResourceLocation(Constants.MOD_ID, "standard");
-    public static final ResourceLocation POS         = new ResourceLocation(Constants.MOD_ID, "pos");
-    public static final ResourceLocation REQUEST     = new ResourceLocation(Constants.MOD_ID, "request");
-    public static final ResourceLocation RECRUITMENT = new ResourceLocation(Constants.MOD_ID, "recruitment");
+    public static final ResourceLocation STANDARD            = new ResourceLocation(Constants.MOD_ID, "standard");
+    public static final ResourceLocation SIMPLE_NOTIFICATION = new ResourceLocation(Constants.MOD_ID, "simplenotification");
+    public static final ResourceLocation POS                 = new ResourceLocation(Constants.MOD_ID, "pos");
+    public static final ResourceLocation REQUEST             = new ResourceLocation(Constants.MOD_ID, "request");
+    public static final ResourceLocation RECRUITMENT         = new ResourceLocation(Constants.MOD_ID, "recruitment");
 
     /**
      * List of entries.
      */
     public static InteractionResponseHandlerEntry standard;
+    public static InteractionResponseHandlerEntry simpleNotification;
     public static InteractionResponseHandlerEntry pos;
     public static InteractionResponseHandlerEntry request;
     public static InteractionResponseHandlerEntry recruitment;

--- a/src/api/java/com/minecolonies/api/entity/citizen/AbstractEntityCitizen.java
+++ b/src/api/java/com/minecolonies/api/entity/citizen/AbstractEntityCitizen.java
@@ -392,6 +392,10 @@ public abstract class AbstractEntityCitizen extends AbstractCivilianEntity imple
      */
     public void setRenderMetadata(final String renderMetadata)
     {
+        if (renderMetadata.equals(getRenderMetadata()))
+        {
+            return;
+        }
         this.renderMetadata = renderMetadata;
         dataManager.set(DATA_RENDER_METADATA, getRenderMetadata());
     }
@@ -570,11 +574,6 @@ public abstract class AbstractEntityCitizen extends AbstractCivilianEntity imple
      * Decrease the saturation of the citizen for 1 action.
      */
     public abstract void decreaseSaturationForContinuousAction();
-
-    /**
-     * Spawn eating particles for the citizen.
-     */
-    public abstract void spawnEatingParticle();
 
     /**
      * The Handler for all experience related methods.

--- a/src/api/java/com/minecolonies/api/entity/citizen/citizenhandlers/ICitizenSleepHandler.java
+++ b/src/api/java/com/minecolonies/api/entity/citizen/citizenhandlers/ICitizenSleepHandler.java
@@ -35,6 +35,13 @@ public interface ICitizenSleepHandler
     void onWakeUp();
 
     /**
+     * Determines the home position
+     *
+     * @return home pos or null
+     */
+    BlockPos findHomePos();
+
+    /**
      * Get the bed location of the citizen.
      *
      * @return the bed location.
@@ -54,4 +61,11 @@ public interface ICitizenSleepHandler
      * @return the offset.
      */
     float getRenderOffsetZ();
+
+    /**
+     * Whether we should start to go sleeping
+     *
+     * @return true if should sleep
+     */
+    boolean shouldGoSleep();
 }

--- a/src/api/java/com/minecolonies/api/util/SoundUtils.java
+++ b/src/api/java/com/minecolonies/api/util/SoundUtils.java
@@ -2,7 +2,6 @@ package com.minecolonies.api.util;
 
 import com.minecolonies.api.MinecoloniesAPIProxy;
 import com.minecolonies.api.colony.ICitizenData;
-import com.minecolonies.api.entity.citizen.AbstractEntityCitizen;
 import com.minecolonies.api.sounds.EventType;
 import net.minecraft.util.SoundCategory;
 import net.minecraft.util.SoundEvent;
@@ -15,7 +14,6 @@ import java.util.Map;
 import java.util.Random;
 
 import static com.minecolonies.api.sounds.ModSoundEvents.SOUND_EVENTS;
-import static com.minecolonies.api.util.constant.Constants.TICKS_SECOND;
 
 /**
  * Utilities for playing sounds.
@@ -76,7 +74,7 @@ public final class SoundUtils
      */
     public static void playRandomSound(@NotNull final World worldIn, @NotNull final BlockPos pos, @NotNull final ICitizenData citizen)
     {
-        final double v = rand.nextDouble() * TICKS_SECOND;
+        final double v = rand.nextDouble();
         if (v <= 0.1)
         {
             if (citizen.getSaturation() < 2)

--- a/src/api/java/com/minecolonies/api/util/WorldUtil.java
+++ b/src/api/java/com/minecolonies/api/util/WorldUtil.java
@@ -9,7 +9,6 @@ import net.minecraft.world.World;
 import net.minecraft.world.chunk.ChunkStatus;
 
 import static com.minecolonies.api.util.constant.CitizenConstants.NIGHT;
-import static com.minecolonies.api.util.constant.CitizenConstants.NOON;
 
 /**
  * Class which has world related util functions like chunk load checks
@@ -119,11 +118,23 @@ public class WorldUtil
 
     /**
      * Check if it's currently day inn the world.
+     *
      * @param world the world to check.
      * @return true if so.
      */
     public static boolean isDayTime(final World world)
     {
         return world.getDayTime() % 24000 <= NIGHT;
+    }
+
+    /**
+     * Check if it's currently day inn the world.
+     *
+     * @param world the world to check.
+     * @return true if so.
+     */
+    public static boolean isPastTime(final World world, final int pastTime)
+    {
+        return world.getDayTime() % 24000 <= pastTime;
     }
 }

--- a/src/main/java/com/minecolonies/apiimp/initializer/ModInteractionsInitializer.java
+++ b/src/main/java/com/minecolonies/apiimp/initializer/ModInteractionsInitializer.java
@@ -26,6 +26,11 @@ public final class ModInteractionsInitializer
                                                     .setRegistryName(ModInteractionResponseHandlers.STANDARD)
                                                     .createEntry();
 
+        ModInteractionResponseHandlers.simpleNotification = new InteractionResponseHandlerEntry.Builder()
+                                                              .setResponseHandlerProducer(StandardInteraction::new)
+                                                              .setRegistryName(ModInteractionResponseHandlers.SIMPLE_NOTIFICATION)
+                                                              .createEntry();
+
         ModInteractionResponseHandlers.pos = new InteractionResponseHandlerEntry.Builder()
                                                .setResponseHandlerProducer(PosBasedInteraction::new)
                                                .setRegistryName(ModInteractionResponseHandlers.POS)
@@ -44,6 +49,7 @@ public final class ModInteractionsInitializer
         reg.register(ModInteractionResponseHandlers.standard);
         reg.register(ModInteractionResponseHandlers.pos);
         reg.register(ModInteractionResponseHandlers.request);
+        reg.register(ModInteractionResponseHandlers.simpleNotification);
         reg.register(ModInteractionResponseHandlers.recruitment);
     }
 }

--- a/src/main/java/com/minecolonies/coremod/colony/CitizenData.java
+++ b/src/main/java/com/minecolonies/coremod/colony/CitizenData.java
@@ -23,8 +23,13 @@ import com.minecolonies.api.util.constant.Suppression;
 import com.minecolonies.coremod.MineColonies;
 import com.minecolonies.coremod.colony.interactionhandling.ServerCitizenInteraction;
 import com.minecolonies.coremod.entity.ai.basic.AbstractAISkeleton;
+import com.minecolonies.coremod.entity.citizen.EntityCitizen;
 import com.minecolonies.coremod.entity.citizen.citizenhandlers.CitizenHappinessHandler;
 import com.minecolonies.coremod.entity.citizen.citizenhandlers.CitizenSkillHandler;
+import com.minecolonies.coremod.research.AdditionModifierResearchEffect;
+import com.minecolonies.coremod.research.MultiplierModifierResearchEffect;
+import com.minecolonies.coremod.util.AttributeModifierUtils;
+import net.minecraft.entity.ai.attributes.AttributeModifier;
 import net.minecraft.entity.ai.attributes.Attributes;
 import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.entity.player.ServerPlayerEntity;
@@ -45,8 +50,9 @@ import java.util.*;
 import java.util.stream.Collectors;
 
 import static com.minecolonies.api.entity.citizen.AbstractEntityCitizen.*;
-import static com.minecolonies.api.util.constant.CitizenConstants.BASE_MAX_HEALTH;
-import static com.minecolonies.api.util.constant.CitizenConstants.MAX_CITIZEN_LEVEL;
+import static com.minecolonies.api.research.util.ResearchConstants.HEALTH;
+import static com.minecolonies.api.research.util.ResearchConstants.WALKING;
+import static com.minecolonies.api.util.constant.CitizenConstants.*;
 import static com.minecolonies.api.util.constant.NbtTagConstants.*;
 
 /**
@@ -394,6 +400,8 @@ public class CitizenData implements ICitizenData
         setLastPosition(citizen.getPosition());
 
         citizen.getCitizenJobHandler().onJobChanged(citizen.getCitizenJobHandler().getColonyJob());
+
+        applyResearchEffects();
 
         markDirty();
     }
@@ -1128,5 +1136,32 @@ public class CitizenData implements ICitizenData
     public Random getRandom()
     {
         return random;
+    }
+
+    @Override
+    public void applyResearchEffects()
+    {
+        if (getEntity().isPresent())
+        {
+            final AbstractEntityCitizen citizen = getEntity().get();
+
+            // Applies entity related research effects.
+            citizen.getNavigator().getPathingOptions().setCanUseRails(((EntityCitizen) citizen).canPathOnRails());
+
+            final MultiplierModifierResearchEffect speedEffect =
+              colony.getResearchManager().getResearchEffects().getEffect(WALKING, MultiplierModifierResearchEffect.class);
+            if (speedEffect != null)
+            {
+                citizen.getAttribute(Attributes.MOVEMENT_SPEED).setBaseValue(BASE_MOVEMENT_SPEED + (BASE_MOVEMENT_SPEED * speedEffect.getEffect()));
+            }
+
+            final AdditionModifierResearchEffect healthEffect =
+              colony.getResearchManager().getResearchEffects().getEffect(HEALTH, AdditionModifierResearchEffect.class);
+            if (healthEffect != null)
+            {
+                final AttributeModifier healthModLevel = new AttributeModifier(HEALTH, healthEffect.getEffect(), AttributeModifier.Operation.ADDITION);
+                AttributeModifierUtils.addHealthModifier(citizen, healthModLevel);
+            }
+        }
     }
 }

--- a/src/main/java/com/minecolonies/coremod/colony/buildings/AbstractBuildingWorker.java
+++ b/src/main/java/com/minecolonies/coremod/colony/buildings/AbstractBuildingWorker.java
@@ -400,7 +400,7 @@ public abstract class AbstractBuildingWorker extends AbstractBuilding implements
 
                 for(PlayerEntity player :colony.getMessagePlayerEntities())
                 {
-                    player.sendMessage(message);
+                    player.sendMessage(message, player.getUniqueID());
                 }
             }
         }

--- a/src/main/java/com/minecolonies/coremod/colony/buildings/AbstractBuildingWorker.java
+++ b/src/main/java/com/minecolonies/coremod/colony/buildings/AbstractBuildingWorker.java
@@ -60,12 +60,13 @@ import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
 import static com.minecolonies.api.research.util.ResearchConstants.RECIPES;
-import static com.minecolonies.api.util.constant.CitizenConstants.BONUS_BUILDING_LEVEL;
+import static com.minecolonies.api.util.constant.Constants.MOD_ID;
 import static com.minecolonies.api.util.constant.NbtTagConstants.*;
 import static com.minecolonies.api.util.constant.ToolLevelConstants.TOOL_LEVEL_MAXIMUM;
 import static com.minecolonies.api.util.constant.ToolLevelConstants.TOOL_LEVEL_WOOD_OR_GOLD;
-import static com.minecolonies.api.util.constant.Constants.MOD_ID;
-import static com.minecolonies.api.util.constant.TranslationConstants.RECIPE_IMPROVED;;
+import static com.minecolonies.api.util.constant.TranslationConstants.RECIPE_IMPROVED;
+
+;
 
 /**
  * The abstract class for each worker building.
@@ -720,7 +721,7 @@ public abstract class AbstractBuildingWorker extends AbstractBuilding implements
     @Override
     public boolean canWorkDuringTheRain()
     {
-        return getBuildingLevel() >= BONUS_BUILDING_LEVEL;
+        return false;
     }
 
     @Override

--- a/src/main/java/com/minecolonies/coremod/colony/buildings/workerbuildings/BuildingUniversity.java
+++ b/src/main/java/com/minecolonies/coremod/colony/buildings/workerbuildings/BuildingUniversity.java
@@ -212,6 +212,11 @@ public class BuildingUniversity extends AbstractBuildingWorker
                   .getResearch(research.getBranch(), research.getId())
                   .research(colony.getResearchManager().getResearchEffects(), colony.getResearchManager().getResearchTree()))
             {
+                for (final ICitizenData citizen : colony.getCitizenManager().getCitizens())
+                {
+                    citizen.applyResearchEffects();
+                }
+
                 LanguageHandler.sendPlayersMessage(colony.getMessagePlayerEntities(),
                   RESEARCH_CONCLUDED + random.nextInt(3),
                   IGlobalResearchTree.getInstance().getResearch(research.getBranch(), research.getId()).getDesc());

--- a/src/main/java/com/minecolonies/coremod/colony/interactionhandling/PosBasedInteraction.java
+++ b/src/main/java/com/minecolonies/coremod/colony/interactionhandling/PosBasedInteraction.java
@@ -18,6 +18,8 @@ import java.util.Collections;
 import java.util.List;
 import java.util.function.BiPredicate;
 
+import static com.minecolonies.coremod.colony.interactionhandling.StandardInteraction.*;
+
 /**
  * The position based interaction response handler.
  */
@@ -27,10 +29,10 @@ public class PosBasedInteraction extends ServerCitizenInteraction
 
     @SuppressWarnings("unchecked")
     private static final Tuple<ITextComponent, ITextComponent>[] responses = (Tuple<ITextComponent, ITextComponent>[]) new Tuple[] {
-      new Tuple<>(new TranslationTextComponent("com.minecolonies.coremod.gui.chat.okay"), null),
-      new Tuple<>(new TranslationTextComponent("com.minecolonies.coremod.gui.chat.ignore"), null),
-      new Tuple<>(new TranslationTextComponent("com.minecolonies.coremod.gui.chat.remindmelater"), null),
-      new Tuple<>(new TranslationTextComponent("com.minecolonies.coremod.gui.chat.skipchitchat"), null)};
+      new Tuple<>(new TranslationTextComponent(INTERACTION_R_OKAY), null),
+      new Tuple<>(new TranslationTextComponent(INTERACTION_R_IGNORE), null),
+      new Tuple<>(new TranslationTextComponent(INTERACTION_R_REMIND), null),
+      new Tuple<>(new TranslationTextComponent(INTERACTION_R_SKIP), null)};
 
     /**
      * The position this is related to.

--- a/src/main/java/com/minecolonies/coremod/colony/interactionhandling/RequestBasedInteraction.java
+++ b/src/main/java/com/minecolonies/coremod/colony/interactionhandling/RequestBasedInteraction.java
@@ -25,6 +25,8 @@ import java.util.Collections;
 import java.util.List;
 import java.util.function.BiPredicate;
 
+import static com.minecolonies.coremod.colony.interactionhandling.StandardInteraction.*;
+
 /**
  * The request based interaction response handler.
  */
@@ -34,17 +36,17 @@ public class RequestBasedInteraction extends ServerCitizenInteraction
 
     @SuppressWarnings("unchecked")
     private static final Tuple<ITextComponent, ITextComponent>[] tuples = (Tuple<ITextComponent, ITextComponent>[]) new Tuple[] {
-      new Tuple<>(new TranslationTextComponent("com.minecolonies.coremod.gui.chat.okay"), null),
-      new Tuple<>(new TranslationTextComponent("com.minecolonies.coremod.gui.chat.remindmelater"), null),
+      new Tuple<>(new TranslationTextComponent(INTERACTION_R_OKAY), null),
+      new Tuple<>(new TranslationTextComponent(INTERACTION_R_REMIND), null),
       new Tuple<>(new TranslationTextComponent("com.minecolonies.coremod.gui.chat.cancel"), null),
       new Tuple<>(new TranslationTextComponent("com.minecolonies.coremod.gui.chat.fulfill"), null)};
 
     @SuppressWarnings("unchecked")
     private static final Tuple<ITextComponent, ITextComponent>[] tuplesAsync = (Tuple<ITextComponent, ITextComponent>[]) new Tuple[] {
-      new Tuple<>(new TranslationTextComponent("com.minecolonies.coremod.gui.chat.okay"), null),
-      new Tuple<>(new TranslationTextComponent("com.minecolonies.coremod.gui.chat.ignore"), null),
-      new Tuple<>(new TranslationTextComponent("com.minecolonies.coremod.gui.chat.remindmelater"), null),
-      new Tuple<>(new TranslationTextComponent("com.minecolonies.coremod.gui.chat.skipchitchat"), null)};
+      new Tuple<>(new TranslationTextComponent(INTERACTION_R_OKAY), null),
+      new Tuple<>(new TranslationTextComponent(INTERACTION_R_IGNORE), null),
+      new Tuple<>(new TranslationTextComponent(INTERACTION_R_REMIND), null),
+      new Tuple<>(new TranslationTextComponent(INTERACTION_R_SKIP), null)};
 
     /**
      * The request this is related to.

--- a/src/main/java/com/minecolonies/coremod/colony/interactionhandling/SimpleNotificationInteraction.java
+++ b/src/main/java/com/minecolonies/coremod/colony/interactionhandling/SimpleNotificationInteraction.java
@@ -1,0 +1,75 @@
+package com.minecolonies.coremod.colony.interactionhandling;
+
+import com.ldtteam.blockout.views.Window;
+import com.minecolonies.api.colony.ICitizenData;
+import com.minecolonies.api.colony.ICitizenDataView;
+import com.minecolonies.api.colony.interactionhandling.IChatPriority;
+import net.minecraft.entity.player.PlayerEntity;
+import net.minecraft.util.text.ITextComponent;
+import net.minecraft.util.text.TranslationTextComponent;
+import net.minecraftforge.api.distmarker.Dist;
+import net.minecraftforge.api.distmarker.OnlyIn;
+
+import static com.minecolonies.api.colony.interactionhandling.ModInteractionResponseHandlers.SIMPLE_NOTIFICATION;
+
+/**
+ * A simple interaction which displays until an acceptable response is clicked
+ */
+public class SimpleNotificationInteraction extends StandardInteraction
+{
+    /**
+     * Whether this interaction is active
+     */
+    private boolean active = true;
+
+    public SimpleNotificationInteraction(
+      final ITextComponent inquiry,
+      final IChatPriority priority)
+    {
+        super(inquiry, null, priority);
+    }
+
+    @Override
+    public void onServerResponseTriggered(final ITextComponent response, final PlayerEntity player, final ICitizenData data)
+    {
+        super.onServerResponseTriggered(response, player, data);
+        onResponse(response);
+    }
+
+    @Override
+    @OnlyIn(Dist.CLIENT)
+    public boolean onClientResponseTriggered(final ITextComponent response, final PlayerEntity player, final ICitizenDataView data, final Window window)
+    {
+        onResponse(response);
+        return super.onClientResponseTriggered(response, player, data, window);
+    }
+
+    /**
+     * Removes the interaction after a response
+     *
+     * @param response response
+     */
+    private void onResponse(final ITextComponent response)
+    {
+        if (response instanceof TranslationTextComponent)
+        {
+            if (((TranslationTextComponent) response).getKey().equals(INTERACTION_R_OKAY)
+                  || ((TranslationTextComponent) response).getKey().equals(INTERACTION_R_IGNORE))
+            {
+                active = false;
+            }
+        }
+    }
+
+    @Override
+    public String getType()
+    {
+        return SIMPLE_NOTIFICATION.getPath();
+    }
+
+    @Override
+    public boolean isValid(final ICitizenData citizen)
+    {
+        return active;
+    }
+}

--- a/src/main/java/com/minecolonies/coremod/colony/interactionhandling/StandardInteraction.java
+++ b/src/main/java/com/minecolonies/coremod/colony/interactionhandling/StandardInteraction.java
@@ -17,12 +17,20 @@ import java.util.List;
  */
 public class StandardInteraction extends ServerCitizenInteraction
 {
+    /**
+     * Standard responses
+     */
+    public static final String INTERACTION_R_OKAY   = "com.minecolonies.coremod.gui.chat.okay";
+    public static final String INTERACTION_R_IGNORE = "com.minecolonies.coremod.gui.chat.ignore";
+    public static final String INTERACTION_R_REMIND = "com.minecolonies.coremod.gui.chat.remindmelater";
+    public static final String INTERACTION_R_SKIP   = "com.minecolonies.coremod.gui.chat.skipchitchat";
+
     @SuppressWarnings("unchecked")
     private static final Tuple<ITextComponent, ITextComponent>[] tuples = (Tuple<ITextComponent, ITextComponent>[]) new Tuple[] {
-      new Tuple<>(new TranslationTextComponent("com.minecolonies.coremod.gui.chat.okay"), null),
-      new Tuple<>(new TranslationTextComponent("com.minecolonies.coremod.gui.chat.ignore"), null),
-      new Tuple<>(new TranslationTextComponent("com.minecolonies.coremod.gui.chat.remindmelater"), null),
-      new Tuple<>(new TranslationTextComponent("com.minecolonies.coremod.gui.chat.skipchitchat"), null)};
+      new Tuple<>(new TranslationTextComponent(INTERACTION_R_OKAY), null),
+      new Tuple<>(new TranslationTextComponent(INTERACTION_R_IGNORE), null),
+      new Tuple<>(new TranslationTextComponent(INTERACTION_R_REMIND), null),
+      new Tuple<>(new TranslationTextComponent(INTERACTION_R_SKIP), null)};
 
     /**
      * The server interaction response handler with custom validator.

--- a/src/main/java/com/minecolonies/coremod/entity/SittingEntity.java
+++ b/src/main/java/com/minecolonies/coremod/entity/SittingEntity.java
@@ -96,17 +96,19 @@ public class SittingEntity extends Entity
 
         if (!this.isBeingRidden() || maxLifeTime-- < 0)
         {
+            // Upsizes entity again
+            if (lastPassenger != null)
+            {
+                lastPassenger.size = lastPassenger.size.scale(1.0f, 2.0f);
+            }
+
             if (getPassengers().size() > 0)
             {
                 Entity e = getPassengers().get(0);
                 this.removePassengers();
                 e.setPosition(this.getPosX(), this.getPosY() + 1, this.getPosZ());
             }
-            // Upsizes entity again
-            if (lastPassenger != null)
-            {
-                lastPassenger.size = lastPassenger.size.scale(1.0f, 2.0f);
-            }
+
             this.remove();
         }
     }

--- a/src/main/java/com/minecolonies/coremod/entity/ai/minimal/EntityAIEatTask.java
+++ b/src/main/java/com/minecolonies/coremod/entity/ai/minimal/EntityAIEatTask.java
@@ -527,6 +527,14 @@ public class EntityAIEatTask extends Goal
     }
 
     @Override
+    public void resetTask()
+    {
+        reset();
+        currentState = IDLE;
+        citizen.getCitizenData().setVisibleStatus(null);
+    }
+
+    @Override
     public void startExecuting()
     {
         citizen.getCitizenData().setVisibleStatus(VisibleCitizenStatus.EAT);

--- a/src/main/java/com/minecolonies/coremod/entity/ai/minimal/EntityAISleep.java
+++ b/src/main/java/com/minecolonies/coremod/entity/ai/minimal/EntityAISleep.java
@@ -5,8 +5,13 @@ import com.minecolonies.api.colony.IColony;
 import com.minecolonies.api.colony.buildings.IBuilding;
 import com.minecolonies.api.entity.ai.DesiredActivity;
 import com.minecolonies.api.entity.ai.Status;
+import com.minecolonies.api.entity.ai.statemachine.states.IState;
+import com.minecolonies.api.entity.ai.statemachine.tickratestatemachine.TickRateStateMachine;
+import com.minecolonies.api.entity.ai.statemachine.tickratestatemachine.TickingTransition;
+import com.minecolonies.api.entity.citizen.VisibleCitizenStatus;
 import com.minecolonies.api.sounds.EventType;
 import com.minecolonies.api.util.CompatibilityUtils;
+import com.minecolonies.api.util.Log;
 import com.minecolonies.api.util.SoundUtils;
 import com.minecolonies.api.util.WorldUtil;
 import com.minecolonies.coremod.Network;
@@ -18,11 +23,12 @@ import net.minecraft.block.BlockState;
 import net.minecraft.entity.ai.goal.Goal;
 import net.minecraft.state.properties.BedPart;
 import net.minecraft.tags.BlockTags;
-import net.minecraft.util.DamageSource;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.World;
 
 import java.util.EnumSet;
+
+import static com.minecolonies.coremod.entity.ai.minimal.EntityAISleep.SleepState.*;
 
 /**
  * AI to send Entity to sleep.
@@ -40,11 +46,6 @@ public class EntityAISleep extends Goal
     private static final int CHANCE = 33;
 
     /**
-     * Damage source if has to kill citizen.
-     */
-    private static final DamageSource CLEANUP_DAMAGE = new DamageSource("CleanUpTask");
-
-    /**
      * Max ticks of putting the citizen to bed.
      */
     private static final int MAX_BED_TICKS = 10;
@@ -60,19 +61,22 @@ public class EntityAISleep extends Goal
     private BlockPos usedBed = null;
 
     /**
-     * Check if the citizen woke up already.
-     */
-    private boolean wokeUp = true;
-
-    /**
-     * Timer for emitting sleeping particle effect
-     */
-    private int tickTimer = 0;
-
-    /**
      * Ticks of putting the citizen into bed.
      */
     private int bedTicks = 0;
+
+    public enum SleepState implements IState
+    {
+        AWAKE,
+        WALKING_HOME,
+        FIND_BED,
+        SLEEPING;
+    }
+
+    /**
+     * The AI's state machine
+     */
+    private TickRateStateMachine<SleepState> stateMachine;
 
     /**
      * Initiate the sleep task.
@@ -84,6 +88,64 @@ public class EntityAISleep extends Goal
         super();
         this.setMutexFlags(EnumSet.of(Flag.MOVE));
         this.citizen = citizen;
+        // 100 blocks - 30 seconds - straight line
+        stateMachine = new TickRateStateMachine<>(SleepState.AWAKE, e -> Log.getLogger().warn(e));
+        stateMachine.addTransition(new TickingTransition<>(AWAKE, this::wantSleep, () -> {
+            initAI();
+            return WALKING_HOME;
+        }, 20));
+
+        stateMachine.addTransition(new TickingTransition<>(WALKING_HOME, () -> true, this::walkHome, 30));
+
+        stateMachine.addTransition(new TickingTransition<>(FIND_BED, this::findBed, () -> SLEEPING, 30));
+
+        stateMachine.addTransition(new TickingTransition<>(SLEEPING, () -> !wantSleep(), () -> {
+            resetAI();
+            return AWAKE;
+        }, 20));
+        stateMachine.addTransition(new TickingTransition<>(SLEEPING, () -> true, this::sleep, TICK_INTERVAL));
+    }
+
+    /**
+     * Walking to the home/bed position
+     *
+     * @return
+     */
+    private SleepState walkHome()
+    {
+        // Go home
+        if (!citizen.getCitizenColonyHandler().isAtHome())
+        {
+            citizen.getCitizenData().setVisibleStatus(VisibleCitizenStatus.SLEEP);
+            goHome();
+            return WALKING_HOME;
+        }
+        return FIND_BED;
+    }
+
+    /**
+     * Tries to find a fitting bed, or timeouts
+     *
+     * @return true if continue to sleep
+     */
+    private boolean findBed()
+    {
+        if (!citizen.getCitizenSleepHandler().isAsleep() || bedTicks < MAX_BED_TICKS)
+        {
+            findBedAndTryToSleep();
+            return false;
+        }
+        return true;
+    }
+
+    /**
+     * Whether the citizen wants to sleep
+     *
+     * @return true if wants to sleep
+     */
+    private boolean wantSleep()
+    {
+        return citizen.getRevengeTarget() == null && (citizen.getDesiredActivity() == DesiredActivity.SLEEP);
     }
 
     /**
@@ -94,7 +156,8 @@ public class EntityAISleep extends Goal
     @Override
     public boolean shouldExecute()
     {
-        return citizen.getDesiredActivity() == DesiredActivity.SLEEP || !wokeUp;
+        stateMachine.tick();
+        return stateMachine.getState() != AWAKE;
     }
 
     /**
@@ -105,39 +168,13 @@ public class EntityAISleep extends Goal
     @Override
     public boolean shouldContinueExecuting()
     {
-        if (citizen.getDesiredActivity() == DesiredActivity.SLEEP)
-        {
-            return true;
-        }
-
-        citizen.getCitizenSleepHandler().onWakeUp();
-        if (usedBed != null)
-        {
-            final BlockState state = citizen.world.getBlockState(usedBed);
-            if (state.getBlock().isIn(BlockTags.BEDS))
-            {
-                final IColony colony = citizen.getCitizenColonyHandler().getColony();
-                if (colony != null && colony.getBuildingManager().getBuilding(citizen.getHomePosition()) != null)
-                {
-                    final IBuilding hut = colony.getBuildingManager().getBuilding(citizen.getHomePosition());
-                    if (hut instanceof BuildingHome)
-                    {
-                        setBedOccupied((BuildingHome) hut, false);
-                    }
-                }
-            }
-            usedBed = null;
-        }
-        wokeUp = true;
-        bedTicks = 0;
-        return false;
+        return stateMachine.getState() != AWAKE;
     }
 
     /**
-     * On start executing set his status to sleeping.
+     * On init set his status to sleeping.
      */
-    @Override
-    public void startExecuting()
+    public void initAI()
     {
         citizen.getCitizenStatusHandler().setStatus(Status.SLEEPING);
         usedBed = null;
@@ -149,29 +186,7 @@ public class EntityAISleep extends Goal
     @Override
     public void tick()
     {
-        tickTimer++;
-        if (tickTimer % TICK_INTERVAL != 0)
-        {
-            return;
-        }
-        tickTimer = 0;
-
-        // Go home
-        if (!citizen.getCitizenColonyHandler().isAtHome())
-        {
-            goHome();
-            return;
-        }
-
-        if (!citizen.getCitizenSleepHandler().isAsleep() || bedTicks < MAX_BED_TICKS)
-        {
-            findBedAndTryToSleep();
-        }
-        else
-        {
-            // Do the actual sleeping action.
-            sleep();
-        }
+        stateMachine.tick();
     }
 
     private void findBedAndTryToSleep()
@@ -186,7 +201,6 @@ public class EntityAISleep extends Goal
             }
         }
 
-        this.wokeUp = false;
         final IColony colony = citizen.getCitizenColonyHandler().getColony();
         if (colony != null && colony.getBuildingManager().getBuilding(citizen.getHomePosition()) != null)
         {
@@ -233,10 +247,11 @@ public class EntityAISleep extends Goal
     /**
      * Make sleeping
      */
-    private void sleep()
+    private SleepState sleep()
     {
         Network.getNetwork().sendToTrackingEntity(new SleepingParticleMessage(citizen.getPosX(), citizen.getPosY() + 1.0d, citizen.getPosZ()), citizen);
         //TODO make sleeping noises here.
+        return null;
     }
 
     /**
@@ -244,28 +259,10 @@ public class EntityAISleep extends Goal
      */
     private void goHome()
     {
-        final BlockPos pos = citizen.getHomePosition();
-        if (pos == null || pos.equals(BlockPos.ZERO))
-        {
-            //If the citizen has no colony as well, remove the citizen.
-            if (citizen.getCitizenColonyHandler().getColony() == null)
-            {
-                citizen.onDeath(CLEANUP_DAMAGE);
-            }
-            else
-            {
-                //If he has no homePosition strangely then try to  move to the colony.
-                citizen.isWorkerAtSiteWithMove(citizen.getCitizenColonyHandler().getColony().getCenter(), 2);
-            }
-            return;
-        }
-        else
-        {
-            citizen.isWorkerAtSiteWithMove(pos, 2);
-        }
+        final BlockPos pos = citizen.getCitizenSleepHandler().findHomePos();
+        citizen.isWorkerAtSiteWithMove(pos, 2);
 
         final int chance = citizen.getRandom().nextInt(CHANCE);
-
         if (chance <= 1 && citizen.getCitizenColonyHandler().getWorkBuilding() != null && citizen.getCitizenJobHandler().getColonyJob() != null)
         {
             SoundUtils.playSoundAtCitizenWith(CompatibilityUtils.getWorldFromCitizen(citizen), citizen.getPosition(), EventType.OFF_TO_BED, citizen.getCitizenData());
@@ -318,6 +315,37 @@ public class EntityAISleep extends Goal
     @Override
     public void resetTask()
     {
+        resetAI();
+        stateMachine.reset();
+    }
+
+    /**
+     * Resets the AI state
+     */
+    private void resetAI()
+    {
         citizen.getCitizenData().setVisibleStatus(null);
+        citizen.getCitizenSleepHandler().onWakeUp();
+
+        // Clean bed state
+        if (usedBed != null)
+        {
+            final BlockState state = citizen.world.getBlockState(usedBed);
+            if (state.getBlock().isIn(BlockTags.BEDS))
+            {
+                final IColony colony = citizen.getCitizenColonyHandler().getColony();
+                if (colony != null && colony.getBuildingManager().getBuilding(citizen.getHomePosition()) != null)
+                {
+                    final IBuilding hut = colony.getBuildingManager().getBuilding(citizen.getHomePosition());
+                    if (hut instanceof BuildingHome)
+                    {
+                        setBedOccupied((BuildingHome) hut, false);
+                    }
+                }
+            }
+            usedBed = null;
+        }
+
+        bedTicks = 0;
     }
 }

--- a/src/main/java/com/minecolonies/coremod/entity/citizen/EntityCitizen.java
+++ b/src/main/java/com/minecolonies/coremod/entity/citizen/EntityCitizen.java
@@ -17,7 +17,12 @@ import com.minecolonies.api.entity.CustomGoalSelector;
 import com.minecolonies.api.entity.ai.DesiredActivity;
 import com.minecolonies.api.entity.ai.Status;
 import com.minecolonies.api.entity.ai.pathfinding.IWalkToProxy;
+import com.minecolonies.api.entity.ai.statemachine.states.IState;
+import com.minecolonies.api.entity.ai.statemachine.tickratestatemachine.ITickRateStateMachine;
+import com.minecolonies.api.entity.ai.statemachine.tickratestatemachine.TickRateStateMachine;
+import com.minecolonies.api.entity.ai.statemachine.tickratestatemachine.TickingTransition;
 import com.minecolonies.api.entity.citizen.AbstractEntityCitizen;
+import com.minecolonies.api.entity.citizen.VisibleCitizenStatus;
 import com.minecolonies.api.entity.citizen.citizenhandlers.*;
 import com.minecolonies.api.entity.pathfinding.PathResult;
 import com.minecolonies.api.inventory.InventoryCitizen;
@@ -28,7 +33,6 @@ import com.minecolonies.api.util.*;
 import com.minecolonies.api.util.constant.TypeConstants;
 import com.minecolonies.coremod.MineColonies;
 import com.minecolonies.coremod.Network;
-import com.minecolonies.coremod.colony.Colony;
 import com.minecolonies.coremod.colony.buildings.AbstractBuildingGuards;
 import com.minecolonies.coremod.colony.jobs.*;
 import com.minecolonies.coremod.entity.SittingEntity;
@@ -40,11 +44,9 @@ import com.minecolonies.coremod.network.messages.server.colony.OpenInventoryMess
 import com.minecolonies.coremod.research.AdditionModifierResearchEffect;
 import com.minecolonies.coremod.research.MultiplierModifierResearchEffect;
 import com.minecolonies.coremod.research.UnlockAbilityResearchEffect;
-import com.minecolonies.coremod.util.AttributeModifierUtils;
 import com.minecolonies.coremod.util.TeleportHelper;
 import io.netty.buffer.Unpooled;
 import net.minecraft.entity.*;
-import net.minecraft.entity.ai.attributes.AttributeModifier;
 import net.minecraft.entity.ai.attributes.Attributes;
 import net.minecraft.entity.ai.goal.LookAtGoal;
 import net.minecraft.entity.ai.goal.LookAtWithoutMovingGoal;
@@ -61,7 +63,6 @@ import net.minecraft.item.ItemStack;
 import net.minecraft.item.NameTagItem;
 import net.minecraft.item.ShieldItem;
 import net.minecraft.nbt.CompoundNBT;
-import net.minecraft.nbt.ListNBT;
 import net.minecraft.network.PacketBuffer;
 import net.minecraft.potion.EffectInstance;
 import net.minecraft.potion.Effects;
@@ -92,7 +93,8 @@ import static com.minecolonies.api.util.constant.CitizenConstants.*;
 import static com.minecolonies.api.util.constant.Constants.*;
 import static com.minecolonies.api.util.constant.NbtTagConstants.*;
 import static com.minecolonies.api.util.constant.Suppression.INCREMENT_AND_DECREMENT_OPERATORS_SHOULD_NOT_BE_USED_IN_A_METHOD_CALL_OR_MIXED_WITH_OTHER_OPERATORS_IN_AN_EXPRESSION;
-import static com.minecolonies.api.util.constant.TranslationConstants.*;
+import static com.minecolonies.api.util.constant.TranslationConstants.CITIZEN_RENAME_NOT_ALLOWED;
+import static com.minecolonies.api.util.constant.TranslationConstants.CITIZEN_RENAME_SAME;
 
 /**
  * The Class used to represent the citizen entities.
@@ -121,7 +123,7 @@ public class EntityCitizen extends AbstractEntityCitizen
     /**
      * It's citizen Id.
      */
-    private       int                       citizenId       = 0;
+    private       int                       citizenId = 0;
     /**
      * The Walk to proxy (Shortest path through intermediate blocks).
      */
@@ -129,20 +131,7 @@ public class EntityCitizen extends AbstractEntityCitizen
     /**
      * Reference to the data representation inside the colony.
      */
-    @Nullable
     private       ICitizenData              citizenData;
-    /**
-     * The entities current Position.
-     */
-    private       BlockPos                  currentPosition = null;
-    /**
-     * Variable to check what time it is for the citizen.
-     */
-    private       boolean                   isDay           = true;
-    /**
-     * Backup of the citizen.
-     */
-    private       CompoundNBT               dataBackup      = null;
     /**
      * The citizen experience handler.
      */
@@ -211,6 +200,27 @@ public class EntityCitizen extends AbstractEntityCitizen
     private ILocation location = null;
 
     /**
+     * The entities states
+     */
+    private enum EntityState implements IState
+    {
+        INIT,
+        ACTIVE_SERVER,
+        ACTIVE_CLIENT,
+        INACTIVE;
+    }
+
+    /**
+     * The statemachine for citizens
+     */
+    private ITickRateStateMachine<EntityState> entityStatemachine = new TickRateStateMachine<>(EntityState.INIT, e -> Log.getLogger().warn(e));
+
+    /**
+     * The desired activity of the citizen
+     */
+    private DesiredActivity desiredActivity = DesiredActivity.IDLE;
+
+    /**
      * Constructor for a new citizen typed entity.
      *
      * @param type  the entity type.
@@ -235,6 +245,71 @@ public class EntityCitizen extends AbstractEntityCitizen
         this.enablePersistence();
         this.setCustomNameVisible(MineColonies.getConfig().getCommon().alwaysRenderNameTag.get());
         initTasks();
+
+        entityStatemachine.addTransition(new TickingTransition<>(EntityState.INIT, () -> true, this::initialize, 40));
+
+        entityStatemachine.addTransition(new TickingTransition<>(EntityState.ACTIVE_CLIENT, () -> {
+            citizenColonyHandler.updateColonyClient();
+            return false;
+        }, () -> null, 1));
+        entityStatemachine.addTransition(new TickingTransition<>(EntityState.ACTIVE_CLIENT, this::shouldBeInactive, () -> EntityState.INACTIVE, TICKS_20));
+        entityStatemachine.addTransition(new TickingTransition<>(EntityState.ACTIVE_CLIENT, this::refreshCitizenDataView, () -> null, TICKS_20));
+
+        entityStatemachine.addTransition(new TickingTransition<>(EntityState.ACTIVE_SERVER, this::updateSaturation, () -> null, HEAL_CITIZENS_AFTER));
+        entityStatemachine.addTransition(new TickingTransition<>(EntityState.ACTIVE_SERVER, this::updateVisualData, () -> null, 200));
+        entityStatemachine.addTransition(new TickingTransition<>(EntityState.ACTIVE_SERVER, this::onServerUpdateHandlers, () -> null, TICKS_20));
+        entityStatemachine.addTransition(new TickingTransition<>(EntityState.ACTIVE_SERVER, this::onTickDecrements, () -> null, 1));
+        entityStatemachine.addTransition(new TickingTransition<>(EntityState.ACTIVE_SERVER, this::shouldBeInactive, () -> EntityState.INACTIVE, TICKS_20));
+        entityStatemachine.addTransition(new TickingTransition<>(EntityState.ACTIVE_SERVER, this::determineDesiredActivity, () -> null, 100));
+
+        entityStatemachine.addTransition(new TickingTransition<>(EntityState.INACTIVE, this::isAlive, () -> EntityState.INIT, 100));
+    }
+
+    /**
+     * Whether the entity should be inactive
+     *
+     * @return
+     */
+    private boolean shouldBeInactive()
+    {
+        if (citizenData == null && citizenDataView == null)
+        {
+            return true;
+        }
+        return !isAlive();
+    }
+
+    /**
+     * Initializes vital colony and data connections before the entity is active
+     */
+    private EntityState initialize()
+    {
+        if (CompatibilityUtils.getWorldFromCitizen(this).isRemote)
+        {
+            citizenColonyHandler.updateColonyClient();
+            if (citizenColonyHandler.getColonyId() != 0 && citizenId != 0)
+            {
+                final IColonyView colonyView = IColonyManager.getInstance().getColonyView(citizenColonyHandler.getColonyId(), world.func_234923_W_().func_240901_a_());
+                if (colonyView != null)
+                {
+                    this.citizenDataView = colonyView.getCitizen(citizenId);
+                    if (citizenDataView != null)
+                    {
+                        return EntityState.ACTIVE_CLIENT;
+                    }
+                }
+            }
+        }
+        else
+        {
+            citizenColonyHandler.registerWithColony(citizenColonyHandler.getColonyId(), citizenId);
+            if (citizenData != null && isAlive() && citizenColonyHandler.getColony() != null)
+            {
+                return EntityState.ACTIVE_SERVER;
+            }
+        }
+
+        return null;
     }
 
     /**
@@ -343,8 +418,6 @@ public class EntityCitizen extends AbstractEntityCitizen
             compound.putInt(TAG_COLONY_ID, citizenColonyHandler.getColony().getID());
             compound.putInt(TAG_CITIZEN, citizenData.getId());
         }
-
-        compound.putBoolean(TAG_DAY, isDay);
         compound.putBoolean(TAG_MOURNING, mourning);
 
         citizenDiseaseHandler.write(compound);
@@ -364,16 +437,9 @@ public class EntityCitizen extends AbstractEntityCitizen
             citizenColonyHandler.registerWithColony(citizenColonyHandler.getColonyId(), citizenId);
         }
 
-        isDay = compound.getBoolean(TAG_DAY);
-
         if (compound.keySet().contains(TAG_MOURNING))
         {
             mourning = compound.getBoolean(TAG_MOURNING);
-        }
-
-        if (compound.keySet().contains(TAG_HELD_ITEM_SLOT) || compound.keySet().contains(TAG_OFFHAND_HELD_ITEM_SLOT))
-        {
-            this.dataBackup = compound;
         }
 
         citizenDiseaseHandler.read(compound);
@@ -386,40 +452,107 @@ public class EntityCitizen extends AbstractEntityCitizen
     public void livingTick()
     {
         super.livingTick();
+        entityStatemachine.tick();
+    }
 
-        decrementCallForHelpCooldown();
-
-        if (recentlyHit > 0)
+    /**
+     * Refreshes the saved view data
+     *
+     * @return false
+     */
+    public boolean refreshCitizenDataView()
+    {
+        if (citizenColonyHandler.getColonyId() != 0 && citizenId != 0)
         {
-            markDirty();
+            final IColonyView colonyView = IColonyManager.getInstance().getColonyView(citizenColonyHandler.getColonyId(), world.func_234923_W_().func_240901_a_());
+            if (colonyView != null)
+            {
+                this.citizenDataView = colonyView.getCitizen(citizenId);
+                this.getNavigator().getPathingOptions().setCanUseRails(canPathOnRails());
+            }
+        }
+        return false;
+    }
+
+    /**
+     * Decrements values each tick
+     *
+     * @return false
+     */
+    private boolean onTickDecrements()
+    {
+        decrementCallForHelpCooldown();
+        decreaseWalkingSaturation();
+        return false;
+    }
+
+    /**
+     * Updates handlers on living tick, each 20 ticks.
+     */
+    private boolean onServerUpdateHandlers()
+    {
+        // Every 20 ticks
+        citizenExperienceHandler.gatherXp();
+        citizenItemHandler.pickupItems();
+        citizenData.setLastPosition(getPosition());
+        citizenDiseaseHandler.tick();
+        onLivingSoundUpdate();
+        return false;
+    }
+
+    /**
+     * Updates visual data for the citizen
+     *
+     * @return false
+     */
+    private boolean updateVisualData()
+    {
+        final ItemStack hat = getItemStackFromSlot(EquipmentSlotType.HEAD);
+        if (LocalDate.now(Clock.systemDefaultZone()).getMonth() == Month.DECEMBER
+              && MineColonies.getConfig().getCommon().holidayFeatures.get()
+              && !(getCitizenJobHandler().getColonyJob() instanceof JobStudent))
+        {
+            if (hat.isEmpty())
+            {
+                this.setItemStackToSlot(EquipmentSlotType.HEAD, new ItemStack(ModItems.santaHat));
+            }
+        }
+        else if (!hat.isEmpty() && hat.getItem() == ModItems.santaHat)
+        {
+            this.setItemStackToSlot(EquipmentSlotType.HEAD, ItemStackUtils.EMPTY);
+        }
+        this.setCustomNameVisible(MineColonies.getConfig().getCommon().alwaysRenderNameTag.get());
+
+        if (!citizenColonyHandler.getColony().getStyle().equals(getDataManager().get(DATA_STYLE)))
+        {
+            getDataManager().set(DATA_STYLE, citizenColonyHandler.getColony().getStyle());
+        }
+        if (!citizenData.getTextureSuffix().equals(getDataManager().get(DATA_TEXTURE_SUFFIX)))
+        {
+            getDataManager().set(DATA_TEXTURE_SUFFIX, citizenData.getTextureSuffix());
         }
 
-        if (CompatibilityUtils.getWorldFromCitizen(this).isRemote)
+        return false;
+    }
+
+    /**
+     * Adds potion effect and regenerates life, depending on saturation
+     */
+    private boolean updateSaturation()
+    {
+        checkHeal();
+        if (citizenData.getSaturation() <= 0)
         {
-            citizenColonyHandler.updateColonyClient();
-            if (citizenColonyHandler.getColonyId() != 0 && citizenId != 0 && getOffsetTicks() % TICKS_20 == 0)
+            if (this.getActivePotionEffect(Effects.SLOWNESS) == null)
             {
-                final IColonyView colonyView = IColonyManager.getInstance().getColonyView(citizenColonyHandler.getColonyId(), world.func_234923_W_().func_240901_a_());
-                if (colonyView != null)
-                {
-                    this.citizenDataView = colonyView.getCitizen(citizenId);
-                    this.getNavigator().getPathingOptions().setCanUseRails(canPathOnRails());
-                }
+                this.addPotionEffect(new EffectInstance(Effects.SLOWNESS, TICKS_SECOND * 30));
             }
         }
         else
         {
-            onLivingUpdateServer();
+            this.removePotionEffect(Effects.SLOWNESS);
         }
-
-        updateMoveAwayPath();
-
-        citizenExperienceHandler.gatherXp();
-        onLivingUpdateOfCitizenData();
-
-        checkForDataBackupLoad();
-
-        checkHeal();
+        return false;
     }
 
     private void decrementCallForHelpCooldown()
@@ -459,70 +592,14 @@ public class EntityCitizen extends AbstractEntityCitizen
         return false;
     }
 
-    private void onLivingUpdateServer()
+    /**
+     * Reduces saturation for walking every 25 blocks.
+     */
+    private void decreaseWalkingSaturation()
     {
-        if (getOffsetTicks() % TICKS_20 == 0)
+        if (((int) (distanceWalkedModified + 1.0) % ACTIONS_EACH_BLOCKS_WALKED) == 0)
         {
-            onPrimaryLivingUpdateTick();
-        }
-
-        citizenDiseaseHandler.tick();
-        if (citizenJobHandler.getColonyJob() == null && WorldUtil.isDayTime(world))
-        {
-            updateCitizenStatus();
-        }
-
-        onLivingSoundUpdate();
-    }
-
-    private void updateMoveAwayPath()
-    {
-        if ((isEntityInsideOpaqueBlock()) && (moveAwayPath == null || !moveAwayPath.isInProgress()))
-        {
-            moveAwayPath = getNavigator().moveAwayFromXYZ(this.getPosition(), MOVE_AWAY_RANGE, MOVE_AWAY_SPEED);
-        }
-    }
-
-    private void onLivingUpdateOfCitizenData()
-    {
-        if (citizenData != null)
-        {
-            if (citizenData.getSaturation() <= 0)
-            {
-                if (this.getActivePotionEffect(Effects.SLOWNESS) == null)
-                {
-                    this.addPotionEffect(new EffectInstance(Effects.SLOWNESS, TICKS_SECOND * 30));
-                }
-            }
-            else
-            {
-                this.removePotionEffect(Effects.SLOWNESS);
-            }
-
-            if ((distanceWalkedModified + 1.0) % ACTIONS_EACH_BLOCKS_WALKED == 0)
-            {
-                decreaseSaturationForAction();
-            }
-        }
-    }
-
-    private void checkForDataBackupLoad()
-    {
-        if (dataBackup != null)
-        {
-            final ListNBT nbttaglist = dataBackup.getList("Inventory", 10);
-            this.getCitizenData().getInventory().read(nbttaglist);
-            if (dataBackup.keySet().contains(TAG_HELD_ITEM_SLOT))
-            {
-                this.getCitizenData().getInventory().setHeldItem(Hand.MAIN_HAND, dataBackup.getInt(TAG_HELD_ITEM_SLOT));
-            }
-
-            if (dataBackup.keySet().contains(TAG_OFFHAND_HELD_ITEM_SLOT))
-            {
-                this.getCitizenData().getInventory().setHeldItem(Hand.OFF_HAND, dataBackup.getInt(TAG_OFFHAND_HELD_ITEM_SLOT));
-            }
-
-            dataBackup = null;
+            decreaseSaturationForContinuousAction();
         }
     }
 
@@ -531,7 +608,7 @@ public class EntityCitizen extends AbstractEntityCitizen
      */
     private void checkHeal()
     {
-        if (citizenData != null && getOffsetTicks() % HEAL_CITIZENS_AFTER == 0 && getHealth() < getMaxHealth())
+        if (getHealth() < getMaxHealth())
         {
             double limitDecrease = 0;
             final AdditionModifierResearchEffect satLimitDecrease =
@@ -549,6 +626,7 @@ public class EntityCitizen extends AbstractEntityCitizen
             else if (citizenData.getSaturation() < LOW_SATURATION)
             {
                 healAmount = 0;
+                return;
             }
 
             final AdditionModifierResearchEffect healEffect =
@@ -566,71 +644,12 @@ public class EntityCitizen extends AbstractEntityCitizen
         }
     }
 
-    private void onPrimaryLivingUpdateTick()
-    {
-        final ItemStack hat = getItemStackFromSlot(EquipmentSlotType.HEAD);
-        if (LocalDate.now(Clock.systemDefaultZone()).getMonth() == Month.DECEMBER
-              && MineColonies.getConfig().getCommon().holidayFeatures.get()
-              && !(getCitizenJobHandler().getColonyJob() instanceof JobStudent))
-        {
-            if (hat.isEmpty())
-            {
-                this.setItemStackToSlot(EquipmentSlotType.HEAD, new ItemStack(ModItems.santaHat));
-            }
-        }
-        else if (!hat.isEmpty() && hat.getItem() == ModItems.santaHat)
-        {
-            this.setItemStackToSlot(EquipmentSlotType.HEAD, ItemStackUtils.EMPTY);
-        }
-
-        this.setCustomNameVisible(MineColonies.getConfig().getCommon().alwaysRenderNameTag.get());
-        citizenItemHandler.pickupItems();
-        citizenColonyHandler.registerWithColony(citizenColonyHandler.getColonyId(), citizenId);
-
-        if (citizenData != null)
-        {
-            citizenData.setLastPosition(getPosition());
-        }
-
-        if (getOffsetTicks() % TICKS_200 == 0)
-        {
-            this.getNavigator().getPathingOptions().setCanUseRails(canPathOnRails());
-
-            final MultiplierModifierResearchEffect speedEffect =
-              getCitizenColonyHandler().getColony().getResearchManager().getResearchEffects().getEffect(WALKING, MultiplierModifierResearchEffect.class);
-            if (speedEffect != null)
-            {
-                this.getAttribute(Attributes.MOVEMENT_SPEED).setBaseValue(BASE_MOVEMENT_SPEED + (BASE_MOVEMENT_SPEED * speedEffect.getEffect()));
-            }
-
-            final AdditionModifierResearchEffect healthEffect =
-              getCitizenColonyHandler().getColony().getResearchManager().getResearchEffects().getEffect(HEALTH, AdditionModifierResearchEffect.class);
-            if (healthEffect != null)
-            {
-                final AttributeModifier healthModLevel = new AttributeModifier(HEALTH, healthEffect.getEffect(), AttributeModifier.Operation.ADDITION);
-                AttributeModifierUtils.addHealthModifier(this, healthModLevel);
-            }
-        }
-
-        getDataManager().set(DATA_STYLE, citizenColonyHandler.getColony().getStyle());
-        getDataManager().set(DATA_TEXTURE_SUFFIX, citizenData.getTextureSuffix());
-    }
-
-    private void updateCitizenStatus()
-    {
-        if (isMourning())
-        {
-            citizenStatusHandler.setLatestStatus(new TranslationTextComponent(COM_MINECOLONIES_COREMOD_MOURN));
-        }
-        else
-        {
-            citizenStatusHandler.setLatestStatus(new TranslationTextComponent("com.minecolonies.coremod.status.waitingForWork"));
-        }
-    }
-
+    /**
+     * Plays a random sound by chance during day
+     */
     private void onLivingSoundUpdate()
     {
-        if (WorldUtil.isDayTime(world) && !world.isRaining() && citizenData != null)
+        if (WorldUtil.isDayTime(world))
         {
             SoundUtils.playRandomSound(world, this.getPosition(), citizenData);
         }
@@ -662,18 +681,10 @@ public class EntityCitizen extends AbstractEntityCitizen
 
         //Display some debug info always available while testing
         //Will help track down some hard to find bugs (Pathfinding etc.)
-        //TODO: Is this actually needed here?
-        if (citizenData != null)
+        if (citizenJobHandler.getColonyJob() != null && MineColonies.getConfig().getCommon().enableInDevelopmentFeatures.get())
         {
-            if (citizenJobHandler.getColonyJob() != null && MineColonies.getConfig().getCommon().enableInDevelopmentFeatures.get())
-            {
-                setCustomName(new StringTextComponent(
-                  citizenData.getName() + " (" + citizenStatusHandler.getStatus() + ")[" + citizenJobHandler.getColonyJob().getNameTagDescription() + "]"));
-            }
-            else
-            {
-                setCustomName(new StringTextComponent(citizenData.getName()));
-            }
+            setCustomName(new StringTextComponent(
+              citizenData.getName() + " (" + citizenStatusHandler.getStatus() + ")[" + citizenJobHandler.getColonyJob().getNameTagDescription() + "]"));
         }
     }
 
@@ -763,48 +774,6 @@ public class EntityCitizen extends AbstractEntityCitizen
         if (citizenData != null)
         {
             citizenData.markDirty();
-        }
-    }
-
-    @Override
-    @NotNull
-    public DesiredActivity getDesiredActivity()
-    {
-        final DesiredActivity primaryActivity = determinePrimaryActivity();
-        if (primaryActivity != null)
-        {
-            return primaryActivity;
-        }
-
-        // Random delay of 60 seconds to detect a new day/night/rain/sun
-        if (Colony.shallUpdate(world, TICKS_SECOND * SECONDS_A_MINUTE))
-        {
-            return determineTaskActivity();
-        }
-
-        if (isDay)
-        {
-            if (isChild() && getCitizenJobHandler().getColonyJob() instanceof JobPupil && world.getDayTime() % 24000 > NOON)
-            {
-                if (getCitizenData().getStatus() == null)
-                {
-                    getCitizenData().setVisibleStatus(HOUSE);
-                }
-                return DesiredActivity.IDLE;
-            }
-            if (hidingFromRain)
-            {
-                if (getCitizenData().getStatus() == null)
-                {
-                    getCitizenData().setVisibleStatus(BAD_WEATHER);
-                }
-                return DesiredActivity.IDLE;
-            }
-            return DesiredActivity.WORK;
-        }
-        else
-        {
-            return DesiredActivity.SLEEP;
         }
     }
 
@@ -915,15 +884,6 @@ public class EntityCitizen extends AbstractEntityCitizen
     public void setCitizenId(final int id)
     {
         this.citizenId = id;
-    }
-
-    /**
-     * Spawn eating particles for the citizen.
-     */
-    @Override
-    public void spawnEatingParticle()
-    {
-        super.triggerItemUseEffects(getHeldItemMainhand(), EATING_PARTICLE_COUNT);
     }
 
     /**
@@ -1077,82 +1037,101 @@ public class EntityCitizen extends AbstractEntityCitizen
         return isOkayToEat() && (citizenJobHandler.getColonyJob() == null || citizenJobHandler.getColonyJob().isIdling());
     }
 
-    @Nullable
-    private DesiredActivity determinePrimaryActivity()
+    /**
+     * Determines the desired activity
+     */
+    private boolean determineDesiredActivity()
     {
         if (citizenJobHandler.getColonyJob() instanceof AbstractJobGuard)
         {
-            return DesiredActivity.WORK;
+            desiredActivity = DesiredActivity.WORK;
+            return false;
         }
 
-        if (getCitizenColonyHandler().getColony() != null && !world.isRemote && (getCitizenColonyHandler().getColony().getRaiderManager().isRaided()))
+        if (getCitizenColonyHandler().getColony().getRaiderManager().isRaided())
         {
-            isDay = false;
-            if (getCitizenData().getStatus() == null)
+            setVisibleStatusIfNone(RAIDED);
+            desiredActivity = DesiredActivity.SLEEP;
+            return false;
+        }
+
+        if (getCitizenColonyHandler().getColony().isMourning() && mourning)
+        {
+            setVisibleStatusIfNone(MOURNING);
+            desiredActivity = DesiredActivity.MOURN;
+            return false;
+        }
+
+        // Sleeping
+        if (!WorldUtil.isPastTime(CompatibilityUtils.getWorldFromCitizen(this), NIGHT - 2000))
+        {
+            if (desiredActivity == DesiredActivity.SLEEP)
             {
-                getCitizenData().setVisibleStatus(RAIDED);
+                setVisibleStatusIfNone(SLEEP);
+                return false;
             }
-            return DesiredActivity.SLEEP;
-        }
 
-        if (getCitizenColonyHandler().getColony() != null && (getCitizenColonyHandler().getColony().isMourning() && mourning))
-        {
-            return DesiredActivity.MOURN;
-        }
-
-        return null;
-    }
-
-    @NotNull
-    private DesiredActivity determineTaskActivity()
-    {
-        if (!WorldUtil.isDayTime(world))
-        {
-            if (isDay && citizenData != null)
+            if (citizenSleepHandler.shouldGoSleep())
             {
-                isDay = false;
-                final double decreaseBy = citizenColonyHandler.getPerBuildingFoodCost() * 2;
-                citizenData.decreaseSaturation(decreaseBy);
+                citizenData.decreaseSaturation(citizenColonyHandler.getPerBuildingFoodCost() * 2);
                 citizenData.markDirty();
+                citizenStatusHandler.setLatestStatus(new TranslationTextComponent("com.minecolonies.coremod.status.sleeping"));
+                desiredActivity = DesiredActivity.SLEEP;
+                return false;
             }
-
-            citizenStatusHandler.setLatestStatus(new TranslationTextComponent("com.minecolonies.coremod.status.sleeping"));
-            if (getCitizenData().getStatus() == null)
-            {
-                getCitizenData().setVisibleStatus(SLEEP);
-            }
-            return DesiredActivity.SLEEP;
         }
-
 
         if (citizenSleepHandler.isAsleep() && !citizenDiseaseHandler.isSick())
         {
             citizenSleepHandler.onWakeUp();
         }
-        isDay = true;
 
-
+        // Raining
         if (CompatibilityUtils.getWorldFromCitizen(this).isRaining() && !shouldWorkWhileRaining())
         {
-            hidingFromRain = true;
             citizenStatusHandler.setLatestStatus(new TranslationTextComponent("com.minecolonies.coremod.status.waiting"),
               new TranslationTextComponent("com.minecolonies.coremod.status.rainStop"));
-            if (getCitizenData().getStatus() == null)
-            {
-                getCitizenData().setVisibleStatus(BAD_WEATHER);
-            }
-            return DesiredActivity.IDLE;
+            setVisibleStatusIfNone(BAD_WEATHER);
+            desiredActivity = DesiredActivity.IDLE;
+            return false;
         }
-        else
-        {
-            hidingFromRain = false;
-            if (this.getNavigator().getPath() != null && this.getNavigator().getPath().getCurrentPathLength() == 0)
-            {
-                this.getNavigator().clearPath();
-            }
 
-            return DesiredActivity.WORK;
+        if (isChild() && getCitizenJobHandler().getColonyJob() instanceof JobPupil && world.getDayTime() % 24000 > NOON)
+        {
+            setVisibleStatusIfNone(HOUSE);
+            desiredActivity = DesiredActivity.IDLE;
+            return false;
         }
+
+        if (getCitizenJobHandler().getColonyJob() != null)
+        {
+            desiredActivity = DesiredActivity.WORK;
+            return false;
+        }
+
+        setVisibleStatusIfNone(HOUSE);
+        desiredActivity = DesiredActivity.IDLE;
+        return false;
+    }
+
+    /**
+     * Sets the visible status if there is none
+     *
+     * @param status status to set
+     */
+    private void setVisibleStatusIfNone(final VisibleCitizenStatus status)
+    {
+        if (getCitizenData().getStatus() == null)
+        {
+            getCitizenData().setVisibleStatus(status);
+        }
+    }
+
+    @Override
+    @NotNull
+    public DesiredActivity getDesiredActivity()
+    {
+        return desiredActivity;
     }
 
     /**
@@ -1246,7 +1225,6 @@ public class EntityCitizen extends AbstractEntityCitizen
     @Override
     public boolean attackEntityFrom(@NotNull final DamageSource damageSource, final float damage)
     {
-        // TODO Remove workaround and fix
         if (handleInWallDamage(damageSource))
         {
             return false;
@@ -1396,7 +1374,10 @@ public class EntityCitizen extends AbstractEntityCitizen
         // Environmental damage
         if (!(attacker instanceof LivingEntity))
         {
-            moveAwayPath = this.getNavigator().moveAwayFromLivingEntity(this, 5, INITIAL_RUN_SPEED_AVOID);
+            if (moveAwayPath == null || !moveAwayPath.isInProgress())
+            {
+                moveAwayPath = this.getNavigator().moveAwayFromLivingEntity(this, 5, INITIAL_RUN_SPEED_AVOID);
+            }
             return;
         }
 
@@ -1413,8 +1394,10 @@ public class EntityCitizen extends AbstractEntityCitizen
         {
             callForHelp(attacker, MAX_GUARD_CALL_RANGE);
         }
-
-        moveAwayPath = this.getNavigator().moveAwayFromLivingEntity(attacker, 15, INITIAL_RUN_SPEED_AVOID);
+        if (moveAwayPath == null || !moveAwayPath.isInProgress())
+        {
+            moveAwayPath = this.getNavigator().moveAwayFromLivingEntity(attacker, 15, INITIAL_RUN_SPEED_AVOID);
+        }
     }
 
     @Override
@@ -1634,7 +1617,7 @@ public class EntityCitizen extends AbstractEntityCitizen
     }
 
     @Override
-    public void setCustomName(@javax.annotation.Nullable final ITextComponent name)
+    public void setCustomName(@Nullable final ITextComponent name)
     {
         if (citizenData != null && citizenColonyHandler.getColony() != null && name != null)
         {

--- a/src/main/java/com/minecolonies/coremod/entity/citizen/VisitorCitizen.java
+++ b/src/main/java/com/minecolonies/coremod/entity/citizen/VisitorCitizen.java
@@ -338,12 +338,6 @@ public class VisitorCitizen extends AbstractEntityCitizen
     }
 
     @Override
-    public void spawnEatingParticle()
-    {
-
-    }
-
-    @Override
     public ICitizenExperienceHandler getCitizenExperienceHandler()
     {
         return citizenExperienceHandler;

--- a/src/main/java/com/minecolonies/coremod/entity/citizen/citizenhandlers/CitizenDiseaseHandler.java
+++ b/src/main/java/com/minecolonies/coremod/entity/citizen/citizenhandlers/CitizenDiseaseHandler.java
@@ -13,7 +13,6 @@ import net.minecraft.nbt.CompoundNBT;
 import net.minecraft.util.math.BlockPos;
 
 import static com.minecolonies.api.util.constant.CitizenConstants.TAG_DISEASE;
-import static com.minecolonies.api.util.constant.CitizenConstants.TICKS_20;
 
 /**
  * Handler taking care of citizens getting stuck.
@@ -56,7 +55,7 @@ public class CitizenDiseaseHandler implements ICitizenDiseaseHandler
     @Override
     public void tick()
     {
-        if (citizen.getTicksExisted() % TICKS_20 == 0 && citizen.getCitizenColonyHandler().getColony().isActive() && !(citizen.getCitizenJobHandler()
+        if (citizen.getCitizenColonyHandler().getColony().isActive() && !(citizen.getCitizenJobHandler()
                                                                                                                          .getColonyJob() instanceof JobHealer)
               && citizen.getCitizenColonyHandler().getColony().getCitizenManager().getCurrentCitizenCount() > IMinecoloniesAPI.getInstance()
                                                                                                                 .getConfig()

--- a/src/main/java/com/minecolonies/coremod/entity/citizen/citizenhandlers/CitizenStatusHandler.java
+++ b/src/main/java/com/minecolonies/coremod/entity/citizen/citizenhandlers/CitizenStatusHandler.java
@@ -3,6 +3,7 @@ package com.minecolonies.coremod.entity.citizen.citizenhandlers;
 import com.minecolonies.api.entity.ai.Status;
 import com.minecolonies.api.entity.citizen.AbstractEntityCitizen;
 import com.minecolonies.api.entity.citizen.citizenhandlers.ICitizenStatusHandler;
+import com.minecolonies.coremod.MineColonies;
 import net.minecraft.util.text.ITextComponent;
 
 import java.util.Objects;
@@ -23,6 +24,11 @@ public class CitizenStatusHandler implements ICitizenStatusHandler
      * The Current Status.
      */
     protected Status status = Status.IDLE;
+
+    /**
+     * Whether the status display is enabled
+     */
+    private boolean enabled = MineColonies.getConfig().getCommon().enableInDevelopmentFeatures.get();
 
     /**
      * The 4 lines of the latest status.
@@ -58,6 +64,11 @@ public class CitizenStatusHandler implements ICitizenStatusHandler
     @Override
     public void setLatestStatus(final ITextComponent... status)
     {
+        if (!enabled)
+        {
+            return;
+        }
+
         boolean hasChanged = false;
         for (int i = 0; i < latestStatus.length; i++)
         {

--- a/src/main/resources/assets/minecolonies/lang/en_us.json
+++ b/src/main/resources/assets/minecolonies/lang/en_us.json
@@ -1734,6 +1734,8 @@
   "com.minecolonies.coremod.gui.chat.recruitstory19": "seems adapt at using swords and says 'if by my life or death I can protect you, I will. You have my sword'",
   "com.minecolonies.coremod.gui.chat.recruitstory20": "is never late, nor early, %s arrives precisely when meant to.",
 
+  "com.minecolonies.coremod.gui.chat.hometoofar": "I have to walk a long way home from work every day, it would be nice if I could live somewhere closer.",
+
   "com.minecolonies.coremod.gui.beekeeper.notcollect": "Collect honey",
   "com.minecolonies.coremod.gui.beekeeper.collect": "Collect honeycomb",
   "com.minecolonies.coremod.gui.beekeeper.addhives": "Get hive tool",


### PR DESCRIPTION
# Changes proposed in this pull request:

Citizens now go to sleep earlier/later depending on distance to go. They also do complain with an interaction if their way is too long(work-home).
Research effects on entities are now applied upon initializing the entity, or upon finishing research rather than each X ticks.
Overhaul sleeping AI, fixing some possible bugs
Overhaul Citizenentity desiredTask and livingticks
Add simplenotification interaction, which disappears after clicking ignore or "I will work on it".

Review please
