### PR TITLE
Fix some edge cases in the smeltercrafter & improve the postbox

### DIFF
--- a/src/api/java/com/minecolonies/api/util/InventoryUtils.java
+++ b/src/api/java/com/minecolonies/api/util/InventoryUtils.java
@@ -1808,7 +1808,7 @@ public class InventoryUtils
      * @param targetHandler               the target.
      * @param slot                        the slot to put it in.
      */
-    public static void transferXOfFirstSlotInItemHandlerWithIntoInItemHandler(
+    public static int transferXOfFirstSlotInItemHandlerWithIntoInItemHandler(
       final IItemHandler sourceHandler,
       final Predicate<ItemStack> itemStackSelectionPredicate,
       final int amount,
@@ -1819,19 +1819,21 @@ public class InventoryUtils
 
         if (desiredItemSlot == -1)
         {
-            return;
+            return 0;
         }
         final ItemStack returnStack = sourceHandler.extractItem(desiredItemSlot, amount, false);
         if (ItemStackUtils.isEmpty(returnStack))
         {
-            return;
+            return 0;
         }
 
         final ItemStack insertResult = targetHandler.insertItem(slot, returnStack, false);
         if (!ItemStackUtils.isEmpty(insertResult))
         {
             sourceHandler.insertItem(desiredItemSlot, insertResult, false);
+            return returnStack.getCount() - insertResult.getCount();
         }
+        return returnStack.getCount();
     }
 
     /**

--- a/src/api/java/com/minecolonies/api/util/InventoryUtils.java
+++ b/src/api/java/com/minecolonies/api/util/InventoryUtils.java
@@ -1807,6 +1807,7 @@ public class InventoryUtils
      * @param amount                      the max amount to extract
      * @param targetHandler               the target.
      * @param slot                        the slot to put it in.
+     * @return                            the count of items actually transferred
      */
     public static int transferXOfFirstSlotInItemHandlerWithIntoInItemHandler(
       final IItemHandler sourceHandler,

--- a/src/api/java/com/minecolonies/api/util/InventoryUtils.java
+++ b/src/api/java/com/minecolonies/api/util/InventoryUtils.java
@@ -1800,6 +1800,40 @@ public class InventoryUtils
     }
 
     /**
+     * Takes an item matching a predicate and moves it form one handler across multiple slots to the other to a specific slot.
+     *
+     * @param sourceHandler               the source handler.
+     * @param itemStackSelectionPredicate the predicate.
+     * @param amount                      the max amount to extract
+     * @param targetHandler               the target.
+     * @param slot                        the slot to put it in.
+     * @return                            the count of items actually transferred
+     */
+    public static int transferXInItemHandlerIntoSlotInItemHandler(
+        final IItemHandler sourceHandler,
+        final Predicate<ItemStack> itemStackSelectionPredicate,
+        final int amount,
+        final IItemHandler targetHandler, final int slot)
+    {        
+        int actualTransferred = 0;
+        while(actualTransferred < amount)
+        {
+            final int transferred = InventoryUtils.transferXOfFirstSlotInItemHandlerWithIntoInItemHandler(
+                                sourceHandler, 
+                                itemStackSelectionPredicate, 
+                                amount - actualTransferred,
+                                targetHandler,
+                                slot);
+            if(transferred <= 0)
+            {
+                break;
+            }
+            actualTransferred += transferred;
+        }
+        return actualTransferred;
+    }
+
+    /**
      * Takes an item matching a predicate and moves it form one handler to the other to a specific slot.
      *
      * @param sourceHandler               the source handler.

--- a/src/main/java/com/minecolonies/coremod/client/gui/WindowPostBox.java
+++ b/src/main/java/com/minecolonies/coremod/client/gui/WindowPostBox.java
@@ -110,17 +110,7 @@ public class WindowPostBox extends AbstractWindowRequestTree
             }
         }
 
-
         Network.getNetwork().sendToServer(new PostBoxRequestMessage(buildingView, stack.copy(), qty, deliverAvailable));
-
-        /*
-        while (qty > 0)
-        {
-            final int requestSize = qty > stack.getMaxStackSize() ? stack.getMaxStackSize() : qty;
-            qty -= requestSize;
-            Network.getNetwork().sendToServer(new PostBoxRequestMessage(buildingView, stack.copy(), requestSize, deliverAvailable));
-        }
-        */
     }
 
     private void deliverPartialClicked(@NotNull final Button button)

--- a/src/main/java/com/minecolonies/coremod/client/gui/WindowPostBox.java
+++ b/src/main/java/com/minecolonies/coremod/client/gui/WindowPostBox.java
@@ -110,12 +110,17 @@ public class WindowPostBox extends AbstractWindowRequestTree
             }
         }
 
+
+        Network.getNetwork().sendToServer(new PostBoxRequestMessage(buildingView, stack.copy(), qty, deliverAvailable));
+
+        /*
         while (qty > 0)
         {
             final int requestSize = qty > stack.getMaxStackSize() ? stack.getMaxStackSize() : qty;
             qty -= requestSize;
             Network.getNetwork().sendToServer(new PostBoxRequestMessage(buildingView, stack.copy(), requestSize, deliverAvailable));
         }
+        */
     }
 
     private void deliverPartialClicked(@NotNull final Button button)

--- a/src/main/java/com/minecolonies/coremod/entity/ai/basic/AbstractEntityAIRequestSmelter.java
+++ b/src/main/java/com/minecolonies/coremod/entity/ai/basic/AbstractEntityAIRequestSmelter.java
@@ -492,22 +492,13 @@ public abstract class AbstractEntityAIRequestSmelter<J extends AbstractJobCrafte
                                 return getState();
                             }
                             worker.getCitizenItemHandler().hitBlockWithToolInHand(walkTo);
-
-                            int actualTransferred = 0;
-                            while(actualTransferred < toTransfer)
-                            {
-                                int transferred = InventoryUtils.transferXOfFirstSlotInItemHandlerWithIntoInItemHandler(
-                                                    worker.getInventoryCitizen(), 
-                                                    smeltable, 
-                                                    toTransfer - actualTransferred,
-                                                    new InvWrapper(furnace), SMELTABLE_SLOT);
-                                if(transferred == 0)
-                                {
-                                    break;
-                                }
-                                actualTransferred += transferred;
-                            }
-                            job.setProgress(job.getProgress() + actualTransferred);
+                            int transferred = InventoryUtils.transferXInItemHandlerIntoSlotInItemHandler(
+                                                worker.getInventoryCitizen(), 
+                                                smeltable, 
+                                                toTransfer,
+                                                new InvWrapper(furnace), 
+                                                SMELTABLE_SLOT);
+                            job.setProgress(job.getProgress() + transferred);
                             }
                     }
                 }

--- a/src/main/java/com/minecolonies/coremod/entity/ai/basic/AbstractEntityAIRequestSmelter.java
+++ b/src/main/java/com/minecolonies/coremod/entity/ai/basic/AbstractEntityAIRequestSmelter.java
@@ -492,22 +492,22 @@ public abstract class AbstractEntityAIRequestSmelter<J extends AbstractJobCrafte
                                 return getState();
                             }
                             worker.getCitizenItemHandler().hitBlockWithToolInHand(walkTo);
-                            //This will pick the first slot in the citizen inventory with a smeltable, even if you are attempting to transfer 10, and the slot has 8.
-                            int transferred = InventoryUtils.transferXOfFirstSlotInItemHandlerWithIntoInItemHandler(
-                                                worker.getInventoryCitizen(), 
-                                                smeltable, 
-                                                toTransfer,
-                                                new InvWrapper(furnace), SMELTABLE_SLOT);
-                            // It's possible we emptied the slot, and transferred less than we want, so try one more time to pick up from another slot. 
-                            if (transferred < toTransfer)
+
+                            int actualTransferred = 0;
+                            while(actualTransferred < toTransfer)
                             {
-                                transferred += InventoryUtils.transferXOfFirstSlotInItemHandlerWithIntoInItemHandler(
-                                                worker.getInventoryCitizen(), 
-                                                smeltable, 
-                                                toTransfer - transferred,
-                                                new InvWrapper(furnace), SMELTABLE_SLOT);
+                                int transferred = InventoryUtils.transferXOfFirstSlotInItemHandlerWithIntoInItemHandler(
+                                                    worker.getInventoryCitizen(), 
+                                                    smeltable, 
+                                                    toTransfer,
+                                                    new InvWrapper(furnace), SMELTABLE_SLOT);
+                                if(transferred == 0)
+                                {
+                                    break;
+                                }
+                                actualTransferred += transferred;
                             }
-                            job.setProgress(job.getProgress() + transferred);
+                            job.setProgress(job.getProgress() + actualTransferred);
                             }
                     }
                 }

--- a/src/main/java/com/minecolonies/coremod/entity/ai/basic/AbstractEntityAIRequestSmelter.java
+++ b/src/main/java/com/minecolonies/coremod/entity/ai/basic/AbstractEntityAIRequestSmelter.java
@@ -492,15 +492,20 @@ public abstract class AbstractEntityAIRequestSmelter<J extends AbstractJobCrafte
                                 return getState();
                             }
                             worker.getCitizenItemHandler().hitBlockWithToolInHand(walkTo);
+                            //This will pick the first slot in the citizen inventory with a smeltable, even if you are attempting to transfer 10, and the slot has 8.
                             int transferred = InventoryUtils.transferXOfFirstSlotInItemHandlerWithIntoInItemHandler(
-                                worker.getInventoryCitizen(), smeltable, toTransfer,
-                                new InvWrapper(furnace), SMELTABLE_SLOT);
-                            // It's possible we have less in the stack than we want to transfer, so transfer what we can, and try one more time. 
+                                                worker.getInventoryCitizen(), 
+                                                smeltable, 
+                                                toTransfer,
+                                                new InvWrapper(furnace), SMELTABLE_SLOT);
+                            // It's possible we emptied the slot, and transferred less than we want, so try one more time to pick up from another slot. 
                             if (transferred < toTransfer)
                             {
                                 transferred += InventoryUtils.transferXOfFirstSlotInItemHandlerWithIntoInItemHandler(
-                                    worker.getInventoryCitizen(), smeltable, toTransfer - transferred,
-                                    new InvWrapper(furnace), SMELTABLE_SLOT);
+                                                worker.getInventoryCitizen(), 
+                                                smeltable, 
+                                                toTransfer - transferred,
+                                                new InvWrapper(furnace), SMELTABLE_SLOT);
                             }
                             job.setProgress(job.getProgress() + transferred);
                             }

--- a/src/main/java/com/minecolonies/coremod/entity/ai/basic/AbstractEntityAIRequestSmelter.java
+++ b/src/main/java/com/minecolonies/coremod/entity/ai/basic/AbstractEntityAIRequestSmelter.java
@@ -499,7 +499,7 @@ public abstract class AbstractEntityAIRequestSmelter<J extends AbstractJobCrafte
                                 int transferred = InventoryUtils.transferXOfFirstSlotInItemHandlerWithIntoInItemHandler(
                                                     worker.getInventoryCitizen(), 
                                                     smeltable, 
-                                                    toTransfer,
+                                                    toTransfer - actualTransferred,
                                                     new InvWrapper(furnace), SMELTABLE_SLOT);
                                 if(transferred == 0)
                                 {

--- a/src/main/java/com/minecolonies/coremod/entity/ai/basic/AbstractEntityAIRequestSmelter.java
+++ b/src/main/java/com/minecolonies/coremod/entity/ai/basic/AbstractEntityAIRequestSmelter.java
@@ -128,7 +128,7 @@ public abstract class AbstractEntityAIRequestSmelter<J extends AbstractJobCrafte
         }
 
         IAIState newState = super.getRecipe();
-        
+
         // This should only happen in the stonesmelter, but it could potentially happen with multiple fuels. 
         if(newState == QUERY_ITEMS && currentRecipeStorage != null && getOwnBuilding().isAllowedFuel(currentRecipeStorage.getPrimaryOutput()))
         {
@@ -190,6 +190,12 @@ public abstract class AbstractEntityAIRequestSmelter<J extends AbstractJobCrafte
             }
         }
         return getState();
+    }
+
+    private int getMaxUsableFurnaces()
+    {
+        final int maxSkillFurnaces = (worker.getCitizenData().getCitizenSkillHandler().getLevel(getOwnBuilding().getPrimarySkill()) / 10) + 1;
+        return Math.min(maxSkillFurnaces, getOwnBuilding().getFurnaces().size());
     }
 
     /**
@@ -307,6 +313,12 @@ public abstract class AbstractEntityAIRequestSmelter<J extends AbstractJobCrafte
             return START_WORKING;
         }
 
+        if (walkToBlock(walkTo))
+        {
+            return getState();
+        }
+        walkTo = null;
+
         final int preExtractCount = InventoryUtils.getItemCountInItemHandler(worker.getInventoryCitizen(), stack -> currentRequest.getRequest().getStack().isItemEqual(stack));
 
         extractFromFurnace((FurnaceTileEntity) entity);
@@ -314,18 +326,13 @@ public abstract class AbstractEntityAIRequestSmelter<J extends AbstractJobCrafte
         final int resultCount = InventoryUtils.getItemCountInItemHandler(worker.getInventoryCitizen(), stack -> currentRequest.getRequest().getStack().isItemEqual(stack)) - preExtractCount;
         if (resultCount > 0)
         {
-            if (walkTo != null && walkToBlock(walkTo))
-            {
-                return getState();
-            }
-            walkTo = null;
             final ItemStack stack = currentRequest.getRequest().getStack().copy();
             stack.setCount(resultCount);
             currentRequest.addDelivery(stack);
 
             job.setCraftCounter(job.getCraftCounter() + resultCount);
             job.setProgress(job.getProgress() - resultCount);
-            if(job.getCraftCounter() >= job.getMaxCraftingCount())
+            if(job.getCraftCounter() >= job.getMaxCraftingCount() && job.getProgress() <= 0)
             {
                 job.finishRequest(true);
                 resetValues();
@@ -360,6 +367,14 @@ public abstract class AbstractEntityAIRequestSmelter<J extends AbstractJobCrafte
      */
     private IAIState checkIfAbleToSmelt(final int amountOfFuel, final boolean checkSmeltables)
     {
+        // We're fully committed currently, try again later.
+        final int burning = countOfBurningFurnaces();
+        if(burning > 0 && (burning >= getMaxUsableFurnaces() || (job.getCraftCounter() + job.getProgress() ) >= job.getMaxCraftingCount()))
+        {
+            setDelay(TICKS_SECOND);
+            return getState();            
+        }
+
         for (final BlockPos pos : getOwnBuilding().getFurnaces())
         {
             final TileEntity entity = world.getTileEntity(pos);
@@ -388,7 +403,7 @@ public abstract class AbstractEntityAIRequestSmelter<J extends AbstractJobCrafte
             }
         }
 
-        if(countOfBurningFurnaces() > 0)
+        if(burning > 0)
         {
             setDelay(TICKS_SECOND);
         }
@@ -421,6 +436,7 @@ public abstract class AbstractEntityAIRequestSmelter<J extends AbstractJobCrafte
             return START_WORKING;
         }
 
+        final int burningCount = countOfBurningFurnaces();
         final TileEntity entity = world.getTileEntity(walkTo);
         if (entity instanceof FurnaceTileEntity)
         {
@@ -438,8 +454,7 @@ public abstract class AbstractEntityAIRequestSmelter<J extends AbstractJobCrafte
 
             if(currentRecipeStorage != null)
             {
-                final int maxSkillFurnaces = (worker.getCitizenData().getCitizenSkillHandler().getLevel(getOwnBuilding().getPrimarySkill()) / 10) + 1;
-                final int maxFurnaces = Math.min(maxSkillFurnaces, getOwnBuilding().getFurnaces().size());
+                final int maxFurnaces = getMaxUsableFurnaces();
                 final Predicate<ItemStack> smeltable = stack -> currentRecipeStorage.getCleanedInput().get(0).getItemStack().isItemEqual(stack);
                 final int targetCount = currentRequest.getRequest().getCount();
                 final int amountOfSmeltableInBuilding = InventoryUtils.getItemCountInProvider(getOwnBuilding(), smeltable);
@@ -455,7 +470,6 @@ public abstract class AbstractEntityAIRequestSmelter<J extends AbstractJobCrafte
                     {
                         int remainingToSmelt = job.getMaxCraftingCount() - (job.getProgress() + job.getCraftCounter());
                         int toTransfer = 0;
-                        int burningCount =countOfBurningFurnaces();
                         if(burningCount < maxFurnaces)
                         {
                             final int availableFurnaces = maxFurnaces - burningCount;
@@ -478,11 +492,18 @@ public abstract class AbstractEntityAIRequestSmelter<J extends AbstractJobCrafte
                                 return getState();
                             }
                             worker.getCitizenItemHandler().hitBlockWithToolInHand(walkTo);
-                            job.setProgress(job.getProgress() + toTransfer);
-                            InventoryUtils.transferXOfFirstSlotInItemHandlerWithIntoInItemHandler(
-                            worker.getInventoryCitizen(), smeltable, toTransfer,
-                            new InvWrapper(furnace), SMELTABLE_SLOT);
-                        }
+                            int transferred = InventoryUtils.transferXOfFirstSlotInItemHandlerWithIntoInItemHandler(
+                                worker.getInventoryCitizen(), smeltable, toTransfer,
+                                new InvWrapper(furnace), SMELTABLE_SLOT);
+                            // It's possible we have less in the stack than we want to transfer, so transfer what we can, and try one more time. 
+                            if (transferred < toTransfer)
+                            {
+                                transferred += InventoryUtils.transferXOfFirstSlotInItemHandlerWithIntoInItemHandler(
+                                    worker.getInventoryCitizen(), smeltable, toTransfer - transferred,
+                                    new InvWrapper(furnace), SMELTABLE_SLOT);
+                            }
+                            job.setProgress(job.getProgress() + transferred);
+                            }
                     }
                 }
                 else if(amountOfSmeltableInInv < targetCount 
@@ -492,7 +513,7 @@ public abstract class AbstractEntityAIRequestSmelter<J extends AbstractJobCrafte
                     needsCurrently = new Tuple<>(smeltable, targetCount);
                     return GATHERING_REQUIRED_MATERIALS;
                 } 
-                else if (countOfBurningFurnaces() == 0)
+                else if (burningCount == 0)
                 {
                     //This is a safety net for the AI getting way out of sync with it's tracking. It shouldn't happen. 
                     job.finishRequest(false);
@@ -534,24 +555,18 @@ public abstract class AbstractEntityAIRequestSmelter<J extends AbstractJobCrafte
             worker.getCitizenData().createRequestAsync(new StackList(possibleFuels, COM_MINECOLONIES_REQUESTS_BURNABLE, STACKSIZE, 1));
         }
 
-        if (currentRecipeStorage == null)
-        {
-            setDelay(TICKS_20);
-            return START_WORKING;
-        }
-
         if (walkToBuilding())
         {
             setDelay(STANDARD_DELAY);
             return getState();
         }
         
-        if(currentRequest == null)
+        if(currentRecipeStorage != null && currentRequest == null)
         {
             currentRequest = job.getCurrentTask();
         }
 
-        if (currentRecipeStorage.getIntermediate() != Blocks.FURNACE)
+        if (currentRecipeStorage != null && currentRecipeStorage.getIntermediate() != Blocks.FURNACE)
         {
             return super.craft();
         }
@@ -582,7 +597,7 @@ public abstract class AbstractEntityAIRequestSmelter<J extends AbstractJobCrafte
         }
 
         // Safety net, should get caught removing things from the furnace.
-        if(job.getMaxCraftingCount() > 0 && job.getCraftCounter() >= job.getMaxCraftingCount())
+        if(currentRequest != null && job.getMaxCraftingCount() > 0 && job.getCraftCounter() >= job.getMaxCraftingCount())
         {
             job.finishRequest(true);
             currentRecipeStorage = null;

--- a/src/main/java/com/minecolonies/coremod/network/messages/server/colony/building/postbox/PostBoxRequestMessage.java
+++ b/src/main/java/com/minecolonies/coremod/network/messages/server/colony/building/postbox/PostBoxRequestMessage.java
@@ -25,6 +25,8 @@ public class PostBoxRequestMessage extends AbstractBuildingServerMessage<PostBox
      */
     private boolean deliverAvailable;
 
+    private int reqQuantity;
+
     /**
      * Empty constructor used when registering the
      */
@@ -44,7 +46,7 @@ public class PostBoxRequestMessage extends AbstractBuildingServerMessage<PostBox
     {
         super(building);
         this.itemStack = itemStack;
-        this.itemStack.setCount(quantity);
+        reqQuantity = quantity;
         this.deliverAvailable = deliverAvailable;
     }
 
@@ -54,6 +56,7 @@ public class PostBoxRequestMessage extends AbstractBuildingServerMessage<PostBox
 
         buf.writeItemStack(itemStack);
         buf.writeBoolean(deliverAvailable);
+        buf.writeInt(reqQuantity);
     }
 
     @Override
@@ -62,6 +65,7 @@ public class PostBoxRequestMessage extends AbstractBuildingServerMessage<PostBox
 
         itemStack = buf.readItemStack();
         deliverAvailable = buf.readBoolean();
+        reqQuantity = buf.readInt();
     }
 
     @Override
@@ -69,8 +73,8 @@ public class PostBoxRequestMessage extends AbstractBuildingServerMessage<PostBox
       final NetworkEvent.Context ctxIn, final boolean isLogicalServer, final IColony colony, final PostBox building)
     {
 
-        int minCount = (deliverAvailable) ? 1 : itemStack.getCount();
-        Stack requestStack = new Stack(itemStack, itemStack.getCount(), minCount);
+        final int minCount = (deliverAvailable) ? 1 : reqQuantity;
+        Stack requestStack = new Stack(itemStack, reqQuantity, minCount);
 
         building.createRequest(requestStack, false);
     }


### PR DESCRIPTION
# Changes proposed in this pull request:
- Smeltercrafter was sometimes thinking it loaded more into a furnace than it did, and thus not completing the job. 
- Smeltercrafter no longer paces when using fewer than all the furnaces in the building
- Smeltercrafter will now recover when a job is cancelled and a furnace runs out of fuel before completing it.
- Postbox no longer breaks requests up into multiple request of single stacks. 

Review please
