### PR TITLE
hotfix xp loop

### DIFF
--- a/src/main/java/com/minecolonies/coremod/entity/citizen/citizenhandlers/CitizenSkillHandler.java
+++ b/src/main/java/com/minecolonies/coremod/entity/citizen/citizenhandlers/CitizenSkillHandler.java
@@ -210,10 +210,10 @@ public class CitizenSkillHandler implements ICitizenSkillHandler
         double xpToDiscount = xp;
         while (xpToDiscount > 0)
         {
-            if (currentXp >= xpToDiscount)
+            if (currentXp >= xpToDiscount || level <= 1)
             {
-                skillMap.put(skill, new Tuple<>(Math.max(1, level), currentXp - xpToDiscount));
-                xpToDiscount = 0;
+                skillMap.put(skill, new Tuple<>(Math.max(1, level), Math.max(0, currentXp - xpToDiscount)));
+                break;
             }
             else
             {

--- a/src/main/java/com/minecolonies/coremod/util/ExperienceUtils.java
+++ b/src/main/java/com/minecolonies/coremod/util/ExperienceUtils.java
@@ -67,8 +67,8 @@ public final class ExperienceUtils
      */
     public static double getXPNeededForNextLevel(final int currentLevel)
     {
-        return 1 + EXPERIENCE_MULTIPLIER *
-                     5 * currentLevel + 0.005 * (currentLevel * currentLevel * currentLevel);
+        return Math.max(1, 1 + EXPERIENCE_MULTIPLIER *
+                                 5 * currentLevel + 0.005 * (currentLevel * currentLevel * currentLevel));
     }
 
     /**


### PR DESCRIPTION
Closes #5870
Closes #
Closes #

# Changes proposed in this pull request:
Fixes the xp loop which happened when it tried to reduce a skills level to zero or lower, causing an int underflow. The new XP formula triggered this bug, as the old one semi-worked for negative levels too since it was quadratic

Review please
