### PR TITLE
Add Min/max level of building to custom recipes

### DIFF
--- a/src/api/java/com/minecolonies/api/configuration/CommonConfiguration.java
+++ b/src/api/java/com/minecolonies/api/configuration/CommonConfiguration.java
@@ -495,7 +495,7 @@ public class CommonConfiguration extends AbstractConfiguration
                      "minecraft:diamond;9",
                      "minecraft:emerald;8",
                      "minecraft:baked_potato;1",
-                     "minecraft:gold;2",
+                     "minecraft:gold_ingot;2",
                      "minecraft:redstone;2",
                      "minecraft:lapis_lazuli;2",
                      "minecraft:cake;7",

--- a/src/main/java/com/minecolonies/coremod/colony/buildings/AbstractBuildingWorker.java
+++ b/src/main/java/com/minecolonies/coremod/colony/buildings/AbstractBuildingWorker.java
@@ -796,7 +796,7 @@ public abstract class AbstractBuildingWorker extends AbstractBuilding implements
             final IRecipeStorage recipeStorage = newRecipe.getRecipeStorage();
             final IToken<?> recipeToken = IColonyManager.getInstance().getRecipeManager().checkOrAddRecipe(recipeStorage);
 
-            if(newRecipe.isValidForColony(colony))
+            if(newRecipe.isValidForBuilding(this))
             {   
                 boolean duplicateFound = false; 
                 for(IToken<?> token : recipes)
@@ -844,6 +844,7 @@ public abstract class AbstractBuildingWorker extends AbstractBuilding implements
                 if(!duplicateFound)
                 {
                     addRecipeToList(recipeToken);    
+                    colony.getRequestManager().onColonyUpdate(request -> request.getRequest() instanceof IDeliverable && ((IDeliverable) request.getRequest()).matches(recipeStorage.getPrimaryOutput()));
                 }
             } 
             else

--- a/src/main/java/com/minecolonies/coremod/colony/crafting/CustomRecipe.java
+++ b/src/main/java/com/minecolonies/coremod/colony/crafting/CustomRecipe.java
@@ -3,6 +3,7 @@ package com.minecolonies.coremod.colony.crafting;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import com.minecolonies.api.colony.IColony;
+import com.minecolonies.api.colony.buildings.IBuilding;
 import com.minecolonies.api.colony.requestsystem.StandardFactoryController;
 import com.minecolonies.api.crafting.IRecipeStorage;
 import com.minecolonies.api.research.effects.IResearchEffect;
@@ -86,6 +87,17 @@ public class CustomRecipe
     public static final String RECIPE_EXCLUDED_RESEARCHID_PROP = "not-research-id";
 
     /**
+     * The property name for the minimum level the building must be
+     */
+    public static final String RECIPE_BUILDING_MIN_LEVEL_PROP = "min-building-level";
+
+    /**
+     * The property name for the maximum level the building can be
+     */
+    public static final String RECIPE_BUILDING_MAX_LEVEL_PROP = "max-building-level";
+
+
+    /**
      * The crafter name for this instance, defaults to 'unknown'
      */
     private String crafter = "unknown";
@@ -119,6 +131,16 @@ public class CustomRecipe
      * ID of the exclusionary research. Null if nothing excludes this recipe
      */
     private String excludedResearchId = null;
+
+    /**
+     * The Minimum Level the building has to be for this recipe to be valid
+     */
+    private int minBldgLevel = 0;
+
+    /**
+     * The Maximum Level the building can to be for this recipe to be valid
+     */
+    private int maxBldgLevel = 5;
 
 
     /**
@@ -187,6 +209,14 @@ public class CustomRecipe
         {
             recipe.excludedResearchId = recipeJson.get(RECIPE_EXCLUDED_RESEARCHID_PROP).getAsString();
         }
+        if(recipeJson.has(RECIPE_BUILDING_MIN_LEVEL_PROP))
+        {
+            recipe.minBldgLevel= recipeJson.get(RECIPE_BUILDING_MIN_LEVEL_PROP).getAsInt();
+        }
+        if(recipeJson.has(RECIPE_BUILDING_MAX_LEVEL_PROP))
+        {
+            recipe.maxBldgLevel= recipeJson.get(RECIPE_BUILDING_MAX_LEVEL_PROP).getAsInt();
+        }
 
         return recipe;
     }
@@ -218,13 +248,15 @@ public class CustomRecipe
     }
  
     /**
-     * Check to see if the recipe is currently valid for the colony
+     * Check to see if the recipe is currently valid for the building
      * This does research checks, to verify that the appropriate researches are in the correct states
      */
-    public boolean isValidForColony(IColony colony)
+    public boolean isValidForBuilding(IBuilding building)
     {
         IResearchEffect<?> requiredEffect = null;
         IResearchEffect<?> excludedEffect = null;
+        final IColony colony = building.getColony();
+        final int bldgLevel = building.getBuildingLevel();
         
         if (researchId != null)
         {
@@ -236,7 +268,10 @@ public class CustomRecipe
             excludedEffect = colony.getResearchManager().getResearchEffects().getEffect(excludedResearchId, UnlockAbilityResearchEffect.class);
         }
 
-        return (researchId == null || requiredEffect != null) && (excludedResearchId == null || excludedEffect == null);
+        return (researchId == null || requiredEffect != null) 
+            && (excludedResearchId == null || excludedEffect == null)
+            && (bldgLevel >= minBldgLevel)
+            && (bldgLevel <= maxBldgLevel);
     }
 
     /**


### PR DESCRIPTION
# Changes proposed in this pull request:
- Change validity check to take building rather than colony
- Check building level against min and max levels 
- Fix the recipe removal code to queue removals during load, and execute on first access after load 
- Tweak XP pickup code to force-pickup within the larger range if it's tried for 5 seconds and failed. 

Review please
