### PR TITLE
Enable datapack-based loading of worker specific recipes

### DIFF
--- a/src/main/java/com/minecolonies/coremod/colony/buildings/AbstractBuildingWorker.java
+++ b/src/main/java/com/minecolonies/coremod/colony/buildings/AbstractBuildingWorker.java
@@ -841,7 +841,6 @@ public abstract class AbstractBuildingWorker extends AbstractBuilding implements
                 }
                 if(!duplicateFound)
                 {
-                    Log.getLogger().info("Adding recipe for " + recipeStorage.getPrimaryOutput());
                     addRecipeToList(recipeToken);    
                 }
             } 

--- a/src/main/java/com/minecolonies/coremod/colony/buildings/AbstractBuildingWorker.java
+++ b/src/main/java/com/minecolonies/coremod/colony/buildings/AbstractBuildingWorker.java
@@ -789,12 +789,12 @@ public abstract class AbstractBuildingWorker extends AbstractBuilding implements
      */
     public void checkForWorkerSpecificRecipes()
     {
-        Set<CustomRecipe> staticRecipes = CustomRecipeManager.getInstance().getRecipes(getJobName());
+        final Set<CustomRecipe> staticRecipes = CustomRecipeManager.getInstance().getRecipes(getJobName());
 
-        for(CustomRecipe newRecipe : staticRecipes)
+        for(final CustomRecipe newRecipe : staticRecipes)
         {
-            IRecipeStorage recipeStorage = newRecipe.getRecipeStorage();
-            IToken<?> recipeToken = IColonyManager.getInstance().getRecipeManager().checkOrAddRecipe(recipeStorage);
+            final IRecipeStorage recipeStorage = newRecipe.getRecipeStorage();
+            final IToken<?> recipeToken = IColonyManager.getInstance().getRecipeManager().checkOrAddRecipe(recipeStorage);
 
             if(newRecipe.isValidForColony(colony))
             {   
@@ -811,23 +811,24 @@ public abstract class AbstractBuildingWorker extends AbstractBuilding implements
                     //Let's verify that this recipe doesn't exist in an improved form
                     if(storage != null && storage.getPrimaryOutput().equals(recipeStorage.getPrimaryOutput(), true))
                     {
-                        List<ItemStorage> storageInput = storage.getCleanedInput();
-                        List<ItemStorage> recipeInput = recipeStorage.getCleanedInput();
+                        List<ItemStorage> recipeInput1 = storage.getCleanedInput();
+                        List<ItemStorage> recipeInput2 = recipeStorage.getCleanedInput();
 
-                        if(storageInput.size() != recipeInput.size())
+                        if(recipeInput1.size() != recipeInput2.size())
                         {
                             continue;
                         }
                         
-                        if(storageInput.size() > 1) {
-                            storageInput.sort(Comparator.comparing(item -> item.toString()));
-                            recipeInput.sort(Comparator.comparing(item -> item.toString()));
+                        if(recipeInput1.size() > 1)
+                        {
+                            recipeInput1.sort(Comparator.comparing(item -> item.toString()));
+                            recipeInput2.sort(Comparator.comparing(item -> item.toString()));
                         }
 
                         boolean allMatch = true;
-                        for(int i=0; i<storageInput.size(); i++)
+                        for(int i=0; i<recipeInput1.size(); i++)
                         {
-                            if(!storageInput.get(i).getItem().equals(recipeInput.get(i).getItem()))
+                            if(!recipeInput1.get(i).getItem().equals(recipeInput2.get(i).getItem()))
                             {
                                 allMatch = false;
                                 break;
@@ -836,6 +837,7 @@ public abstract class AbstractBuildingWorker extends AbstractBuilding implements
                         if(allMatch)
                         {
                             duplicateFound = true;
+                            break;
                         }
                     }
                 }

--- a/src/main/java/com/minecolonies/coremod/colony/buildings/AbstractBuildingWorker.java
+++ b/src/main/java/com/minecolonies/coremod/colony/buildings/AbstractBuildingWorker.java
@@ -25,6 +25,8 @@ import com.minecolonies.coremod.Network;
 import com.minecolonies.coremod.colony.buildings.views.AbstractBuildingView;
 import com.minecolonies.coremod.colony.buildings.workerbuildings.BuildingBuilder;
 import com.minecolonies.coremod.colony.buildings.workerbuildings.BuildingWareHouse;
+import com.minecolonies.coremod.colony.crafting.CustomRecipe;
+import com.minecolonies.coremod.colony.crafting.CustomRecipeManager;
 import com.minecolonies.coremod.colony.requestsystem.resolvers.BuildingRequestResolver;
 import com.minecolonies.coremod.colony.requestsystem.resolvers.PrivateWorkerCraftingProductionResolver;
 import com.minecolonies.coremod.colony.requestsystem.resolvers.PrivateWorkerCraftingRequestResolver;
@@ -222,7 +224,7 @@ public abstract class AbstractBuildingWorker extends AbstractBuilding implements
     /**
      * Get the count of items in all the warehouses
      */
-    private int getWarehouseCount(ItemStorage item)
+    protected int getWarehouseCount(ItemStorage item)
     {
         int count = 0;
         final Set<IBuilding> wareHouses = colony.getBuildingManager().getBuildings().values().stream()
@@ -787,7 +789,71 @@ public abstract class AbstractBuildingWorker extends AbstractBuilding implements
      */
     public void checkForWorkerSpecificRecipes()
     {
-        // Override if necessary.
+        Set<CustomRecipe> staticRecipes = CustomRecipeManager.getInstance().getRecipes(getJobName());
+
+        for(CustomRecipe newRecipe : staticRecipes)
+        {
+            IRecipeStorage recipeStorage = newRecipe.getRecipeStorage();
+            IToken<?> recipeToken = IColonyManager.getInstance().getRecipeManager().checkOrAddRecipe(recipeStorage);
+
+            if(newRecipe.isValidForColony(colony))
+            {   
+                boolean duplicateFound = false; 
+                for(IToken<?> token : recipes)
+                {
+                    if(token == recipeToken)
+                    {
+                        duplicateFound = true;
+                        break;
+                    }
+                    final IRecipeStorage storage = IColonyManager.getInstance().getRecipeManager().getRecipes().get(token);
+
+                    //Let's verify that this recipe doesn't exist in an improved form
+                    if(storage != null && storage.getPrimaryOutput().equals(recipeStorage.getPrimaryOutput(), true))
+                    {
+                        List<ItemStorage> storageInput = storage.getCleanedInput();
+                        List<ItemStorage> recipeInput = recipeStorage.getCleanedInput();
+
+                        if(storageInput.size() != recipeInput.size())
+                        {
+                            continue;
+                        }
+                        
+                        if(storageInput.size() > 1) {
+                            storageInput.sort(Comparator.comparing(item -> item.toString()));
+                            recipeInput.sort(Comparator.comparing(item -> item.toString()));
+                        }
+
+                        boolean allMatch = true;
+                        for(int i=0; i<storageInput.size(); i++)
+                        {
+                            if(!storageInput.get(i).getItem().equals(recipeInput.get(i).getItem()))
+                            {
+                                allMatch = false;
+                                break;
+                            }
+                        }
+                        if(allMatch)
+                        {
+                            duplicateFound = true;
+                        }
+                    }
+                }
+                if(!duplicateFound)
+                {
+                    Log.getLogger().info("Adding recipe for " + recipeStorage.getPrimaryOutput());
+                    addRecipeToList(recipeToken);    
+                }
+            } 
+            else
+            {
+                if(recipes.contains(recipeToken))
+                {
+                    removeRecipe(recipeToken);
+                }
+            }
+        }
+        markDirty();
     }
 
     /**

--- a/src/main/java/com/minecolonies/coremod/colony/buildings/workerbuildings/BuildingCrusher.java
+++ b/src/main/java/com/minecolonies/coremod/colony/buildings/workerbuildings/BuildingCrusher.java
@@ -127,42 +127,6 @@ public class BuildingCrusher extends AbstractBuildingCrafter
         }
     }
 
-    @Override
-    public void checkForWorkerSpecificRecipes()
-    {
-        loadCurrentRecipes();
-    }
-
-    /**
-     * Reload all of the current crusher recipes
-     */
-    private void loadCurrentRecipes()
-    {
-        for (final IRecipeStorage recipe : crusherRecipes.values())
-        {
-            final IToken<?> token = IColonyManager.getInstance().getRecipeManager().checkOrAddRecipe(recipe);
-            final IRecipeStorage oldRecipe = getFirstRecipe(recipe.getPrimaryOutput());
-            if(oldRecipe != null && !oldRecipe.getToken().equals(token))
-            {
-                replaceRecipe(oldRecipe.getToken(), token);
-            }
-            else
-            {
-                addRecipe(token);
-            }
-        }
-
-        final IRecipeStorage clayballStorage = StandardFactoryController.getInstance().getNewInstance(
-            TypeConstants.RECIPE,
-            StandardFactoryController.getInstance().getNewInstance(TypeConstants.ITOKEN),
-            ImmutableList.of(new ItemStack(Blocks.CLAY, 1)),
-            1,
-            new ItemStack(Items.CLAY_BALL, 4),
-            Blocks.AIR);
-  
-        addRecipe(IColonyManager.getInstance().getRecipeManager().checkOrAddRecipe(clayballStorage));    
-    }
-
     /**
      * Get the recipe storage of the current mode.
      *
@@ -297,11 +261,6 @@ public class BuildingCrusher extends AbstractBuildingCrafter
         }
 
         this.oneByOne = compound.getBoolean(CRUSHING_11);
-
-        if (super.recipes.isEmpty())
-        {
-            loadCurrentRecipes();
-        }
     }
 
     @Override
@@ -331,8 +290,6 @@ public class BuildingCrusher extends AbstractBuildingCrafter
         if (crusherRecipes.isEmpty() || oneOne && !oneByOne)
         {
             loadCrusherMode();
-
-            loadCurrentRecipes();
         }
 
         if (crusherMode == null)

--- a/src/main/java/com/minecolonies/coremod/colony/buildings/workerbuildings/BuildingDyer.java
+++ b/src/main/java/com/minecolonies/coremod/colony/buildings/workerbuildings/BuildingDyer.java
@@ -73,38 +73,6 @@ public class BuildingDyer extends AbstractBuildingSmelterCrafter
         super(c, l);
     }
 
-    @Override
-    public void checkForWorkerSpecificRecipes()
-    {
-        final IRecipeStorage cactusStorage = StandardFactoryController.getInstance().getNewInstance(
-          TypeConstants.RECIPE,
-          StandardFactoryController.getInstance().getNewInstance(TypeConstants.ITOKEN),
-          ImmutableList.of(new ItemStack(Blocks.CACTUS, 1)),
-          1,
-          new ItemStack(Items.GREEN_DYE, 1),
-          Blocks.FURNACE);
-
-          final IRecipeStorage redsandStorage = StandardFactoryController.getInstance().getNewInstance(
-            TypeConstants.RECIPE,
-            StandardFactoryController.getInstance().getNewInstance(TypeConstants.ITOKEN),
-            ImmutableList.of(new ItemStack(Blocks.SAND, 4), new ItemStack(Items.RED_DYE)),
-            1,
-            new ItemStack(Blocks.RED_SAND, 4),
-            Blocks.AIR);
-
-        final IRecipeStorage darkPrismarineStorage = StandardFactoryController.getInstance().getNewInstance(
-            TypeConstants.RECIPE,
-            StandardFactoryController.getInstance().getNewInstance(TypeConstants.ITOKEN),
-            ImmutableList.of(new ItemStack(Blocks.PRISMARINE, 4), new ItemStack(Items.BLACK_DYE)),
-            1,
-            new ItemStack(Blocks.DARK_PRISMARINE, 4),
-            Blocks.AIR);
-                
-        addRecipeToList(IColonyManager.getInstance().getRecipeManager().checkOrAddRecipe(cactusStorage));
-        addRecipeToList(IColonyManager.getInstance().getRecipeManager().checkOrAddRecipe(redsandStorage));
-        addRecipeToList(IColonyManager.getInstance().getRecipeManager().checkOrAddRecipe(darkPrismarineStorage));
-    }
-
     @NotNull
     @Override
     public String getSchematicName()

--- a/src/main/java/com/minecolonies/coremod/colony/buildings/workerbuildings/BuildingFarmer.java
+++ b/src/main/java/com/minecolonies/coremod/colony/buildings/workerbuildings/BuildingFarmer.java
@@ -343,20 +343,6 @@ public class BuildingFarmer extends AbstractBuildingCrafter
     }
 
     @Override
-    public void checkForWorkerSpecificRecipes()
-    {
-        final IRecipeStorage carvedPumpkinStorage = StandardFactoryController.getInstance().getNewInstance(
-          TypeConstants.RECIPE,
-          StandardFactoryController.getInstance().getNewInstance(TypeConstants.ITOKEN),
-          ImmutableList.of(new ItemStack(Blocks.PUMPKIN, 1)),
-          1,
-          new ItemStack(Blocks.CARVED_PUMPKIN, 1),
-          Blocks.AIR);
-
-         addRecipeToList(IColonyManager.getInstance().getRecipeManager().checkOrAddRecipe(carvedPumpkinStorage));
-    }
-    
-    @Override
     public boolean canRecipeBeAdded(final IToken<?> token)
     {
 

--- a/src/main/java/com/minecolonies/coremod/colony/buildings/workerbuildings/BuildingFletcher.java
+++ b/src/main/java/com/minecolonies/coremod/colony/buildings/workerbuildings/BuildingFletcher.java
@@ -134,29 +134,6 @@ public class BuildingFletcher extends AbstractBuildingCrafter
     }
 
     @Override
-    public void checkForWorkerSpecificRecipes()
-    {
-        final IRecipeStorage stringStorage = StandardFactoryController.getInstance().getNewInstance(
-          TypeConstants.RECIPE,
-          StandardFactoryController.getInstance().getNewInstance(TypeConstants.ITOKEN),
-          ImmutableList.of(new ItemStack(Items.WHITE_WOOL, 1)),
-          1,
-          new ItemStack(Items.STRING, 4),
-          Blocks.AIR);
-
-        final IRecipeStorage flintStorage = StandardFactoryController.getInstance().getNewInstance(
-          TypeConstants.RECIPE,
-          StandardFactoryController.getInstance().getNewInstance(TypeConstants.ITOKEN),
-          ImmutableList.of(new ItemStack(Blocks.GRAVEL, 3)),
-          1,
-          new ItemStack(Items.FLINT, 4),
-          Blocks.AIR);
-          
-        addRecipeToList(IColonyManager.getInstance().getRecipeManager().checkOrAddRecipe(stringStorage));
-        addRecipeToList(IColonyManager.getInstance().getRecipeManager().checkOrAddRecipe(flintStorage));
-    }
-
-    @Override
     public BuildingEntry getBuildingRegistryEntry()
     {
         return ModBuildings.fletcher;

--- a/src/main/java/com/minecolonies/coremod/colony/buildings/workerbuildings/BuildingLumberjack.java
+++ b/src/main/java/com/minecolonies/coremod/colony/buildings/workerbuildings/BuildingLumberjack.java
@@ -110,40 +110,6 @@ public class BuildingLumberjack extends AbstractFilterableListCrafter
     }
 
     @Override
-    public void checkForWorkerSpecificRecipes()
-    {
-        if (recipes.isEmpty())
-        {
-            addStrippedWoodRecipe(Items.OAK_LOG, Items.STRIPPED_OAK_LOG);
-            addStrippedWoodRecipe(Items.SPRUCE_LOG, Items.STRIPPED_SPRUCE_LOG);
-            addStrippedWoodRecipe(Items.BIRCH_LOG, Items.STRIPPED_BIRCH_LOG);
-            addStrippedWoodRecipe(Items.JUNGLE_LOG, Items.STRIPPED_JUNGLE_LOG);
-            addStrippedWoodRecipe(Items.ACACIA_LOG, Items.STRIPPED_ACACIA_LOG);
-            addStrippedWoodRecipe(Items.DARK_OAK_LOG, Items.STRIPPED_DARK_OAK_LOG);
-            addStrippedWoodRecipe(Items.OAK_WOOD, Items.STRIPPED_OAK_WOOD);
-            addStrippedWoodRecipe(Items.SPRUCE_WOOD, Items.STRIPPED_SPRUCE_WOOD);
-            addStrippedWoodRecipe(Items.BIRCH_WOOD, Items.STRIPPED_BIRCH_WOOD);
-            addStrippedWoodRecipe(Items.JUNGLE_WOOD, Items.STRIPPED_JUNGLE_WOOD);
-            addStrippedWoodRecipe(Items.ACACIA_WOOD, Items.STRIPPED_ACACIA_WOOD);
-            addStrippedWoodRecipe(Items.DARK_OAK_WOOD, Items.STRIPPED_DARK_OAK_WOOD);
-            markDirty();
-        }
-    }
-
-    public final void addStrippedWoodRecipe(final Item baseVariant, final Item strippedVariant)
-    {
-        final IRecipeStorage storage = StandardFactoryController.getInstance().getNewInstance(
-          TypeConstants.RECIPE,
-          StandardFactoryController.getInstance().getNewInstance(TypeConstants.ITOKEN),
-          ImmutableList.of(new ItemStack(baseVariant, 1)),
-          1,
-          new ItemStack(strippedVariant, 1),
-          Blocks.AIR);
-
-        addRecipeToList(IColonyManager.getInstance().getRecipeManager().checkOrAddRecipe(storage));
-    }
-
-    @Override
     public boolean canBeGathered()
     {
         // Normal crafters are only gatherable when they have a task, i.e. while producing stuff.

--- a/src/main/java/com/minecolonies/coremod/colony/buildings/workerbuildings/BuildingStonemason.java
+++ b/src/main/java/com/minecolonies/coremod/colony/buildings/workerbuildings/BuildingStonemason.java
@@ -56,48 +56,6 @@ public class BuildingStonemason extends AbstractBuildingCrafter
         super(c, l);
     }
 
-    @Override
-    public void checkForWorkerSpecificRecipes()
-    {
-        final IRecipeStorage sandstoneStorage = StandardFactoryController.getInstance().getNewInstance(
-          TypeConstants.RECIPE,
-          StandardFactoryController.getInstance().getNewInstance(TypeConstants.ITOKEN),
-          ImmutableList.of(new ItemStack(Blocks.COBBLESTONE, 1), new ItemStack(Blocks.SAND, 1)),
-          1,
-          new ItemStack(Blocks.SANDSTONE, 1),
-          Blocks.AIR);
-
-        final IRecipeStorage redsandstoneStorage = StandardFactoryController.getInstance().getNewInstance(
-          TypeConstants.RECIPE,
-          StandardFactoryController.getInstance().getNewInstance(TypeConstants.ITOKEN),
-          ImmutableList.of(new ItemStack(Blocks.COBBLESTONE, 1), new ItemStack(Blocks.RED_SAND, 1)),
-          1,
-          new ItemStack(Blocks.RED_SANDSTONE, 1),
-          Blocks.AIR);
-
-        final IRecipeStorage prismarineBlockStorage = StandardFactoryController.getInstance().getNewInstance(
-          TypeConstants.RECIPE,
-          StandardFactoryController.getInstance().getNewInstance(TypeConstants.ITOKEN),
-          ImmutableList.of(new ItemStack(Blocks.COBBLESTONE, 1), new ItemStack(Items.PRISMARINE_SHARD, 1)),
-          1,
-          new ItemStack(Blocks.PRISMARINE, 1),
-          Blocks.AIR);
-
-        final IRecipeStorage prismarineBrickStorage = StandardFactoryController.getInstance().getNewInstance(
-          TypeConstants.RECIPE,
-          StandardFactoryController.getInstance().getNewInstance(TypeConstants.ITOKEN),
-          ImmutableList.of(new ItemStack(Blocks.STONE_BRICKS, 1), new ItemStack(Items.PRISMARINE_SHARD, 1)),
-          1,
-          new ItemStack(Blocks.PRISMARINE_BRICKS, 1),
-          Blocks.AIR);
-            
-        addRecipeToList(IColonyManager.getInstance().getRecipeManager().checkOrAddRecipe(sandstoneStorage));
-        addRecipeToList(IColonyManager.getInstance().getRecipeManager().checkOrAddRecipe(redsandstoneStorage));
-        addRecipeToList(IColonyManager.getInstance().getRecipeManager().checkOrAddRecipe(prismarineBlockStorage));
-        addRecipeToList(IColonyManager.getInstance().getRecipeManager().checkOrAddRecipe(prismarineBrickStorage));
-
-    }
-
     @NotNull
     @Override
     public String getSchematicName()

--- a/src/main/java/com/minecolonies/coremod/colony/crafting/CustomRecipe.java
+++ b/src/main/java/com/minecolonies/coremod/colony/crafting/CustomRecipe.java
@@ -42,6 +42,11 @@ public class CustomRecipe
     public static final String RECIPE_TYPE_REMOVE = "remove";
 
     /**
+     * The property name that indicates the recipe to remove
+     */
+    public static final String RECIPE_ID_TO_REMOVE_PROP = "recipe-id-to-remove";
+
+    /**
      * The property name that indicates crafter type for the recipe
      */
     public static final String RECIPE_CRAFTER_PROP = "crafter";
@@ -89,7 +94,7 @@ public class CustomRecipe
     /**
      * The recipe id for this instance, used for removal and lookup
      */
-    private String recipeId = "";
+    private ResourceLocation recipeId = null;
 
     /**
      * The list of ItemStacks for input to the recipe
@@ -200,7 +205,7 @@ public class CustomRecipe
      * Get the ID for this recipe
      * @return
      */
-    public String getRecipeId()
+    public ResourceLocation getRecipeId()
     {
         return recipeId;
     }
@@ -208,7 +213,7 @@ public class CustomRecipe
     /**
      * Set the ID for this recipe
      */
-    public void setRecipeId(String recipeId)
+    public void setRecipeId(ResourceLocation recipeId)
     {
         this.recipeId = recipeId;
     }

--- a/src/main/java/com/minecolonies/coremod/colony/crafting/CustomRecipe.java
+++ b/src/main/java/com/minecolonies/coremod/colony/crafting/CustomRecipe.java
@@ -8,6 +8,7 @@ import com.minecolonies.api.crafting.IRecipeStorage;
 import com.minecolonies.api.research.effects.IResearchEffect;
 import com.minecolonies.api.util.constant.TypeConstants;
 import com.minecolonies.coremod.research.UnlockAbilityResearchEffect;
+import org.jetbrains.annotations.NotNull;
 
 import net.minecraft.block.Block;
 import net.minecraft.block.Blocks;
@@ -28,7 +29,7 @@ public class CustomRecipe
     /**
      * The property name that indicates type for the recipe
      */
-    public static final String RECIPE_TYPE = "type";
+    public static final String RECIPE_TYPE_PROP = "type";
 
     /**
      * The recipe type 
@@ -43,42 +44,42 @@ public class CustomRecipe
     /**
      * The property name that indicates crafter type for the recipe
      */
-    public static final String RECIPE_CRAFTER = "crafter";
+    public static final String RECIPE_CRAFTER_PROP = "crafter";
 
     /**
      * The property name for the inputs array
      */
-    public static final String RECIPE_INPUTS = "inputs";
+    public static final String RECIPE_INPUTS_PROP = "inputs";
 
     /**
      * The property name for the result item 
      */
-    public static final String RECIPE_RESULT = "result";
+    public static final String RECIPE_RESULT_PROP = "result";
 
     /**
      * The property name for Count, used both in inputs array and for result
      */
-    public static final String COUNT = "count";
+    public static final String COUNT_PROP = "count";
 
     /**
      * The property name for the item id in the inputs array
      */
-    public static final String ITEM = "item";
+    public static final String ITEM_PROP = "item";
 
     /**
      * The property name for the intermediate block ID
      */
-    public static final String RECIPE_INTERMEDIATE = "intermediate";
+    public static final String RECIPE_INTERMEDIATE_PROP = "intermediate";
 
     /**
      * The property name for the required research id
      */
-    public static final String RECIPE_RESEARCHID = "research-id";
+    public static final String RECIPE_RESEARCHID_PROP = "research-id";
 
     /**
      * The property name for the research id that invalidates this recipe
      */
-    public static final String RECIPE_EXCLUDED_RESEARCHID = "not-research-id";
+    public static final String RECIPE_EXCLUDED_RESEARCHID_PROP = "not-research-id";
 
     /**
      * The crafter name for this instance, defaults to 'unknown'
@@ -90,18 +91,37 @@ public class CustomRecipe
      */
     private String recipeId = "";
 
+    /**
+     * The list of ItemStacks for input to the recipe
+     */
     private ArrayList<ItemStack> inputs = new ArrayList<>();
+
+    /**
+     * the result ItemStack
+     */
     private ItemStack result = null;
+
+    /**
+     * The Intermediate Block
+     */
     private Block intermediate = Blocks.AIR;
 
+    /**
+     * ID of the required research. Null if none required
+     */
     private String researchId = null;
+
+    /**
+     * ID of the exclusionary research. Null if nothing excludes this recipe
+     */
     private String excludedResearchId = null;
 
 
     /**
      * This class can only be created by the parse static
      */
-    private CustomRecipe() {
+    private CustomRecipe()
+    {
 
     }
     
@@ -110,29 +130,29 @@ public class CustomRecipe
      * @param recipeJson the json representing the recipe
      * @return new instance of CustomRecipe
      */
-    public static CustomRecipe parse(JsonObject recipeJson)
+    public static CustomRecipe parse(@NotNull final JsonObject recipeJson)
     {
-        CustomRecipe recipe = new CustomRecipe();
+        final CustomRecipe recipe = new CustomRecipe();
         
-        if (recipeJson.has(RECIPE_CRAFTER))
+        if (recipeJson.has(RECIPE_CRAFTER_PROP))
         {
-            recipe.crafter = recipeJson.get(RECIPE_CRAFTER).getAsString();
+            recipe.crafter = recipeJson.get(RECIPE_CRAFTER_PROP).getAsString();
         }
-        if (recipeJson.has(RECIPE_INPUTS))
+        if (recipeJson.has(RECIPE_INPUTS_PROP))
         {
-            for(JsonElement e : recipeJson.get(RECIPE_INPUTS).getAsJsonArray())
+            for(JsonElement e : recipeJson.get(RECIPE_INPUTS_PROP).getAsJsonArray())
             {   
                 if(e instanceof JsonElement && e.isJsonObject())
                 {
                     JsonObject ingredient = e.getAsJsonObject();
-                    if(ingredient.has(ITEM))
+                    if(ingredient.has(ITEM_PROP))
                     {
-                        final String[] split = ingredient.get(ITEM).getAsString().split(":");
+                        final String[] split = ingredient.get(ITEM_PROP).getAsString().split(":");
                         final Item item = ForgeRegistries.ITEMS.getValue(new ResourceLocation(split[0], split[1]));
                         final ItemStack stack = new ItemStack(item);
-                        if(ingredient.has(COUNT))
+                        if(ingredient.has(COUNT_PROP))
                         {
-                            stack.setCount(ingredient.get(COUNT).getAsInt());
+                            stack.setCount(ingredient.get(COUNT_PROP).getAsInt());
                         }
                         recipe.inputs.add(stack);
                     }
@@ -140,28 +160,28 @@ public class CustomRecipe
                 }
             }
         }
-        if (recipeJson.has(RECIPE_RESULT))
+        if (recipeJson.has(RECIPE_RESULT_PROP))
         {
-            final String[] split = recipeJson.get(RECIPE_RESULT).getAsString().split(":");
+            final String[] split = recipeJson.get(RECIPE_RESULT_PROP).getAsString().split(":");
             final Item item = ForgeRegistries.ITEMS.getValue(new ResourceLocation(split[0], split[1]));
             recipe.result = new ItemStack(item);
         }
-        if (recipeJson.has(COUNT) && recipe.result != null)
+        if (recipeJson.has(COUNT_PROP) && recipe.result != null)
         {
-            recipe.result.setCount(recipeJson.get(COUNT).getAsInt());
+            recipe.result.setCount(recipeJson.get(COUNT_PROP).getAsInt());
         }
-        if (recipeJson.has(RECIPE_INTERMEDIATE))
+        if (recipeJson.has(RECIPE_INTERMEDIATE_PROP))
         {
-            final String[] split = recipeJson.get(RECIPE_INTERMEDIATE).getAsString().split(":");
+            final String[] split = recipeJson.get(RECIPE_INTERMEDIATE_PROP).getAsString().split(":");
             recipe.intermediate = ForgeRegistries.BLOCKS.getValue(new ResourceLocation(split[0], split[1]));
         }
-        if (recipeJson.has(RECIPE_RESEARCHID))
+        if (recipeJson.has(RECIPE_RESEARCHID_PROP))
         {
-            recipe.researchId = recipeJson.get(RECIPE_RESEARCHID).getAsString();
+            recipe.researchId = recipeJson.get(RECIPE_RESEARCHID_PROP).getAsString();
         }
-        if (recipeJson.has(RECIPE_EXCLUDED_RESEARCHID))
+        if (recipeJson.has(RECIPE_EXCLUDED_RESEARCHID_PROP))
         {
-            recipe.excludedResearchId = recipeJson.get(RECIPE_EXCLUDED_RESEARCHID).getAsString();
+            recipe.excludedResearchId = recipeJson.get(RECIPE_EXCLUDED_RESEARCHID_PROP).getAsString();
         }
 
         return recipe;

--- a/src/main/java/com/minecolonies/coremod/colony/crafting/CustomRecipe.java
+++ b/src/main/java/com/minecolonies/coremod/colony/crafting/CustomRecipe.java
@@ -1,0 +1,232 @@
+package com.minecolonies.coremod.colony.crafting;
+
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.minecolonies.api.colony.IColony;
+import com.minecolonies.api.colony.requestsystem.StandardFactoryController;
+import com.minecolonies.api.crafting.IRecipeStorage;
+import com.minecolonies.api.research.effects.IResearchEffect;
+import com.minecolonies.api.util.constant.TypeConstants;
+import com.minecolonies.coremod.research.UnlockAbilityResearchEffect;
+
+import net.minecraft.block.Block;
+import net.minecraft.block.Blocks;
+import net.minecraft.item.Item;
+import net.minecraft.item.ItemStack;
+import net.minecraft.util.ResourceLocation;
+import net.minecraftforge.registries.ForgeRegistries;
+
+import java.util.ArrayList;
+
+/**
+ * This class represents a recipe loaded from custom data that is available to a crafter
+ * but not to a player
+ */
+public class CustomRecipe
+{
+
+    /**
+     * The property name that indicates type for the recipe
+     */
+    public static final String RECIPE_TYPE = "type";
+
+    /**
+     * The recipe type 
+     */
+    public static final String RECIPE_TYPE_RECIPE = "recipe";
+
+    /**
+     * The remove type 
+     */
+    public static final String RECIPE_TYPE_REMOVE = "remove";
+
+    /**
+     * The property name that indicates crafter type for the recipe
+     */
+    public static final String RECIPE_CRAFTER = "crafter";
+
+    /**
+     * The property name for the inputs array
+     */
+    public static final String RECIPE_INPUTS = "inputs";
+
+    /**
+     * The property name for the result item 
+     */
+    public static final String RECIPE_RESULT = "result";
+
+    /**
+     * The property name for Count, used both in inputs array and for result
+     */
+    public static final String COUNT = "count";
+
+    /**
+     * The property name for the item id in the inputs array
+     */
+    public static final String ITEM = "item";
+
+    /**
+     * The property name for the intermediate block ID
+     */
+    public static final String RECIPE_INTERMEDIATE = "intermediate";
+
+    /**
+     * The property name for the required research id
+     */
+    public static final String RECIPE_RESEARCHID = "research-id";
+
+    /**
+     * The property name for the research id that invalidates this recipe
+     */
+    public static final String RECIPE_EXCLUDED_RESEARCHID = "not-research-id";
+
+    /**
+     * The crafter name for this instance, defaults to 'unknown'
+     */
+    private String crafter = "unknown";
+
+    /**
+     * The recipe id for this instance, used for removal and lookup
+     */
+    private String recipeId = "";
+
+    private ArrayList<ItemStack> inputs = new ArrayList<>();
+    private ItemStack result = null;
+    private Block intermediate = Blocks.AIR;
+
+    private String researchId = null;
+    private String excludedResearchId = null;
+
+
+    /**
+     * This class can only be created by the parse static
+     */
+    private CustomRecipe() {
+
+    }
+    
+    /**
+     * Parse a Json object into a Custom recipe
+     * @param recipeJson the json representing the recipe
+     * @return new instance of CustomRecipe
+     */
+    public static CustomRecipe parse(JsonObject recipeJson)
+    {
+        CustomRecipe recipe = new CustomRecipe();
+        
+        if (recipeJson.has(RECIPE_CRAFTER))
+        {
+            recipe.crafter = recipeJson.get(RECIPE_CRAFTER).getAsString();
+        }
+        if (recipeJson.has(RECIPE_INPUTS))
+        {
+            for(JsonElement e : recipeJson.get(RECIPE_INPUTS).getAsJsonArray())
+            {   
+                if(e instanceof JsonElement && e.isJsonObject())
+                {
+                    JsonObject ingredient = e.getAsJsonObject();
+                    if(ingredient.has(ITEM))
+                    {
+                        final String[] split = ingredient.get(ITEM).getAsString().split(":");
+                        final Item item = ForgeRegistries.ITEMS.getValue(new ResourceLocation(split[0], split[1]));
+                        final ItemStack stack = new ItemStack(item);
+                        if(ingredient.has(COUNT))
+                        {
+                            stack.setCount(ingredient.get(COUNT).getAsInt());
+                        }
+                        recipe.inputs.add(stack);
+                    }
+
+                }
+            }
+        }
+        if (recipeJson.has(RECIPE_RESULT))
+        {
+            final String[] split = recipeJson.get(RECIPE_RESULT).getAsString().split(":");
+            final Item item = ForgeRegistries.ITEMS.getValue(new ResourceLocation(split[0], split[1]));
+            recipe.result = new ItemStack(item);
+        }
+        if (recipeJson.has(COUNT) && recipe.result != null)
+        {
+            recipe.result.setCount(recipeJson.get(COUNT).getAsInt());
+        }
+        if (recipeJson.has(RECIPE_INTERMEDIATE))
+        {
+            final String[] split = recipeJson.get(RECIPE_INTERMEDIATE).getAsString().split(":");
+            recipe.intermediate = ForgeRegistries.BLOCKS.getValue(new ResourceLocation(split[0], split[1]));
+        }
+        if (recipeJson.has(RECIPE_RESEARCHID))
+        {
+            recipe.researchId = recipeJson.get(RECIPE_RESEARCHID).getAsString();
+        }
+        if (recipeJson.has(RECIPE_EXCLUDED_RESEARCHID))
+        {
+            recipe.excludedResearchId = recipeJson.get(RECIPE_EXCLUDED_RESEARCHID).getAsString();
+        }
+
+        return recipe;
+    }
+
+    /**
+     * Get the name of the crafter this recipe applies to
+     * @return crafter name
+     */
+    public String getCrafter()
+    {
+        return crafter;
+    }
+
+    /**
+     * Get the ID for this recipe
+     * @return
+     */
+    public String getRecipeId()
+    {
+        return recipeId;
+    }
+
+    /**
+     * Set the ID for this recipe
+     */
+    public void setRecipeId(String recipeId)
+    {
+        this.recipeId = recipeId;
+    }
+ 
+    /**
+     * Check to see if the recipe is currently valid for the colony
+     * This does research checks, to verify that the appropriate researches are in the correct states
+     */
+    public boolean isValidForColony(IColony colony)
+    {
+        IResearchEffect<?> requiredEffect = null;
+        IResearchEffect<?> excludedEffect = null;
+        
+        if (researchId != null)
+        {
+            requiredEffect = colony.getResearchManager().getResearchEffects().getEffect(researchId, UnlockAbilityResearchEffect.class);
+        }
+
+        if (excludedResearchId != null)
+        {
+            excludedEffect = colony.getResearchManager().getResearchEffects().getEffect(excludedResearchId, UnlockAbilityResearchEffect.class);
+        }
+
+        return (researchId == null || requiredEffect != null) && (excludedResearchId == null || excludedEffect == null);
+    }
+
+    /**
+     * Get a the recipe storage represented by this recipe
+     * @return
+     */
+    public IRecipeStorage getRecipeStorage()
+    {
+        return StandardFactoryController.getInstance().getNewInstance(
+            TypeConstants.RECIPE,
+            StandardFactoryController.getInstance().getNewInstance(TypeConstants.ITOKEN),
+            inputs,
+            1,
+            result,
+            intermediate);
+      }
+}

--- a/src/main/java/com/minecolonies/coremod/colony/crafting/CustomRecipeManager.java
+++ b/src/main/java/com/minecolonies/coremod/colony/crafting/CustomRecipeManager.java
@@ -1,0 +1,86 @@
+package com.minecolonies.coremod.colony.crafting;
+
+import java.util.*;
+import java.util.stream.Collectors;
+import com.google.gson.JsonObject;
+import com.ldtteam.blockout.Log;
+
+import static com.minecolonies.coremod.colony.crafting.CustomRecipe.*;
+
+/**
+ * Manager class for tracking Custom recipes during load and use
+ * This class is a singleton
+ */
+public class CustomRecipeManager
+{
+    private static CustomRecipeManager instance = new CustomRecipeManager();
+    private HashMap<String, HashMap<String, CustomRecipe>> recipeMap = new HashMap<>();
+
+    private CustomRecipeManager()
+    {
+    }
+        
+    /**
+     * Get the singleton instance of this class
+     * @return
+     */
+    public static CustomRecipeManager getInstance()
+    {
+        return instance;
+    }
+
+    /**
+     * Add a recipe Json to the manager
+     * @param recipeJson
+     * @param namespace
+     * @param path
+     */
+    public void addRecipe(JsonObject recipeJson, String namespace, String path)
+    {
+        CustomRecipe recipe = CustomRecipe.parse(recipeJson);
+        recipe.setRecipeId(namespace + ":" + path);
+        Log.getLogger().info("Parsed: " + recipe.getRecipeId());
+
+        if(!recipeMap.containsKey(recipe.getCrafter()))
+        {
+            Log.getLogger().info("Adding collection for: " + recipe.getCrafter());
+            recipeMap.put(recipe.getCrafter(), new HashMap<>());
+        }
+        recipeMap.get(recipe.getCrafter()).put(recipe.getRecipeId(), recipe);
+    }
+
+    /**
+     * Remove a recipe from the manager
+     * This allows modpacks to remove 'bad' recipes in addition to adding good ones
+     * @param recipeJson
+     * @param namespace
+     * @param path
+     */
+    public void removeRecipe(JsonObject recipeJson, String namespace, String path)
+    {
+        final String id = namespace + ":" + path;
+        if (recipeJson.has(RECIPE_TYPE) && recipeJson.get(RECIPE_TYPE).getAsString().equals("remove") && recipeJson.has("recipe-id-to-remove"))
+        {
+            final Optional<HashMap<String, CustomRecipe>> crafterMap = recipeMap.entrySet().stream().map(r -> r.getValue()).filter(r1 -> r1.keySet().contains(id)).findFirst();
+            if(crafterMap.isPresent())
+            {
+                crafterMap.get().remove(id);
+            }
+        }
+    }
+
+    /**
+     * Get all of the custom recipes that apply to a particular crafter
+     * @param crafter
+     * @return
+     */
+    public Set<CustomRecipe> getRecipes(String crafter)
+    {
+        if(recipeMap.containsKey(crafter))
+        {
+            return recipeMap.get(crafter).entrySet().stream().map(x -> x.getValue()).collect(Collectors.toSet());
+        }
+        return new HashSet<>();
+    }
+    
+}

--- a/src/main/java/com/minecolonies/coremod/colony/crafting/CustomRecipeManager.java
+++ b/src/main/java/com/minecolonies/coremod/colony/crafting/CustomRecipeManager.java
@@ -3,6 +3,8 @@ package com.minecolonies.coremod.colony.crafting;
 import java.util.*;
 import java.util.stream.Collectors;
 import com.google.gson.JsonObject;
+import com.ldtteam.blockout.Log;
+import org.jetbrains.annotations.NotNull;
 
 import static com.minecolonies.coremod.colony.crafting.CustomRecipe.*;
 
@@ -12,7 +14,14 @@ import static com.minecolonies.coremod.colony.crafting.CustomRecipe.*;
  */
 public class CustomRecipeManager
 {
+    /**
+     * The internal static instance of the singleton
+     */
     private static CustomRecipeManager instance = new CustomRecipeManager();
+
+    /**
+     * The map of loaded recipes
+     */
     private HashMap<String, HashMap<String, CustomRecipe>> recipeMap = new HashMap<>();
 
     private CustomRecipeManager()
@@ -34,7 +43,7 @@ public class CustomRecipeManager
      * @param namespace
      * @param path
      */
-    public void addRecipe(JsonObject recipeJson, String namespace, String path)
+    public void addRecipe(@NotNull final JsonObject recipeJson, @NotNull final String namespace, @NotNull final String path)
     {
         CustomRecipe recipe = CustomRecipe.parse(recipeJson);
         recipe.setRecipeId(namespace + ":" + path);
@@ -53,10 +62,10 @@ public class CustomRecipeManager
      * @param namespace
      * @param path
      */
-    public void removeRecipe(JsonObject recipeJson, String namespace, String path)
+    public void removeRecipe(@NotNull final JsonObject recipeJson, @NotNull final String namespace, @NotNull final String path)
     {
         final String id = namespace + ":" + path;
-        if (recipeJson.has(RECIPE_TYPE) && recipeJson.get(RECIPE_TYPE).getAsString().equals("remove") && recipeJson.has("recipe-id-to-remove"))
+        if (recipeJson.has(RECIPE_TYPE_PROP) && recipeJson.get(RECIPE_TYPE_PROP).getAsString().equals("remove") && recipeJson.has("recipe-id-to-remove"))
         {
             final Optional<HashMap<String, CustomRecipe>> crafterMap = recipeMap.entrySet().stream().map(r -> r.getValue()).filter(r1 -> r1.keySet().contains(id)).findFirst();
             if(crafterMap.isPresent())
@@ -71,7 +80,7 @@ public class CustomRecipeManager
      * @param crafter
      * @return
      */
-    public Set<CustomRecipe> getRecipes(String crafter)
+    public Set<CustomRecipe> getRecipes(@NotNull final String crafter)
     {
         if(recipeMap.containsKey(crafter))
         {

--- a/src/main/java/com/minecolonies/coremod/colony/crafting/CustomRecipeManager.java
+++ b/src/main/java/com/minecolonies/coremod/colony/crafting/CustomRecipeManager.java
@@ -3,7 +3,6 @@ package com.minecolonies.coremod.colony.crafting;
 import java.util.*;
 import java.util.stream.Collectors;
 import com.google.gson.JsonObject;
-import com.ldtteam.blockout.Log;
 
 import static com.minecolonies.coremod.colony.crafting.CustomRecipe.*;
 
@@ -39,11 +38,9 @@ public class CustomRecipeManager
     {
         CustomRecipe recipe = CustomRecipe.parse(recipeJson);
         recipe.setRecipeId(namespace + ":" + path);
-        Log.getLogger().info("Parsed: " + recipe.getRecipeId());
 
         if(!recipeMap.containsKey(recipe.getCrafter()))
         {
-            Log.getLogger().info("Adding collection for: " + recipe.getCrafter());
             recipeMap.put(recipe.getCrafter(), new HashMap<>());
         }
         recipeMap.get(recipe.getCrafter()).put(recipe.getRecipeId(), recipe);

--- a/src/main/java/com/minecolonies/coremod/colony/crafting/CustomRecipeManager.java
+++ b/src/main/java/com/minecolonies/coremod/colony/crafting/CustomRecipeManager.java
@@ -6,6 +6,8 @@ import com.google.gson.JsonObject;
 import com.ldtteam.blockout.Log;
 import org.jetbrains.annotations.NotNull;
 
+import net.minecraft.util.ResourceLocation;
+
 import static com.minecolonies.coremod.colony.crafting.CustomRecipe.*;
 
 /**
@@ -22,7 +24,7 @@ public class CustomRecipeManager
     /**
      * The map of loaded recipes
      */
-    private HashMap<String, HashMap<String, CustomRecipe>> recipeMap = new HashMap<>();
+    private HashMap<String, HashMap<ResourceLocation, CustomRecipe>> recipeMap = new HashMap<>();
 
     private CustomRecipeManager()
     {
@@ -43,16 +45,17 @@ public class CustomRecipeManager
      * @param namespace
      * @param path
      */
-    public void addRecipe(@NotNull final JsonObject recipeJson, @NotNull final String namespace, @NotNull final String path)
+    public void addRecipe(@NotNull final JsonObject recipeJson, @NotNull final ResourceLocation recipeLocation)
     {
         CustomRecipe recipe = CustomRecipe.parse(recipeJson);
-        recipe.setRecipeId(namespace + ":" + path);
+        recipe.setRecipeId(recipeLocation);
 
         if(!recipeMap.containsKey(recipe.getCrafter()))
         {
             recipeMap.put(recipe.getCrafter(), new HashMap<>());
         }
-        recipeMap.get(recipe.getCrafter()).put(recipe.getRecipeId(), recipe);
+
+        recipeMap.get(recipe.getCrafter()).put(recipeLocation, recipe);
     }
 
     /**
@@ -62,15 +65,15 @@ public class CustomRecipeManager
      * @param namespace
      * @param path
      */
-    public void removeRecipe(@NotNull final JsonObject recipeJson, @NotNull final String namespace, @NotNull final String path)
+    public void removeRecipe(@NotNull final JsonObject recipeJson, @NotNull final ResourceLocation recipeLocation)
     {
-        final String id = namespace + ":" + path;
-        if (recipeJson.has(RECIPE_TYPE_PROP) && recipeJson.get(RECIPE_TYPE_PROP).getAsString().equals("remove") && recipeJson.has("recipe-id-to-remove"))
+        if (recipeJson.has(RECIPE_TYPE_PROP) && recipeJson.get(RECIPE_TYPE_PROP).getAsString().equals(RECIPE_TYPE_REMOVE) && recipeJson.has(RECIPE_ID_TO_REMOVE_PROP))
         {
-            final Optional<HashMap<String, CustomRecipe>> crafterMap = recipeMap.entrySet().stream().map(r -> r.getValue()).filter(r1 -> r1.keySet().contains(id)).findFirst();
+            ResourceLocation toRemove = new ResourceLocation(recipeJson.get(RECIPE_ID_TO_REMOVE_PROP).getAsString());
+            final Optional<HashMap<ResourceLocation, CustomRecipe>> crafterMap = recipeMap.entrySet().stream().map(r -> r.getValue()).filter(r1 -> r1.keySet().contains(toRemove)).findFirst();
             if(crafterMap.isPresent())
             {
-                crafterMap.get().remove(id);
+                crafterMap.get().remove(toRemove);
             }
         }
     }

--- a/src/main/java/com/minecolonies/coremod/colony/jobs/JobDeliveryman.java
+++ b/src/main/java/com/minecolonies/coremod/colony/jobs/JobDeliveryman.java
@@ -267,6 +267,7 @@ public class JobDeliveryman extends AbstractJob<EntityAIWorkDeliveryman, JobDeli
         else if (request.getRequest() instanceof Pickup)
         {
             getTaskQueueFromDataStore().remove(request.getId());
+            getColony().getRequestManager().updateRequestState(current, successful ? RequestState.RESOLVED : RequestState.FAILED);
         }
         else
         {
@@ -294,7 +295,10 @@ public class JobDeliveryman extends AbstractJob<EntityAIWorkDeliveryman, JobDeli
             getTaskQueueFromDataStore().remove(token);
         }
 
-        getCitizen().getWorkBuilding().markDirty();
+        if (getCitizen().getWorkBuilding() != null)
+        {
+            getCitizen().getWorkBuilding().markDirty();
+        }
     }
 
     /**

--- a/src/main/java/com/minecolonies/coremod/colony/managers/BuildingManager.java
+++ b/src/main/java/com/minecolonies/coremod/colony/managers/BuildingManager.java
@@ -429,8 +429,6 @@ public class BuildingManager implements IBuildingManager
             wareHouses.remove(building);
         }
 
-        colony.getRequestManager().onProviderRemovedFromColony(building);
-
         //Allow Citizens to fix up any data that wasn't fixed up by the AbstractBuilding's own onDestroyed
         for (@NotNull final ICitizenData citizen : colony.getCitizenManager().getCitizens())
         {
@@ -438,6 +436,7 @@ public class BuildingManager implements IBuildingManager
             building.cancelAllRequestsOfCitizen(citizen);
         }
 
+        colony.getRequestManager().onProviderRemovedFromColony(building);
         colony.getCitizenManager().calculateMaxCitizens();
     }
 

--- a/src/main/java/com/minecolonies/coremod/datalistener/CrafterRecipeListener.java
+++ b/src/main/java/com/minecolonies/coremod/datalistener/CrafterRecipeListener.java
@@ -1,0 +1,55 @@
+package com.minecolonies.coremod.datalistener;
+
+import com.google.gson.*;
+import com.ldtteam.blockout.Log;
+import com.minecolonies.coremod.colony.crafting.CustomRecipeManager;
+
+import net.minecraft.client.resources.JsonReloadListener;
+import net.minecraft.profiler.IProfiler;
+import net.minecraft.resources.IResourceManager;
+import net.minecraft.util.ResourceLocation;
+
+import java.util.Map;
+
+import static com.minecolonies.coremod.colony.crafting.CustomRecipe.*;
+
+/**
+ * Loader for Json based crafter specific recipes
+ */
+public class CrafterRecipeListener extends JsonReloadListener
+{
+    private static final Gson GSON = new GsonBuilder().setPrettyPrinting().disableHtmlEscaping().create();
+
+    /**
+     * Set up the core loading, with the directory in the datapack that contains this data
+     * Directory is: <namespace>/crafterrecipes/<path>
+     */
+    public CrafterRecipeListener()
+    {
+        super(GSON, "crafterrecipes");
+    }
+
+    @Override
+    protected void apply(Map<ResourceLocation, JsonObject> object, IResourceManager resourceManager, IProfiler profiler)
+    {
+        Log.getLogger().info("Beginning load of custom recipes for colony workers");
+
+        CustomRecipeManager recipeManager = CustomRecipeManager.getInstance();
+        for(Map.Entry<ResourceLocation, JsonObject> entry : object.entrySet())
+        {
+            ResourceLocation key = entry.getKey();
+            JsonObject recipeJson = entry.getValue();
+
+            if(recipeJson.has(RECIPE_TYPE) && recipeJson.get(RECIPE_TYPE).getAsString().equals(RECIPE_TYPE_RECIPE)) 
+            {
+                Log.getLogger().info("Loading: " + key.getNamespace() + ":" + key.getPath());
+                recipeManager.addRecipe(recipeJson, key.getNamespace(), key.getPath());
+            }
+
+            if(recipeJson.has(RECIPE_TYPE) && recipeJson.get(RECIPE_TYPE).getAsString().equals(RECIPE_TYPE_REMOVE)) 
+            {
+                recipeManager.removeRecipe(recipeJson, key.getNamespace(), key.getPath());
+            }
+        } 
+    }
+}

--- a/src/main/java/com/minecolonies/coremod/datalistener/CrafterRecipeListener.java
+++ b/src/main/java/com/minecolonies/coremod/datalistener/CrafterRecipeListener.java
@@ -42,12 +42,12 @@ public class CrafterRecipeListener extends JsonReloadListener
 
             if(recipeJson.has(RECIPE_TYPE_PROP) && recipeJson.get(RECIPE_TYPE_PROP).getAsString().equals(RECIPE_TYPE_RECIPE)) 
             {
-                recipeManager.addRecipe(recipeJson, key.getNamespace(), key.getPath());
+                recipeManager.addRecipe(recipeJson, key);
             }
 
             if(recipeJson.has(RECIPE_TYPE_PROP) && recipeJson.get(RECIPE_TYPE_PROP).getAsString().equals(RECIPE_TYPE_REMOVE)) 
             {
-                recipeManager.removeRecipe(recipeJson, key.getNamespace(), key.getPath());
+                recipeManager.removeRecipe(recipeJson, key);
             }
         } 
     }

--- a/src/main/java/com/minecolonies/coremod/datalistener/CrafterRecipeListener.java
+++ b/src/main/java/com/minecolonies/coremod/datalistener/CrafterRecipeListener.java
@@ -42,7 +42,6 @@ public class CrafterRecipeListener extends JsonReloadListener
 
             if(recipeJson.has(RECIPE_TYPE) && recipeJson.get(RECIPE_TYPE).getAsString().equals(RECIPE_TYPE_RECIPE)) 
             {
-                Log.getLogger().info("Loading: " + key.getNamespace() + ":" + key.getPath());
                 recipeManager.addRecipe(recipeJson, key.getNamespace(), key.getPath());
             }
 

--- a/src/main/java/com/minecolonies/coremod/datalistener/CrafterRecipeListener.java
+++ b/src/main/java/com/minecolonies/coremod/datalistener/CrafterRecipeListener.java
@@ -40,12 +40,12 @@ public class CrafterRecipeListener extends JsonReloadListener
             ResourceLocation key = entry.getKey();
             JsonObject recipeJson = entry.getValue();
 
-            if(recipeJson.has(RECIPE_TYPE) && recipeJson.get(RECIPE_TYPE).getAsString().equals(RECIPE_TYPE_RECIPE)) 
+            if(recipeJson.has(RECIPE_TYPE_PROP) && recipeJson.get(RECIPE_TYPE_PROP).getAsString().equals(RECIPE_TYPE_RECIPE)) 
             {
                 recipeManager.addRecipe(recipeJson, key.getNamespace(), key.getPath());
             }
 
-            if(recipeJson.has(RECIPE_TYPE) && recipeJson.get(RECIPE_TYPE).getAsString().equals(RECIPE_TYPE_REMOVE)) 
+            if(recipeJson.has(RECIPE_TYPE_PROP) && recipeJson.get(RECIPE_TYPE_PROP).getAsString().equals(RECIPE_TYPE_REMOVE)) 
             {
                 recipeManager.removeRecipe(recipeJson, key.getNamespace(), key.getPath());
             }

--- a/src/main/java/com/minecolonies/coremod/entity/ai/basic/AbstractEntityAIRequestSmelter.java
+++ b/src/main/java/com/minecolonies/coremod/entity/ai/basic/AbstractEntityAIRequestSmelter.java
@@ -307,8 +307,6 @@ public abstract class AbstractEntityAIRequestSmelter<J extends AbstractJobCrafte
             return START_WORKING;
         }
 
-        walkTo = null;
-
         final int preExtractCount = InventoryUtils.getItemCountInItemHandler(worker.getInventoryCitizen(), stack -> currentRequest.getRequest().getStack().isItemEqual(stack));
 
         extractFromFurnace((FurnaceTileEntity) entity);
@@ -316,10 +314,11 @@ public abstract class AbstractEntityAIRequestSmelter<J extends AbstractJobCrafte
         final int resultCount = InventoryUtils.getItemCountInItemHandler(worker.getInventoryCitizen(), stack -> currentRequest.getRequest().getStack().isItemEqual(stack)) - preExtractCount;
         if (resultCount > 0)
         {
-            if (walkToBlock(walkTo))
+            if (walkTo != null && walkToBlock(walkTo))
             {
                 return getState();
             }
+            walkTo = null;
             final ItemStack stack = currentRequest.getRequest().getStack().copy();
             stack.setCount(resultCount);
             currentRequest.addDelivery(stack);

--- a/src/main/java/com/minecolonies/coremod/event/FMLEventHandler.java
+++ b/src/main/java/com/minecolonies/coremod/event/FMLEventHandler.java
@@ -57,9 +57,7 @@ public class FMLEventHandler
     @SubscribeEvent
     public static void onServerAboutToStart(FMLServerAboutToStartEvent event)
     {
-        IReloadableResourceManager resourceManager = event.getServer().getResourceManager();
-
-        resourceManager.addReloadListener(new CrafterRecipeListener());
+        event.getServer().getResourceManager().addReloadListener(new CrafterRecipeListener());
     }
 
     @SubscribeEvent

--- a/src/main/java/com/minecolonies/coremod/event/FMLEventHandler.java
+++ b/src/main/java/com/minecolonies/coremod/event/FMLEventHandler.java
@@ -3,13 +3,16 @@ package com.minecolonies.coremod.event;
 import com.minecolonies.api.colony.IColonyManager;
 import com.minecolonies.coremod.Network;
 import com.minecolonies.coremod.commands.EntryPoint;
+import com.minecolonies.coremod.datalistener.CrafterRecipeListener;
 import com.minecolonies.coremod.entity.pathfinding.Pathfinding;
 import com.minecolonies.coremod.network.messages.client.ColonyStylesMessage;
 import com.minecolonies.coremod.network.messages.client.ServerUUIDMessage;
 import net.minecraft.entity.player.ServerPlayerEntity;
+import net.minecraft.resources.IReloadableResourceManager;
 import net.minecraftforge.event.TickEvent;
 import net.minecraftforge.event.entity.player.PlayerEvent;
 import net.minecraftforge.eventbus.api.SubscribeEvent;
+import net.minecraftforge.fml.event.server.FMLServerAboutToStartEvent;
 import net.minecraftforge.fml.event.server.FMLServerStartingEvent;
 import net.minecraftforge.fml.event.server.FMLServerStoppingEvent;
 import org.jetbrains.annotations.NotNull;
@@ -49,6 +52,14 @@ public class FMLEventHandler
             IColonyManager.getInstance().getIColonyByOwner(((ServerPlayerEntity) event.getPlayer()).getServerWorld(), event.getPlayer());
             //ColonyManager.syncAllColoniesAchievements();
         }
+    }
+
+    @SubscribeEvent
+    public static void onServerAboutToStart(FMLServerAboutToStartEvent event)
+    {
+        IReloadableResourceManager resourceManager = event.getServer().getResourceManager();
+
+        resourceManager.addReloadListener(new CrafterRecipeListener());
     }
 
     @SubscribeEvent

--- a/src/main/resources/data/minecolonies/crafterrecipes/crusher/clay1.json
+++ b/src/main/resources/data/minecolonies/crafterrecipes/crusher/clay1.json
@@ -1,0 +1,14 @@
+{
+  "type" : "recipe",
+  "crafter": "crusher",
+  "inputs": [
+    {
+        "item" : "minecraft:sand",
+        "count": "2"
+    }
+  ],
+  "result": "minecraft:clay",
+  "count": "1",
+  "intermediate" : "minecraft:air",
+  "not-research-id" : "gildedhammer"
+}

--- a/src/main/resources/data/minecolonies/crafterrecipes/crusher/clay2.json
+++ b/src/main/resources/data/minecolonies/crafterrecipes/crusher/clay2.json
@@ -1,0 +1,14 @@
+{
+  "type" : "recipe",
+  "crafter": "crusher",
+  "inputs": [
+    {
+        "item" : "minecraft:sand",
+        "count": "1"
+    }
+  ],
+  "result": "minecraft:clay",
+  "count": "1",
+  "intermediate" : "minecraft:air",
+  "research-id" : "gildedhammer"
+}

--- a/src/main/resources/data/minecolonies/crafterrecipes/crusher/clay_ball.json
+++ b/src/main/resources/data/minecolonies/crafterrecipes/crusher/clay_ball.json
@@ -1,0 +1,13 @@
+{
+  "type" : "recipe",
+  "crafter": "crusher",
+  "inputs": [
+    {
+        "item" : "minecraft:clay",
+        "count": "1"
+    }
+  ],
+  "result": "minecraft:clay_ball",
+  "count": "4",
+  "intermediate" : "minecraft:air"
+}

--- a/src/main/resources/data/minecolonies/crafterrecipes/crusher/gravel1.json
+++ b/src/main/resources/data/minecolonies/crafterrecipes/crusher/gravel1.json
@@ -1,0 +1,14 @@
+{
+  "type" : "recipe",
+  "crafter": "crusher",
+  "inputs": [
+    {
+        "item" : "minecraft:cobblestone",
+        "count": "2"
+    }
+  ],
+  "result": "minecraft:gravel",
+  "count": "1",
+  "intermediate" : "minecraft:air",
+  "not-research-id" : "gildedhammer"
+}

--- a/src/main/resources/data/minecolonies/crafterrecipes/crusher/gravel2.json
+++ b/src/main/resources/data/minecolonies/crafterrecipes/crusher/gravel2.json
@@ -1,0 +1,14 @@
+{
+  "type" : "recipe",
+  "crafter": "crusher",
+  "inputs": [
+    {
+        "item" : "minecraft:cobblestone",
+        "count": "1"
+    }
+  ],
+  "result": "minecraft:gravel",
+  "count": "1",
+  "intermediate" : "minecraft:air",
+  "research-id" : "gildedhammer"
+}

--- a/src/main/resources/data/minecolonies/crafterrecipes/crusher/sand1.json
+++ b/src/main/resources/data/minecolonies/crafterrecipes/crusher/sand1.json
@@ -1,0 +1,14 @@
+{
+  "type" : "recipe",
+  "crafter": "crusher",
+  "inputs": [
+    {
+        "item" : "minecraft:gravel",
+        "count": "2"
+    }
+  ],
+  "result": "minecraft:sand",
+  "count": "1",
+  "intermediate" : "minecraft:air",
+  "not-research-id" : "gildedhammer"
+}

--- a/src/main/resources/data/minecolonies/crafterrecipes/crusher/sand2.json
+++ b/src/main/resources/data/minecolonies/crafterrecipes/crusher/sand2.json
@@ -1,0 +1,14 @@
+{
+  "type" : "recipe",
+  "crafter": "crusher",
+  "inputs": [
+    {
+        "item" : "minecraft:gravel",
+        "count": "1"
+    }
+  ],
+  "result": "minecraft:sand",
+  "count": "1",
+  "intermediate" : "minecraft:air",
+  "research-id" : "gildedhammer"
+}

--- a/src/main/resources/data/minecolonies/crafterrecipes/dyer/dark_prismarine.json
+++ b/src/main/resources/data/minecolonies/crafterrecipes/dyer/dark_prismarine.json
@@ -1,0 +1,17 @@
+{
+  "type" : "recipe",
+  "crafter": "dyer",
+  "inputs": [
+    {
+        "item" : "minecraft:prismarine",
+        "count": "4"
+    },
+    {
+        "item" : "minecraft:black_dye",
+        "count": "1"
+    }
+  ],
+  "result": "minecraft:dark_prismarine",
+  "count": "4",
+  "intermediate" : "minecraft:air"
+}

--- a/src/main/resources/data/minecolonies/crafterrecipes/dyer/green_dye.json
+++ b/src/main/resources/data/minecolonies/crafterrecipes/dyer/green_dye.json
@@ -1,0 +1,13 @@
+{
+  "type" : "recipe",
+  "crafter": "dyer",
+  "inputs": [
+    {
+        "item" : "minecraft:cactus",
+        "count": "1"
+    }
+  ],
+  "result": "minecraft:green_dye",
+  "count": "1",
+  "intermediate" : "minecraft:furnace"
+}

--- a/src/main/resources/data/minecolonies/crafterrecipes/dyer/red_sand.json
+++ b/src/main/resources/data/minecolonies/crafterrecipes/dyer/red_sand.json
@@ -1,0 +1,17 @@
+{
+  "type" : "recipe",
+  "crafter": "dyer",
+  "inputs": [
+    {
+        "item" : "minecraft:sand",
+        "count": "4"
+    },
+    {
+        "item" : "minecraft:red_dye",
+        "count": "1"
+    }
+  ],
+  "result": "minecraft:red_sand",
+  "count": "4",
+  "intermediate" : "minecraft:air"
+}

--- a/src/main/resources/data/minecolonies/crafterrecipes/farmer/carved_pumpkin.json
+++ b/src/main/resources/data/minecolonies/crafterrecipes/farmer/carved_pumpkin.json
@@ -1,0 +1,13 @@
+{
+  "type" : "recipe",
+  "crafter": "farmer",
+  "inputs": [
+    {
+        "item" : "minecraft:pumpkin",
+        "count": "1"
+    }
+  ],
+  "result": "minecraft:carved_pumpkin",
+  "count": "4",
+  "intermediate" : "minecraft:air"
+}

--- a/src/main/resources/data/minecolonies/crafterrecipes/fletcher/flint.json
+++ b/src/main/resources/data/minecolonies/crafterrecipes/fletcher/flint.json
@@ -1,0 +1,13 @@
+{
+  "type" : "recipe",
+  "crafter": "fletcher",
+  "inputs": [
+    {
+        "item" : "minecraft:gravel",
+        "count": "3"
+    }
+  ],
+  "result": "minecraft:flint",
+  "count": "1",
+  "intermediate" : "minecraft:air"
+}

--- a/src/main/resources/data/minecolonies/crafterrecipes/fletcher/string.json
+++ b/src/main/resources/data/minecolonies/crafterrecipes/fletcher/string.json
@@ -1,0 +1,13 @@
+{
+  "type" : "recipe",
+  "crafter": "fletcher",
+  "inputs": [
+    {
+        "item" : "minecraft:white_wool",
+        "count": "1"
+    }
+  ],
+  "result": "minecraft:string",
+  "count": "4",
+  "intermediate" : "minecraft:air"
+}

--- a/src/main/resources/data/minecolonies/crafterrecipes/lumberjack/stripped_acacia_log.json
+++ b/src/main/resources/data/minecolonies/crafterrecipes/lumberjack/stripped_acacia_log.json
@@ -1,0 +1,13 @@
+{
+  "type" : "recipe",
+  "crafter": "lumberjack",
+  "inputs": [
+    {
+        "item" : "minecraft:acacia_log",
+        "count": "1"
+    }
+  ],
+  "result": "minecraft:stripped_acacia_log",
+  "count": "1",
+  "intermediate" : "minecraft:air"
+}

--- a/src/main/resources/data/minecolonies/crafterrecipes/lumberjack/stripped_acacia_log2.json
+++ b/src/main/resources/data/minecolonies/crafterrecipes/lumberjack/stripped_acacia_log2.json
@@ -1,0 +1,13 @@
+{
+  "type" : "recipe",
+  "crafter": "lumberjack",
+  "inputs": [
+    {
+        "item" : "minecraft:acacia_wood",
+        "count": "1"
+    }
+  ],
+  "result": "minecraft:stripped_acacia_log",
+  "count": "1",
+  "intermediate" : "minecraft:air"
+}

--- a/src/main/resources/data/minecolonies/crafterrecipes/lumberjack/stripped_birch_log.json
+++ b/src/main/resources/data/minecolonies/crafterrecipes/lumberjack/stripped_birch_log.json
@@ -1,0 +1,13 @@
+{
+  "type" : "recipe",
+  "crafter": "lumberjack",
+  "inputs": [
+    {
+        "item" : "minecraft:birch_log",
+        "count": "1"
+    }
+  ],
+  "result": "minecraft:stripped_birch_log",
+  "count": "1",
+  "intermediate" : "minecraft:air"
+}

--- a/src/main/resources/data/minecolonies/crafterrecipes/lumberjack/stripped_birch_log2.json
+++ b/src/main/resources/data/minecolonies/crafterrecipes/lumberjack/stripped_birch_log2.json
@@ -1,0 +1,13 @@
+{
+  "type" : "recipe",
+  "crafter": "lumberjack",
+  "inputs": [
+    {
+        "item" : "minecraft:birch_wood",
+        "count": "1"
+    }
+  ],
+  "result": "minecraft:stripped_birch_log",
+  "count": "1",
+  "intermediate" : "minecraft:air"
+}

--- a/src/main/resources/data/minecolonies/crafterrecipes/lumberjack/stripped_dark_oak_log.json
+++ b/src/main/resources/data/minecolonies/crafterrecipes/lumberjack/stripped_dark_oak_log.json
@@ -1,0 +1,13 @@
+{
+  "type" : "recipe",
+  "crafter": "lumberjack",
+  "inputs": [
+    {
+        "item" : "minecraft:dark_oak_log",
+        "count": "1"
+    }
+  ],
+  "result": "minecraft:stripped_dark_oak_log",
+  "count": "1",
+  "intermediate" : "minecraft:air"
+}

--- a/src/main/resources/data/minecolonies/crafterrecipes/lumberjack/stripped_dark_oak_log2.json
+++ b/src/main/resources/data/minecolonies/crafterrecipes/lumberjack/stripped_dark_oak_log2.json
@@ -1,0 +1,13 @@
+{
+  "type" : "recipe",
+  "crafter": "lumberjack",
+  "inputs": [
+    {
+        "item" : "minecraft:dark_oak_wood",
+        "count": "1"
+    }
+  ],
+  "result": "minecraft:stripped_dark_oak_log",
+  "count": "1",
+  "intermediate" : "minecraft:air"
+}

--- a/src/main/resources/data/minecolonies/crafterrecipes/lumberjack/stripped_jungle_log.json
+++ b/src/main/resources/data/minecolonies/crafterrecipes/lumberjack/stripped_jungle_log.json
@@ -1,0 +1,13 @@
+{
+  "type" : "recipe",
+  "crafter": "lumberjack",
+  "inputs": [
+    {
+        "item" : "minecraft:jungle_log",
+        "count": "1"
+    }
+  ],
+  "result": "minecraft:stripped_jungle_log",
+  "count": "1",
+  "intermediate" : "minecraft:air"
+}

--- a/src/main/resources/data/minecolonies/crafterrecipes/lumberjack/stripped_jungle_log2.json
+++ b/src/main/resources/data/minecolonies/crafterrecipes/lumberjack/stripped_jungle_log2.json
@@ -1,0 +1,13 @@
+{
+  "type" : "recipe",
+  "crafter": "lumberjack",
+  "inputs": [
+    {
+        "item" : "minecraft:jungle_wood",
+        "count": "1"
+    }
+  ],
+  "result": "minecraft:stripped_jungle_log",
+  "count": "1",
+  "intermediate" : "minecraft:air"
+}

--- a/src/main/resources/data/minecolonies/crafterrecipes/lumberjack/stripped_oak_log.json
+++ b/src/main/resources/data/minecolonies/crafterrecipes/lumberjack/stripped_oak_log.json
@@ -1,0 +1,13 @@
+{
+  "type" : "recipe",
+  "crafter": "lumberjack",
+  "inputs": [
+    {
+        "item" : "minecraft:oak_log",
+        "count": "1"
+    }
+  ],
+  "result": "minecraft:stripped_oak_log",
+  "count": "1",
+  "intermediate" : "minecraft:air"
+}

--- a/src/main/resources/data/minecolonies/crafterrecipes/lumberjack/stripped_oak_log2.json
+++ b/src/main/resources/data/minecolonies/crafterrecipes/lumberjack/stripped_oak_log2.json
@@ -1,0 +1,13 @@
+{
+  "type" : "recipe",
+  "crafter": "lumberjack",
+  "inputs": [
+    {
+        "item" : "minecraft:oak_wood",
+        "count": "1"
+    }
+  ],
+  "result": "minecraft:stripped_oak_log",
+  "count": "1",
+  "intermediate" : "minecraft:air"
+}

--- a/src/main/resources/data/minecolonies/crafterrecipes/lumberjack/stripped_spruce_log.json
+++ b/src/main/resources/data/minecolonies/crafterrecipes/lumberjack/stripped_spruce_log.json
@@ -1,0 +1,13 @@
+{
+  "type" : "recipe",
+  "crafter": "lumberjack",
+  "inputs": [
+    {
+        "item" : "minecraft:spruce_log",
+        "count": "1"
+    }
+  ],
+  "result": "minecraft:stripped_spruce_log",
+  "count": "1",
+  "intermediate" : "minecraft:air"
+}

--- a/src/main/resources/data/minecolonies/crafterrecipes/lumberjack/stripped_spruce_log2.json
+++ b/src/main/resources/data/minecolonies/crafterrecipes/lumberjack/stripped_spruce_log2.json
@@ -1,0 +1,13 @@
+{
+  "type" : "recipe",
+  "crafter": "lumberjack",
+  "inputs": [
+    {
+        "item" : "minecraft:spruce_wood",
+        "count": "1"
+    }
+  ],
+  "result": "minecraft:stripped_spruce_log",
+  "count": "1",
+  "intermediate" : "minecraft:air"
+}

--- a/src/main/resources/data/minecolonies/crafterrecipes/stonemason/prismarine.json
+++ b/src/main/resources/data/minecolonies/crafterrecipes/stonemason/prismarine.json
@@ -1,0 +1,16 @@
+{
+  "type" : "recipe",
+  "crafter": "stonemason",
+  "inputs": [
+    {
+        "item" : "minecraft:cobblestone",
+        "count": "1"
+    },
+    {
+        "item" : "minecraft:prismarine_shard",
+        "count": "1"
+    }  ],
+  "result": "minecraft:prismarine",
+  "count": "1",
+  "intermediate" : "minecraft:air"
+}

--- a/src/main/resources/data/minecolonies/crafterrecipes/stonemason/prismarine_brick.json
+++ b/src/main/resources/data/minecolonies/crafterrecipes/stonemason/prismarine_brick.json
@@ -1,0 +1,17 @@
+{
+  "type" : "recipe",
+  "crafter": "stonemason",
+  "inputs": [
+    {
+        "item" : "minecraft:stone_bricks",
+        "count": "1"
+    },
+    {
+        "item" : "minecraft:prismarine_shard",
+        "count": "1"
+    }
+  ],
+  "result": "minecraft:prismarine_bricks",
+  "count": "1",
+  "intermediate" : "minecraft:air"
+}

--- a/src/main/resources/data/minecolonies/crafterrecipes/stonemason/red_sandstone.json
+++ b/src/main/resources/data/minecolonies/crafterrecipes/stonemason/red_sandstone.json
@@ -1,0 +1,17 @@
+{
+  "type" : "recipe",
+  "crafter": "stonemason",
+  "inputs": [
+    {
+        "item" : "minecraft:cobblestone",
+        "count": "1"
+    },
+    {
+        "item" : "minecraft:red_sand",
+        "count": "1"
+    }
+  ],
+  "result": "minecraft:red_sandstone",
+  "count": "1",
+  "intermediate" : "minecraft:air"
+}

--- a/src/main/resources/data/minecolonies/crafterrecipes/stonemason/sandstone.json
+++ b/src/main/resources/data/minecolonies/crafterrecipes/stonemason/sandstone.json
@@ -1,0 +1,17 @@
+{
+  "type" : "recipe",
+  "crafter": "stonemason",
+  "inputs": [
+    {
+        "item" : "minecraft:cobblestone",
+        "count": "1"
+    },
+    {
+        "item" : "minecraft:sand",
+        "count": "1"
+    }
+  ],
+  "result": "minecraft:sandstone",
+  "count": "1",
+  "intermediate" : "minecraft:air"
+}


### PR DESCRIPTION
# Changes proposed in this pull request:
- Enable loading of embedded recipes for workers from datapacks
- Update Crusher to load from data
- Update Dyer to load from data
- Update Farmer to load from data
- Update Fletcher to load from data
- Update Lumberjack to load from data
- Update Stonemason to load from data

Review please
