### PR TITLE
Make the miner less likely to get stuck

### DIFF
--- a/src/main/java/com/minecolonies/coremod/colony/buildings/workerbuildings/BuildingMiner.java
+++ b/src/main/java/com/minecolonies/coremod/colony/buildings/workerbuildings/BuildingMiner.java
@@ -587,7 +587,12 @@ public class BuildingMiner extends AbstractBuildingStructureBuilder
     @NotNull
     public Node getActiveNode()
     {
-        return activeNode == null || activeNode.getStatus() == Node.NodeStatus.COMPLETED ? levels.get(currentLevel).getRandomNode(oldNode) : activeNode;
+        Node calcNode = activeNode == null || activeNode.getStatus() == Node.NodeStatus.COMPLETED ? levels.get(currentLevel).getRandomNode(oldNode) : activeNode;
+        if (activeNode != calcNode)
+        {
+            activeNode = calcNode;
+        }
+        return activeNode;
     }
 
     /**

--- a/src/main/java/com/minecolonies/coremod/entity/ai/citizen/miner/EntityAIStructureMiner.java
+++ b/src/main/java/com/minecolonies/coremod/entity/ai/citizen/miner/EntityAIStructureMiner.java
@@ -689,6 +689,12 @@ public class EntityAIStructureMiner extends AbstractEntityAIStructureWithWorkOrd
             rotation = ROTATE_ONCE;
         }
 
+
+        if(workingNode.getRot().isPresent() && workingNode.getRot().get() != rotation)
+        {
+            Log.getLogger().warn("Calculated rotation doesn't match recorded: x:" + workingNodeX + " z:" + workingNodeZ);
+        }
+
         final Node parentNode = currentLevel.getNode(workingNode.getParent());
         if (parentNode != null && parentNode.getStyle() != Node.NodeType.SHAFT && (parentNode.getStatus() != Node.NodeStatus.COMPLETED || !(world.getBlockState(new BlockPos(
           parentNode.getX(),
@@ -698,12 +704,16 @@ public class EntityAIStructureMiner extends AbstractEntityAIStructureWithWorkOrd
             workingNode = parentNode;
             workingNode.setStatus(Node.NodeStatus.AVAILABLE);
             buildingMiner.setActiveNode(parentNode);
+            buildingMiner.markDirty();
+            //We need to make sure to walk back to the last valid parent
+            return MINER_CHECK_MINESHAFT;
         }
 
         @NotNull final BlockPos standingPosition = new BlockPos(workingNode.getParent().getX(), currentLevel.getDepth(), workingNode.getParent().getZ());
         currentStandingPosition = standingPosition;
         if ((workingNode.getStatus() == Node.NodeStatus.AVAILABLE || workingNode.getStatus() == Node.NodeStatus.IN_PROGRESS) && !walkToBlock(standingPosition))
         {
+            workingNode.setRot(rotation);
             return executeStructurePlacement(workingNode, standingPosition, rotation);
         }
         return MINER_CHECK_MINESHAFT;
@@ -825,6 +835,7 @@ public class EntityAIStructureMiner extends AbstractEntityAIStructureWithWorkOrd
     private IAIState executeStructurePlacement(@NotNull final Node mineNode, @NotNull final BlockPos standingPosition, final int rotation)
     {
         mineNode.setStatus(Node.NodeStatus.IN_PROGRESS);
+        getOwnBuilding().markDirty();
         //Preload structures
         if (job.getBlueprint() == null)
         {

--- a/src/main/java/com/minecolonies/coremod/entity/ai/citizen/miner/Level.java
+++ b/src/main/java/com/minecolonies/coremod/entity/ai/citizen/miner/Level.java
@@ -1,5 +1,6 @@
 package com.minecolonies.coremod.entity.ai.citizen.miner;
 
+import com.ldtteam.blockout.Log;
 import com.minecolonies.api.util.BlockPosUtil;
 import com.minecolonies.api.util.Vec2i;
 import com.minecolonies.coremod.colony.buildings.workerbuildings.BuildingMiner;
@@ -194,7 +195,7 @@ public class Level
     public Node getRandomNode(@Nullable final Node node)
     {
         Node nextNode = null;
-        if (node != null && rand.nextInt(RANDOM_TYPES) > 0)
+        if (node != null && getNumberOfBuiltNodes() > 10 && rand.nextInt(RANDOM_TYPES) > 0)
         {
             nextNode = node.getRandomNextNode(this, 0);
         }
@@ -245,7 +246,12 @@ public class Level
             nodes.put(pos, tempNodeToAdd);
             openNodes.add(tempNodeToAdd);
         }
-        nodes.get(new Vec2i(tempNode.getX(), tempNode.getZ())).setStatus(Node.NodeStatus.COMPLETED);
+        Node I = nodes.get(new Vec2i(tempNode.getX(), tempNode.getZ())); //.setStatus(Node.NodeStatus.COMPLETED);
+        if(!tempNode.equals(I))
+        {
+            Log.getLogger().warn("Nodes not equal during close");
+        }
+        tempNode.setStatus(Node.NodeStatus.COMPLETED);
         openNodes.removeIf(tempNode::equals);
     }
 

--- a/src/main/java/com/minecolonies/coremod/entity/ai/citizen/miner/Level.java
+++ b/src/main/java/com/minecolonies/coremod/entity/ai/citizen/miner/Level.java
@@ -231,6 +231,9 @@ public class Level
                 nodeCenterList.add(getNextNodePositionFromNodeWithRotation(tempNode, rotation, ROTATE_ONCE));
                 nodeCenterList.add(getNextNodePositionFromNodeWithRotation(tempNode, rotation, ROTATE_THREE_TIMES));
                 break;
+            case UNDEFINED:
+                Log.getLogger().warn("Node: " + node.getX() + ":" + node.getZ() +" style undefined, not creating children");
+                return;
             default:
                 return;
         }
@@ -246,13 +249,14 @@ public class Level
             nodes.put(pos, tempNodeToAdd);
             openNodes.add(tempNodeToAdd);
         }
-        Node I = nodes.get(new Vec2i(tempNode.getX(), tempNode.getZ())); //.setStatus(Node.NodeStatus.COMPLETED);
+        Node I = nodes.get(new Vec2i(tempNode.getX(), tempNode.getZ()));
         if(!tempNode.equals(I))
         {
             Log.getLogger().warn("Nodes not equal during close");
         }
         tempNode.setStatus(Node.NodeStatus.COMPLETED);
         openNodes.removeIf(tempNode::equals);
+
     }
 
     /**

--- a/src/main/java/com/minecolonies/coremod/entity/ai/citizen/miner/Level.java
+++ b/src/main/java/com/minecolonies/coremod/entity/ai/citizen/miner/Level.java
@@ -1,7 +1,7 @@
 package com.minecolonies.coremod.entity.ai.citizen.miner;
 
-import com.ldtteam.blockout.Log;
 import com.minecolonies.api.util.BlockPosUtil;
+import com.minecolonies.api.util.Log;
 import com.minecolonies.api.util.Vec2i;
 import com.minecolonies.coremod.colony.buildings.workerbuildings.BuildingMiner;
 import net.minecraft.nbt.CompoundNBT;
@@ -13,6 +13,7 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.*;
+
 
 import static com.minecolonies.coremod.entity.ai.citizen.miner.Node.NodeType.*;
 
@@ -49,10 +50,9 @@ public class Level
      */
     private static final int              RANDOM_TYPES       = 4;
     /**
-     * Comparator to compare two nodes, for the priority queue.
+     * The number of nodes that need to be built near the main shaft before randomly picking the next
      */
-    @NotNull
-    private static final Comparator<Node> NODE_COMPARATOR    = (Node n1, Node n2) -> rand.nextInt(100) > 50 ? 1 : -1;
+    private static final int              MINIMUM_NODES_FOR_RANDOM = 10;
     /**
      * The hashMap of nodes, check for nodes with the tuple of the parent x and z.
      */
@@ -62,7 +62,7 @@ public class Level
      * The queue of open Nodes. Get a new node to work on here.
      */
     @NotNull
-    private final        Queue<Node>      openNodes          = new PriorityQueue<>(11, NODE_COMPARATOR);
+    private final        Queue<Node>      openNodes          = new ArrayDeque<>(11);
 
     /**
      * The depth of the level stored as the y coordinate.
@@ -195,7 +195,7 @@ public class Level
     public Node getRandomNode(@Nullable final Node node)
     {
         Node nextNode = null;
-        if (node != null && getNumberOfBuiltNodes() > 10 && rand.nextInt(RANDOM_TYPES) > 0)
+        if (node != null && getNumberOfBuiltNodes() > MINIMUM_NODES_FOR_RANDOM && rand.nextInt(RANDOM_TYPES) > 0)
         {
             nextNode = node.getRandomNextNode(this, 0);
         }
@@ -232,7 +232,7 @@ public class Level
                 nodeCenterList.add(getNextNodePositionFromNodeWithRotation(tempNode, rotation, ROTATE_THREE_TIMES));
                 break;
             case UNDEFINED:
-                Log.getLogger().warn("Node: " + node.getX() + ":" + node.getZ() +" style undefined, not creating children");
+                Log.getLogger().error("Minecolonies node: " + node.getX() + ":" + node.getZ() +" style undefined creating children, Please tell the mod authors about this");
                 return;
             default:
                 return;
@@ -252,7 +252,7 @@ public class Level
         Node I = nodes.get(new Vec2i(tempNode.getX(), tempNode.getZ()));
         if(!tempNode.equals(I))
         {
-            Log.getLogger().warn("Nodes not equal during close");
+            Log.getLogger().warn("Minecolonies node: " + node.getX() + ":" + node.getZ() + " not equal to storage during close, Please tell the mod authors about this");
         }
         tempNode.setStatus(Node.NodeStatus.COMPLETED);
         openNodes.removeIf(tempNode::equals);

--- a/src/main/java/com/minecolonies/coremod/entity/ai/citizen/miner/Node.java
+++ b/src/main/java/com/minecolonies/coremod/entity/ai/citizen/miner/Node.java
@@ -102,7 +102,6 @@ public class Node
 
         final int x;
         final int z;
-        Optional<Integer> rot = Optional.empty();
         if (hasDoubles)
         {
             x = MathHelper.floor(compound.getDouble(TAG_X));
@@ -112,11 +111,6 @@ public class Node
         {
             x = compound.getInt(TAG_X);
             z = compound.getInt(TAG_Z);
-        }
-
-        if(compound.keySet().contains(TAG_ROT))
-        {
-            rot = Optional.of(compound.getInt(TAG_ROT));
         }
 
         final NodeType style = NodeType.valueOf(compound.getString(TAG_STYLE));
@@ -146,9 +140,9 @@ public class Node
         node.setStyle(style);
         node.setStatus(status);
 
-        if(rot.isPresent())
+        if(compound.keySet().contains(TAG_ROT))
         {
-            node.setRot(rot.get());
+            node.setRot(compound.getInt(TAG_ROT));
         }
 
         return node;

--- a/src/main/java/com/minecolonies/coremod/entity/ai/citizen/miner/Node.java
+++ b/src/main/java/com/minecolonies/coremod/entity/ai/citizen/miner/Node.java
@@ -83,7 +83,7 @@ public class Node
     {
         this.x = x;
         this.z = z;
-        this.style = NodeType.CROSSROAD;
+        this.style = NodeType.UNDEFINED;
         this.status = NodeStatus.AVAILABLE;
         this.parent = parent;
     }
@@ -139,6 +139,10 @@ public class Node
 
         //Set the node status in all directions.
         @NotNull final Node node = new Node(x, z, parent);
+        if(style == NodeType.UNDEFINED)
+        {
+            com.ldtteam.blockout.Log.getLogger().warn("Node " + x + "," + z + " has an undefined style");
+        }
         node.setStyle(style);
         node.setStatus(status);
 
@@ -389,7 +393,9 @@ public class Node
         //Crossroad structure
         CROSSROAD,
         //Bending tunnle
-        BEND
+        BEND,
+        //New node, undefined
+        UNDEFINED
     }
 
     public Optional<Integer> getRot()

--- a/src/main/java/com/minecolonies/coremod/entity/ai/citizen/miner/Node.java
+++ b/src/main/java/com/minecolonies/coremod/entity/ai/citizen/miner/Node.java
@@ -141,7 +141,7 @@ public class Node
         @NotNull final Node node = new Node(x, z, parent);
         if(style == NodeType.UNDEFINED)
         {
-            com.ldtteam.blockout.Log.getLogger().warn("Node " + x + "," + z + " has an undefined style");
+            Log.getLogger().error("Minecolonies Node " + x + "," + z + " has an undefined style, please tell the mod author about this");
         }
         node.setStyle(style);
         node.setStatus(status);
@@ -398,11 +398,19 @@ public class Node
         UNDEFINED
     }
 
+    /**
+     * Get rotation stored in the node as an optional, only set if actually stored. 
+     * @return
+     */
     public Optional<Integer> getRot()
     {
         return rot;
     }
 
+    /**
+     * Set rotation storaged in the node
+     * @param rot
+     */
     public void setRot(int rot)
     {
         this.rot = Optional.of(rot);

--- a/src/main/java/com/minecolonies/coremod/entity/ai/citizen/miner/Node.java
+++ b/src/main/java/com/minecolonies/coremod/entity/ai/citizen/miner/Node.java
@@ -6,8 +6,8 @@ import net.minecraft.nbt.CompoundNBT;
 import net.minecraft.util.math.MathHelper;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
-
 import java.util.Objects;
+import java.util.Optional;
 import java.util.Random;
 
 /**
@@ -23,6 +23,7 @@ public class Node
      */
     private static final String TAG_X       = "idX";
     private static final String TAG_Z       = "idZ";
+    private static final String TAG_ROT     = "rotation";
     private static final String TAG_STYLE   = "Style";
     private static final String TAG_STATUS  = "Status";
     private static final String TAG_PARENTX = "ParentX";
@@ -47,6 +48,11 @@ public class Node
      * Z position of the node.
      */
     private final int z;
+
+    /**
+     * The rotation that was calculated and used at build time
+     */
+    private Optional<Integer> rot = Optional.empty();
 
     /**
      * Central position of parent node.
@@ -96,6 +102,7 @@ public class Node
 
         final int x;
         final int z;
+        Optional<Integer> rot = Optional.empty();
         if (hasDoubles)
         {
             x = MathHelper.floor(compound.getDouble(TAG_X));
@@ -105,6 +112,11 @@ public class Node
         {
             x = compound.getInt(TAG_X);
             z = compound.getInt(TAG_Z);
+        }
+
+        if(compound.keySet().contains(TAG_ROT))
+        {
+            rot = Optional.of(compound.getInt(TAG_ROT));
         }
 
         final NodeType style = NodeType.valueOf(compound.getString(TAG_STYLE));
@@ -130,6 +142,11 @@ public class Node
         node.setStyle(style);
         node.setStatus(status);
 
+        if(rot.isPresent())
+        {
+            node.setRot(rot.get());
+        }
+
         return node;
     }
 
@@ -142,6 +159,11 @@ public class Node
     {
         compound.putInt(TAG_X, x);
         compound.putInt(TAG_Z, z);
+        
+        if(rot.isPresent())
+        {
+            compound.putInt(TAG_ROT, rot.get());
+        }
 
         compound.putString(TAG_STYLE, style.name());
         compound.putString(TAG_STATUS, status.name());
@@ -368,5 +390,15 @@ public class Node
         CROSSROAD,
         //Bending tunnle
         BEND
+    }
+
+    public Optional<Integer> getRot()
+    {
+        return rot;
+    }
+
+    public void setRot(int rot)
+    {
+        this.rot = Optional.of(rot);
     }
 }


### PR DESCRIPTION
# Changes proposed in this pull request:
- Make getWorkingNode more stable/deterministic
- Add tracking and validation of rotation 
- Make node picking sequential until there are 10 nodes built on a level - this should do at least 2 nodes out from shaft on a new level

Review please
