### PR TITLE
Fixes a setting in the Town Hall going over the edge of the page

### DIFF
--- a/src/main/resources/assets/minecolonies/lang/en_us.json
+++ b/src/main/resources/assets/minecolonies/lang/en_us.json
@@ -720,7 +720,7 @@
   "com.minecolonies.coremod.gui.workerhuts.saplinglist": "Saplings",
 
   "com.minecolonies.coremod.gui.townhall.housing": "Housing Assignment Mode:",
-  "com.minecolonies.coremod.gui.townhall.movein": "Children will be born (if there's space):",
+  "com.minecolonies.coremod.gui.townhall.movein": "Kids will be born:",
   "com.minecolonies.coremod.gui.home.assign": "Assign %d citizens",
   "com.minecolonies.coremod.gui.workerhuts.unassign": "Remove Citizen",
   "block.minecolonies.blockminecoloniesrack": "Rack",


### PR DESCRIPTION
Closes #
Closes #
Closes #

# Changes proposed in this pull request:
- The setting in the TH for allowing kids to move in went over the edge of the page. This shortens it.
-
-

Review please
