### PR TITLE
Fix misspell of "level" in users.json

### DIFF
--- a/scripts/users.json
+++ b/scripts/users.json
@@ -152,31 +152,31 @@
   {
     "uuid": "879f8b90-baa5-4cfe-8dc4-7446a8a15363",
     "name": "StrikerIV",
-    "lavel": 4
+    "level": 4
   },
   {
     "uuid": "15ac50c5-5b8b-41c5-a361-c482a6680cdd",
     "name": "Samdrei",
-    "lavel": 4
+    "level": 4
   },
   {
     "uuid": "b5723332-b1ee-4aac-ac87-3008a0f99d16",
     "name": "ChaoticCreeper08",
-    "lavel": 4
+    "level": 4
   },
   {
     "uuid": "74f6cf6f-71fc-4820-a61b-a9cdde7e06f6",
     "name": "DanicaKai",
-    "lavel": 4
+    "level": 4
   },
   {
     "uuid": "636dbc6c-4798-4e9d-91eb-2cefb37952fe",
     "name": "green8751",
-    "lavel": 4
+    "level": 4
   },
   {
     "uuid": "9f2a2aa1-0666-4e73-9015-156a0a0755ad",
     "name": "SadHorizion77210",
-    "lavel": 4
+    "level": 4
   }
 ]


### PR DESCRIPTION
## Changes proposed in this pull request:
- Change the misspelled word `lavel` to `level` in `scripts/users.json`

_Done on [suggestion of AshersLab on Forgecord][ashers_suggestion]._

[ashers_suggestion]: https://discordapp.com/channels/313125603924639766/313125603924639766/761551411489538068
