### PR TITLE
Add alternate level scaling

### DIFF
--- a/src/main/java/com/minecolonies/coremod/util/ExperienceUtils.java
+++ b/src/main/java/com/minecolonies/coremod/util/ExperienceUtils.java
@@ -67,9 +67,8 @@ public final class ExperienceUtils
      */
     public static double getXPNeededForNextLevel(final int currentLevel)
     {
-        return EXPERIENCE_MULTIPLIER
-                 * (currentLevel + 1)
-                 * (currentLevel + 1);
+        return 1 + EXPERIENCE_MULTIPLIER *
+                     5 * currentLevel + 0.005 * (currentLevel * currentLevel * currentLevel);
     }
 
     /**


### PR DESCRIPTION
# Changes proposed in this pull request:
This adds an alternate level scaling with a more delayed XP required curve, while keeping the starting levels more linear. So that we then have citizens more beeing able to reach higher levels like 45+ while not reducing the inital levels xp much.
This also makes them a bit better in comparison to recruitable visitors, which start with higher skills.

Suggested scaling: 
![image](https://user-images.githubusercontent.com/38401808/95002641-9ec84f80-05d6-11eb-9a8d-5782491d99d5.png)

Previous scaling:
![image](https://user-images.githubusercontent.com/38401808/95002661-c7504980-05d6-11eb-891f-f0c5d7eeb6bc.png)


Review please
