### PR TITLE
Avoid a cast failure in smeltercrafter

### DIFF
--- a/src/main/java/com/minecolonies/coremod/entity/ai/basic/AbstractEntityAICrafting.java
+++ b/src/main/java/com/minecolonies/coremod/entity/ai/basic/AbstractEntityAICrafting.java
@@ -375,6 +375,9 @@ public abstract class AbstractEntityAICrafting<J extends AbstractJobCrafter<?, J
 
     /**
      * Get the required progress to execute a recipe.
+     * 
+     * AbstractBuildingCrafter based buildings will use getCraftSpeedSkill
+     * Other buildings (smeltercrafters etc) will use old getJobModifier
      *
      * @return the amount of hits required.
      */

--- a/src/main/java/com/minecolonies/coremod/entity/ai/basic/AbstractEntityAICrafting.java
+++ b/src/main/java/com/minecolonies/coremod/entity/ai/basic/AbstractEntityAICrafting.java
@@ -20,7 +20,7 @@ import com.minecolonies.coremod.colony.jobs.AbstractJobCrafter;
 import net.minecraft.block.Blocks;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.Hand;
-import org.jetbrains.annotations.NotNull;
+ import org.jetbrains.annotations.NotNull;
 
 import java.util.List;
 import java.util.function.Predicate;
@@ -380,8 +380,13 @@ public abstract class AbstractEntityAICrafting<J extends AbstractJobCrafter<?, J
      */
     private int getRequiredProgressForMakingRawMaterial()
     {
-        final int jobModifier = worker.getCitizenData().getCitizenSkillHandler().getLevel(((AbstractBuildingCrafter) getOwnBuilding()).getCraftSpeedSkill()) / 2;
-        return PROGRESS_MULTIPLIER / Math.min(jobModifier + 1, MAX_LEVEL) * HITTING_TIME;
+        //This won't work for smeltercrafters
+        if(getOwnBuilding() instanceof AbstractBuildingCrafter)
+        {
+            final int jobModifier = worker.getCitizenData().getCitizenSkillHandler().getLevel(((AbstractBuildingCrafter) getOwnBuilding()).getCraftSpeedSkill()) / 2;
+            return PROGRESS_MULTIPLIER / Math.min(jobModifier + 1, MAX_LEVEL) * HITTING_TIME;
+        }
+        return PROGRESS_MULTIPLIER / Math.min(worker.getCitizenData().getJobModifier() + 1, MAX_LEVEL) * HITTING_TIME;
     }
 
     @Override

--- a/src/main/java/com/minecolonies/coremod/entity/ai/basic/AbstractEntityAICrafting.java
+++ b/src/main/java/com/minecolonies/coremod/entity/ai/basic/AbstractEntityAICrafting.java
@@ -20,7 +20,7 @@ import com.minecolonies.coremod.colony.jobs.AbstractJobCrafter;
 import net.minecraft.block.Blocks;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.Hand;
- import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.NotNull;
 
 import java.util.List;
 import java.util.function.Predicate;


### PR DESCRIPTION
# Changes proposed in this pull request:
- Fix so that the smeltercrafter doesn't throw a cast exception while crafting as it doesn't inherit from AbstractBuildingCrafter

While this effects all smeltercrafters, it blocks both dyer and glassblower for all taught recipes. 

Review please
