### PR TITLE
Adds more dynamic difficulty to raids

### DIFF
--- a/src/api/java/com/minecolonies/api/colony/colonyEvents/IColonyRaidEvent.java
+++ b/src/api/java/com/minecolonies/api/colony/colonyEvents/IColonyRaidEvent.java
@@ -9,11 +9,6 @@ import net.minecraft.util.math.BlockPos;
 public interface IColonyRaidEvent extends IColonyEntitySpawnEvent
 {
     /**
-     * Set that a citizen was killed in a raid.
-     */
-    void setKilledCitizenInRaid();
-
-    /**
      * Get the normal raider type.
      *
      * @return the normal type.

--- a/src/api/java/com/minecolonies/api/colony/managers/interfaces/IRaiderManager.java
+++ b/src/api/java/com/minecolonies/api/colony/managers/interfaces/IRaiderManager.java
@@ -163,13 +163,35 @@ public interface IRaiderManager
      */
     BlockPos getRandomBuilding();
 
-    int getRaidDifficulty();
-
+    /**
+     * Gets the difficulty modifier for raids, default difficulty is 1.0
+     *
+     * @return difficulty
+     */
     double getRaidDifficultyModifier();
 
+    /**
+     * Called on loosing a citizen, to record deaths during raids
+     * @param citizen that died
+     */
     void onLostCitizen(ICitizenData citizen);
 
+    /**
+     * Writes the raid manager to nbt
+     * @param compound to write to
+     */
     void write(CompoundNBT compound);
 
+    /**
+     * Reads the raid manager form nbt
+     * @param compound to read from
+     */
     void read(CompoundNBT compound);
+
+    /**
+     * Gets the amount of citizens lost in a raid.
+     *
+     * @return weighted amount of list citizen
+     */
+    int getLostCitizen();
 }

--- a/src/api/java/com/minecolonies/api/colony/managers/interfaces/IRaiderManager.java
+++ b/src/api/java/com/minecolonies/api/colony/managers/interfaces/IRaiderManager.java
@@ -1,6 +1,8 @@
 package com.minecolonies.api.colony.managers.interfaces;
 
+import com.minecolonies.api.colony.ICitizenData;
 import com.minecolonies.api.colony.IColony;
+import net.minecraft.nbt.CompoundNBT;
 import net.minecraft.util.math.BlockPos;
 
 import java.util.List;
@@ -95,9 +97,10 @@ public interface IRaiderManager
     /**
      * Calculates the barbarian amount for raids
      *
+     * @param raidLevel the colonies raidlevel
      * @return the number of barbs.
      */
-    int calcBarbarianAmount();
+    int calculateRaiderAmount(final int raidLevel);
 
     /**
      * Whether the colony is currently raided.
@@ -159,4 +162,14 @@ public interface IRaiderManager
      * @return a random building.
      */
     BlockPos getRandomBuilding();
+
+    int getRaidDifficulty();
+
+    double getRaidDifficultyModifier();
+
+    void onLostCitizen(ICitizenData citizen);
+
+    void write(CompoundNBT compound);
+
+    void read(CompoundNBT compound);
 }

--- a/src/api/java/com/minecolonies/api/configuration/CommonConfiguration.java
+++ b/src/api/java/com/minecolonies/api/configuration/CommonConfiguration.java
@@ -378,7 +378,7 @@ public class CommonConfiguration extends AbstractConfiguration
         allowInfiniteColonies = defineBoolean(builder, "allowinfinitecolonies", false);
         allowOtherDimColonies = defineBoolean(builder, "allowotherdimcolonies", false);
         citizenRespawnInterval = defineInteger(builder, "citizenrespawninterval", 60, CITIZEN_RESPAWN_INTERVAL_MIN, CITIZEN_RESPAWN_INTERVAL_MAX);
-        maxCitizenPerColony = defineInteger(builder, "maxcitizenpercolony", 75, 4, 500);
+        maxCitizenPerColony = defineInteger(builder, "maxcitizenpercolony", 150, 4, 500);
         builderInfiniteResources = defineBoolean(builder, "builderinfiniteresources", false);
         limitToOneWareHousePerColony = defineBoolean(builder, "limittoonewarehousepercolony", true);
         builderBuildBlockDelay = defineInteger(builder, "builderbuildblockdelay", 15, 1, 500);
@@ -442,8 +442,8 @@ public class CommonConfiguration extends AbstractConfiguration
         spawnBarbarianSize = defineInteger(builder, "spawnbarbariansize", 5, MIN_SPAWN_BARBARIAN_HORDE_SIZE, MAX_SPAWN_BARBARIAN_HORDE_SIZE);
         maxBarbarianSize = defineInteger(builder, "maxBarbarianSize", 80, MIN_BARBARIAN_HORDE_SIZE, MAX_BARBARIAN_HORDE_SIZE);
         doBarbariansBreakThroughWalls = defineBoolean(builder, "dobarbariansbreakthroughwalls", true);
-        averageNumberOfNightsBetweenRaids = defineInteger(builder, "averagenumberofnightsbetweenraids", 7, 1, 10);
-        minimumNumberOfNightsBetweenRaids = defineInteger(builder, "minimumnumberofnightsbetweenraids", 5, 1, 30);
+        averageNumberOfNightsBetweenRaids = defineInteger(builder, "averagenumberofnightsbetweenraids", 12, 1, 10);
+        minimumNumberOfNightsBetweenRaids = defineInteger(builder, "minimumnumberofnightsbetweenraids", 8, 1, 30);
         mobAttackCitizens = defineBoolean(builder, "mobattackcitizens", true);
         shouldRaidersBreakDoors = defineBoolean(builder, "shouldraiderbreakdoors", true);
         citizenCallForHelp = defineBoolean(builder, "citizencallforhelp", true);

--- a/src/api/java/com/minecolonies/api/entity/mobs/AbstractEntityMinecoloniesMob.java
+++ b/src/api/java/com/minecolonies/api/entity/mobs/AbstractEntityMinecoloniesMob.java
@@ -13,6 +13,7 @@ import net.minecraft.entity.*;
 import net.minecraft.nbt.CompoundNBT;
 import net.minecraft.potion.EffectInstance;
 import net.minecraft.potion.Effects;
+import net.minecraft.scoreboard.ScorePlayerTeam;
 import net.minecraft.util.DamageSource;
 import net.minecraft.util.SoundEvent;
 import net.minecraft.world.DifficultyInstance;
@@ -34,6 +35,11 @@ import static com.minecolonies.api.util.constant.RaiderConstants.*;
  */
 public abstract class AbstractEntityMinecoloniesMob extends MobEntity
 {
+    /**
+     * Difficulty at which raiders team up
+     */
+    private static final double TEAM_DIFFICULTY = 2.0d;
+
     /**
      * The New PathNavigate navigator.
      */
@@ -112,7 +118,13 @@ public abstract class AbstractEntityMinecoloniesMob extends MobEntity
     /**
      * The collision threshold
      */
-    private final static int COLL_THRESHOLD = 50;
+    private final static int    COLL_THRESHOLD = 50;
+    private final static String RAID_TEAM      = "RAIDERS_TEAM";
+
+    /**
+     * Mob difficulty
+     */
+    private double difficulty = 1.0d;
 
     /**
      * Constructor method for Abstract Barbarians.
@@ -505,6 +517,7 @@ public abstract class AbstractEntityMinecoloniesMob extends MobEntity
     {
         this.getAttribute(MOB_ATTACK_DAMAGE).setBaseValue(baseDamage);
 
+        this.difficulty = difficulty;
         final double armor = difficulty * ARMOR;
         this.getAttribute(SharedMonsterAttributes.ARMOR).setBaseValue(armor);
         this.setEnvDamageInterval((int) (BASE_ENV_DAMAGE_RESIST * difficulty));
@@ -514,7 +527,47 @@ public abstract class AbstractEntityMinecoloniesMob extends MobEntity
             this.setEnvDamageImmunity(true);
         }
 
+        if (difficulty >= TEAM_DIFFICULTY)
+        {
+            world.getScoreboard().addPlayerToTeam(getScoreboardName(), checkOrCreateTeam());
+        }
+
         this.getAttribute(SharedMonsterAttributes.MAX_HEALTH).setBaseValue(baseHealth);
         this.setHealth(this.getMaxHealth());
+    }
+
+    /**
+     * Creates or gets the scoreboard team
+     *
+     * @return Scoreboard team
+     */
+    private ScorePlayerTeam checkOrCreateTeam()
+    {
+        if (this.world.getScoreboard().getTeam(getTeamName()) == null)
+        {
+            this.world.getScoreboard().createTeam(getTeamName());
+            this.world.getScoreboard().getTeam(getTeamName()).setAllowFriendlyFire(false);
+        }
+        return this.world.getScoreboard().getTeam(getTeamName());
+    }
+
+    /**
+     * Gets the scoreboard team name
+     *
+     * @return
+     */
+    protected String getTeamName()
+    {
+        return RAID_TEAM;
+    }
+
+    /**
+     * Get the mobs difficulty
+     *
+     * @return difficulty
+     */
+    public double getDifficulty()
+    {
+        return difficulty;
     }
 }

--- a/src/api/java/com/minecolonies/api/entity/mobs/RaiderMobUtils.java
+++ b/src/api/java/com/minecolonies/api/entity/mobs/RaiderMobUtils.java
@@ -2,7 +2,6 @@ package com.minecolonies.api.entity.mobs;
 
 import com.google.common.collect.Multimap;
 import com.minecolonies.api.IMinecoloniesAPI;
-import com.minecolonies.api.MinecoloniesAPIProxy;
 import com.minecolonies.api.colony.IColony;
 import com.minecolonies.api.entity.mobs.barbarians.IChiefBarbarianEntity;
 import com.minecolonies.api.entity.mobs.barbarians.IMeleeBarbarianEntity;
@@ -30,7 +29,6 @@ import net.minecraft.world.World;
 import java.util.List;
 import java.util.Random;
 
-import static com.minecolonies.api.util.constant.Constants.DEFAULT_BARBARIAN_DIFFICULTY;
 import static com.minecolonies.api.util.constant.RaiderConstants.*;
 
 /**
@@ -86,10 +84,9 @@ public final class RaiderMobUtils
      */
     public static void setMobAttributes(final AbstractEntityMinecoloniesMob mob, final IColony colony)
     {
-        final double difficultyModifier = (mob.world.getDifficulty().getId() / 2d) * (MinecoloniesAPIProxy.getInstance().getConfig().getCommon().barbarianHordeDifficulty.get()
-                                                                                        / (double) DEFAULT_BARBARIAN_DIFFICULTY);
+        final double difficultyModifier = colony.getRaiderManager().getRaidDifficultyModifier();
         mob.getAttribute(SharedMonsterAttributes.FOLLOW_RANGE).setBaseValue(FOLLOW_RANGE * 2);
-        mob.getAttribute(SharedMonsterAttributes.MOVEMENT_SPEED).setBaseValue(MOVEMENT_SPEED);
+        mob.getAttribute(SharedMonsterAttributes.MOVEMENT_SPEED).setBaseValue(difficultyModifier < 2.4 ? MOVEMENT_SPEED : MOVEMENT_SPEED + 0.1);
         final int raidLevel = colony.getRaiderManager().getColonyRaidLevel();
 
         // Base damage

--- a/src/api/java/com/minecolonies/api/entity/pathfinding/PathingOptions.java
+++ b/src/api/java/com/minecolonies/api/entity/pathfinding/PathingOptions.java
@@ -8,7 +8,7 @@ public class PathingOptions
     /**
      * Additional cost of jumping and dropping - base 1.
      */
-    public double jumpDropCost = 2.0D;
+    public double jumpDropCost = 1.1D;
 
     /**
      * Cost improvement of paths - base 1.

--- a/src/api/java/com/minecolonies/api/util/BlockPosUtil.java
+++ b/src/api/java/com/minecolonies/api/util/BlockPosUtil.java
@@ -102,7 +102,7 @@ public final class BlockPosUtil
                  || !WorldUtil.isEntityBlockLoaded(world, pos)
                  || world.getBlockState(pos).getMaterial().isLiquid()
                  || !world.getBlockState(pos.down()).getMaterial().isSolid()
-                 || (!world.isAirBlock(pos) && !world.isAirBlock(pos.up())))
+                 || (!world.isAirBlock(pos) || !world.isAirBlock(pos.up())))
         {
             final Tuple<Direction, Direction> direction = getRandomDirectionTuple(random);
             pos =

--- a/src/api/java/com/minecolonies/api/util/constant/GuardConstants.java
+++ b/src/api/java/com/minecolonies/api/util/constant/GuardConstants.java
@@ -76,7 +76,7 @@ public final class GuardConstants
     /**
      * Flee distance from Target
      */
-    public static final int RANGED_FLEE_SQDIST = 5;
+    public static final int RANGED_FLEE_SQDIST = 7;
 
     /**
      * Ranged attack velocity

--- a/src/api/java/com/minecolonies/api/util/constant/RaiderConstants.java
+++ b/src/api/java/com/minecolonies/api/util/constant/RaiderConstants.java
@@ -55,7 +55,7 @@ public final class RaiderConstants
     /**
      * Barbarian Attack Damage.
      */
-    public static final double ATTACK_DAMAGE = 3.0D;
+    public static final double ATTACK_DAMAGE = 2.0D;
 
     /**
      * Raiders environmental resistance
@@ -89,10 +89,10 @@ public final class RaiderConstants
      */
     public static final double FOLLOW_RANGE                = 35.0D;
     public static final double MOVEMENT_SPEED              = 0.25D;
-    public static final double ARMOR                       = 4D;
+    public static final double ARMOR                       = 3D;
     public static final double CHIEF_BONUS_ARMOR           = 2D;
-    public static final double BARBARIAN_BASE_HEALTH       = 15;
-    public static final double BARBARIAN_HEALTH_MULTIPLIER = 0.1;
+    public static final double BARBARIAN_BASE_HEALTH       = 10;
+    public static final double BARBARIAN_HEALTH_MULTIPLIER = 0.05;
     public static final double ATTACK_SPEED_DIVIDER        = 3;
 
     /**

--- a/src/main/java/com/minecolonies/coremod/colony/Colony.java
+++ b/src/main/java/com/minecolonies/coremod/colony/Colony.java
@@ -710,19 +710,7 @@ public class Colony implements IColony
             this.style = compound.getString(TAG_STYLE);
         }
 
-        if (compound.keySet().contains(TAG_RAIDABLE))
-        {
-            this.raidManager.setCanHaveRaiderEvents(compound.getBoolean(TAG_RAIDABLE));
-        }
-        else
-        {
-            this.raidManager.setCanHaveRaiderEvents(true);
-        }
-
-        if (compound.contains(TAG_NIGHTS_SINCE_LAST_RAID))
-        {
-            raidManager.setNightsSinceLastRaid(compound.getInt(TAG_NIGHTS_SINCE_LAST_RAID));
-        }
+        raidManager.read(compound);
 
         if (compound.keySet().contains(TAG_AUTO_DELETE))
         {
@@ -844,8 +832,6 @@ public class Colony implements IColony
         compound.putBoolean(TAG_MOVE_IN, moveIn);
         compound.put(TAG_REQUESTMANAGER, getRequestManager().serializeNBT());
         compound.putString(TAG_STYLE, style);
-        compound.putBoolean(TAG_RAIDABLE, raidManager.canHaveRaiderEvents());
-        compound.putInt(TAG_NIGHTS_SINCE_LAST_RAID, raidManager.getNightsSinceLastRaid());
         compound.putBoolean(TAG_AUTO_DELETE, canColonyBeAutoDeleted);
         compound.putInt(TAG_TEAM_COLOR, colonyTeamColor.ordinal());
         compound.put(TAG_FLAG_PATTERNS, colonyFlag);

--- a/src/main/java/com/minecolonies/coremod/colony/buildings/AbstractBuildingWorker.java
+++ b/src/main/java/com/minecolonies/coremod/colony/buildings/AbstractBuildingWorker.java
@@ -62,11 +62,13 @@ import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
 import static com.minecolonies.api.research.util.ResearchConstants.RECIPES;
+import static com.minecolonies.api.util.constant.Constants.MOD_ID;
 import static com.minecolonies.api.util.constant.NbtTagConstants.*;
 import static com.minecolonies.api.util.constant.ToolLevelConstants.TOOL_LEVEL_MAXIMUM;
 import static com.minecolonies.api.util.constant.ToolLevelConstants.TOOL_LEVEL_WOOD_OR_GOLD;
-import static com.minecolonies.api.util.constant.Constants.MOD_ID;
-import static com.minecolonies.api.util.constant.TranslationConstants.RECIPE_IMPROVED;;
+import static com.minecolonies.api.util.constant.TranslationConstants.RECIPE_IMPROVED;
+
+;
 
 /**
  * The abstract class for each worker building.
@@ -660,6 +662,7 @@ public abstract class AbstractBuildingWorker extends AbstractBuilding implements
             super.removeCitizen(citizen);
             citizen.setWorkBuilding(null);
             cancelAllRequestsOfCitizen(citizen);
+            citizen.setVisibleStatus(null);
         }
     }
 

--- a/src/main/java/com/minecolonies/coremod/colony/buildings/workerbuildings/BuildingHome.java
+++ b/src/main/java/com/minecolonies/coremod/colony/buildings/workerbuildings/BuildingHome.java
@@ -68,7 +68,7 @@ public class BuildingHome extends AbstractBuilding implements IBuildingBedProvid
     /**
      * Interval at which the childen are created, in ticks. Every 20 min it tries to spawn a child, 20min*60s*20ticks
      */
-    private int childCreationInterval = 600;
+    private final static int CHILD_SPAWN_INTERVAL = 20 * 60;
 
     /**
      * The timer counting ticks to the next time creating a child
@@ -85,7 +85,7 @@ public class BuildingHome extends AbstractBuilding implements IBuildingBedProvid
     {
         super(c, l);
         final Random rand = new Random();
-        childCreationTimer = rand.nextInt(childCreationInterval) + MIN_TIME_BEFORE_SPAWNTRY;
+        childCreationTimer = rand.nextInt(CHILD_SPAWN_INTERVAL) + MIN_TIME_BEFORE_SPAWNTRY;
     }
 
     @Override
@@ -241,12 +241,14 @@ public class BuildingHome extends AbstractBuilding implements IBuildingBedProvid
     @Override
     public void onColonyTick(@NotNull final IColony colony)
     {
-        if (childCreationTimer > childCreationInterval)
+        if (childCreationTimer <= 0)
         {
-            childCreationTimer = 0;
+            childCreationTimer =
+              (int) (colony.getWorld().rand.nextInt(500) + CHILD_SPAWN_INTERVAL * (1.0 - colony.getCitizenManager().getCurrentCitizenCount() / colony.getCitizenManager()
+                                                                                                                                                 .getMaxCitizens()));
             trySpawnChild();
         }
-        childCreationTimer += TWENTYFIVESEC;
+        childCreationTimer -= TWENTYFIVESEC;
 
         if (getAssignedCitizen().size() < getMaxInhabitants() && !getColony().isManualHousing())
         {

--- a/src/main/java/com/minecolonies/coremod/colony/buildings/workerbuildings/BuildingTavern.java
+++ b/src/main/java/com/minecolonies/coremod/colony/buildings/workerbuildings/BuildingTavern.java
@@ -181,7 +181,9 @@ public class BuildingTavern extends BuildingHome
         if (getBuildingLevel() > 0 && externalCitizens.size() < 3 * getBuildingLevel() && noVisitorTime <= 0)
         {
             spawnVisitor();
-            noVisitorTime = colony.getWorld().getRandom().nextInt(3000) + 6000 / getBuildingLevel();
+            noVisitorTime =
+              colony.getWorld().getRandom().nextInt(3000) + (6000 / getBuildingLevel()) * colony.getCitizenManager().getCurrentCitizenCount() / colony.getCitizenManager()
+                                                                                                                                                  .getMaxCitizens();
         }
     }
 

--- a/src/main/java/com/minecolonies/coremod/colony/colonyEvents/raidEvents/AbstractShipRaidEvent.java
+++ b/src/main/java/com/minecolonies/coremod/colony/colonyEvents/raidEvents/AbstractShipRaidEvent.java
@@ -121,11 +121,6 @@ public abstract class AbstractShipRaidEvent implements IColonyRaidEvent, IColony
     private List<Tuple<EntityType<?>, BlockPos>> respawns = new ArrayList<>();
 
     /**
-     * If a citizen was killed during the raid.
-     */
-    private boolean killedCitizenInRaid = false;
-
-    /**
      * Rotation of the ship to spawn
      */
     private int shipRotation = 0;
@@ -460,7 +455,6 @@ public abstract class AbstractShipRaidEvent implements IColonyRaidEvent, IColony
         compound.putInt(TAG_SPAWNER_COUNT, maxSpawners);
         BlockPosUtil.write(compound, TAG_SPAWN_POS, spawnPoint);
         compound.putInt(TAG_SHIPSIZE, shipSize.ordinal());
-        compound.putBoolean(TAG_KILLED, killedCitizenInRaid);
         compound.putInt(TAG_SHIPROTATION, shipRotation);
         return compound;
     }
@@ -481,7 +475,6 @@ public abstract class AbstractShipRaidEvent implements IColonyRaidEvent, IColony
         maxSpawners = compound.getInt(TAG_SPAWNER_COUNT);
         spawnPoint = BlockPosUtil.read(compound, TAG_SPAWN_POS);
         shipSize = ShipSize.values()[compound.getInt(TAG_SHIPSIZE)];
-        killedCitizenInRaid = compound.getBoolean(TAG_KILLED);
         shipRotation = compound.getInt(TAG_SHIPROTATION);
     }
 
@@ -490,11 +483,5 @@ public abstract class AbstractShipRaidEvent implements IColonyRaidEvent, IColony
     {
         this.spawners.add(pos);
         maxSpawners++;
-    }
-
-    @Override
-    public void setKilledCitizenInRaid()
-    {
-        killedCitizenInRaid = true;
     }
 }

--- a/src/main/java/com/minecolonies/coremod/colony/colonyEvents/raidEvents/HordeRaidEvent.java
+++ b/src/main/java/com/minecolonies/coremod/colony/colonyEvents/raidEvents/HordeRaidEvent.java
@@ -39,7 +39,6 @@ import static com.minecolonies.api.util.constant.ColonyConstants.SMALL_HORDE_SIZ
 import static com.minecolonies.api.util.constant.Constants.TAG_COMPOUND;
 import static com.minecolonies.api.util.constant.TranslationConstants.*;
 import static com.minecolonies.coremod.colony.colonyEvents.raidEvents.pirateEvent.PirateRaidEvent.TAG_DAYS_LEFT;
-import static com.minecolonies.coremod.colony.colonyEvents.raidEvents.pirateEvent.PirateRaidEvent.TAG_KILLED;
 
 /**
  * Horde raid event for the colony, triggers a horde that spawn and attack the colony.
@@ -109,11 +108,6 @@ public abstract class HordeRaidEvent implements IColonyRaidEvent, IColonyCampFir
     protected EventStatus status = EventStatus.STARTING;
 
     /**
-     * If a citizen was killed during the raid.
-     */
-    private boolean killedCitizenInRaid = false;
-
-    /**
      * Days the event can last, to make sure it eventually despawns.
      */
     private int daysToGo = 3;
@@ -149,12 +143,6 @@ public abstract class HordeRaidEvent implements IColonyRaidEvent, IColonyCampFir
         entities.addAll(boss.keySet());
         entities.addAll(normal.keySet());
         return entities;
-    }
-
-    @Override
-    public void setKilledCitizenInRaid()
-    {
-        killedCitizenInRaid = true;
     }
 
     @Override
@@ -438,7 +426,7 @@ public abstract class HordeRaidEvent implements IColonyRaidEvent, IColonyCampFir
         if (total == 0)
         {
             LanguageHandler.sendPlayersMessage(colony.getImportantMessageEntityPlayers(), ALL_BARBARIANS_KILLED_MESSAGE);
-            if (!this.killedCitizenInRaid)
+            if (colony.getRaiderManager().getLostCitizen() == 0)
             {
                 colony.getCitizenManager().updateModifier("raidwithoutdeath");
             }
@@ -465,7 +453,6 @@ public abstract class HordeRaidEvent implements IColonyRaidEvent, IColonyCampFir
         compound.putInt(TAG_EVENT_STATUS, status.ordinal());
         compound.putInt(TAG_DAYS_LEFT, daysToGo);
         horde.writeToNbt(compound);
-        compound.putBoolean(TAG_KILLED, killedCitizenInRaid);
         return compound;
     }
 
@@ -489,7 +476,6 @@ public abstract class HordeRaidEvent implements IColonyRaidEvent, IColonyCampFir
 
         status = EventStatus.values()[compound.getInt(TAG_EVENT_STATUS)];
         daysToGo = compound.getInt(TAG_DAYS_LEFT);
-        killedCitizenInRaid = compound.getBoolean(TAG_KILLED);
     }
 
     @Override

--- a/src/main/java/com/minecolonies/coremod/colony/colonyEvents/raidEvents/babarianEvent/Horde.java
+++ b/src/main/java/com/minecolonies/coremod/colony/colonyEvents/raidEvents/babarianEvent/Horde.java
@@ -97,7 +97,7 @@ public class Horde
     {
         if (!compound.contains(TAG_HORDESIZE))
         {
-            return null;
+            return new Horde(5);
         }
 
         Horde horde = new Horde(compound.getInt(TAG_HORDESIZE));

--- a/src/main/java/com/minecolonies/coremod/colony/colonyEvents/raidEvents/pirateEvent/ShipBasedRaiderUtils.java
+++ b/src/main/java/com/minecolonies/coremod/colony/colonyEvents/raidEvents/pirateEvent/ShipBasedRaiderUtils.java
@@ -136,7 +136,7 @@ public final class ShipBasedRaiderUtils
         }
 
         final World world = colony.getWorld();
-        final String shipSize = ShipSize.getShipForRaidLevel(raidLevel).schematicPrefix + event.getShipDesc();
+        final String shipSize = ShipSize.getShipForRaiderAmount(raidLevel).schematicPrefix + event.getShipDesc();
 
         final CreativeBuildingStructureHandler
           structure = new CreativeBuildingStructureHandler(colony.getWorld(), spawnPoint, Structures.SCHEMATICS_PREFIX + SHIP_FOLDER + shipSize, new PlacementSettings(), true);

--- a/src/main/java/com/minecolonies/coremod/colony/colonyEvents/raidEvents/pirateEvent/ShipSize.java
+++ b/src/main/java/com/minecolonies/coremod/colony/colonyEvents/raidEvents/pirateEvent/ShipSize.java
@@ -73,7 +73,7 @@ public enum ShipSize
      * @param raidLevel the raid level.
      * @return the ship size.
      */
-    public static ShipSize getShipForRaidLevel(final int raidLevel)
+    public static ShipSize getShipForRaiderAmount(final int raidLevel)
     {
         ShipSize shipSize;
         if (raidLevel <= SMALL_SHIP_SIZE_AMOUNT)

--- a/src/main/java/com/minecolonies/coremod/colony/managers/RaidManager.java
+++ b/src/main/java/com/minecolonies/coremod/colony/managers/RaidManager.java
@@ -77,6 +77,7 @@ public class RaidManager implements IRaiderManager
      * Difficulty nbt tag
      */
     private static final String TAG_RAID_DIFFICULTY = "difficulty";
+    private static final String TAG_LOST_CITIZENS   = "lostCitizens";
 
     /**
      * Min required raidlevel
@@ -708,12 +709,6 @@ public class RaidManager implements IRaiderManager
     }
 
     @Override
-    public int getRaidDifficulty()
-    {
-        return raidDifficulty;
-    }
-
-    @Override
     public double getRaidDifficultyModifier()
     {
         return (raidDifficulty / (double) NORMAL_RAID_DIFFICULTY) * (MinecoloniesAPIProxy.getInstance().getConfig().getCommon().barbarianHordeDifficulty.get()
@@ -752,6 +747,7 @@ public class RaidManager implements IRaiderManager
         compound.putBoolean(TAG_RAIDABLE, canHaveRaiderEvents());
         compound.putInt(TAG_NIGHTS_SINCE_LAST_RAID, getNightsSinceLastRaid());
         compound.putInt(TAG_RAID_DIFFICULTY, raidDifficulty);
+        compound.putInt(TAG_LOST_CITIZENS, lostCitizens);
     }
 
     @Override
@@ -771,9 +767,13 @@ public class RaidManager implements IRaiderManager
             setNightsSinceLastRaid(compound.getInt(TAG_NIGHTS_SINCE_LAST_RAID));
         }
 
-        if (compound.contains(TAG_RAID_DIFFICULTY))
-        {
             raidDifficulty = compound.getInt(TAG_RAID_DIFFICULTY);
-        }
+        lostCitizens = compound.getInt(TAG_LOST_CITIZENS);
+    }
+
+    @Override
+    public int getLostCitizen()
+    {
+        return lostCitizens;
     }
 }

--- a/src/main/java/com/minecolonies/coremod/entity/ai/citizen/guard/AbstractEntityAIGuard.java
+++ b/src/main/java/com/minecolonies/coremod/entity/ai/citizen/guard/AbstractEntityAIGuard.java
@@ -99,6 +99,11 @@ public abstract class AbstractEntityAIGuard<J extends AbstractJobGuard<J>, B ext
     private static final int TARGET_RANGE_ATTACK_RANGE_BONUS = 18;
 
     /**
+     * The amount of time the guard counts as in combat after last combat action
+     */
+    protected static final int COMBAT_TIME = 30;
+
+    /**
      * How many more ticks we have until next attack.
      */
     protected int currentAttackDelay = 0;
@@ -181,7 +186,7 @@ public abstract class AbstractEntityAIGuard<J extends AbstractJobGuard<J>, B ext
     /**
      * Timer for fighting, goes down to 0 when hasnt been fighting for a while
      */
-    private int fighttimer = 0;
+    protected int fighttimer = 0;
 
     /**
      * The sleeping guard we found
@@ -434,7 +439,7 @@ public abstract class AbstractEntityAIGuard<J extends AbstractJobGuard<J>, B ext
                 }
             }
 
-            fighttimer = 30;
+            fighttimer = COMBAT_TIME;
             equipInventoryArmor();
             moveInAttackPosition();
             return getAttackState();

--- a/src/main/java/com/minecolonies/coremod/entity/ai/citizen/guard/EntityAIKnight.java
+++ b/src/main/java/com/minecolonies/coremod/entity/ai/citizen/guard/EntityAIKnight.java
@@ -27,8 +27,8 @@ import net.minecraft.inventory.EquipmentSlotType;
 import net.minecraft.item.ItemStack;
 import net.minecraft.item.Items;
 import net.minecraft.item.SwordItem;
-import net.minecraft.particles.ParticleTypes;
 import net.minecraft.nbt.CompoundNBT;
+import net.minecraft.particles.ParticleTypes;
 import net.minecraft.util.DamageSource;
 import net.minecraft.util.Hand;
 import net.minecraft.util.ResourceLocation;
@@ -197,6 +197,7 @@ public class EntityAIKnight extends AbstractEntityAIGuard<JobKnight, AbstractBui
             return state;
         }
 
+        fighttimer = COMBAT_TIME;
         moveInAttackPosition();
         reduceAttackDelay(GUARD_ATTACK_INTERVAL);
         if (currentAttackDelay > 0)

--- a/src/main/java/com/minecolonies/coremod/entity/ai/citizen/guard/EntityAIRanger.java
+++ b/src/main/java/com/minecolonies/coremod/entity/ai/citizen/guard/EntityAIRanger.java
@@ -210,6 +210,7 @@ public class EntityAIRanger extends AbstractEntityAIGuard<JobRanger, AbstractBui
             return state;
         }
 
+        fighttimer = COMBAT_TIME;
         final double sqDistanceToEntity = BlockPosUtil.getDistanceSquared2D(worker.getPosition(), target.getPosition());
         final boolean canSee = worker.getEntitySenses().canSee(target);
         final double sqAttackRange = getRealAttackRange() * getRealAttackRange();
@@ -271,7 +272,7 @@ public class EntityAIRanger extends AbstractEntityAIGuard<JobRanger, AbstractBui
             strafingTime = -1;
 
             // Fleeing
-            if (!fleeing && !movingToTarget && sqDistanceToEntity < RANGED_FLEE_SQDIST && tooCloseNumTicks > 5)
+            if (!fleeing && !movingToTarget && sqDistanceToEntity < RANGED_FLEE_SQDIST && tooCloseNumTicks > 3)
             {
                 fleePath = worker.getNavigator().moveAwayFromLivingEntity(target, getRealAttackRange() / 2.0, getCombatMovementSpeed());
                 fleeing = true;

--- a/src/main/java/com/minecolonies/coremod/entity/citizen/EntityCitizen.java
+++ b/src/main/java/com/minecolonies/coremod/entity/citizen/EntityCitizen.java
@@ -4,8 +4,6 @@ import com.ldtteam.structurize.util.LanguageHandler;
 import com.minecolonies.api.colony.*;
 import com.minecolonies.api.colony.buildings.IBuilding;
 import com.minecolonies.api.colony.buildings.IGuardBuilding;
-import com.minecolonies.api.colony.colonyEvents.IColonyEvent;
-import com.minecolonies.api.colony.colonyEvents.IColonyRaidEvent;
 import com.minecolonies.api.colony.jobs.IJob;
 import com.minecolonies.api.colony.permissions.Action;
 import com.minecolonies.api.colony.permissions.IPermissions;
@@ -1457,13 +1455,7 @@ public class EntityCitizen extends AbstractEntityCitizen
         currentlyFleeing = false;
         if (citizenColonyHandler.getColony() != null && getCitizenData() != null)
         {
-            for (final IColonyEvent event : citizenColonyHandler.getColony().getEventManager().getEvents().values())
-            {
-                if (event instanceof IColonyRaidEvent)
-                {
-                    ((IColonyRaidEvent) event).setKilledCitizenInRaid();
-                }
-            }
+            citizenColonyHandler.getColony().getRaiderManager().onLostCitizen(getCitizenData());
 
             citizenExperienceHandler.dropExperience();
             this.remove();

--- a/src/main/java/com/minecolonies/coremod/entity/mobs/aitasks/EntityAIAttackArcher.java
+++ b/src/main/java/com/minecolonies/coremod/entity/mobs/aitasks/EntityAIAttackArcher.java
@@ -28,6 +28,11 @@ public class EntityAIAttackArcher extends Goal
      */
     private static final int MAX_ATTACK_DELAY = 80;
 
+    /**
+     * Difficulty leve at which arrows do pierce
+     */
+    private static final double ARROW_PIERCE_DIFFICULTY = 3.0d;
+
     private static final double                        PITCH_MULTIPLIER               = 0.4;
     private static final double                        HALF_ROTATION                  = 180;
     private static final double                        ATTACK_SPEED                   = 1.3;
@@ -109,7 +114,7 @@ public class EntityAIAttackArcher extends Goal
         }
         tickTimer = 10;
 
-        if ((entity.getDistance(target) >= MAX_ATTACK_DISTANCE && !EntityUtils.isFlying(target)) || !entity.canEntityBeSeen(target))
+        if ((entity.getDistance(target) >= MAX_ATTACK_DISTANCE * Math.max(entity.getDifficulty(), 2.0d) && !EntityUtils.isFlying(target)) || !entity.canEntityBeSeen(target))
         {
             entity.getNavigator().tryMoveToEntityLiving(target, ATTACK_SPEED);
         }
@@ -140,6 +145,12 @@ public class EntityAIAttackArcher extends Goal
                 final double dist3d = MathHelper.sqrt(yVector * yVector + xVector * xVector + zVector * zVector);
                 //Lower the variable higher the chance that the arrows hits the target.
                 arrowEntity.setDamage(entity.getAttribute(MOB_ATTACK_DAMAGE).getValue());
+
+                if (entity.getDifficulty() > ARROW_PIERCE_DIFFICULTY)
+                {
+                    arrowEntity.setPierceLevel((byte) 2);
+                }
+
                 if (EntityUtils.isFlying(target))
                 {
                     arrowEntity.setFire(200);

--- a/src/main/java/com/minecolonies/coremod/entity/mobs/aitasks/EntityAIRaiderAttackMelee.java
+++ b/src/main/java/com/minecolonies/coremod/entity/mobs/aitasks/EntityAIRaiderAttackMelee.java
@@ -25,7 +25,19 @@ public class EntityAIRaiderAttackMelee extends Goal
     private static final double                        MIN_DISTANCE_FOR_ATTACK = 2.5;
     private static final double                        ATTACK_SPEED            = 1.3;
     public static final  int                           MUTEX_BITS              = 3;
-    private static final double                        MELEE_DAMAGE_BONUS      = 1.0;
+
+    /**
+     * Extended reach based on difficulty
+     */
+    private static final double EXTENDED_REACH_DIFFICUTLY = 1.9;
+    private static final double EXTENDED_REACH            = 0.4;
+
+    /**
+     * Additional movement speed difficulty
+     */
+    private static final double ADD_SPEED_DIFFICULTY = 2.3;
+    private static final double ADD_SPEED            = 0.3;
+
     private final        AbstractEntityMinecoloniesMob entity;
     private              LivingEntity                  target;
     private              int                           lastAttack              = 0;
@@ -98,9 +110,10 @@ public class EntityAIRaiderAttackMelee extends Goal
 
         if (target != null)
         {
-            double damageToBeDealt = entity.getAttribute(MOB_ATTACK_DAMAGE).getValue() + MELEE_DAMAGE_BONUS;
+            double damageToBeDealt = entity.getAttribute(MOB_ATTACK_DAMAGE).getValue();
 
-            if (entity.getDistance(target) <= MIN_DISTANCE_FOR_ATTACK && lastAttack <= 0 && entity.canEntityBeSeen(target))
+            if (entity.getDistance(target) <= (entity.getDifficulty() < EXTENDED_REACH_DIFFICUTLY ? MIN_DISTANCE_FOR_ATTACK : MIN_DISTANCE_FOR_ATTACK + EXTENDED_REACH)
+                  && lastAttack <= 0 && entity.canEntityBeSeen(target))
             {
                 target.attackEntityFrom(new EntityDamageSource(entity.getType().getTranslationKey(), entity), (float) damageToBeDealt);
                 entity.swingArm(Hand.MAIN_HAND);
@@ -116,7 +129,7 @@ public class EntityAIRaiderAttackMelee extends Goal
             entity.faceEntity(target, (float) HALF_ROTATION, (float) HALF_ROTATION);
             entity.getLookController().setLookPositionWithEntity(target, (float) HALF_ROTATION, (float) HALF_ROTATION);
 
-            entity.getNavigator().tryMoveToEntityLiving(target, ATTACK_SPEED);
+            entity.getNavigator().tryMoveToEntityLiving(target, entity.getDifficulty() < ADD_SPEED_DIFFICULTY ? ATTACK_SPEED : ATTACK_SPEED + ADD_SPEED);
         }
     }
 

--- a/src/main/java/com/minecolonies/coremod/entity/mobs/aitasks/EntityAIWalkToRandomHuts.java
+++ b/src/main/java/com/minecolonies/coremod/entity/mobs/aitasks/EntityAIWalkToRandomHuts.java
@@ -1,28 +1,35 @@
 package com.minecolonies.coremod.entity.mobs.aitasks;
 
+import com.minecolonies.api.colony.buildings.IBuilding;
 import com.minecolonies.api.colony.colonyEvents.EventStatus;
 import com.minecolonies.api.colony.colonyEvents.IColonyEvent;
 import com.minecolonies.api.entity.mobs.AbstractEntityMinecoloniesMob;
 import com.minecolonies.api.util.BlockPosUtil;
 import com.minecolonies.api.util.EntityUtils;
+import com.minecolonies.api.util.ItemStackUtils;
 import com.minecolonies.coremod.MineColonies;
 import com.minecolonies.coremod.colony.colonyEvents.raidEvents.HordeRaidEvent;
 import com.minecolonies.coremod.entity.pathfinding.GeneralEntityWalkToProxy;
 import net.minecraft.block.*;
 import net.minecraft.entity.ai.goal.Goal;
 import net.minecraft.fluid.Fluids;
+import net.minecraft.inventory.EquipmentSlotType;
 import net.minecraft.pathfinding.Path;
 import net.minecraft.pathfinding.PathPoint;
+import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.Direction;
+import net.minecraft.util.Hand;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.Difficulty;
 import net.minecraft.world.World;
+import net.minecraftforge.items.IItemHandler;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.*;
 
 import static com.minecolonies.api.util.constant.Constants.LEVITATION_EFFECT;
 import static com.minecolonies.api.util.constant.Constants.SECONDS_A_MINUTE;
+import static net.minecraftforge.items.CapabilityItemHandler.ITEM_HANDLER_CAPABILITY;
 
 /**
  * Raider Pathing Class
@@ -167,6 +174,20 @@ public class EntityAIWalkToRandomHuts extends Goal
 
         if (this.isEntityAtSiteWithMove(targetBlock, 2))
         {
+            entity.swingArm(Hand.OFF_HAND);
+            final IBuilding building = entity.getColony().getBuildingManager().getBuilding(targetBlock);
+            if (building != null && building.getTileEntity() != null)
+            {
+                final TileEntity te = building.getTileEntity();
+                if (te.getCapability(ITEM_HANDLER_CAPABILITY, null).isPresent())
+                {
+                    final IItemHandler handler = te.getCapability(ITEM_HANDLER_CAPABILITY, null).orElse(null);
+                    if (ItemStackUtils.isEmpty(entity.getItemStackFromSlot(EquipmentSlotType.OFFHAND)))
+                    {
+                        entity.setItemStackToSlot(EquipmentSlotType.OFFHAND, handler.extractItem(entity.world.rand.nextInt(handler.getSlots()), 1, false));
+                    }
+                }
+            }
             targetBlock = getRandomBuilding();
             resetStuckCounters();
         }

--- a/src/main/java/com/minecolonies/coremod/entity/mobs/aitasks/EntityAIWalkToRandomHuts.java
+++ b/src/main/java/com/minecolonies/coremod/entity/mobs/aitasks/EntityAIWalkToRandomHuts.java
@@ -1,35 +1,28 @@
 package com.minecolonies.coremod.entity.mobs.aitasks;
 
-import com.minecolonies.api.colony.buildings.IBuilding;
 import com.minecolonies.api.colony.colonyEvents.EventStatus;
 import com.minecolonies.api.colony.colonyEvents.IColonyEvent;
 import com.minecolonies.api.entity.mobs.AbstractEntityMinecoloniesMob;
 import com.minecolonies.api.util.BlockPosUtil;
 import com.minecolonies.api.util.EntityUtils;
-import com.minecolonies.api.util.ItemStackUtils;
 import com.minecolonies.coremod.MineColonies;
 import com.minecolonies.coremod.colony.colonyEvents.raidEvents.HordeRaidEvent;
 import com.minecolonies.coremod.entity.pathfinding.GeneralEntityWalkToProxy;
 import net.minecraft.block.*;
 import net.minecraft.entity.ai.goal.Goal;
 import net.minecraft.fluid.Fluids;
-import net.minecraft.inventory.EquipmentSlotType;
 import net.minecraft.pathfinding.Path;
 import net.minecraft.pathfinding.PathPoint;
-import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.Direction;
-import net.minecraft.util.Hand;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.Difficulty;
 import net.minecraft.world.World;
-import net.minecraftforge.items.IItemHandler;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.*;
 
 import static com.minecolonies.api.util.constant.Constants.LEVITATION_EFFECT;
 import static com.minecolonies.api.util.constant.Constants.SECONDS_A_MINUTE;
-import static net.minecraftforge.items.CapabilityItemHandler.ITEM_HANDLER_CAPABILITY;
 
 /**
  * Raider Pathing Class
@@ -174,20 +167,6 @@ public class EntityAIWalkToRandomHuts extends Goal
 
         if (this.isEntityAtSiteWithMove(targetBlock, 2))
         {
-            entity.swingArm(Hand.OFF_HAND);
-            final IBuilding building = entity.getColony().getBuildingManager().getBuilding(targetBlock);
-            if (building != null && building.getTileEntity() != null)
-            {
-                final TileEntity te = building.getTileEntity();
-                if (te.getCapability(ITEM_HANDLER_CAPABILITY, null).isPresent())
-                {
-                    final IItemHandler handler = te.getCapability(ITEM_HANDLER_CAPABILITY, null).orElse(null);
-                    if (ItemStackUtils.isEmpty(entity.getItemStackFromSlot(EquipmentSlotType.OFFHAND)))
-                    {
-                        entity.setItemStackToSlot(EquipmentSlotType.OFFHAND, handler.extractItem(entity.world.rand.nextInt(handler.getSlots()), 1, false));
-                    }
-                }
-            }
             targetBlock = getRandomBuilding();
             resetStuckCounters();
         }

--- a/src/main/java/com/minecolonies/coremod/entity/pathfinding/MinecoloniesAdvancedPathNavigate.java
+++ b/src/main/java/com/minecolonies/coremod/entity/pathfinding/MinecoloniesAdvancedPathNavigate.java
@@ -429,7 +429,7 @@ public class MinecoloniesAdvancedPathNavigate extends AbstractAdvancedPathNaviga
                 }
             }
 
-            tempPath = new Path(Arrays.asList(newPoints), getTargetPos(), false);
+            tempPath = new Path(Arrays.asList(newPoints), path.getTarget(), path.reachesTarget());
 
             final PathPointExtended finalPoint = newPoints[pathLength - 1];
             destination = new BlockPos(finalPoint.x, finalPoint.y, finalPoint.z);

--- a/src/main/java/com/minecolonies/coremod/entity/pathfinding/pathjobs/AbstractPathJob.java
+++ b/src/main/java/com/minecolonies/coremod/entity/pathfinding/pathjobs/AbstractPathJob.java
@@ -19,7 +19,6 @@ import net.minecraft.block.*;
 import net.minecraft.block.material.Material;
 import net.minecraft.entity.LivingEntity;
 import net.minecraft.fluid.Fluids;
-import net.minecraft.fluid.FluidState;
 import net.minecraft.fluid.IFluidState;
 import net.minecraft.pathfinding.Path;
 import net.minecraft.pathfinding.PathPoint;
@@ -676,7 +675,18 @@ public abstract class AbstractPathJob implements Callable<Path>
 
         doDebugPrinting(points);
 
-        return new Path(Arrays.asList(points), targetNode.pos, false);
+        return new Path(Arrays.asList(points), getPathTargetPos(targetNode), isAtDestination(targetNode));
+    }
+
+    /**
+     * Creates the path for the given points
+     *
+     * @param finalNode
+     * @return
+     */
+    protected BlockPos getPathTargetPos(final Node finalNode)
+    {
+        return finalNode.pos;
     }
 
     /**

--- a/src/main/java/com/minecolonies/coremod/entity/pathfinding/pathjobs/PathJobMoveToLocation.java
+++ b/src/main/java/com/minecolonies/coremod/entity/pathfinding/pathjobs/PathJobMoveToLocation.java
@@ -67,6 +67,12 @@ public class PathJobMoveToLocation extends AbstractPathJob
     }
 
     @Override
+    protected BlockPos getPathTargetPos(final Node finalNode)
+    {
+        return destination;
+    }
+
+    @Override
     protected double computeHeuristic(@NotNull final BlockPos pos)
     {
         return Math.sqrt(destination.distanceSq(pos));


### PR DESCRIPTION
# Changes proposed in this pull request:
Colonies now have an individual raid difficulty, increasing and decreasing with success of raids for a better balanced experience. Colonies start with the lowest difficulty. Difficulty scales between 20% and 200%.
Raids start happening based on a minimum raidlevel instead of plain citizencount now.

Extra difficulty utlities for raiders:
- Teaming up: raiders get put on the same scoreboard team so they cannot hurt eachother
- Movementspeed bonus: Raiders can get a bit faster, letting them catch up to players better (high difficulty)
- Archer arrows can get pierce effect
- Archers gain range through difficulty
- Melees get slightly increased hit range at high difficulty

Citizen homes and Tavern recruits now have spawntimes in relation to missing citizen count, allowing for easier recruiting.

Fix paths not properly getting their target position and reach target flags in the pathfinding.
Fix guards sometimes starting to eat mid-combat due to not resetting their fight timer
Fix a bug where randomPos sometimes returns non-air positions.

Review please
