### PR TITLE
Fix recipe storage to compare input counts and other minor changes

### DIFF
--- a/src/api/java/com/minecolonies/api/crafting/RecipeStorage.java
+++ b/src/api/java/com/minecolonies/api/crafting/RecipeStorage.java
@@ -175,7 +175,7 @@ public class RecipeStorage implements IRecipeStorage
 
         for (int i = 0; i < input.size(); i++)
         {
-            if (!that.input.get(i).isItemEqual(input.get(i)))
+            if (!(that.input.get(i).isItemEqual(input.get(i)) && that.input.get(i).getCount() == input.get(i).getCount()))
             {
                 return false;
             }

--- a/src/main/java/com/minecolonies/coremod/colony/crafting/CustomRecipe.java
+++ b/src/main/java/com/minecolonies/coremod/colony/crafting/CustomRecipe.java
@@ -9,15 +9,14 @@ import com.minecolonies.api.research.effects.IResearchEffect;
 import com.minecolonies.api.util.constant.TypeConstants;
 import com.minecolonies.coremod.research.UnlockAbilityResearchEffect;
 import org.jetbrains.annotations.NotNull;
-
 import net.minecraft.block.Block;
 import net.minecraft.block.Blocks;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.ResourceLocation;
 import net.minecraftforge.registries.ForgeRegistries;
-
 import java.util.ArrayList;
+import java.util.Objects;
 
 /**
  * This class represents a recipe loaded from custom data that is available to a crafter
@@ -253,5 +252,33 @@ public class CustomRecipe
             1,
             result,
             intermediate);
-      }
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return Objects.hash(result, researchId, excludedResearchId, inputs);
+    }
+
+    @Override
+    public boolean equals(final Object o)
+    {
+        if (this == o)
+        {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass())
+        {
+            return false;
+        }
+
+        final CustomRecipe that = (CustomRecipe) o;
+
+
+        return result.isItemEqual(that.result) 
+            && researchId.equals(that.researchId)
+            && excludedResearchId.equals(that.excludedResearchId)
+            && inputs.equals(that.inputs);
+    }
+
 }

--- a/src/main/java/com/minecolonies/coremod/entity/citizen/citizenhandlers/CitizenExperienceHandler.java
+++ b/src/main/java/com/minecolonies/coremod/entity/citizen/citizenhandlers/CitizenExperienceHandler.java
@@ -165,7 +165,9 @@ public class CitizenExperienceHandler implements ICitizenExperienceHandler
             return;
         }
 
-        final AxisAlignedBB box = citizen.getBoundingBox().grow(2);
+        final int growSize = citizen.getRandom().nextInt(100) < 20 ? 6 : 2;
+
+        final AxisAlignedBB box = citizen.getBoundingBox().grow(growSize);
         if (!WorldUtil.isAABBLoaded(citizen.world, box))
         {
             return;


### PR DESCRIPTION
# Changes proposed in this pull request:
- add input counts to RecipeStorage.equals()
- add hashcode and equals implementations to CustomRecipe
- Expand Citizen XP search box 20% of the time

Review please
