### PR TITLE
Add auto-hire from training centers

### DIFF
--- a/src/api/java/com/minecolonies/api/colony/buildings/IBuildingBedProvider.java
+++ b/src/api/java/com/minecolonies/api/colony/buildings/IBuildingBedProvider.java
@@ -1,0 +1,16 @@
+package com.minecolonies.api.colony.buildings;
+
+import java.util.List;
+import org.jetbrains.annotations.NotNull;
+import net.minecraft.util.math.BlockPos;
+
+public interface IBuildingBedProvider
+{
+    /**
+     * Gets a list of all beds in this building.
+     *
+     * @return a list of all beds in this building.
+     */
+    @NotNull
+    public List<BlockPos> getBedList();
+}

--- a/src/api/java/com/minecolonies/api/util/constant/WindowConstants.java
+++ b/src/api/java/com/minecolonies/api/util/constant/WindowConstants.java
@@ -589,6 +589,7 @@ public final class WindowConstants
     public static final String  GUI_BUTTON_ASSIGNMENT_MODE = "assign";
     public static final String  GUI_BUTTON_PATROL_MODE     = "patrol";
     public static final String  GUI_BUTTON_RETRIEVAL_MODE  = "retrieve";
+    public static final String  GUI_BUTTON_TRAINEE_MODE    = "trainees";
     public static final String  GUI_BUTTON_SET_TARGET      = "setTarget";
     public static final String  GUI_BUTTON_RECALCULATE     = "recalculate";
     //GUI Switches

--- a/src/main/java/com/minecolonies/coremod/client/gui/WindowGuardControl.java
+++ b/src/main/java/com/minecolonies/coremod/client/gui/WindowGuardControl.java
@@ -58,6 +58,11 @@ public class WindowGuardControl extends AbstractWindowSkeleton
     private boolean tightGrouping = true;
 
     /**
+     * Whether to hire from training facility
+     */
+    private boolean hireTrainees = true;
+
+    /**
      * The GuardTask of the guard.
      */
     private GuardTask task = GuardTask.GUARD;
@@ -90,6 +95,7 @@ public class WindowGuardControl extends AbstractWindowSkeleton
 
         registerButton(GUI_BUTTON_PATROL_MODE, this::switchPatrolMode);
         registerButton(GUI_BUTTON_RETRIEVAL_MODE, this::switchRetrievalMode);
+        registerButton(GUI_BUTTON_TRAINEE_MODE, this::switchTraineeMode);
         registerButton(GUI_BUTTON_RECALCULATE, this::recalculate);
         registerButton(GUI_BUTTON_SET_TARGET, this::setTarget);
 
@@ -205,6 +211,7 @@ public class WindowGuardControl extends AbstractWindowSkeleton
     {
         this.patrolManually = building.isPatrolManually();
         this.retrieveOnLowHealth = building.isRetrieveOnLowHealth();
+        this.hireTrainees = building.isHireTrainees();
         this.tightGrouping = building.isTightGrouping();
         this.task = building.getTask();
         this.patrolTargets = building.getPatrolTargets();
@@ -217,7 +224,7 @@ public class WindowGuardControl extends AbstractWindowSkeleton
     {
         final ResourceLocation resourceName = building.getGuardType() == null ? new ResourceLocation("") : building.getGuardType().getRegistryName();
         Network.getNetwork()
-          .sendToServer(new GuardTaskMessage(building, resourceName, building.isAssignManually(), patrolManually, retrieveOnLowHealth, task.ordinal(), tightGrouping));
+          .sendToServer(new GuardTaskMessage(building, resourceName, building.isAssignManually(), patrolManually, retrieveOnLowHealth, task.ordinal(), tightGrouping, hireTrainees));
     }
 
     /**
@@ -365,6 +372,17 @@ public class WindowGuardControl extends AbstractWindowSkeleton
         pullInfoFromHut();
         sendChangesToServer();
         this.findPaneOfTypeByID(GUI_BUTTON_RETRIEVAL_MODE, Button.class).setLabel(retrieveOnLowHealth ? GUI_SWITCH_ON : GUI_SWITCH_OFF);
+    }
+
+    /**
+     * Switch the trainee mode.
+     */
+    private void switchTraineeMode()
+    {
+        building.setHireTrainees(!building.isHireTrainees());
+        pullInfoFromHut();
+        sendChangesToServer();
+        this.findPaneOfTypeByID(GUI_BUTTON_TRAINEE_MODE, Button.class).setLabel(hireTrainees ? GUI_SWITCH_ON : GUI_SWITCH_OFF);
     }
 
     /**

--- a/src/main/java/com/minecolonies/coremod/client/gui/WindowHutGuardTower.java
+++ b/src/main/java/com/minecolonies/coremod/client/gui/WindowHutGuardTower.java
@@ -71,6 +71,11 @@ public class WindowHutGuardTower extends AbstractWindowWorkerBuilding<AbstractBu
     private boolean tightGrouping = true;
 
     /**
+     * Whether to hire from training facilities
+     */
+    private boolean hireTrainees = true;
+
+    /**
      * The GuardTask of the guard.
      */
     private GuardTask task = GuardTask.GUARD;
@@ -103,6 +108,7 @@ public class WindowHutGuardTower extends AbstractWindowWorkerBuilding<AbstractBu
         registerButton(GUI_BUTTON_ASSIGNMENT_MODE, this::switchAssignmentMode);
         registerButton(GUI_BUTTON_PATROL_MODE, this::switchPatrolMode);
         registerButton(GUI_BUTTON_RETRIEVAL_MODE, this::switchRetrievalMode);
+        registerButton(GUI_BUTTON_TRAINEE_MODE, this::switchTraineeMode);
         registerButton(GUI_BUTTON_SET_TARGET, this::setTarget);
         registerButton(GUI_BUTTON_RECALCULATE, this::recalculate);
         registerButton(BUTTON_GET_TOOL, this::getTool);
@@ -411,6 +417,7 @@ public class WindowHutGuardTower extends AbstractWindowWorkerBuilding<AbstractBu
         this.patrolManually = building.isPatrolManually();
         this.retrieveOnLowHealth = building.isRetrieveOnLowHealth();
         this.tightGrouping = building.isTightGrouping();
+        this.hireTrainees = building.isHireTrainees();
         this.task = building.getTask();
         this.job = building.getGuardType();
         this.patrolTargets = building.getPatrolTargets();
@@ -524,6 +531,17 @@ public class WindowHutGuardTower extends AbstractWindowWorkerBuilding<AbstractBu
     }
 
     /**
+     * Switch the trainee mode.
+     */
+    private void switchTraineeMode()
+    {
+        building.setHireTrainees(!building.isHireTrainees());
+        pullInfoFromHut();
+        sendChangesToServer();
+        this.findPaneOfTypeByID(GUI_BUTTON_TRAINEE_MODE, Button.class).setLabel(hireTrainees ? GUI_SWITCH_ON : GUI_SWITCH_OFF);
+    }
+
+    /**
      * Switch the patrol mode.
      */
     private void switchPatrolMode()
@@ -549,6 +567,6 @@ public class WindowHutGuardTower extends AbstractWindowWorkerBuilding<AbstractBu
     private void sendChangesToServer()
     {
         final ResourceLocation resourceName = building.getGuardType() == null ? new ResourceLocation("") : building.getGuardType().getRegistryName();
-        Network.getNetwork().sendToServer(new GuardTaskMessage(building, resourceName, assignManually, patrolManually, retrieveOnLowHealth, task.ordinal(), tightGrouping));
+        Network.getNetwork().sendToServer(new GuardTaskMessage(building, resourceName, assignManually, patrolManually, retrieveOnLowHealth, task.ordinal(), tightGrouping, hireTrainees));
     }
 }

--- a/src/main/java/com/minecolonies/coremod/colony/buildings/AbstractBuildingGuards.java
+++ b/src/main/java/com/minecolonies/coremod/colony/buildings/AbstractBuildingGuards.java
@@ -809,11 +809,18 @@ public abstract class AbstractBuildingGuards extends AbstractBuildingWorker impl
             return tightGrouping;
         }
 
+        /**
+         * Is hiring from training facilities enabled
+         * @return
+         */
         public boolean isHireTrainees()
         {
             return hireTrainees;
         }
 
+        /**
+         * Set whether or not to hire from training facilities
+         */
         public void setHireTrainees(final boolean hireTrainees)
         {
             this.hireTrainees = hireTrainees;
@@ -1198,11 +1205,18 @@ public abstract class AbstractBuildingGuards extends AbstractBuildingWorker impl
         return true;
     }
 
+    /**
+     * is hiring from training facilities enabled
+     * @return
+     */
     public boolean isHireTrainees()
     {
         return hireTrainees;
     }
 
+    /**
+     * set hiring from training facilities
+     */
     public void setHireTrainees(boolean hireTrainees)
     {
         this.hireTrainees = hireTrainees;

--- a/src/main/java/com/minecolonies/coremod/colony/buildings/AbstractBuildingGuards.java
+++ b/src/main/java/com/minecolonies/coremod/colony/buildings/AbstractBuildingGuards.java
@@ -475,28 +475,22 @@ public abstract class AbstractBuildingGuards extends AbstractBuildingWorker impl
         if (hireTrainees && !isFull() && ((getBuildingLevel() > 0 && isBuilt()))
               && (this.getHiringMode() == HiringMode.DEFAULT && !this.getColony().isManualHiring() || this.getHiringMode() == HiringMode.AUTO))
         {
-            List<ICitizenData> trainingCitizens = null;
-            
-            if(this.getGuardType() == ModGuardTypes.ranger)
-            {
-                trainingCitizens = colony.getCitizenManager().getCitizens().stream().filter(x -> x.getJob() instanceof JobArcherTraining).collect(Collectors.toList());
-            }
-            else if (this.getGuardType() == ModGuardTypes.knight)
-            {
-                trainingCitizens = colony.getCitizenManager().getCitizens().stream().filter(x -> x.getJob() instanceof JobCombatTraining).collect(Collectors.toList());
-            }
+            ICitizenData trainingCitizen = null;
+            int maxSkill = 0;
 
-            if(trainingCitizens != null && !trainingCitizens.isEmpty())
+            for(ICitizenData trainee:colony.getCitizenManager().getCitizens())
             {
-                Comparator<ICitizenData> skillComparator = Comparator.comparingInt(e -> e.getCitizenSkillHandler().getLevel(job.getPrimarySkill()));
-                skillComparator = skillComparator.reversed();
-                trainingCitizens.sort(skillComparator);
-
-                final ICitizenData traineeCitizen = trainingCitizens.get(0);
-                if (traineeCitizen != null)
+                if((this.getGuardType() == ModGuardTypes.ranger && trainee instanceof JobArcherTraining) || (this.getGuardType() == ModGuardTypes.knight && trainee instanceof JobCombatTraining)
+                    &&  trainee.getCitizenSkillHandler().getLevel(job.getPrimarySkill()) > maxSkill)
                 {
-                    assignCitizen(traineeCitizen);
+                    maxSkill = trainee.getCitizenSkillHandler().getLevel(job.getPrimarySkill());
+                    trainingCitizen = trainee;
                 }
+            }
+
+            if(trainingCitizen != null )
+            {
+                assignCitizen(trainingCitizen);
             }
         }
 

--- a/src/main/java/com/minecolonies/coremod/colony/buildings/workerbuildings/BuildingArchery.java
+++ b/src/main/java/com/minecolonies/coremod/colony/buildings/workerbuildings/BuildingArchery.java
@@ -4,6 +4,8 @@ import com.ldtteam.blockout.views.Window;
 import com.minecolonies.api.colony.ICitizenData;
 import com.minecolonies.api.colony.IColony;
 import com.minecolonies.api.colony.IColonyView;
+import com.minecolonies.api.colony.buildings.IBuilding;
+import com.minecolonies.api.colony.buildings.IBuildingBedProvider;
 import com.minecolonies.api.colony.buildings.ModBuildings;
 import com.minecolonies.api.colony.buildings.registry.BuildingEntry;
 import com.minecolonies.api.colony.jobs.IJob;
@@ -20,6 +22,7 @@ import net.minecraft.block.FenceBlock;
 import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.nbt.CompoundNBT;
 import net.minecraft.nbt.ListNBT;
+import net.minecraft.nbt.NBTUtil;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.text.TranslationTextComponent;
 import net.minecraft.world.World;
@@ -36,7 +39,7 @@ import static com.minecolonies.api.util.constant.NbtTagConstants.*;
 /**
  * Building class for the Archery.
  */
-public class BuildingArchery extends AbstractBuildingWorker
+public class BuildingArchery extends AbstractBuildingWorker implements IBuildingBedProvider
 {
     /**
      * The Schematic name.
@@ -59,6 +62,12 @@ public class BuildingArchery extends AbstractBuildingWorker
     private final List<BlockPos> shootingTargets = new ArrayList<>();
 
     /**
+     * List of all beds.
+     */
+    @NotNull
+    private final List<BlockPos> bedList = new ArrayList<>();
+
+    /**
      * The abstract constructor of the building.
      *
      * @param c the colony
@@ -74,6 +83,30 @@ public class BuildingArchery extends AbstractBuildingWorker
     public IJob<?> createJob(final ICitizenData citizen)
     {
         return new JobArcherTraining(citizen);
+    }
+
+    @NotNull
+    @Override
+    public List<BlockPos> getBedList()
+    {
+        return new ArrayList<>(bedList);
+    }
+
+    @Override
+    public boolean assignCitizen(final ICitizenData citizen)
+    {
+        if (super.assignCitizen(citizen) && citizen != null)
+        {
+            // Set new home, since guards are housed at their workerbuilding.
+            final IBuilding building = citizen.getHomeBuilding();
+            if (building != null && !building.getID().equals(this.getID()))
+            {
+                building.removeCitizen(citizen);
+            }
+            citizen.setHomeBuilding(this);
+            return true;
+        }
+        return false;
     }
 
     @Override
@@ -114,6 +147,17 @@ public class BuildingArchery extends AbstractBuildingWorker
 
         final ListNBT standTagList = compound.getList(TAG_ARCHERY_STANDS, Constants.NBT.TAG_COMPOUND);
         shootingStands.addAll(NBTUtils.streamCompound(standTagList).map(targetCompound -> BlockPosUtil.read(targetCompound, TAG_STAND)).collect(Collectors.toList()));
+
+        final ListNBT bedTagList = compound.getList(TAG_BEDS, Constants.NBT.TAG_COMPOUND);
+        for (int i = 0; i < bedTagList.size(); ++i)
+        {
+            final CompoundNBT bedCompound = bedTagList.getCompound(i);
+            final BlockPos bedPos = NBTUtil.readBlockPos(bedCompound);
+            if (!bedList.contains(bedPos))
+            {
+                bedList.add(bedPos);
+            }
+        }
     }
 
     @Override
@@ -126,6 +170,16 @@ public class BuildingArchery extends AbstractBuildingWorker
 
         final ListNBT standTagList = shootingStands.stream().map(target -> BlockPosUtil.write(new CompoundNBT(), TAG_STAND, target)).collect(NBTUtils.toListNBT());
         compound.put(TAG_ARCHERY_STANDS, standTagList);
+        
+        if (!bedList.isEmpty())
+        {
+            @NotNull final ListNBT bedTagList = new ListNBT();
+            for (@NotNull final BlockPos pos : bedList)
+            {
+                bedTagList.add(NBTUtil.writeBlockPos(pos));
+            }
+            compound.put(TAG_BEDS, bedTagList);
+        }
 
         return compound;
     }

--- a/src/main/java/com/minecolonies/coremod/colony/buildings/workerbuildings/BuildingCombatAcademy.java
+++ b/src/main/java/com/minecolonies/coremod/colony/buildings/workerbuildings/BuildingCombatAcademy.java
@@ -6,6 +6,8 @@ import com.ldtteam.blockout.views.Window;
 import com.minecolonies.api.colony.ICitizenData;
 import com.minecolonies.api.colony.IColony;
 import com.minecolonies.api.colony.IColonyView;
+import com.minecolonies.api.colony.buildings.IBuilding;
+import com.minecolonies.api.colony.buildings.IBuildingBedProvider;
 import com.minecolonies.api.colony.buildings.ModBuildings;
 import com.minecolonies.api.colony.buildings.registry.BuildingEntry;
 import com.minecolonies.api.colony.jobs.IJob;
@@ -23,6 +25,7 @@ import net.minecraft.block.HayBlock;
 import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.nbt.CompoundNBT;
 import net.minecraft.nbt.ListNBT;
+import net.minecraft.nbt.NBTUtil;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.text.TranslationTextComponent;
 import net.minecraft.world.World;
@@ -40,7 +43,7 @@ import static com.minecolonies.api.util.constant.NbtTagConstants.*;
 /**
  * Building class for the Combat Academy.
  */
-public class BuildingCombatAcademy extends AbstractBuildingWorker
+public class BuildingCombatAcademy extends AbstractBuildingWorker implements IBuildingBedProvider
 {
     /**
      * The Schematic name.
@@ -63,6 +66,12 @@ public class BuildingCombatAcademy extends AbstractBuildingWorker
     private final BiMap<Integer, Integer> trainingPartners = HashBiMap.create();
 
     /**
+     * List of all beds.
+     */
+    @NotNull
+    private final List<BlockPos> bedList = new ArrayList<>();
+
+    /**
      * The abstract constructor of the building.
      *
      * @param c the colony
@@ -78,6 +87,30 @@ public class BuildingCombatAcademy extends AbstractBuildingWorker
     public IJob<?> createJob(final ICitizenData citizen)
     {
         return new JobCombatTraining(citizen);
+    }
+
+    @NotNull
+    @Override
+    public List<BlockPos> getBedList()
+    {
+        return new ArrayList<>(bedList);
+    }
+    
+    @Override
+    public boolean assignCitizen(final ICitizenData citizen)
+    {
+        if (super.assignCitizen(citizen) && citizen != null)
+        {
+            // Set new home, since guards are housed at their workerbuilding.
+            final IBuilding building = citizen.getHomeBuilding();
+            if (building != null && !building.getID().equals(this.getID()))
+            {
+                building.removeCitizen(citizen);
+            }
+            citizen.setHomeBuilding(this);
+            return true;
+        }
+        return false;
     }
 
     @Override
@@ -115,6 +148,17 @@ public class BuildingCombatAcademy extends AbstractBuildingWorker
         final ListNBT partnersTagList = compound.getList(TAG_COMBAT_PARTNER, Constants.NBT.TAG_COMPOUND);
         trainingPartners.putAll(NBTUtils.streamCompound(partnersTagList)
                                   .collect(Collectors.toMap(targetCompound -> targetCompound.getInt(TAG_PARTNER1), targetCompound -> targetCompound.getInt(TAG_PARTNER2))));
+        
+        final ListNBT bedTagList = compound.getList(TAG_BEDS, Constants.NBT.TAG_COMPOUND);
+        for (int i = 0; i < bedTagList.size(); ++i)
+        {
+            final CompoundNBT bedCompound = bedTagList.getCompound(i);
+            final BlockPos bedPos = NBTUtil.readBlockPos(bedCompound);
+            if (!bedList.contains(bedPos))
+            {
+                bedList.add(bedPos);
+            }
+        }
     }
 
     @Override
@@ -128,6 +172,16 @@ public class BuildingCombatAcademy extends AbstractBuildingWorker
         final ListNBT partnersTagList = trainingPartners.entrySet().stream().map(BuildingCombatAcademy::writePartnerTupleToNBT).collect(NBTUtils.toListNBT());
         compound.put(TAG_COMBAT_PARTNER, partnersTagList);
 
+        if (!bedList.isEmpty())
+        {
+            @NotNull final ListNBT bedTagList = new ListNBT();
+            for (@NotNull final BlockPos pos : bedList)
+            {
+                bedTagList.add(NBTUtil.writeBlockPos(pos));
+            }
+            compound.put(TAG_BEDS, bedTagList);
+        }
+        
         return compound;
     }
 

--- a/src/main/java/com/minecolonies/coremod/colony/buildings/workerbuildings/BuildingHome.java
+++ b/src/main/java/com/minecolonies/coremod/colony/buildings/workerbuildings/BuildingHome.java
@@ -7,6 +7,7 @@ import com.minecolonies.api.colony.ICitizenData;
 import com.minecolonies.api.colony.IColony;
 import com.minecolonies.api.colony.IColonyView;
 import com.minecolonies.api.colony.buildings.IBuilding;
+import com.minecolonies.api.colony.buildings.IBuildingBedProvider;
 import com.minecolonies.api.colony.buildings.ModBuildings;
 import com.minecolonies.api.colony.buildings.registry.BuildingEntry;
 import com.minecolonies.api.entity.citizen.AbstractEntityCitizen;
@@ -36,7 +37,7 @@ import static com.minecolonies.api.util.constant.NbtTagConstants.TAG_RESIDENTS;
 /**
  * The class of the citizen hut.
  */
-public class BuildingHome extends AbstractBuilding
+public class BuildingHome extends AbstractBuilding implements IBuildingBedProvider
 {
     /**
      * The string describing the hut.
@@ -507,12 +508,8 @@ public class BuildingHome extends AbstractBuilding
         getColony().getCitizenManager().calculateMaxCitizens();
     }
 
-    /**
-     * Gets a list of all beds in this building.
-     *
-     * @return a list of all beds in this building.
-     */
     @NotNull
+    @Override
     public List<BlockPos> getBedList()
     {
         return new ArrayList<>(bedList);

--- a/src/main/java/com/minecolonies/coremod/colony/managers/CitizenManager.java
+++ b/src/main/java/com/minecolonies/coremod/colony/managers/CitizenManager.java
@@ -6,6 +6,7 @@ import com.minecolonies.api.colony.ICitizenDataManager;
 import com.minecolonies.api.colony.ICivilianData;
 import com.minecolonies.api.colony.IColony;
 import com.minecolonies.api.colony.buildings.IBuilding;
+import com.minecolonies.api.colony.buildings.IBuildingBedProvider;
 import com.minecolonies.api.colony.managers.interfaces.ICitizenManager;
 import com.minecolonies.api.entity.ModEntities;
 import com.minecolonies.api.entity.citizen.AbstractCivilianEntity;
@@ -373,7 +374,7 @@ public class CitizenManager implements ICitizenManager
         {
             if (b.getBuildingLevel() > 0)
             {
-                if (b instanceof BuildingHome)
+                if (b instanceof IBuildingBedProvider)
                 {
                     newMaxCitizens += b.getMaxInhabitants();
                 }

--- a/src/main/java/com/minecolonies/coremod/entity/ai/minimal/EntityAISleep.java
+++ b/src/main/java/com/minecolonies/coremod/entity/ai/minimal/EntityAISleep.java
@@ -3,6 +3,7 @@ package com.minecolonies.coremod.entity.ai.minimal;
 import com.minecolonies.api.colony.ICitizenData;
 import com.minecolonies.api.colony.IColony;
 import com.minecolonies.api.colony.buildings.IBuilding;
+import com.minecolonies.api.colony.buildings.IBuildingBedProvider;
 import com.minecolonies.api.entity.ai.DesiredActivity;
 import com.minecolonies.api.entity.ai.Status;
 import com.minecolonies.api.entity.ai.statemachine.states.IState;
@@ -210,9 +211,9 @@ public class EntityAISleep extends Goal
             if (usedBed == null)
             {
                 final IBuilding hut = colony.getBuildingManager().getBuilding(citizen.getHomePosition());
-                if (hut instanceof BuildingHome)
+                if (hut instanceof IBuildingBedProvider)
                 {
-                    for (final BlockPos pos : ((BuildingHome) hut).getBedList())
+                    for (final BlockPos pos : ((IBuildingBedProvider) hut).getBedList())
                     {
                         if (WorldUtil.isEntityBlockLoaded(citizen.world, pos))
                         {

--- a/src/main/java/com/minecolonies/coremod/network/messages/server/colony/building/guard/GuardTaskMessage.java
+++ b/src/main/java/com/minecolonies/coremod/network/messages/server/colony/building/guard/GuardTaskMessage.java
@@ -27,6 +27,8 @@ public class GuardTaskMessage extends AbstractBuildingServerMessage<AbstractBuil
      */
     private boolean tightGrouping;
 
+    private boolean hireTrainees;
+
     /**
      * Empty standard constructor.
      */
@@ -53,7 +55,8 @@ public class GuardTaskMessage extends AbstractBuildingServerMessage<AbstractBuil
       final boolean patrollingMode,
       final boolean retrieval,
       final int task,
-      final boolean tightGrouping
+      final boolean tightGrouping,
+      final boolean hireTrainees
     )
     {
         super(building);
@@ -63,6 +66,7 @@ public class GuardTaskMessage extends AbstractBuildingServerMessage<AbstractBuil
         this.retrieval = retrieval;
         this.task = task;
         this.tightGrouping = tightGrouping;
+        this.hireTrainees = hireTrainees;
     }
 
     @Override
@@ -75,6 +79,7 @@ public class GuardTaskMessage extends AbstractBuildingServerMessage<AbstractBuil
         tightGrouping = buf.readBoolean();
         retrieval = buf.readBoolean();
         task = buf.readInt();
+        hireTrainees = buf.readBoolean();
     }
 
     @Override
@@ -87,6 +92,7 @@ public class GuardTaskMessage extends AbstractBuildingServerMessage<AbstractBuil
         buf.writeBoolean(tightGrouping);
         buf.writeBoolean(retrieval);
         buf.writeInt(task);
+        buf.writeBoolean(hireTrainees);
     }
 
     @Override
@@ -99,6 +105,7 @@ public class GuardTaskMessage extends AbstractBuildingServerMessage<AbstractBuil
         building.setTightGrouping(tightGrouping);
         building.setRetrieveOnLowHealth(retrieval);
         building.setTask(GuardTask.values()[task]);
+        building.setHireTrainees(hireTrainees);
 
         if (building.getTask().equals(GuardTask.FOLLOW))
         {

--- a/src/main/resources/assets/minecolonies/gui/windowguardcontrol.xml
+++ b/src/main/resources/assets/minecolonies/gui/windowguardcontrol.xml
@@ -10,18 +10,23 @@
                  source="minecolonies:textures/gui/builderhut/builder_button_medium.png"
                  label="$(com.minecolonies.coremod.gui.workerhuts.retrieveOff)" textcolor="black"/>
 
-    <button id="patrolling" size="50 14" pos="15 72"
+    <label size="50 11" pos="12 62" label="$(com.minecolonies.coremod.gui.workerhuts.trainees)" color="white" style="bold"/>
+    <buttonimage id="trainees" size="86 17" pos="42 83"
+                 source="minecolonies:textures/gui/builderhut/builder_button_medium.png"
+                 label="$(com.minecolonies.coremod.gui.workerhuts.retrieveOff)" textcolor="black"/>
+
+    <button id="patrolling" size="50 14" pos="15 102"
             label="$(com.minecolonies.coremod.gui.workerhuts.task.patrol)"/>
-    <button id="following" size="50 14" pos="67 72"
+    <button id="following" size="50 14" pos="67 102"
             label="$(com.minecolonies.coremod.gui.workerhuts.task.follow)"/>
-    <button id="guarding" size="50 14" pos="119 72"
+    <button id="guarding" size="50 14" pos="119 102"
             label="$(com.minecolonies.coremod.gui.workerhuts.task.guard)"/>
 
-    <buttonimage id="setTarget" size="129 17" pos="25 100"
+    <buttonimage id="setTarget" size="129 17" pos="25 130"
                  source="minecolonies:textures/gui/builderhut/builder_button_medium_large.png"
                  label="$(com.minecolonies.coremod.gui.workerhuts.setTarget)" textcolor="black"/>
 
-    <list id="positions" size="129 100" pos="25 122">
+    <list id="positions" size="129 100" pos="25 152">
         <box size="100% 15" linewidth="2">
             <label id="position" size="100 12" pos="5 2" color="white"/>
         </box>

--- a/src/main/resources/assets/minecolonies/gui/windowhutguardtower.xml
+++ b/src/main/resources/assets/minecolonies/gui/windowhutguardtower.xml
@@ -32,11 +32,17 @@
                          source="minecolonies:textures/gui/builderhut/builder_button_medium.png"
                          label="$(com.minecolonies.coremod.gui.workerhuts.retrieveOff)"/>
 
-            <button id="patrolling" size="30% 14" pos="15 139"
+            <label size="164 11" pos="13 138" color="black" textalign="MIDDLE"
+                   label="$(com.minecolonies.coremod.gui.workerhuts.trainees)"/>
+            <buttonimage id="trainees" size="86 17" pos="52 149" textcolor="black"
+                         source="minecolonies:textures/gui/builderhut/builder_button_medium.png"
+                         label="$(com.minecolonies.coremod.gui.workerhuts.retrieveOn)"/>
+
+            <button id="patrolling" size="30% 14" pos="15 169"
                     label="$(com.minecolonies.coremod.gui.workerhuts.task.patrol)"/>
-            <button id="following" size="30% 14" pos="67 139"
+            <button id="following" size="30% 14" pos="67 169"
                     label="$(com.minecolonies.coremod.gui.workerhuts.task.follow)"/>
-            <button id="guarding" size="30% 14" pos="119 139"
+            <button id="guarding" size="30% 14" pos="119 169"
                     label="$(com.minecolonies.coremod.gui.workerhuts.task.guard)"/>
 
             <buttonimage id="setTarget" size="129 17" pos="30 164" textcolor="black"

--- a/src/main/resources/assets/minecolonies/lang/en_us.json
+++ b/src/main/resources/assets/minecolonies/lang/en_us.json
@@ -587,6 +587,7 @@
   "com.minecolonies.coremod.gui.workerhuts.assign": "Assign the guard to the job:",
   "com.minecolonies.coremod.gui.workerhuts.patrol": "Find patrol target:",
   "com.minecolonies.coremod.gui.workerhuts.retrieve": "Try to retreat on low health:",
+  "com.minecolonies.coremod.gui.workerhuts.trainees": "Try to hire from training facility:",
   "com.minecolonies.coremod.gui.workerhuts.knight": "Knight",
   "com.minecolonies.coremod.gui.workerhuts.ranger": "Archer",
   "com.minecolonies.coremod.gui.workerhuts.modem": "Manually",


### PR DESCRIPTION
# Changes proposed in this pull request:
- Guard towers will now attempt to hire the best from the respective training centers before hiring unemployed
- There is a new button in the Guard towers to turn off trainee hiring, it defaults to on. 
- Training centers are now 'homes' for their workers
- Added bed registration to training centers, though not all schematics have beds yet.

Review please
