### PR TITLE
Fix fuel check in smeltercrafter when furnace goes missing

### DIFF
--- a/src/main/java/com/minecolonies/coremod/entity/ai/basic/AbstractEntityAIRequestSmelter.java
+++ b/src/main/java/com/minecolonies/coremod/entity/ai/basic/AbstractEntityAIRequestSmelter.java
@@ -257,6 +257,11 @@ public abstract class AbstractEntityAIRequestSmelter<J extends AbstractJobCrafte
             if (WorldUtil.isBlockLoaded(world, pos))
             {
                 final TileEntity entity = world.getTileEntity(pos);
+                if(!(entity instanceof FurnaceTileEntity))
+                {
+                    getOwnBuilding().removeFromFurnaces(pos);
+                    continue;
+                }
                 final FurnaceTileEntity furnace = (FurnaceTileEntity) entity;
                 if (!furnace.isBurning() && (hasSmeltableInFurnaceAndNoFuel(furnace) || hasNeitherFuelNorSmeltAble(furnace)) && currentRecipeStorage != null && currentRecipeStorage.getIntermediate() == Blocks.FURNACE) 
                 {


### PR DESCRIPTION
Closes #5850 

# Changes proposed in this pull request:
- If the furnace position doesn't have a furnace, remove it from the list and move on. 

Review please
