### PR TITLE
Fix AbstractEntityAIStructureWithWorkOrder.java

### DIFF
--- a/src/main/java/com/minecolonies/coremod/entity/ai/basic/AbstractEntityAIStructureWithWorkOrder.java
+++ b/src/main/java/com/minecolonies/coremod/entity/ai/basic/AbstractEntityAIStructureWithWorkOrder.java
@@ -322,7 +322,7 @@ public abstract class AbstractEntityAIStructureWithWorkOrder<J extends AbstractJ
         }
         else if (wo instanceof WorkOrderBuildRemoval)
         {
-            worker.getCitizenChatHandler().sendLocalizedChat(COM_MINECOLONIES_COREMOD_ENTITY_BUILDER_BUILDCOMPLETE, structureName);
+            worker.getCitizenChatHandler().sendLocalizedChat(COM_MINECOLONIES_COREMOD_ENTITY_BUILDER_DECONSTRUCTION_COMPLETE, structureName);
         }
 
         if (wo == null)


### PR DESCRIPTION
sending wrong chat message after deconstructing a building.

Closes #
Closes #
Closes #

# Changes proposed in this pull request:
- Fix AbstractEntityAIStructureWithWorkOrder.java sending an incorrect chat message after finishing deconstructing a building.
-
-

Review please
