### PR TITLE
Add nether supply ships

### DIFF
--- a/src/api/java/com/minecolonies/api/util/constant/TranslationConstants.java
+++ b/src/api/java/com/minecolonies/api/util/constant/TranslationConstants.java
@@ -258,6 +258,8 @@ public final class TranslationConstants
     @NonNls
     public static final String SUPPLY_CAMP_INVALID_NOT_WATER_MESSAGE_KEY                           = "item.supplycampdeployer.invalid.water_block_needed";
     @NonNls
+    public static final String SUPPLY_CAMP_INVALID_NOT_LAVA_MESSAGE_KEY                            = "item.supplycampdeployer.invalid.lava_block_needed";
+    @NonNls
     public static final String SUPPLY_CAMP_INVALID_NEEDS_AIR_ABOVE_MESSAGE_KEY                     = "item.supplycampdeployer.invalid.air_block_needed";
     @NonNls
     public static final String SUPPLY_CAMP_INVALID_INSIDE_COLONY_MESSAGE_KEY                       = "item.supplycampdeployer.invalid.inside_existing_colony";

--- a/src/main/java/com/minecolonies/coremod/client/gui/WindowMinecoloniesBuildTool.java
+++ b/src/main/java/com/minecolonies/coremod/client/gui/WindowMinecoloniesBuildTool.java
@@ -19,6 +19,7 @@ import net.minecraft.client.gui.screen.Screen;
 import net.minecraft.entity.player.PlayerInventory;
 import net.minecraft.item.BlockItem;
 import net.minecraft.util.math.BlockPos;
+import net.minecraft.world.DimensionType;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -109,10 +110,12 @@ public class WindowMinecoloniesBuildTool extends WindowBuildTool
     public void checkAndPlace()
     {
         final List<PlacementError> placementErrorList = new ArrayList<>();
-        if (Settings.instance.getStaticSchematicName().contains("supplyship"))
+        final String schemName = Settings.instance.getStaticSchematicName();
+
+        if (schemName.contains("supplyship") || schemName.contains("nethership"))
         {
             if (ItemSupplyChestDeployer.canShipBePlaced(Minecraft.getInstance().world, Settings.instance.getPosition(),
-              new BlockPos(Settings.instance.getActiveStructure().getSizeX(), Settings.instance.getActiveStructure().getSizeY(), Settings.instance.getActiveStructure().getSizeZ()),
+              Settings.instance.getActiveStructure(),
               placementErrorList,
               Minecraft.getInstance().player))
             {
@@ -123,7 +126,7 @@ public class WindowMinecoloniesBuildTool extends WindowBuildTool
                 LanguageHandler.sendPlayerMessage(Minecraft.getInstance().player, "item.supplyChestDeployer.invalid");
             }
         }
-        else if (Settings.instance.getStaticSchematicName().contains("supplycamp"))
+        else if (schemName.contains("supplycamp"))
         {
             if (ItemSupplyCampDeployer.canCampBePlaced(Minecraft.getInstance().world, Settings.instance.getPosition(),
               new BlockPos(Settings.instance.getActiveStructure().getSizeX(), Settings.instance.getActiveStructure().getSizeY(), Settings.instance.getActiveStructure().getSizeZ()),
@@ -143,10 +146,10 @@ public class WindowMinecoloniesBuildTool extends WindowBuildTool
                 final PlacementError.PlacementErrorType placementErrorType = entry.getKey();
                 final List<BlockPos> blockPosList = entry.getValue();
 
-                final int numberOfBlocksTOReport = blockPosList.size() > 5 ? 5 : blockPosList.size();
-                final List<BlockPos> blocksToReportList = blockPosList.subList(0, numberOfBlocksTOReport);
+                final int numberOfBlocksToReport = blockPosList.size() > 5 ? 5 : blockPosList.size();
+                final List<BlockPos> blocksToReportList = blockPosList.subList(0, numberOfBlocksToReport);
                 String outputList = PlacementError.blockListToCommaSeparatedString(blocksToReportList);
-                if (blockPosList.size() > numberOfBlocksTOReport)
+                if (blockPosList.size() > numberOfBlocksToReport)
                 {
                     outputList += "...";
                 }
@@ -154,7 +157,10 @@ public class WindowMinecoloniesBuildTool extends WindowBuildTool
                 switch (placementErrorType)
                 {
                     case NOT_WATER:
-                        errorMessage = String.format(TranslationConstants.SUPPLY_CAMP_INVALID_NOT_WATER_MESSAGE_KEY, outputList);
+                        final String dim = Minecraft.getInstance().world.getDimensionTypeKey().equals(DimensionType.THE_NETHER)
+                                ? TranslationConstants.SUPPLY_CAMP_INVALID_NOT_LAVA_MESSAGE_KEY
+                                : TranslationConstants.SUPPLY_CAMP_INVALID_NOT_WATER_MESSAGE_KEY;
+                        errorMessage = String.format(dim, outputList);
                         LanguageHandler.sendPlayerMessage(Minecraft.getInstance().player, errorMessage, outputList);
                         break;
                     case NOT_SOLID:

--- a/src/main/resources/assets/minecolonies/lang/en_us.json
+++ b/src/main/resources/assets/minecolonies/lang/en_us.json
@@ -694,6 +694,7 @@
 
   "item.supplycampdeployer.invalid": "Requires a flat ground at least 16*17 blocks without grass, flowers, or holes!",
   "item.supplycampdeployer.invalid.water_block_needed": "Placing a Supply Ship requires water under the ship. These blocks must be water: %s.",
+  "item.supplycampdeployer.invalid.lava_block_needed": "Placing a Supply Ship requires lava under the ship. These blocks must be lava: %s.",
   "item.supplycampdeployer.invalid.solid_block_needed": "Placing a Supply Camp requires flat, solid ground. These blocks must be solid: %s.",
   "item.supplycampdeployer.invalid.air_block_needed": "Placing a Supply Camp or Ship requires air above the ground/sea level. These blocks must be air: %s.",
   "item.supplycampdeployer.invalid.inside_existing_colony": "You cannot place your Supply Camp or Ship near an existing colony.",
@@ -857,7 +858,7 @@
   "com.minecolonies.coremod.item.gate.place": "Autoplaces parts. The max size is 5x4 which needs a stack of 20.",
 
   "com.minecolonies.coremod.gui.workerhuts.buildprio": "Pickup Prio.: ",
-  "item.supplychestdeployer.invalid": "You must place it in a fitting pool of water.",
+  "item.supplychestdeployer.invalid": "You must place it in a fitting ocean or river.",
   "item.supplychestdeployer.missing": "Are you trying to trick me by picking up that Supply Ship (or Camp) again?",
   "com.minecolonies.coremod.citizen.rename.same": "Renaming failed, as two citizens are not allowed to have the same name!",
   "com.minecolonies.coremod.citizen.rename.notallowed": "Renaming failed, as you're not allowed to rename your citizen!",

--- a/src/main/resources/assets/minecolonies/lang/en_us.json
+++ b/src/main/resources/assets/minecolonies/lang/en_us.json
@@ -694,7 +694,7 @@
 
   "item.supplycampdeployer.invalid": "Requires a flat ground at least 16*17 blocks without grass, flowers, or holes!",
   "item.supplycampdeployer.invalid.water_block_needed": "Placing a Supply Ship requires water under the ship. These blocks must be water: %s.",
-  "item.supplycampdeployer.invalid.lava_block_needed": "Placing a Supply Ship requires lava under the ship. These blocks must be lava: %s.",
+  "item.supplycampdeployer.invalid.lava_block_needed": "Placing a Supply Ship in the Nether requires lava under the ship. These blocks must be lava: %s.",
   "item.supplycampdeployer.invalid.solid_block_needed": "Placing a Supply Camp requires flat, solid ground. These blocks must be solid: %s.",
   "item.supplycampdeployer.invalid.air_block_needed": "Placing a Supply Camp or Ship requires air above the ground/sea level. These blocks must be air: %s.",
   "item.supplycampdeployer.invalid.inside_existing_colony": "You cannot place your Supply Camp or Ship near an existing colony.",


### PR DESCRIPTION
For AravanFox *et al.* builders

# Changes proposed in this pull request:
- Searches for schematics in ``nethership`` folders.
- Only netherships will work in the nether, and supplyships will only work in the overworld
- Netherships require a pool of lava to be placed in
- NOTE: not sure what the story is with the End, so I didn't really account for it.

Review please
