### PR TITLE
Multi-Output recipes, and reliable secondary outputs

### DIFF
--- a/src/api/java/com/minecolonies/api/IMinecoloniesAPI.java
+++ b/src/api/java/com/minecolonies/api/IMinecoloniesAPI.java
@@ -15,6 +15,7 @@ import com.minecolonies.api.colony.jobs.registry.IJobDataManager;
 import com.minecolonies.api.colony.jobs.registry.JobEntry;
 import com.minecolonies.api.compatibility.IFurnaceRecipes;
 import com.minecolonies.api.configuration.Configuration;
+import com.minecolonies.api.crafting.registry.RecipeTypeEntry;
 import com.minecolonies.api.entity.ai.registry.IMobAIRegistry;
 import com.minecolonies.api.entity.pathfinding.registry.IPathNavigateRegistry;
 import com.minecolonies.api.research.IGlobalResearchTree;
@@ -63,4 +64,6 @@ public interface IMinecoloniesAPI
     IForgeRegistry<ColonyEventTypeRegistryEntry> getColonyEventRegistry();
 
     IForgeRegistry<ColonyEventDescriptionTypeRegistryEntry> getColonyEventDescriptionRegistry();
+
+    IForgeRegistry<RecipeTypeEntry> getRecipeTypeRegistry();
 }

--- a/src/api/java/com/minecolonies/api/MinecoloniesAPIProxy.java
+++ b/src/api/java/com/minecolonies/api/MinecoloniesAPIProxy.java
@@ -15,6 +15,7 @@ import com.minecolonies.api.colony.jobs.registry.IJobDataManager;
 import com.minecolonies.api.colony.jobs.registry.JobEntry;
 import com.minecolonies.api.compatibility.IFurnaceRecipes;
 import com.minecolonies.api.configuration.Configuration;
+import com.minecolonies.api.crafting.registry.RecipeTypeEntry;
 import com.minecolonies.api.entity.ai.registry.IMobAIRegistry;
 import com.minecolonies.api.entity.pathfinding.registry.IPathNavigateRegistry;
 import com.minecolonies.api.research.IGlobalResearchTree;
@@ -146,5 +147,11 @@ public final class MinecoloniesAPIProxy implements IMinecoloniesAPI
     public IForgeRegistry<ColonyEventDescriptionTypeRegistryEntry> getColonyEventDescriptionRegistry()
     {
         return apiInstance.getColonyEventDescriptionRegistry();
+    }
+
+    @Override
+    public IForgeRegistry<RecipeTypeEntry> getRecipeTypeRegistry()
+    {
+        return apiInstance.getRecipeTypeRegistry();
     }
 }

--- a/src/api/java/com/minecolonies/api/crafting/AbstractRecipeType.java
+++ b/src/api/java/com/minecolonies/api/crafting/AbstractRecipeType.java
@@ -5,6 +5,9 @@ import com.google.common.collect.ImmutableList;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.ResourceLocation;
 
+/**
+ * Base class for RecipeStorage types
+ */
 public abstract class AbstractRecipeType<R extends IRecipeStorage>
 {
     final IRecipeStorage recipe;

--- a/src/api/java/com/minecolonies/api/crafting/AbstractRecipeType.java
+++ b/src/api/java/com/minecolonies/api/crafting/AbstractRecipeType.java
@@ -1,0 +1,41 @@
+package com.minecolonies.api.crafting;
+
+import java.util.List;
+import com.google.common.collect.ImmutableList;
+import net.minecraft.item.ItemStack;
+import net.minecraft.util.ResourceLocation;
+
+public abstract class AbstractRecipeType<R extends IRecipeStorage>
+{
+    final IRecipeStorage recipe;
+    ResourceLocation id; 
+
+    /**
+     * Constructor basis for recipe types
+     */
+    public AbstractRecipeType(final R recipe)
+    {
+        this.recipe = recipe;
+    }
+
+    /**
+     * Get the recipe this type instance is associated with
+     */
+    public IRecipeStorage getRecipe()
+    {
+        return this.recipe;
+    }
+
+    /**
+     * Get the ID of this type
+     */
+    public abstract ResourceLocation getId();
+
+    /**
+     * The output display stacks, for rotation through in the views
+     */
+    public List<ItemStack> getOutputDisplayStacks()
+    {
+        return ImmutableList.of(recipe.getPrimaryOutput());
+    }
+}

--- a/src/api/java/com/minecolonies/api/crafting/ClassicRecipe.java
+++ b/src/api/java/com/minecolonies/api/crafting/ClassicRecipe.java
@@ -1,0 +1,21 @@
+package com.minecolonies.api.crafting;
+
+import net.minecraft.util.ResourceLocation;
+
+public class ClassicRecipe extends AbstractRecipeType<IRecipeStorage>
+{
+    /**
+     * Classic Recipe constructor
+     */
+    public ClassicRecipe(IRecipeStorage recipe)
+    {
+        super(recipe);
+    }
+
+    @Override
+    public ResourceLocation getId()
+    {
+        return ModRecipeTypes.CLASSIC_ID;
+    }
+    
+}

--- a/src/api/java/com/minecolonies/api/crafting/ClassicRecipe.java
+++ b/src/api/java/com/minecolonies/api/crafting/ClassicRecipe.java
@@ -2,6 +2,9 @@ package com.minecolonies.api.crafting;
 
 import net.minecraft.util.ResourceLocation;
 
+/**
+ * The Classic Recipe type
+ */
 public class ClassicRecipe extends AbstractRecipeType<IRecipeStorage>
 {
     /**

--- a/src/api/java/com/minecolonies/api/crafting/IRecipeStorage.java
+++ b/src/api/java/com/minecolonies/api/crafting/IRecipeStorage.java
@@ -17,15 +17,6 @@ import java.util.function.Predicate;
 public interface IRecipeStorage
 {
     /**
-     * Enum of the different types of storage
-     */
-    public enum RecipeStorageType
-    {
-        CLASSIC,
-        MULTI_OUTPUT
-    }
-
-    /**
      * Get the list of input items. Suppressing Sonar Rule Squid:S2384 The rule thinks we should return a copy of the list and not the list itself. But in this case the rule does
      * not apply because the list is an unmodifiable list already
      *
@@ -85,10 +76,10 @@ public interface IRecipeStorage
 
     /**
      * Get which type this recipe is
-     * CLASSIC or MULTI-OUTPUT are the only valid ones currently
+     * This type comes from the RecipeTypes registry
      * @return The recipe type
      */
-    public RecipeStorageType getRecipeType();
+    public AbstractRecipeType<IRecipeStorage> getRecipeType();
 
     /**
      * Get a list of alternates to getPrimaryOutput

--- a/src/api/java/com/minecolonies/api/crafting/IRecipeStorage.java
+++ b/src/api/java/com/minecolonies/api/crafting/IRecipeStorage.java
@@ -3,6 +3,7 @@ package com.minecolonies.api.crafting;
 import com.minecolonies.api.colony.requestsystem.token.IToken;
 import net.minecraft.block.Block;
 import net.minecraft.item.ItemStack;
+import net.minecraft.util.ResourceLocation;
 import net.minecraftforge.items.IItemHandler;
 import org.jetbrains.annotations.NotNull;
 
@@ -113,7 +114,7 @@ public interface IRecipeStorage
      * Source of the recipe, ie registry name.
      * @return
      */
-    public String getRecipeSource();
+    public ResourceLocation getRecipeSource();
 
     /**
      * Get the secondary (leave behind in grid) outputs

--- a/src/api/java/com/minecolonies/api/crafting/IRecipeStorage.java
+++ b/src/api/java/com/minecolonies/api/crafting/IRecipeStorage.java
@@ -8,12 +8,22 @@ import org.jetbrains.annotations.NotNull;
 
 import java.util.Arrays;
 import java.util.List;
+import java.util.function.Predicate;
 
 /**
  * Interface which describes the RecipeStorage.
  */
 public interface IRecipeStorage
 {
+    /**
+     * Enum of the different types of storage
+     */
+    public enum RecipeStorageType
+    {
+        CLASSIC,
+        MULTI_OUTPUT
+    }
+
     /**
      * Get the list of input items. Suppressing Sonar Rule Squid:S2384 The rule thinks we should return a copy of the list and not the list itself. But in this case the rule does
      * not apply because the list is an unmodifiable list already
@@ -71,6 +81,45 @@ public interface IRecipeStorage
      * @return true if succesful.
      */
     boolean fullfillRecipe(final List<IItemHandler> handlers);
+
+    /**
+     * Get which type this recipe is
+     * CLASSIC or MULTI-OUTPUT are the only valid ones currently
+     * @return The recipe type
+     */
+    public RecipeStorageType getRecipeType();
+
+    /**
+     * Get a list of alternates to getPrimaryOutput
+     * @return a list if Itemstacks that this recipe can produce instead of getPrimaryOutput
+     */
+    public List<ItemStack> getAlternateOutputs();
+
+    /**
+     * Get the classic version of this recipe with GetPrimaryOutput targetted correctly from the chosen alternate
+     * @param requiredOutput Which output wanted
+     * @return the RecipeStorage that is "right" for that output
+     */
+    public RecipeStorage getClassicForMultiOutput(ItemStack requiredOutput);
+
+    /**
+     * Get the classic version of this recipe with GetPrimaryOutput targetted correctly from the chosen alternate
+     * @param stackPredicate Predicate to select the right stack
+     * @return the RecipeStorage that is "right" for that output
+     */
+    public RecipeStorage getClassicForMultiOutput(final Predicate<ItemStack> stackPredicate);
+
+    /**
+     * Source of the recipe, ie registry name.
+     * @return
+     */
+    public String getRecipeSource();
+
+    /**
+     * Get the secondary (leave behind in grid) outputs
+     * @return list of items that weren't consumed during crafting
+     */
+    public List<ItemStack> getSecondaryOutputs();
 
     /**
      * Get the unique token of the recipe.

--- a/src/api/java/com/minecolonies/api/crafting/IRecipeStorageFactory.java
+++ b/src/api/java/com/minecolonies/api/crafting/IRecipeStorageFactory.java
@@ -3,7 +3,7 @@ package com.minecolonies.api.crafting;
 import com.minecolonies.api.colony.requestsystem.factory.IFactory;
 import com.minecolonies.api.colony.requestsystem.factory.IFactoryController;
 import com.minecolonies.api.colony.requestsystem.token.IToken;
-import com.minecolonies.api.crafting.RecipeStorage.RecipeStorageType;
+import com.minecolonies.api.crafting.IRecipeStorage.RecipeStorageType;
 
 import net.minecraft.block.Block;
 import net.minecraft.item.ItemStack;
@@ -26,8 +26,7 @@ public interface IRecipeStorageFactory extends IFactory<IToken<?>, RecipeStorage
     {
         if (context.length < MIN_PARAMS_IRECIPESTORAGE || context.length > MAX_PARAMS_IRECIPESTORAGE)
         {
-           //TODO: Make sure this is right
-           // throw new IllegalArgumentException("Unsupported context - Not correct number of parameters. At least 3 at max 5 are needed.!");
+            throw new IllegalArgumentException("Unsupported context - Not correct number of parameters. At least 3 at max 5 are needed.!");
         }
 
         if (!(context[0] instanceof List))
@@ -45,12 +44,12 @@ public interface IRecipeStorageFactory extends IFactory<IToken<?>, RecipeStorage
             throw new IllegalArgumentException("Third parameter is supposed to be an ItemStack!");
         }
 
-        if (context.length > MIN_PARAMS_IRECIPESTORAGE && !(context[3] instanceof Block))
+        if (context.length > MIN_PARAMS_IRECIPESTORAGE && context[3] != null && !(context[3] instanceof Block))
         {
             throw new IllegalArgumentException("Fourth parameter is supposed to be a Block or Null!");
         }
 
-        if (context.length > MIN_PARAMS_IRECIPESTORAGE && !(context[4] instanceof String))
+        if (context.length > MIN_PARAMS_IRECIPESTORAGE + 1 && context[4] != null && !(context[4] instanceof String))
         {
             throw new IllegalArgumentException("Fifth parameter is supposed to be a String or Null!");
         }
@@ -64,7 +63,8 @@ public interface IRecipeStorageFactory extends IFactory<IToken<?>, RecipeStorage
         final String source = context.length < 5 ? null : (String) context[4];
         final RecipeStorageType type  = context.length < 6 ? null : (RecipeStorageType) context[5];
         final List<ItemStack> altOutputs = context.length < 7 ? null :  (List<ItemStack>) context[6];
-        return getNewInstance(token, input, gridSize, primaryOutput, intermediate, source, type, altOutputs);
+        final List<ItemStack> secOutputs = context.length < 8 ? null :  (List<ItemStack>) context[7];
+        return getNewInstance(token, input, gridSize, primaryOutput, intermediate, source, type, altOutputs, secOutputs);
     }
 
     /**
@@ -86,6 +86,8 @@ public interface IRecipeStorageFactory extends IFactory<IToken<?>, RecipeStorage
       @Nullable final Block intermediate,
       @Nullable final String source,
       @Nullable final RecipeStorageType type,
-      @Nullable final List<ItemStack> altOutputs);
+      @Nullable final List<ItemStack> altOutputs,
+      @Nullable final List<ItemStack> secOutputs
+      );
 }
 

--- a/src/api/java/com/minecolonies/api/crafting/IRecipeStorageFactory.java
+++ b/src/api/java/com/minecolonies/api/crafting/IRecipeStorageFactory.java
@@ -3,7 +3,6 @@ package com.minecolonies.api.crafting;
 import com.minecolonies.api.colony.requestsystem.factory.IFactory;
 import com.minecolonies.api.colony.requestsystem.factory.IFactoryController;
 import com.minecolonies.api.colony.requestsystem.token.IToken;
-import com.minecolonies.api.crafting.IRecipeStorage.RecipeStorageType;
 import net.minecraft.block.Block;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.ResourceLocation;
@@ -49,19 +48,32 @@ public interface IRecipeStorageFactory extends IFactory<IToken<?>, RecipeStorage
             throw new IllegalArgumentException("Fourth parameter is supposed to be a Block or Null!");
         }
 
-        if (context.length > MIN_PARAMS_IRECIPESTORAGE + 1 && context[4] != null && !(context[4] instanceof String))
+        if (context.length > MIN_PARAMS_IRECIPESTORAGE + 1 && context[4] != null && !(context[4] instanceof ResourceLocation))
         {
-            throw new IllegalArgumentException("Fifth parameter is supposed to be a String or Null!");
+            throw new IllegalArgumentException("Fifth parameter is supposed to be a ResourceLocation or Null!");
         }
 
-        //TODO: Add remaining parameters
+        if (context.length > MIN_PARAMS_IRECIPESTORAGE + 2 && context[5] != null && !(context[5] instanceof ResourceLocation))
+        {
+            throw new IllegalArgumentException("Sixth parameter is supposed to be a ResourceLocation or Null!");
+        }
+
+        if (context.length > MIN_PARAMS_IRECIPESTORAGE + 3 && context[6] != null && !(context[6] instanceof List))
+        {
+            throw new IllegalArgumentException("Seventh parameter is supposed to be a List<ItemStack> or Null!");
+        }
+
+        if (context.length > MIN_PARAMS_IRECIPESTORAGE + 4 && context[7] != null && !(context[7] instanceof List))
+        {
+            throw new IllegalArgumentException("Eighth parameter is supposed to be a List<ItemStack> or Null!");
+        }
 
         final List<ItemStack> input = (List<ItemStack>) context[0];
         final int gridSize = (int) context[1];
         final ItemStack primaryOutput = (ItemStack) context[2];
         final Block intermediate = context.length < 4 ? null : (Block) context[3];
         final ResourceLocation source = context.length < 5 ? null : (ResourceLocation) context[4];
-        final RecipeStorageType type  = context.length < 6 ? null : (RecipeStorageType) context[5];
+        final ResourceLocation type  = context.length < 6 ? null : (ResourceLocation) context[5];
         final List<ItemStack> altOutputs = context.length < 7 ? null :  (List<ItemStack>) context[6];
         final List<ItemStack> secOutputs = context.length < 8 ? null :  (List<ItemStack>) context[7];
         return getNewInstance(token, input, gridSize, primaryOutput, intermediate, source, type, altOutputs, secOutputs);
@@ -89,7 +101,7 @@ public interface IRecipeStorageFactory extends IFactory<IToken<?>, RecipeStorage
       @NotNull final ItemStack primaryOutput,
       @Nullable final Block intermediate,
       @Nullable final ResourceLocation source,
-      @Nullable final RecipeStorageType type,
+      @Nullable final ResourceLocation type,
       @Nullable final List<ItemStack> altOutputs,
       @Nullable final List<ItemStack> secOutputs
       );

--- a/src/api/java/com/minecolonies/api/crafting/IRecipeStorageFactory.java
+++ b/src/api/java/com/minecolonies/api/crafting/IRecipeStorageFactory.java
@@ -4,9 +4,9 @@ import com.minecolonies.api.colony.requestsystem.factory.IFactory;
 import com.minecolonies.api.colony.requestsystem.factory.IFactoryController;
 import com.minecolonies.api.colony.requestsystem.token.IToken;
 import com.minecolonies.api.crafting.IRecipeStorage.RecipeStorageType;
-
 import net.minecraft.block.Block;
 import net.minecraft.item.ItemStack;
+import net.minecraft.util.ResourceLocation;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -60,7 +60,7 @@ public interface IRecipeStorageFactory extends IFactory<IToken<?>, RecipeStorage
         final int gridSize = (int) context[1];
         final ItemStack primaryOutput = (ItemStack) context[2];
         final Block intermediate = context.length < 4 ? null : (Block) context[3];
-        final String source = context.length < 5 ? null : (String) context[4];
+        final ResourceLocation source = context.length < 5 ? null : (ResourceLocation) context[4];
         final RecipeStorageType type  = context.length < 6 ? null : (RecipeStorageType) context[5];
         final List<ItemStack> altOutputs = context.length < 7 ? null :  (List<ItemStack>) context[6];
         final List<ItemStack> secOutputs = context.length < 8 ? null :  (List<ItemStack>) context[7];
@@ -88,7 +88,7 @@ public interface IRecipeStorageFactory extends IFactory<IToken<?>, RecipeStorage
       final int gridSize,
       @NotNull final ItemStack primaryOutput,
       @Nullable final Block intermediate,
-      @Nullable final String source,
+      @Nullable final ResourceLocation source,
       @Nullable final RecipeStorageType type,
       @Nullable final List<ItemStack> altOutputs,
       @Nullable final List<ItemStack> secOutputs

--- a/src/api/java/com/minecolonies/api/crafting/IRecipeStorageFactory.java
+++ b/src/api/java/com/minecolonies/api/crafting/IRecipeStorageFactory.java
@@ -75,6 +75,10 @@ public interface IRecipeStorageFactory extends IFactory<IToken<?>, RecipeStorage
      * @param gridSize      the grid size.
      * @param primaryOutput the primary output.
      * @param intermediate  the intermediate.
+     * @param source        the source of this recipe, either a registry name or the player name
+     * @param type          What type this recipe is, classic or multi-recipe
+     * @param altOutputs    possible alternate outputs other than the primaryOutput
+     * @param secOutputs    Leave-behind items in the grid. ie: bucket, pot, juicer, or hammer
      * @return a new Instance of IRecipeStorage.
      */
     @NotNull

--- a/src/api/java/com/minecolonies/api/crafting/IRecipeStorageFactory.java
+++ b/src/api/java/com/minecolonies/api/crafting/IRecipeStorageFactory.java
@@ -3,6 +3,8 @@ package com.minecolonies.api.crafting;
 import com.minecolonies.api.colony.requestsystem.factory.IFactory;
 import com.minecolonies.api.colony.requestsystem.factory.IFactoryController;
 import com.minecolonies.api.colony.requestsystem.token.IToken;
+import com.minecolonies.api.crafting.RecipeStorage.RecipeStorageType;
+
 import net.minecraft.block.Block;
 import net.minecraft.item.ItemStack;
 import org.jetbrains.annotations.NotNull;
@@ -24,7 +26,8 @@ public interface IRecipeStorageFactory extends IFactory<IToken<?>, RecipeStorage
     {
         if (context.length < MIN_PARAMS_IRECIPESTORAGE || context.length > MAX_PARAMS_IRECIPESTORAGE)
         {
-            throw new IllegalArgumentException("Unsupported context - Not correct number of parameters. At least 3 at max 4 are needed.!");
+           //TODO: Make sure this is right
+           // throw new IllegalArgumentException("Unsupported context - Not correct number of parameters. At least 3 at max 5 are needed.!");
         }
 
         if (!(context[0] instanceof List))
@@ -42,16 +45,26 @@ public interface IRecipeStorageFactory extends IFactory<IToken<?>, RecipeStorage
             throw new IllegalArgumentException("Third parameter is supposed to be an ItemStack!");
         }
 
-        if (context.length > MIN_PARAMS_IRECIPESTORAGE && !(context[MAX_PARAMS_IRECIPESTORAGE - 1] instanceof Block))
+        if (context.length > MIN_PARAMS_IRECIPESTORAGE && !(context[3] instanceof Block))
         {
-            throw new IllegalArgumentException("Forth parameter is supposed to be a Block or Null!");
+            throw new IllegalArgumentException("Fourth parameter is supposed to be a Block or Null!");
         }
+
+        if (context.length > MIN_PARAMS_IRECIPESTORAGE && !(context[4] instanceof String))
+        {
+            throw new IllegalArgumentException("Fifth parameter is supposed to be a String or Null!");
+        }
+
+        //TODO: Add remaining parameters
 
         final List<ItemStack> input = (List<ItemStack>) context[0];
         final int gridSize = (int) context[1];
         final ItemStack primaryOutput = (ItemStack) context[2];
         final Block intermediate = context.length < 4 ? null : (Block) context[3];
-        return getNewInstance(token, input, gridSize, primaryOutput, intermediate);
+        final String source = context.length < 5 ? null : (String) context[4];
+        final RecipeStorageType type  = context.length < 6 ? null : (RecipeStorageType) context[5];
+        final List<ItemStack> altOutputs = context.length < 7 ? null :  (List<ItemStack>) context[6];
+        return getNewInstance(token, input, gridSize, primaryOutput, intermediate, source, type, altOutputs);
     }
 
     /**
@@ -70,6 +83,9 @@ public interface IRecipeStorageFactory extends IFactory<IToken<?>, RecipeStorage
       @NotNull final List<ItemStack> input,
       final int gridSize,
       @NotNull final ItemStack primaryOutput,
-      @Nullable final Block intermediate);
+      @Nullable final Block intermediate,
+      @Nullable final String source,
+      @Nullable final RecipeStorageType type,
+      @Nullable final List<ItemStack> altOutputs);
 }
 

--- a/src/api/java/com/minecolonies/api/crafting/ModRecipeTypes.java
+++ b/src/api/java/com/minecolonies/api/crafting/ModRecipeTypes.java
@@ -1,0 +1,20 @@
+package com.minecolonies.api.crafting;
+
+import com.minecolonies.api.crafting.registry.RecipeTypeEntry;
+import com.minecolonies.api.util.constant.Constants;
+import net.minecraft.util.ResourceLocation;
+
+public final class ModRecipeTypes
+{
+
+    public static final ResourceLocation CLASSIC_ID    = new ResourceLocation(Constants.MOD_ID, "classic");
+    public static final ResourceLocation MULTI_OUTPUT_ID    = new ResourceLocation(Constants.MOD_ID, "multi_output");
+
+    public static RecipeTypeEntry Classic;
+    public static RecipeTypeEntry MultiOutput;
+
+    private ModRecipeTypes()
+    {
+        throw new IllegalStateException("Tried to initialize: ModJobs but this is a Utility class.");
+    }
+}

--- a/src/api/java/com/minecolonies/api/crafting/MultiOutputRecipe.java
+++ b/src/api/java/com/minecolonies/api/crafting/MultiOutputRecipe.java
@@ -8,6 +8,9 @@ import com.google.common.collect.ImmutableList;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.ResourceLocation;
 
+/**
+ * The mult-output recipe type
+ */
 public class MultiOutputRecipe extends AbstractRecipeType<IRecipeStorage>
 {
     /**

--- a/src/api/java/com/minecolonies/api/crafting/MultiOutputRecipe.java
+++ b/src/api/java/com/minecolonies/api/crafting/MultiOutputRecipe.java
@@ -1,0 +1,42 @@
+package com.minecolonies.api.crafting;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import com.google.common.collect.ImmutableList;
+
+import net.minecraft.item.ItemStack;
+import net.minecraft.util.ResourceLocation;
+
+public class MultiOutputRecipe extends AbstractRecipeType<IRecipeStorage>
+{
+    /**
+     * Cache of item stacks for display
+     */
+    private final ArrayList<ItemStack> outputDisplayStacks = new ArrayList<>();
+
+    /**
+     * Multi-Output recipe type
+     */
+    public MultiOutputRecipe(IRecipeStorage recipe)
+    {
+        super(recipe);
+    }
+
+    @Override
+    public List<ItemStack> getOutputDisplayStacks()
+    {
+        if(outputDisplayStacks.isEmpty())
+        {
+            outputDisplayStacks.add(recipe.getPrimaryOutput());
+            outputDisplayStacks.addAll(recipe.getAlternateOutputs());
+        }
+        return ImmutableList.copyOf(outputDisplayStacks);
+    }
+
+    @Override
+    public ResourceLocation getId()
+    {
+        return ModRecipeTypes.MULTI_OUTPUT_ID;
+    }
+}

--- a/src/api/java/com/minecolonies/api/crafting/RecipeStorage.java
+++ b/src/api/java/com/minecolonies/api/crafting/RecipeStorage.java
@@ -352,10 +352,11 @@ public class RecipeStorage implements IRecipeStorage
      */
     private boolean checkForFreeSpace(final List<IItemHandler> handlers)
     {
-        final List<ItemStack> secondaryStacks = new ArrayList<>();
+        final List<ItemStack> resultStacks = new ArrayList<>();
+        //Calculate space needed by the secondary outputs
         if(!secondaryOutputs.isEmpty())
         {
-            secondaryStacks.addAll(secondaryOutputs);
+            resultStacks.addAll(secondaryOutputs);
         }
         else
         {
@@ -365,12 +366,13 @@ public class RecipeStorage implements IRecipeStorage
                 if (!ItemStackUtils.isEmpty(container))
                 {
                     container.setCount(stack.getCount());
-                    secondaryStacks.add(container);
+                    resultStacks.add(container);
                 }
             }
         }
-        secondaryStacks.add(getPrimaryOutput());
-        if (secondaryStacks.size() > getInput().size())
+        //Include the primary output in the space check
+        resultStacks.add(getPrimaryOutput());
+        if (resultStacks.size() > getInput().size())
         {
             int freeSpace = 0;
             for (final IItemHandler handler : handlers)
@@ -378,7 +380,7 @@ public class RecipeStorage implements IRecipeStorage
                 freeSpace += handler.getSlots() - InventoryUtils.getAmountOfStacksInItemHandler(handler);
             }
 
-            return freeSpace >= secondaryStacks.size() - getInput().size();
+            return freeSpace >= resultStacks.size() - getInput().size();
         }
         return true;
     }

--- a/src/api/java/com/minecolonies/api/crafting/RecipeStorage.java
+++ b/src/api/java/com/minecolonies/api/crafting/RecipeStorage.java
@@ -257,7 +257,8 @@ public class RecipeStorage implements IRecipeStorage
               || input.size() != that.input.size()
               || cleanedInput.size() != that.cleanedInput.size()
               || (alternateOutputs.size() != that.alternateOutputs.size())
-              || (secondaryOutputs != null && that.secondaryOutputs != null && secondaryOutputs.size() != that.secondaryOutputs.size())
+              || ((secondaryOutputs == null) != (that.secondaryOutputs == null))
+              || (secondaryOutputs != null && secondaryOutputs.size() != that.secondaryOutputs.size())
               || !ItemStackUtils.compareItemStacksIgnoreStackSize(primaryOutput, that.primaryOutput, false, true))
         {
             return false;

--- a/src/api/java/com/minecolonies/api/crafting/RecipeStorage.java
+++ b/src/api/java/com/minecolonies/api/crafting/RecipeStorage.java
@@ -13,11 +13,11 @@ import net.minecraft.item.ItemStack;
 import net.minecraftforge.items.IItemHandler;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
-
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.function.Predicate;
+import java.util.stream.Collectors;
 
 /**
  * Class used to represent a recipe in minecolonies.
@@ -98,7 +98,7 @@ public class RecipeStorage implements IRecipeStorage
         this.cleanedInput.addAll(this.calculateCleanedInput());
         this.primaryOutput = primaryOutput;
         this.alternateOutputs = altOutputs != null ? altOutputs : ImmutableList.of();
-        this.secondaryOutputs = secOutputs != null ? secOutputs: ImmutableList.of();
+        this.secondaryOutputs = secOutputs != null ? secOutputs.stream().filter(i -> i.getItem() != ModItems.buildTool).collect(Collectors.toList()): ImmutableList.of();
         this.gridSize = gridSize;
         this.intermediate = intermediate;
         this.token = token;

--- a/src/api/java/com/minecolonies/api/crafting/RecipeStorage.java
+++ b/src/api/java/com/minecolonies/api/crafting/RecipeStorage.java
@@ -278,7 +278,9 @@ public class RecipeStorage implements IRecipeStorage
             }
             for(int i = 0; i< alternateOutputs.size(); i++)
             {
-                if(!ItemStackUtils.compareItemStacksIgnoreStackSize(alternateOutputs.get(i),that.alternateOutputs.get(i), false, true))
+                ItemStack left = alternateOutputs.get(i);
+                ItemStack right = that.alternateOutputs.get(i);
+                if(!ItemStackUtils.compareItemStacksIgnoreStackSize(left, right, false, true) || left.getCount() != right.getCount())
                 {
                     return false;
                 }

--- a/src/api/java/com/minecolonies/api/crafting/RecipeStorage.java
+++ b/src/api/java/com/minecolonies/api/crafting/RecipeStorage.java
@@ -10,6 +10,7 @@ import com.minecolonies.api.util.ItemStackUtils;
 import com.minecolonies.api.util.constant.TypeConstants;
 import net.minecraft.block.Block;
 import net.minecraft.item.ItemStack;
+import net.minecraft.util.ResourceLocation;
 import net.minecraftforge.items.IItemHandler;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -34,7 +35,7 @@ public class RecipeStorage implements IRecipeStorage
      * Where this recipe came from
      * For custom recipes, it's the id of the recipe
      */
-    private final String recipeSource;
+    private final ResourceLocation recipeSource;
 
     /**
      * Input required for the recipe.
@@ -91,7 +92,7 @@ public class RecipeStorage implements IRecipeStorage
      * @param altOutputs    List of alternate outputs for a multi-output recipe
      * @param secOutputs    List of secondary outputs for a recipe. this includes containers, etc. 
      */
-    public RecipeStorage(final IToken<?> token, final List<ItemStack> input, final int gridSize, @NotNull final ItemStack primaryOutput, final Block intermediate, final String source, final RecipeStorageType type, final List<ItemStack> altOutputs, final List<ItemStack> secOutputs)
+    public RecipeStorage(final IToken<?> token, final List<ItemStack> input, final int gridSize, @NotNull final ItemStack primaryOutput, final Block intermediate, final ResourceLocation source, final RecipeStorageType type, final List<ItemStack> altOutputs, final List<ItemStack> secOutputs)
     {
         this.input = Collections.unmodifiableList(input);
         this.cleanedInput = new ArrayList<>();
@@ -102,7 +103,7 @@ public class RecipeStorage implements IRecipeStorage
         this.gridSize = gridSize;
         this.intermediate = intermediate;
         this.token = token;
-        this.recipeSource = source != null ? source : "";
+        this.recipeSource = source;
         this.recipeType = type == null ? RecipeStorageType.CLASSIC : type;
     }
 
@@ -312,7 +313,7 @@ public class RecipeStorage implements IRecipeStorage
         result = 31 * result + primaryOutput.hashCode();
         result = 31 * result + (intermediate != null ? intermediate.hashCode() : 0);
         result = 31 * result + gridSize;
-        if(recipeSource != null && !recipeSource.isEmpty())
+        if(recipeSource != null)
         {
             result = 31 * result + recipeSource.hashCode();
         }
@@ -495,8 +496,7 @@ public class RecipeStorage implements IRecipeStorage
     @Override
     public RecipeStorage getClassicForMultiOutput(final ItemStack requiredOutput)
     {
-        return StandardFactoryController.getInstance().getNewInstance(
-            TypeConstants.RECIPE,
+        return new RecipeStorage(
             StandardFactoryController.getInstance().getNewInstance(TypeConstants.ITOKEN),
             this.input,
             this.gridSize,
@@ -505,7 +505,7 @@ public class RecipeStorage implements IRecipeStorage
             this.recipeSource,
             RecipeStorageType.CLASSIC,
             null, //alternate outputs
-            null //secondary output
+            this.secondaryOutputs //secondary output
             );
 
     }
@@ -536,9 +536,9 @@ public class RecipeStorage implements IRecipeStorage
     }
 
     @Override
-    public String getRecipeSource()
+    public ResourceLocation getRecipeSource()
     {
-        return recipeSource != null ? recipeSource : "";
+        return recipeSource;
     }
 
     @Override

--- a/src/api/java/com/minecolonies/api/crafting/registry/RecipeTypeEntry.java
+++ b/src/api/java/com/minecolonies/api/crafting/registry/RecipeTypeEntry.java
@@ -1,0 +1,84 @@
+package com.minecolonies.api.crafting.registry;
+
+import com.minecolonies.api.colony.ICitizenData;
+import com.minecolonies.api.crafting.IRecipeStorage;
+import com.minecolonies.api.crafting.AbstractRecipeType;
+import net.minecraft.util.ResourceLocation;
+import net.minecraftforge.registries.ForgeRegistryEntry;
+import org.apache.commons.lang3.Validate;
+
+import java.util.function.Function;
+
+/**
+ * Entry for the {@link AbstractRecipeType} registry.
+ */
+@SuppressWarnings("PMD.MissingStaticMethodInNonInstantiatableClass") //Use the builder to create one.
+public final class RecipeTypeEntry extends ForgeRegistryEntry<RecipeTypeEntry>
+{
+
+    private final Function<IRecipeStorage, AbstractRecipeType<IRecipeStorage>> recipeTypeProducer;
+
+    /**
+     * Builder for a {@link AbstractRecipeType}.
+     */
+    public static final class Builder
+    {
+        private Function<IRecipeStorage, AbstractRecipeType<IRecipeStorage>> recipeTypeProducer;
+        private ResourceLocation                registryName;
+
+        /**
+         * Setter the for the producer.
+         *
+         * @param recipeTypeProducer The producer for {@link AbstractRecipeType}.
+         * @return The builder.
+         */
+        public Builder setRecipeTypeProducer(final Function<IRecipeStorage, AbstractRecipeType<IRecipeStorage>> recipeTypeProducer)
+        {
+            this.recipeTypeProducer = recipeTypeProducer;
+            return this;
+        }
+
+        /**
+         * Setter for the registry name.
+         *
+         * @param registryName The registry name.
+         * @return The builder.
+         */
+        public Builder setRegistryName(final ResourceLocation registryName)
+        {
+            this.registryName = registryName;
+            return this;
+        }
+
+        /**
+         * Creates a new {@link JobEntry} builder.
+         *
+         * @return The created {@link JobEntry}.
+         */
+        @SuppressWarnings("PMD.AccessorClassGeneration") //The builder is explicitly allowed to create one.
+        public RecipeTypeEntry createRecipeTypeEntry()
+        {
+            Validate.notNull(recipeTypeProducer);
+            Validate.notNull(registryName);
+
+            return new RecipeTypeEntry(recipeTypeProducer).setRegistryName(registryName);
+        }
+    }
+
+    /**
+     * The producer for the {@link AbstractRecipeType}. Creates the job from a {@link ICitizenData} instance.
+     *
+     * @return The created {@link AbstractRecipeType}.
+     */
+    public Function<IRecipeStorage, AbstractRecipeType<IRecipeStorage>> getHandlerProducer()
+    {
+        return recipeTypeProducer;
+    }
+
+    private RecipeTypeEntry(
+      final Function<IRecipeStorage, AbstractRecipeType<IRecipeStorage>> recipeTypeProducer)
+    {
+        super();
+        this.recipeTypeProducer = recipeTypeProducer;
+    }
+}

--- a/src/api/java/com/minecolonies/api/inventory/container/ContainerCrafting.java
+++ b/src/api/java/com/minecolonies/api/inventory/container/ContainerCrafting.java
@@ -2,7 +2,6 @@ package com.minecolonies.api.inventory.container;
 
 import com.ldtteam.structurize.api.util.ItemStackUtils;
 import com.minecolonies.api.inventory.ModContainers;
-import net.minecraft.client.util.ClientRecipeBook;
 import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.entity.player.PlayerInventory;
 import net.minecraft.entity.player.ServerPlayerEntity;

--- a/src/api/java/com/minecolonies/api/inventory/container/ContainerCrafting.java
+++ b/src/api/java/com/minecolonies/api/inventory/container/ContainerCrafting.java
@@ -16,7 +16,6 @@ import net.minecraft.inventory.container.Slot;
 import net.minecraft.item.ItemStack;
 import net.minecraft.item.crafting.ICraftingRecipe;
 import net.minecraft.item.crafting.IRecipeType;
-import net.minecraft.item.crafting.RecipeBook;
 import net.minecraft.network.PacketBuffer;
 import net.minecraft.network.play.server.SSetSlotPacket;
 import net.minecraft.util.math.BlockPos;
@@ -24,6 +23,7 @@ import net.minecraft.world.GameRules;
 import net.minecraft.world.World;
 import org.jetbrains.annotations.NotNull;
 import java.util.ArrayList;
+import java.util.List;
 import java.util.Optional;
 
 import static com.minecolonies.api.util.constant.InventoryConstants.*;
@@ -51,7 +51,7 @@ public class ContainerCrafting extends Container
     /**
      * The secondary outputs
      */
-    private final java.util.List<ItemStack> remainingItems;
+    private final List<ItemStack> remainingItems;
 
     /**
      * Boolean variable defining if complete grid or not 3x3(true), 2x2(false).
@@ -380,24 +380,12 @@ public class ContainerCrafting extends Container
      * Get for the remaining items. 
      * @return
      */
-    public java.util.List<ItemStack> getRemainingItems()
+    public List<ItemStack> getRemainingItems()
     {
         final Optional<ICraftingRecipe> iRecipe = this.world.getRecipeManager().getRecipe(IRecipeType.CRAFTING, craftMatrix, world);
-        RecipeBook r;
-        if(world.isRemote)
+        if (iRecipe.isPresent())
         {
-            r = new ClientRecipeBook(this.world.getRecipeManager());
-        }
-        else
-        {
-            r = new RecipeBook();
-        }
-        if (iRecipe.isPresent() && (iRecipe.get().isDynamic()
-        || !world.getGameRules().getBoolean(GameRules.DO_LIMITED_CRAFTING)
-        || r.isUnlocked(iRecipe.get())
-        || inv.player.isCreative()))
-        {
-            java.util.List<ItemStack> ri = iRecipe.get().getRemainingItems(this.craftMatrix);
+            List<ItemStack> ri = iRecipe.get().getRemainingItems(this.craftMatrix);
             remainingItems.clear();
             for(int i = 0; i< ri.size(); i++)
             {

--- a/src/api/java/com/minecolonies/api/util/InventoryUtils.java
+++ b/src/api/java/com/minecolonies/api/util/InventoryUtils.java
@@ -714,7 +714,7 @@ public class InventoryUtils
             totalCount += provider.getTileEntity().getAllContent().getOrDefault(stack, 0);
         }
 
-        if (totalCount > count)
+        if (totalCount > count && count > 0)
         {
             return Integer.MAX_VALUE;
         }

--- a/src/api/java/com/minecolonies/api/util/constant/Constants.java
+++ b/src/api/java/com/minecolonies/api/util/constant/Constants.java
@@ -47,7 +47,7 @@ public final class Constants
     public static final int    UPDATE_FLAG                      = 0x03;
     public static final int    TICKS_HOUR                       = TICKS_SECOND * SECONDS_A_MINUTE * SECONDS_A_MINUTE;
     public static final int    TICKS_FOURTY_MIN                 = 48000;
-    public static final int    MAX_PARAMS_IRECIPESTORAGE        = 4;
+    public static final int    MAX_PARAMS_IRECIPESTORAGE        = 6;
     public static final int    MIN_PARAMS_IRECIPESTORAGE        = 3;
     public static final int    PARAMS_ITEMSTORAGE               = 2;
     public static final int    PARAMS_RESEARCH_EFFECT           = 2;

--- a/src/api/java/com/minecolonies/api/util/constant/Constants.java
+++ b/src/api/java/com/minecolonies/api/util/constant/Constants.java
@@ -47,7 +47,7 @@ public final class Constants
     public static final int    UPDATE_FLAG                      = 0x03;
     public static final int    TICKS_HOUR                       = TICKS_SECOND * SECONDS_A_MINUTE * SECONDS_A_MINUTE;
     public static final int    TICKS_FOURTY_MIN                 = 48000;
-    public static final int    MAX_PARAMS_IRECIPESTORAGE        = 6;
+    public static final int    MAX_PARAMS_IRECIPESTORAGE        = 8;
     public static final int    MIN_PARAMS_IRECIPESTORAGE        = 3;
     public static final int    PARAMS_ITEMSTORAGE               = 2;
     public static final int    PARAMS_RESEARCH_EFFECT           = 2;

--- a/src/api/java/com/minecolonies/api/util/constant/TranslationConstants.java
+++ b/src/api/java/com/minecolonies/api/util/constant/TranslationConstants.java
@@ -487,6 +487,8 @@ public final class TranslationConstants
     public static final String DIST = "com.minecolonies.coremod.dist.blocks";
     @NonNls
     public static final String NOT_RESOLVED = "com.minecolonies.coremod.notresolved";
+    @NonNls
+    public static final String REQUEST_CRAFTING_DISPLAY = "com.minecolonies.coremod.request.crafting.display";
 
     private TranslationConstants()
     {

--- a/src/main/java/com/minecolonies/apiimp/CommonMinecoloniesAPIImpl.java
+++ b/src/main/java/com/minecolonies/apiimp/CommonMinecoloniesAPIImpl.java
@@ -17,6 +17,7 @@ import com.minecolonies.api.colony.jobs.registry.IJobDataManager;
 import com.minecolonies.api.colony.jobs.registry.JobEntry;
 import com.minecolonies.api.compatibility.IFurnaceRecipes;
 import com.minecolonies.api.configuration.Configuration;
+import com.minecolonies.api.crafting.registry.RecipeTypeEntry;
 import com.minecolonies.api.entity.ai.registry.IMobAIRegistry;
 import com.minecolonies.api.entity.pathfinding.registry.IPathNavigateRegistry;
 import com.minecolonies.api.research.IGlobalResearchTree;
@@ -54,6 +55,7 @@ public class CommonMinecoloniesAPIImpl implements IMinecoloniesAPI
     private        IForgeRegistry<ColonyEventTypeRegistryEntry>            colonyEventRegistry;
     private        IForgeRegistry<ColonyEventDescriptionTypeRegistryEntry> colonyEventDescriptionRegistry;
     private static IGlobalResearchTree                                     globalResearchTree     = new GlobalResearchTree();
+    private        IForgeRegistry<RecipeTypeEntry>                         recipeTypeEntryRegistry;
 
     @Override
     @NotNull
@@ -207,6 +209,12 @@ public class CommonMinecoloniesAPIImpl implements IMinecoloniesAPI
                 .setDefaultKey(new ResourceLocation(Constants.MOD_ID, "null"))
                 .disableSaving().allowModification().setType(ColonyEventDescriptionTypeRegistryEntry.class)
                 .setIDRange(0, Integer.MAX_VALUE - 1).create();
+
+        recipeTypeEntryRegistry = new RegistryBuilder<RecipeTypeEntry>()
+                                    .setName(new ResourceLocation(Constants.MOD_ID, "recipetypeentries"))
+                                    .setDefaultKey(new ResourceLocation(Constants.MOD_ID, "classic"))
+                                    .disableSaving().allowModification().setType(RecipeTypeEntry.class)
+                                    .setIDRange(0, Integer.MAX_VALUE - 1).create();
     }
 
     @Override
@@ -219,6 +227,12 @@ public class CommonMinecoloniesAPIImpl implements IMinecoloniesAPI
     public IForgeRegistry<ColonyEventDescriptionTypeRegistryEntry> getColonyEventDescriptionRegistry()
     {
         return colonyEventDescriptionRegistry;
+    }
+
+    @Override
+    public IForgeRegistry<RecipeTypeEntry> getRecipeTypeRegistry()
+    {
+        return recipeTypeEntryRegistry;
     }
 }
 

--- a/src/main/java/com/minecolonies/apiimp/initializer/ModRecipeTypesInitializer.java
+++ b/src/main/java/com/minecolonies/apiimp/initializer/ModRecipeTypesInitializer.java
@@ -1,0 +1,35 @@
+package com.minecolonies.apiimp.initializer;
+
+import com.minecolonies.api.crafting.ClassicRecipe;
+import com.minecolonies.api.crafting.ModRecipeTypes;
+import com.minecolonies.api.crafting.MultiOutputRecipe;
+import com.minecolonies.api.crafting.registry.RecipeTypeEntry;
+import net.minecraftforge.event.RegistryEvent;
+import net.minecraftforge.registries.IForgeRegistry;
+
+public final class ModRecipeTypesInitializer
+{
+
+    private ModRecipeTypesInitializer()
+    {
+        throw new IllegalStateException("Tried to initialize: ModRecipeTypesInitializer but this is a Utility class.");
+    }
+
+    public static void init(final RegistryEvent.Register<RecipeTypeEntry> event)
+    {
+        final IForgeRegistry<RecipeTypeEntry> reg = event.getRegistry();
+
+        ModRecipeTypes.Classic = new RecipeTypeEntry.Builder()
+                                .setRecipeTypeProducer(ClassicRecipe::new)
+                                .setRegistryName(ModRecipeTypes.CLASSIC_ID)
+                                .createRecipeTypeEntry();
+
+        ModRecipeTypes.MultiOutput = new RecipeTypeEntry.Builder()
+                                .setRecipeTypeProducer(MultiOutputRecipe::new)
+                                .setRegistryName(ModRecipeTypes.MULTI_OUTPUT_ID)
+                                .createRecipeTypeEntry();
+
+        reg.register(ModRecipeTypes.Classic);
+        reg.register(ModRecipeTypes.MultiOutput);
+    }
+}

--- a/src/main/java/com/minecolonies/coremod/client/gui/WindowListRecipes.java
+++ b/src/main/java/com/minecolonies/coremod/client/gui/WindowListRecipes.java
@@ -9,7 +9,6 @@ import com.ldtteam.blockout.views.ScrollingList;
 import com.ldtteam.blockout.views.Window;
 import com.minecolonies.api.colony.IColonyView;
 import com.minecolonies.api.crafting.IRecipeStorage;
-import com.minecolonies.api.crafting.IRecipeStorage.RecipeStorageType;
 import com.minecolonies.api.util.constant.Constants;
 import com.minecolonies.coremod.Network;
 import com.minecolonies.coremod.colony.buildings.AbstractBuildingWorker;
@@ -119,23 +118,8 @@ public class WindowListRecipes extends Window implements ButtonHandler
             {
                 @NotNull final IRecipeStorage recipe = recipes.get(index);
                 final ItemIcon icon = rowPane.findPaneOfTypeByID(OUTPUT_ICON, ItemIcon.class);
-                if(recipe.getRecipeType() == RecipeStorageType.MULTI_OUTPUT)
-                {
-                    List<ItemStack> displayStacks = recipe.getAlternateOutputs();
-                    final int iconIndex = (lifeCount / LIFE_COUNT_DIVIDER) % (displayStacks.size() + 1);
-                    if(iconIndex == 0)
-                    {
-                        icon.setItem(recipe.getPrimaryOutput());
-                    }
-                    else
-                    {
-                        icon.setItem(displayStacks.get(iconIndex - 1));
-                    }
-                }
-                else
-                {
-                    icon.setItem(recipe.getPrimaryOutput());
-                }
+                List<ItemStack> displayStacks = recipe.getRecipeType().getOutputDisplayStacks();
+                icon.setItem(displayStacks.get((lifeCount / LIFE_COUNT_DIVIDER) % (displayStacks.size())));
 
                 if (!building.isRecipeAlterationAllowed())
                 {

--- a/src/main/java/com/minecolonies/coremod/client/gui/WindowListRecipes.java
+++ b/src/main/java/com/minecolonies/coremod/client/gui/WindowListRecipes.java
@@ -9,11 +9,14 @@ import com.ldtteam.blockout.views.ScrollingList;
 import com.ldtteam.blockout.views.Window;
 import com.minecolonies.api.colony.IColonyView;
 import com.minecolonies.api.crafting.IRecipeStorage;
+import com.minecolonies.api.crafting.IRecipeStorage.RecipeStorageType;
 import com.minecolonies.api.util.constant.Constants;
 import com.minecolonies.coremod.Network;
 import com.minecolonies.coremod.colony.buildings.AbstractBuildingWorker;
 import com.minecolonies.coremod.network.messages.server.colony.building.worker.AddRemoveRecipeMessage;
 import com.minecolonies.coremod.network.messages.server.colony.building.worker.ChangeRecipePriorityMessage;
+import net.minecraft.client.gui.screen.Screen;
+import net.minecraft.item.ItemStack;
 import net.minecraft.util.math.BlockPos;
 import org.jetbrains.annotations.NotNull;
 
@@ -68,6 +71,11 @@ public class WindowListRecipes extends Window implements ButtonHandler
     private final ScrollingList recipeList;
 
     /**
+     * Life count.
+     */
+    private int lifeCount = 0;
+
+    /**
      * Constructor for the window when the player wants to see the list of a building's recipes.
      *
      * @param c          the colony view.
@@ -111,7 +119,23 @@ public class WindowListRecipes extends Window implements ButtonHandler
             {
                 @NotNull final IRecipeStorage recipe = recipes.get(index);
                 final ItemIcon icon = rowPane.findPaneOfTypeByID(OUTPUT_ICON, ItemIcon.class);
-                icon.setItem(recipe.getPrimaryOutput());
+                if(recipe.getRecipeType() == RecipeStorageType.MULTI_OUTPUT)
+                {
+                    List<ItemStack> displayStacks = recipe.getAlternateOutputs();
+                    final int iconIndex = (lifeCount / LIFE_COUNT_DIVIDER) % (displayStacks.size() + 1);
+                    if(iconIndex == 0)
+                    {
+                        icon.setItem(recipe.getPrimaryOutput());
+                    }
+                    else
+                    {
+                        icon.setItem(displayStacks.get(iconIndex - 1));
+                    }
+                }
+                else
+                {
+                    icon.setItem(recipe.getPrimaryOutput());
+                }
 
                 if (!building.isRecipeAlterationAllowed())
                 {
@@ -147,6 +171,10 @@ public class WindowListRecipes extends Window implements ButtonHandler
     public void onUpdate()
     {
         updateRecipes();
+        if (!Screen.hasShiftDown())
+        {
+            lifeCount++;
+        }
         window.findPaneOfTypeByID(RECIPE_LIST, ScrollingList.class).refreshElementPanes();
     }
 

--- a/src/main/java/com/minecolonies/coremod/client/gui/containers/WindowCrafting.java
+++ b/src/main/java/com/minecolonies/coremod/client/gui/containers/WindowCrafting.java
@@ -4,6 +4,7 @@ import com.ldtteam.structurize.util.LanguageHandler;
 import com.minecolonies.api.colony.IColonyManager;
 import com.minecolonies.api.inventory.container.ContainerCrafting;
 import com.minecolonies.api.util.ItemStackUtils;
+import com.minecolonies.api.util.Log;
 import com.minecolonies.api.util.constant.Constants;
 import com.minecolonies.coremod.Network;
 import com.minecolonies.coremod.colony.buildings.AbstractBuildingWorker;
@@ -134,10 +135,11 @@ public class WindowCrafting extends ContainerScreen<ContainerCrafting>
                 }
 
                 final ItemStack primaryOutput = container.craftResult.getStackInSlot(0).getStack().copy();
+                final List<ItemStack> secondaryOutputs = container.getRemainingItems();
 
                 if (!ItemStackUtils.isEmpty(primaryOutput))
                 {
-                    Network.getNetwork().sendToServer(new AddRemoveRecipeMessage(building, input, completeCrafting ? 3 : 2, primaryOutput, false));
+                    Network.getNetwork().sendToServer(new AddRemoveRecipeMessage(building, input, completeCrafting ? 3 : 2, primaryOutput, secondaryOutputs, false));
                 }
             }
             onClose();

--- a/src/main/java/com/minecolonies/coremod/client/gui/containers/WindowFurnaceCrafting.java
+++ b/src/main/java/com/minecolonies/coremod/client/gui/containers/WindowFurnaceCrafting.java
@@ -101,7 +101,7 @@ public class WindowFurnaceCrafting extends ContainerScreen<ContainerCraftingFurn
 
                 if (!ItemStackUtils.isEmpty(primaryOutput))
                 {
-                    Network.getNetwork().sendToServer(new AddRemoveRecipeMessage(building, input, 1, primaryOutput, null, false));
+                    Network.getNetwork().sendToServer(new AddRemoveRecipeMessage(building, input, 1, primaryOutput, ImmutableList.of(), false));
                 }
             }
         }

--- a/src/main/java/com/minecolonies/coremod/client/gui/containers/WindowFurnaceCrafting.java
+++ b/src/main/java/com/minecolonies/coremod/client/gui/containers/WindowFurnaceCrafting.java
@@ -1,5 +1,6 @@
 package com.minecolonies.coremod.client.gui.containers;
 
+import com.google.common.collect.ImmutableList;
 import com.ldtteam.structurize.util.LanguageHandler;
 import com.minecolonies.api.colony.IColonyManager;
 import com.minecolonies.api.inventory.container.ContainerCraftingFurnace;
@@ -97,10 +98,11 @@ public class WindowFurnaceCrafting extends ContainerScreen<ContainerCraftingFurn
                 final List<ItemStack> input = new ArrayList<>();
                 input.add(container.inventorySlots.get(0).getStack());
                 final ItemStack primaryOutput = container.inventorySlots.get(1).getStack().copy();
+                final List<ItemStack> alternateOutputs = ImmutableList.of();
 
                 if (!ItemStackUtils.isEmpty(primaryOutput))
                 {
-                    Network.getNetwork().sendToServer(new AddRemoveRecipeMessage(building, input, 1, primaryOutput, false));
+                    Network.getNetwork().sendToServer(new AddRemoveRecipeMessage(building, input, 1, primaryOutput, alternateOutputs, false));
                 }
             }
         }

--- a/src/main/java/com/minecolonies/coremod/client/gui/containers/WindowFurnaceCrafting.java
+++ b/src/main/java/com/minecolonies/coremod/client/gui/containers/WindowFurnaceCrafting.java
@@ -98,11 +98,10 @@ public class WindowFurnaceCrafting extends ContainerScreen<ContainerCraftingFurn
                 final List<ItemStack> input = new ArrayList<>();
                 input.add(container.inventorySlots.get(0).getStack());
                 final ItemStack primaryOutput = container.inventorySlots.get(1).getStack().copy();
-                final List<ItemStack> alternateOutputs = ImmutableList.of();
 
                 if (!ItemStackUtils.isEmpty(primaryOutput))
                 {
-                    Network.getNetwork().sendToServer(new AddRemoveRecipeMessage(building, input, 1, primaryOutput, alternateOutputs, false));
+                    Network.getNetwork().sendToServer(new AddRemoveRecipeMessage(building, input, 1, primaryOutput, null, false));
                 }
             }
         }

--- a/src/main/java/com/minecolonies/coremod/colony/buildings/AbstractBuildingWorker.java
+++ b/src/main/java/com/minecolonies/coremod/colony/buildings/AbstractBuildingWorker.java
@@ -233,7 +233,7 @@ public abstract class AbstractBuildingWorker extends AbstractBuilding implements
 
         for(IBuilding wareHouse: wareHouses)
         {
-            count += InventoryUtils.hasBuildingEnoughElseCount(wareHouse, item, 1);
+            count += InventoryUtils.hasBuildingEnoughElseCount(wareHouse, item, 0);
         }
         return count;
     }

--- a/src/main/java/com/minecolonies/coremod/colony/buildings/AbstractBuildingWorker.java
+++ b/src/main/java/com/minecolonies/coremod/colony/buildings/AbstractBuildingWorker.java
@@ -7,6 +7,7 @@ import com.minecolonies.api.colony.buildings.HiringMode;
 import com.minecolonies.api.colony.buildings.IBuilding;
 import com.minecolonies.api.colony.buildings.IBuildingWorker;
 import com.minecolonies.api.colony.buildings.IBuildingWorkerView;
+import com.minecolonies.api.colony.buildings.workerbuildings.IWareHouse;
 import com.minecolonies.api.colony.requestsystem.StandardFactoryController;
 import com.minecolonies.api.colony.requestsystem.request.IRequest;
 import com.minecolonies.api.colony.requestsystem.requestable.IDeliverable;
@@ -26,7 +27,6 @@ import com.minecolonies.api.util.constant.TypeConstants;
 import com.minecolonies.coremod.Network;
 import com.minecolonies.coremod.colony.buildings.views.AbstractBuildingView;
 import com.minecolonies.coremod.colony.buildings.workerbuildings.BuildingBuilder;
-import com.minecolonies.coremod.colony.buildings.workerbuildings.BuildingWareHouse;
 import com.minecolonies.coremod.colony.crafting.CustomRecipe;
 import com.minecolonies.coremod.colony.crafting.CustomRecipeManager;
 import com.minecolonies.coremod.colony.requestsystem.resolvers.BuildingRequestResolver;
@@ -238,11 +238,9 @@ public abstract class AbstractBuildingWorker extends AbstractBuilding implements
     protected int getWarehouseCount(ItemStorage item)
     {
         int count = 0;
-        final Set<IBuilding> wareHouses = colony.getBuildingManager().getBuildings().values().stream()
-                                                .filter(building -> building instanceof BuildingWareHouse)
-                                                .collect(Collectors.toSet());
+        final List<IWareHouse> wareHouses = colony.getBuildingManager().getWareHouses();
 
-        for(IBuilding wareHouse: wareHouses)
+        for(IWareHouse wareHouse: wareHouses)
         {
             count += InventoryUtils.hasBuildingEnoughElseCount(wareHouse, item, 0);
         }

--- a/src/main/java/com/minecolonies/coremod/colony/buildings/AbstractBuildingWorker.java
+++ b/src/main/java/com/minecolonies/coremod/colony/buildings/AbstractBuildingWorker.java
@@ -819,7 +819,8 @@ public abstract class AbstractBuildingWorker extends AbstractBuilding implements
 
             if(newRecipe.isValidForBuilding(this))
             {   
-                IToken<?> duplicateFound = null; 
+                IToken<?> duplicateFound = null;
+                boolean forceReplace = false;  
                 for(IToken<?> token : recipes)
                 {
                     if(token == recipeToken)
@@ -858,6 +859,16 @@ public abstract class AbstractBuildingWorker extends AbstractBuilding implements
                         if(allMatch)
                         {
                             duplicateFound = token;
+                            if(storage.getRecipeType() == RecipeStorageType.CLASSIC && recipeStorage.getRecipeType() == RecipeStorageType.MULTI_OUTPUT)
+                            {
+                                //This catches the old recipes without a RecipeSource
+                                forceReplace = true;
+                            }
+                            if(storage.getRecipeSource().equals(recipeStorage.getRecipeSource()))
+                            {
+                                //This will only happen if the tokens don't match, aka: the recipe has changed.
+                                forceReplace = true;
+                            }
                             break;
                         }
                     }
@@ -867,7 +878,7 @@ public abstract class AbstractBuildingWorker extends AbstractBuilding implements
                     addRecipeToList(recipeToken);    
                     colony.getRequestManager().onColonyUpdate(request -> request.getRequest() instanceof IDeliverable && ((IDeliverable) request.getRequest()).matches(recipeStorage.getPrimaryOutput()));
                 }
-                else if(newRecipe.getMustExist() && duplicateFound != recipeToken)
+                else if((forceReplace || newRecipe.getMustExist()) && duplicateFound != recipeToken)
                 {
                     //We found the base recipe for a multi-recipe, replace it with the multi-recipe
                     replaceRecipe(duplicateFound, recipeToken);

--- a/src/main/java/com/minecolonies/coremod/colony/buildings/AbstractBuildingWorker.java
+++ b/src/main/java/com/minecolonies/coremod/colony/buildings/AbstractBuildingWorker.java
@@ -12,9 +12,10 @@ import com.minecolonies.api.colony.requestsystem.request.IRequest;
 import com.minecolonies.api.colony.requestsystem.requestable.IDeliverable;
 import com.minecolonies.api.colony.requestsystem.resolver.IRequestResolver;
 import com.minecolonies.api.colony.requestsystem.token.IToken;
+import com.minecolonies.api.crafting.ClassicRecipe;
 import com.minecolonies.api.crafting.IRecipeStorage;
 import com.minecolonies.api.crafting.ItemStorage;
-import com.minecolonies.api.crafting.IRecipeStorage.RecipeStorageType;
+import com.minecolonies.api.crafting.MultiOutputRecipe;
 import com.minecolonies.api.entity.citizen.Skill;
 import com.minecolonies.api.inventory.container.ContainerCrafting;
 import com.minecolonies.api.util.InventoryUtils;
@@ -218,7 +219,7 @@ public abstract class AbstractBuildingWorker extends AbstractBuilding implements
             foundRecipe = candidates.entrySet().stream().min(Map.Entry.comparingByValue(Comparator.reverseOrder())).get().getKey();
         }
 
-        if(foundRecipe != null && foundRecipe.getRecipeType() == RecipeStorageType.MULTI_OUTPUT)
+        if(foundRecipe != null && foundRecipe.getRecipeType() instanceof MultiOutputRecipe)
         {
             foundRecipe = foundRecipe.getClassicForMultiOutput(stackPredicate);
         }
@@ -264,7 +265,7 @@ public abstract class AbstractBuildingWorker extends AbstractBuilding implements
             if (storage != null && (stackPredicate.test(storage.getPrimaryOutput()) || storage.getAlternateOutputs().stream().anyMatch(i -> stackPredicate.test(i))))
             {
                 final List<IItemHandler> handlers = getHandlers();
-                IRecipeStorage toTest = storage.getRecipeType() == RecipeStorageType.MULTI_OUTPUT ? storage.getClassicForMultiOutput(stackPredicate) : storage;
+                IRecipeStorage toTest = storage.getRecipeType() instanceof MultiOutputRecipe ? storage.getClassicForMultiOutput(stackPredicate) : storage;
                 if (toTest.canFullFillRecipe(count, handlers.toArray(new IItemHandler[0])))
                 {
                     return toTest;
@@ -859,12 +860,12 @@ public abstract class AbstractBuildingWorker extends AbstractBuilding implements
                         if(allMatch)
                         {
                             duplicateFound = token;
-                            if(storage.getRecipeType() == RecipeStorageType.CLASSIC && recipeStorage.getRecipeType() == RecipeStorageType.MULTI_OUTPUT)
+                            if(storage.getRecipeType() instanceof ClassicRecipe && recipeStorage.getRecipeType() instanceof MultiOutputRecipe)
                             {
-                                //This catches the old recipes without a RecipeSource
+                                //This catches the old custom recipes without a RecipeSource
                                 forceReplace = true;
                             }
-                            if(storage.getRecipeSource().equals(recipeStorage.getRecipeSource()))
+                            if(storage.getRecipeSource() != null && storage.getRecipeSource().equals(recipeStorage.getRecipeSource()))
                             {
                                 //This will only happen if the tokens don't match, aka: the recipe has changed.
                                 forceReplace = true;
@@ -889,7 +890,7 @@ public abstract class AbstractBuildingWorker extends AbstractBuilding implements
                     for(IToken<?> token : this.getRecipes())
                     {
                         final IRecipeStorage storage = IColonyManager.getInstance().getRecipeManager().getRecipes().get(token);
-                        if(storage.getRecipeType() == RecipeStorageType.CLASSIC && ItemStackUtils.compareItemStackListIgnoreStackSize(alternates, storage.getPrimaryOutput(), false, true))
+                        if(storage.getRecipeType() instanceof ClassicRecipe && ItemStackUtils.compareItemStackListIgnoreStackSize(alternates, storage.getPrimaryOutput(), false, true))
                         {
                             removeRecipe(token);
                         }

--- a/src/main/java/com/minecolonies/coremod/colony/buildings/AbstractBuildingWorker.java
+++ b/src/main/java/com/minecolonies/coremod/colony/buildings/AbstractBuildingWorker.java
@@ -867,7 +867,7 @@ public abstract class AbstractBuildingWorker extends AbstractBuilding implements
                     addRecipeToList(recipeToken);    
                     colony.getRequestManager().onColonyUpdate(request -> request.getRequest() instanceof IDeliverable && ((IDeliverable) request.getRequest()).matches(recipeStorage.getPrimaryOutput()));
                 }
-                else if(newRecipe.isMustExist() && duplicateFound != recipeToken)
+                else if(newRecipe.getMustExist() && duplicateFound != recipeToken)
                 {
                     //We found the base recipe for a multi-recipe, replace it with the multi-recipe
                     replaceRecipe(duplicateFound, recipeToken);

--- a/src/main/java/com/minecolonies/coremod/colony/buildings/AbstractBuildingWorker.java
+++ b/src/main/java/com/minecolonies/coremod/colony/buildings/AbstractBuildingWorker.java
@@ -189,7 +189,7 @@ public abstract class AbstractBuildingWorker extends AbstractBuilding implements
     @Nullable
     public IRecipeStorage getFirstRecipe(final Predicate<ItemStack> stackPredicate)
     {
-        IRecipeStorage firstFound = null;
+        IRecipeStorage foundRecipe = null;
         final HashMap<IRecipeStorage, Integer> candidates = new HashMap<>();
 
 
@@ -199,9 +199,9 @@ public abstract class AbstractBuildingWorker extends AbstractBuilding implements
             final IRecipeStorage storage = IColonyManager.getInstance().getRecipeManager().getRecipes().get(token);
             if (storage != null && (stackPredicate.test(storage.getPrimaryOutput()) || storage.getAlternateOutputs().stream().anyMatch(i -> stackPredicate.test(i))))
             {
-                if(firstFound == null)
+                if(foundRecipe == null)
                 {
-                    firstFound = storage;
+                    foundRecipe = storage;
                 }
                 candidates.put(storage, 0);
             }
@@ -215,15 +215,15 @@ public abstract class AbstractBuildingWorker extends AbstractBuilding implements
                 final ItemStorage checkItem = foo.getKey().getCleanedInput().stream().max(Comparator.comparingInt(ItemStorage::getAmount)).get();
                 candidates.put(foo.getKey(), getWarehouseCount(checkItem));
             }
-            firstFound = candidates.entrySet().stream().min(Map.Entry.comparingByValue(Comparator.reverseOrder())).get().getKey();
+            foundRecipe = candidates.entrySet().stream().min(Map.Entry.comparingByValue(Comparator.reverseOrder())).get().getKey();
         }
 
-        if(firstFound != null && firstFound.getRecipeType() == RecipeStorageType.MULTI_OUTPUT)
+        if(foundRecipe != null && foundRecipe.getRecipeType() == RecipeStorageType.MULTI_OUTPUT)
         {
-            firstFound = firstFound.getClassicForMultiOutput(stackPredicate);
+            foundRecipe = foundRecipe.getClassicForMultiOutput(stackPredicate);
         }
 
-        return firstFound;
+        return foundRecipe;
     }
 
     /**

--- a/src/main/java/com/minecolonies/coremod/colony/buildings/workerbuildings/BuildingArchery.java
+++ b/src/main/java/com/minecolonies/coremod/colony/buildings/workerbuildings/BuildingArchery.java
@@ -284,6 +284,30 @@ public class BuildingArchery extends AbstractBuildingWorker implements IBuilding
         return ModBuildings.archery;
     }
 
+    @Override
+    public void onWakeUp()
+    {
+        super.onWakeUp();
+        
+        final World world = getColony().getWorld();
+        if (world == null)
+        {
+            return;
+        }
+
+        for (final BlockPos pos : bedList)
+        {
+            BlockState state = world.getBlockState(pos);
+            state = state.getBlock().getExtendedState(state, world, pos);
+            if (state.getBlock() instanceof BedBlock
+                  && state.get(BedBlock.OCCUPIED)
+                  && state.get(BedBlock.PART).equals(BedPart.HEAD))
+            {
+                world.setBlockState(pos, state.with(BedBlock.OCCUPIED, false), 0x03);
+            }
+        }
+    }    
+
     /**
      * The client view for the bakery building.
      */

--- a/src/main/java/com/minecolonies/coremod/colony/buildings/workerbuildings/BuildingCombatAcademy.java
+++ b/src/main/java/com/minecolonies/coremod/colony/buildings/workerbuildings/BuildingCombatAcademy.java
@@ -378,6 +378,30 @@ public class BuildingCombatAcademy extends AbstractBuildingWorker implements IBu
         return ModBuildings.combatAcademy;
     }
 
+    @Override
+    public void onWakeUp()
+    {
+        super.onWakeUp();
+        
+        final World world = getColony().getWorld();
+        if (world == null)
+        {
+            return;
+        }
+
+        for (final BlockPos pos : bedList)
+        {
+            BlockState state = world.getBlockState(pos);
+            state = state.getBlock().getExtendedState(state, world, pos);
+            if (state.getBlock() instanceof BedBlock
+                  && state.get(BedBlock.OCCUPIED)
+                  && state.get(BedBlock.PART).equals(BedPart.HEAD))
+            {
+                world.setBlockState(pos, state.with(BedBlock.OCCUPIED, false), 0x03);
+            }
+        }
+    }    
+
     /**
      * The client view for the bakery building.
      */

--- a/src/main/java/com/minecolonies/coremod/colony/crafting/CustomRecipe.java
+++ b/src/main/java/com/minecolonies/coremod/colony/crafting/CustomRecipe.java
@@ -374,7 +374,7 @@ public class CustomRecipe
         {
             boolean found = false;
             final IRecipeStorage compareStorage = this.getRecipeStorage();
-            final String recipeSource = this.getRecipeId().toString();
+            final ResourceLocation recipeSource = this.getRecipeId();
             for(IToken<?> recipeToken: building.getRecipes())
             {
                 final IRecipeStorage storage = IColonyManager.getInstance().getRecipeManager().getRecipes().get(recipeToken);
@@ -411,7 +411,7 @@ public class CustomRecipe
                 1,
                 result,
                 intermediate,
-                this.getRecipeId().toString(),
+                this.getRecipeId(),
                 RecipeStorageType.CLASSIC,
                 null, //alternate outputs
                 null //secondary output
@@ -426,7 +426,7 @@ public class CustomRecipe
                 1,
                 result,
                 intermediate,
-                this.getRecipeId().toString(),
+                this.getRecipeId(),
                 RecipeStorageType.MULTI_OUTPUT,
                 altOutputs, //alternate outputs
                 null //secondary output

--- a/src/main/java/com/minecolonies/coremod/colony/crafting/CustomRecipe.java
+++ b/src/main/java/com/minecolonies/coremod/colony/crafting/CustomRecipe.java
@@ -8,6 +8,8 @@ import com.minecolonies.api.colony.requestsystem.StandardFactoryController;
 import com.minecolonies.api.crafting.IRecipeStorage;
 import com.minecolonies.api.research.IGlobalResearchTree;
 import com.minecolonies.api.research.effects.AbstractResearchEffect;
+import com.minecolonies.api.crafting.RecipeStorage;
+import com.minecolonies.api.research.effects.IResearchEffect;
 import com.minecolonies.api.util.Log;
 import com.minecolonies.api.util.constant.TypeConstants;
 import com.mojang.brigadier.exceptions.CommandSyntaxException;
@@ -37,6 +39,17 @@ public class CustomRecipe
      * The recipe type
      */
     public static final String RECIPE_TYPE_RECIPE = "recipe";
+
+    /**
+     * The multiple output recipe type
+     */
+    public static final String RECIPE_TYPE_RECIPE_MULT_OUT = "recipe-multi-out";
+
+    /**
+     * The multiple input recipe type
+     */
+    public static final String RECIPE_TYPE_RECIPE_MULT_IN = "recipe-multi-in";
+
 
     /**
      * The remove type
@@ -329,7 +342,9 @@ public class CustomRecipe
             inputs,
             1,
             result,
-            intermediate);
+            intermediate,
+            this.getRecipeId().toString()
+            );
     }
 
     @Override

--- a/src/main/java/com/minecolonies/coremod/colony/crafting/CustomRecipe.java
+++ b/src/main/java/com/minecolonies/coremod/colony/crafting/CustomRecipe.java
@@ -464,7 +464,7 @@ public class CustomRecipe
     /**
      * Does this require it to already be there? 
      */
-    public boolean isMustExist()
+    public boolean getMustExist()
     {
         return mustExist;
     }

--- a/src/main/java/com/minecolonies/coremod/colony/crafting/CustomRecipe.java
+++ b/src/main/java/com/minecolonies/coremod/colony/crafting/CustomRecipe.java
@@ -8,7 +8,7 @@ import com.minecolonies.api.colony.buildings.IBuildingWorker;
 import com.minecolonies.api.colony.requestsystem.StandardFactoryController;
 import com.minecolonies.api.colony.requestsystem.token.IToken;
 import com.minecolonies.api.crafting.IRecipeStorage;
-import com.minecolonies.api.crafting.IRecipeStorage.RecipeStorageType;
+import com.minecolonies.api.crafting.ModRecipeTypes;
 import com.minecolonies.api.research.IGlobalResearchTree;
 import com.minecolonies.api.research.effects.AbstractResearchEffect;
 import com.minecolonies.api.util.Log;
@@ -378,7 +378,7 @@ public class CustomRecipe
             for(IToken<?> recipeToken: building.getRecipes())
             {
                 final IRecipeStorage storage = IColonyManager.getInstance().getRecipeManager().getRecipes().get(recipeToken);
-                if(storage.getRecipeSource().equals(recipeSource) || (storage.getCleanedInput().containsAll(compareStorage.getCleanedInput()) && compareStorage.getCleanedInput().containsAll(storage.getCleanedInput())))
+                if((storage.getRecipeSource() != null && storage.getRecipeSource().equals(recipeSource)) || (storage.getCleanedInput().containsAll(compareStorage.getCleanedInput()) && compareStorage.getCleanedInput().containsAll(storage.getCleanedInput())))
                 {
                     found = true;
                     break;
@@ -412,7 +412,7 @@ public class CustomRecipe
                 result,
                 intermediate,
                 this.getRecipeId(),
-                RecipeStorageType.CLASSIC,
+                ModRecipeTypes.CLASSIC_ID,
                 null, //alternate outputs
                 null //secondary output
                 );
@@ -427,7 +427,7 @@ public class CustomRecipe
                 result,
                 intermediate,
                 this.getRecipeId(),
-                RecipeStorageType.MULTI_OUTPUT,
+                ModRecipeTypes.MULTI_OUTPUT_ID,
                 altOutputs, //alternate outputs
                 null //secondary output
                 );

--- a/src/main/java/com/minecolonies/coremod/colony/crafting/CustomRecipe.java
+++ b/src/main/java/com/minecolonies/coremod/colony/crafting/CustomRecipe.java
@@ -272,7 +272,7 @@ public class CustomRecipe
         {
             for (JsonElement e : recipeJson.get(RECIPE_ALTERNATE_PROP).getAsJsonArray())
             {
-                if (e instanceof JsonElement && e.isJsonObject())
+                if (e.isJsonObject())
                 {
                     JsonObject ingredient = e.getAsJsonObject();
                     if (ingredient.has(ITEM_PROP))

--- a/src/main/java/com/minecolonies/coremod/colony/crafting/CustomRecipe.java
+++ b/src/main/java/com/minecolonies/coremod/colony/crafting/CustomRecipe.java
@@ -247,7 +247,7 @@ public class CustomRecipe
         {
             for (JsonElement e : recipeJson.get(RECIPE_INPUTS_PROP).getAsJsonArray())
             {
-                if (e instanceof JsonElement && e.isJsonObject())
+                if (e.isJsonObject())
                 {
                     JsonObject ingredient = e.getAsJsonObject();
                     if (ingredient.has(ITEM_PROP))

--- a/src/main/java/com/minecolonies/coremod/colony/crafting/CustomRecipeManager.java
+++ b/src/main/java/com/minecolonies/coremod/colony/crafting/CustomRecipeManager.java
@@ -23,7 +23,7 @@ public class CustomRecipeManager
     /**
      * The map of loaded recipes
      */
-    private HashMap<String, HashMap<ResourceLocation, CustomRecipe>> recipeMap = new HashMap<>();
+    private HashMap<String, Map<ResourceLocation, CustomRecipe>> recipeMap = new HashMap<>();
 
     /**
      * The recipes that are marked for removal after loading all resource packs
@@ -93,7 +93,7 @@ public class CustomRecipeManager
         {
             for(ResourceLocation toRemove: removedRecipes)
             {
-                final Optional<HashMap<ResourceLocation, CustomRecipe>> crafterMap = recipeMap.entrySet().stream().map(r -> r.getValue()).filter(r1 -> r1.keySet().contains(toRemove)).findFirst();
+                final Optional<Map<ResourceLocation, CustomRecipe>> crafterMap = recipeMap.entrySet().stream().map(r -> r.getValue()).filter(r1 -> r1.keySet().contains(toRemove)).findFirst();
                 if(crafterMap.isPresent())
                 {
                     crafterMap.get().remove(toRemove);
@@ -107,6 +107,14 @@ public class CustomRecipeManager
             return recipeMap.get(crafter).entrySet().stream().map(x -> x.getValue()).collect(Collectors.toSet());
         }
         return new HashSet<>();
+    }
+
+    /**
+     * The complete list of custom recipes, by crafter. 
+     */
+    public Map<String, Map<ResourceLocation, CustomRecipe>> getAllRecipes()
+    {
+        return recipeMap;
     }
     
 }

--- a/src/main/java/com/minecolonies/coremod/colony/crafting/RecipeStorageFactory.java
+++ b/src/main/java/com/minecolonies/coremod/colony/crafting/RecipeStorageFactory.java
@@ -5,8 +5,8 @@ import com.minecolonies.api.colony.requestsystem.StandardFactoryController;
 import com.minecolonies.api.colony.requestsystem.factory.IFactoryController;
 import com.minecolonies.api.colony.requestsystem.token.IToken;
 import com.minecolonies.api.crafting.IRecipeStorageFactory;
+import com.minecolonies.api.crafting.ModRecipeTypes;
 import com.minecolonies.api.crafting.RecipeStorage;
-import com.minecolonies.api.crafting.IRecipeStorage.RecipeStorageType;
 import com.minecolonies.api.util.constant.TypeConstants;
 import net.minecraft.block.Block;
 import net.minecraft.item.ItemStack;
@@ -86,7 +86,7 @@ public class RecipeStorageFactory implements IRecipeStorageFactory
       @NotNull final ItemStack primaryOutput,
       final Block intermediate, 
       final ResourceLocation source,
-      final RecipeStorageType type,
+      final ResourceLocation type,
       final List<ItemStack> altOutputs,
       final List<ItemStack> secOutputs)
     {
@@ -116,9 +116,9 @@ public class RecipeStorageFactory implements IRecipeStorageFactory
         compound.put(TAG_TOKEN, StandardFactoryController.getInstance().serialize(recipeStorage.getToken()));
         if(recipeStorage.getRecipeSource() != null)
         {
-            compound.putString(SOURCE_TAG, recipeStorage.getRecipeSource().getPath());
+            compound.putString(SOURCE_TAG, recipeStorage.getRecipeSource().toString());
         }
-        compound.putString(TYPE_TAG, recipeStorage.getRecipeType().toString());
+        compound.putString(TYPE_TAG, recipeStorage.getRecipeType().getId().toString());
 
         @NotNull final ListNBT altOutputTagList = new ListNBT();
         for (@NotNull final ItemStack stack : recipeStorage.getAlternateOutputs())
@@ -161,7 +161,7 @@ public class RecipeStorageFactory implements IRecipeStorageFactory
 
         final ResourceLocation source = nbt.contains(SOURCE_TAG) ? new ResourceLocation(nbt.getString(SOURCE_TAG)) : null; 
 
-        final RecipeStorageType type = nbt.contains(TYPE_TAG) ? Enum.valueOf(RecipeStorageType.class, nbt.getString(TYPE_TAG)) : null; 
+        final ResourceLocation type = nbt.contains(TYPE_TAG) ? new ResourceLocation(nbt.getString(TYPE_TAG).toLowerCase()): ModRecipeTypes.CLASSIC_ID;
 
         final ListNBT altOutputTagList = nbt.getList(ALTOUTPUT_TAG, Constants.NBT.TAG_COMPOUND);
 
@@ -199,7 +199,7 @@ public class RecipeStorageFactory implements IRecipeStorageFactory
 
         packetBuffer.writeInt(input.getGridSize());
 
-        packetBuffer.writeEnumValue(input.getRecipeType());
+        packetBuffer.writeResourceLocation(input.getRecipeType().getId());
 
         packetBuffer.writeInt(input.getAlternateOutputs().size());
         input.getAlternateOutputs().forEach(stack -> packetBuffer.writeItemStack(stack));
@@ -223,7 +223,7 @@ public class RecipeStorageFactory implements IRecipeStorageFactory
         final ItemStack primaryOutput = buffer.readItemStack();
         final Block intermediate = buffer.readBoolean() ? Block.getStateById(buffer.readInt()).getBlock() : null;
         final int gridSize = buffer.readInt();
-        final RecipeStorageType type = buffer.readEnumValue(RecipeStorageType.class);
+        final ResourceLocation type = buffer.readResourceLocation();
 
         final List<ItemStack> altOutputs = new ArrayList<>();
         final int altOutputSize = buffer.readInt();

--- a/src/main/java/com/minecolonies/coremod/colony/crafting/RecipeStorageFactory.java
+++ b/src/main/java/com/minecolonies/coremod/colony/crafting/RecipeStorageFactory.java
@@ -6,6 +6,7 @@ import com.minecolonies.api.colony.requestsystem.factory.IFactoryController;
 import com.minecolonies.api.colony.requestsystem.token.IToken;
 import com.minecolonies.api.crafting.IRecipeStorageFactory;
 import com.minecolonies.api.crafting.RecipeStorage;
+import com.minecolonies.api.crafting.RecipeStorage.RecipeStorageType;
 import com.minecolonies.api.util.constant.TypeConstants;
 import net.minecraft.block.Block;
 import net.minecraft.item.ItemStack;
@@ -41,6 +42,21 @@ public class RecipeStorageFactory implements IRecipeStorageFactory
      */
     private static final String INPUT_TAG = "input";
 
+    /**
+     * Compound tag for the alternate outputs.
+     */
+    private static final String ALTOUTPUT_TAG = "altoutput";
+
+    /**
+     * Compound tag for Source
+     */
+    private static final String SOURCE_TAG = "source";
+
+    /**
+     * Compound tag for Type
+     */
+    private static final String TYPE_TAG = "type";
+
     @NotNull
     @Override
     public TypeToken<RecipeStorage> getFactoryOutputType()
@@ -62,9 +78,12 @@ public class RecipeStorageFactory implements IRecipeStorageFactory
       @NotNull final List<ItemStack> input,
       final int gridSize,
       @NotNull final ItemStack primaryOutput,
-      final Block intermediate)
+      final Block intermediate, 
+      final String source,
+      final RecipeStorageType type,
+      final List<ItemStack> altOutputs)
     {
-        return new RecipeStorage(token, input, gridSize, primaryOutput, intermediate);
+        return new RecipeStorage(token, input, gridSize, primaryOutput, intermediate, source, type, altOutputs);
     }
 
     @NotNull
@@ -88,6 +107,11 @@ public class RecipeStorageFactory implements IRecipeStorageFactory
         }
         compound.putInt(TAG_GRID, recipeStorage.getGridSize());
         compound.put(TAG_TOKEN, StandardFactoryController.getInstance().serialize(recipeStorage.getToken()));
+        if(recipeStorage.getRecipeSource() != null)
+        {
+            compound.putString(SOURCE_TAG, recipeStorage.getRecipeSource());
+        }
+        compound.putString(TYPE_TAG, recipeStorage.getRecipeType().toString());
         return compound;
     }
 
@@ -108,7 +132,20 @@ public class RecipeStorageFactory implements IRecipeStorageFactory
         final int gridSize = nbt.getInt(TAG_GRID);
         final IToken<?> token = StandardFactoryController.getInstance().deserialize(nbt.getCompound(TAG_TOKEN));
 
-        return this.getNewInstance(token, input, gridSize, primaryOutput, intermediate);
+        final String source = nbt.contains(SOURCE_TAG) ? nbt.getString(SOURCE_TAG) : null; 
+
+        final RecipeStorageType type = nbt.contains(TYPE_TAG) ? Enum.valueOf(RecipeStorageType.class, nbt.getString(TYPE_TAG)) : null; 
+
+        final ListNBT altOutputTagList = nbt.getList(ALTOUTPUT_TAG, Constants.NBT.TAG_COMPOUND);
+
+        final List<ItemStack> altOutputs = new ArrayList<>();
+        for (int i = 0; i < altOutputTagList.size(); ++i)
+        {
+            final CompoundNBT altOutputTag = altOutputTagList.getCompound(i);
+            altOutputs.add(ItemStack.read(altOutputTag));
+        }
+
+        return this.getNewInstance(token, input, gridSize, primaryOutput, intermediate, source, type, altOutputs.isEmpty() ? null : altOutputs);
     }
 
     @Override
@@ -125,6 +162,12 @@ public class RecipeStorageFactory implements IRecipeStorageFactory
         }
 
         packetBuffer.writeInt(input.getGridSize());
+
+        packetBuffer.writeEnumValue(input.getRecipeType());
+
+        packetBuffer.writeInt(input.getAlternateOutputs().size());
+        input.getAlternateOutputs().forEach(stack -> packetBuffer.writeItemStack(stack));
+
         controller.serialize(packetBuffer, input.getToken());
     }
 
@@ -141,9 +184,18 @@ public class RecipeStorageFactory implements IRecipeStorageFactory
         final ItemStack primaryOutput = buffer.readItemStack();
         final Block intermediate = buffer.readBoolean() ? Block.getStateById(buffer.readInt()).getBlock() : null;
         final int gridSize = buffer.readInt();
-        final IToken<?> token = controller.deserialize(buffer);
+        final RecipeStorageType type = buffer.readEnumValue(RecipeStorageType.class);
 
-        return this.getNewInstance(token, input, gridSize, primaryOutput, intermediate);
+        final List<ItemStack> altOutputs = new ArrayList<>();
+        final int altOutputSize = buffer.readInt();
+        for (int i = 0; i < altOutputSize; ++i)
+        {
+            altOutputs.add(buffer.readItemStack());
+        }
+
+
+        final IToken<?> token = controller.deserialize(buffer);
+        return this.getNewInstance(token, input, gridSize, primaryOutput, intermediate, null, type, altOutputs.isEmpty() ? null : altOutputs);
     }
 
     @Override

--- a/src/main/java/com/minecolonies/coremod/colony/crafting/RecipeStorageFactory.java
+++ b/src/main/java/com/minecolonies/coremod/colony/crafting/RecipeStorageFactory.java
@@ -14,6 +14,7 @@ import net.minecraft.nbt.CompoundNBT;
 import net.minecraft.nbt.ListNBT;
 import net.minecraft.nbt.NBTUtil;
 import net.minecraft.network.PacketBuffer;
+import net.minecraft.util.ResourceLocation;
 import net.minecraftforge.common.util.Constants;
 import org.jetbrains.annotations.NotNull;
 
@@ -84,7 +85,7 @@ public class RecipeStorageFactory implements IRecipeStorageFactory
       final int gridSize,
       @NotNull final ItemStack primaryOutput,
       final Block intermediate, 
-      final String source,
+      final ResourceLocation source,
       final RecipeStorageType type,
       final List<ItemStack> altOutputs,
       final List<ItemStack> secOutputs)
@@ -115,7 +116,7 @@ public class RecipeStorageFactory implements IRecipeStorageFactory
         compound.put(TAG_TOKEN, StandardFactoryController.getInstance().serialize(recipeStorage.getToken()));
         if(recipeStorage.getRecipeSource() != null)
         {
-            compound.putString(SOURCE_TAG, recipeStorage.getRecipeSource());
+            compound.putString(SOURCE_TAG, recipeStorage.getRecipeSource().getPath());
         }
         compound.putString(TYPE_TAG, recipeStorage.getRecipeType().toString());
 
@@ -158,7 +159,7 @@ public class RecipeStorageFactory implements IRecipeStorageFactory
         final int gridSize = nbt.getInt(TAG_GRID);
         final IToken<?> token = StandardFactoryController.getInstance().deserialize(nbt.getCompound(TAG_TOKEN));
 
-        final String source = nbt.contains(SOURCE_TAG) ? nbt.getString(SOURCE_TAG) : null; 
+        final ResourceLocation source = nbt.contains(SOURCE_TAG) ? new ResourceLocation(nbt.getString(SOURCE_TAG)) : null; 
 
         final RecipeStorageType type = nbt.contains(TYPE_TAG) ? Enum.valueOf(RecipeStorageType.class, nbt.getString(TYPE_TAG)) : null; 
 

--- a/src/main/java/com/minecolonies/coremod/colony/jobs/JobArcherTraining.java
+++ b/src/main/java/com/minecolonies/coremod/colony/jobs/JobArcherTraining.java
@@ -30,7 +30,7 @@ public class JobArcherTraining extends AbstractJob<EntityAIArcherTraining, JobAr
     @Override
     public String getName()
     {
-        return "ArcherTraining";
+        return "com.minecolonies.coremod.job.archertraining";
     }
 
     @Override

--- a/src/main/java/com/minecolonies/coremod/colony/jobs/JobCombatTraining.java
+++ b/src/main/java/com/minecolonies/coremod/colony/jobs/JobCombatTraining.java
@@ -30,7 +30,7 @@ public class JobCombatTraining extends AbstractJob<EntityAICombatTraining, JobCo
     @Override
     public String getName()
     {
-        return "CombatTraining";
+        return "com.minecolonies.coremod.job.combattraining";
     }
 
     @Override

--- a/src/main/java/com/minecolonies/coremod/colony/requestsystem/management/manager/StandardRecipeManager.java
+++ b/src/main/java/com/minecolonies/coremod/colony/requestsystem/management/manager/StandardRecipeManager.java
@@ -55,10 +55,6 @@ public class StandardRecipeManager implements IRecipeManager
         recipes.put(storage.getToken(), storage);
         usedRecipes.add(storage.getToken());
         cache = null;
-        if(!usedRecipes.contains(storage.getToken()))
-        {
-            usedRecipes.add(storage.getToken());
-        }
         return storage.getToken();
     }
 

--- a/src/main/java/com/minecolonies/coremod/colony/requestsystem/management/manager/StandardRecipeManager.java
+++ b/src/main/java/com/minecolonies/coremod/colony/requestsystem/management/manager/StandardRecipeManager.java
@@ -55,6 +55,10 @@ public class StandardRecipeManager implements IRecipeManager
         recipes.put(storage.getToken(), storage);
         usedRecipes.add(storage.getToken());
         cache = null;
+        if(!usedRecipes.contains(storage.getToken()))
+        {
+            usedRecipes.add(storage.getToken());
+        }
         return storage.getToken();
     }
 

--- a/src/main/java/com/minecolonies/coremod/colony/requestsystem/requests/StandardRequests.java
+++ b/src/main/java/com/minecolonies/coremod/colony/requestsystem/requests/StandardRequests.java
@@ -343,11 +343,9 @@ public final class StandardRequests
         public final ITextComponent getShortDisplayString()
         {
             final ITextComponent result = new NonSiblingFormattingTextComponent();
-            final ITextComponent preType = new TranslationTextComponent(getTranslationKey());
 
-            result.appendSibling(preType);
-
-            preType.appendSibling(getRequest().getStack().getTextComponent());
+            result.appendSibling(new StringTextComponent(getRequest().getMinCount() + " * Recipe:"));
+            result.appendSibling(getRequest().getStack().getTextComponent());
 
             return result;
         }

--- a/src/main/java/com/minecolonies/coremod/colony/requestsystem/requests/StandardRequests.java
+++ b/src/main/java/com/minecolonies/coremod/colony/requestsystem/requests/StandardRequests.java
@@ -342,12 +342,7 @@ public final class StandardRequests
         @Override
         public final ITextComponent getShortDisplayString()
         {
-            final ITextComponent result = new NonSiblingFormattingTextComponent();
-
-            result.appendSibling(new StringTextComponent(getRequest().getMinCount() + " * Recipe:"));
-            result.appendSibling(getRequest().getStack().getTextComponent());
-
-            return result;
+            return new TranslationTextComponent(TranslationConstants.REQUEST_CRAFTING_DISPLAY, new StringTextComponent(String.valueOf(getRequest().getMinCount())), getRequest().getStack().getTextComponent());
         }
 
         protected abstract String getTranslationKey();

--- a/src/main/java/com/minecolonies/coremod/colony/requestsystem/resolvers/core/AbstractCraftingProductionResolver.java
+++ b/src/main/java/com/minecolonies/coremod/colony/requestsystem/resolvers/core/AbstractCraftingProductionResolver.java
@@ -144,7 +144,11 @@ public abstract class AbstractCraftingProductionResolver<C extends AbstractCraft
                 final ItemStack craftingHelperStack = ingredient.getItemStack().copy();
                 final ItemStack container = ingredient.getItem().getContainerItem(ingredient.getItemStack());
                 //if recipe secondary produces craftinghelperstack, don't add it by count, add it once. Or get fancy and calculate durability and add appropriately
-                if (!ItemStackUtils.isEmpty(container) && ItemStackUtils.compareItemStacksIgnoreStackSize(container, craftingHelperStack, false, true))
+                if(!storage.getSecondaryOutputs().isEmpty() && ItemStackUtils.compareItemStackListIgnoreStackSize(storage.getSecondaryOutputs(), craftingHelperStack, false, true))
+                {
+                    materialRequests.add(createNewRequestForStack(manager, craftingHelperStack, ingredient.getAmount(), ingredient.getAmount()));
+                }
+                else if (!ItemStackUtils.isEmpty(container) && ItemStackUtils.compareItemStacksIgnoreStackSize(container, craftingHelperStack, false, true))
                 {
                     materialRequests.add(createNewRequestForStack(manager, craftingHelperStack, ingredient.getAmount(), ingredient.getAmount()));
                 } 

--- a/src/main/java/com/minecolonies/coremod/colony/requestsystem/resolvers/core/AbstractCraftingProductionResolver.java
+++ b/src/main/java/com/minecolonies/coremod/colony/requestsystem/resolvers/core/AbstractCraftingProductionResolver.java
@@ -148,13 +148,13 @@ public abstract class AbstractCraftingProductionResolver<C extends AbstractCraft
                 {
                     materialRequests.add(createNewRequestForStack(manager, craftingHelperStack, ingredient.getAmount(), ingredient.getAmount()));
                 }
-                else if (ItemStackUtils.isEmpty(container) || ItemStackUtils.compareItemStacksIgnoreStackSize(container, craftingHelperStack, false, true))
+                else if (!ItemStackUtils.isEmpty(container) && ItemStackUtils.compareItemStacksIgnoreStackSize(container, craftingHelperStack, false, true))
                 {
-                    materialRequests.add(createNewRequestForStack(manager, craftingHelperStack, ingredient.getAmount() * count, ingredient.getAmount() * minCount ));
+                    materialRequests.add(createNewRequestForStack(manager, craftingHelperStack, ingredient.getAmount(), ingredient.getAmount()));
                 } 
                 else
                 {
-                    materialRequests.add(createNewRequestForStack(manager, craftingHelperStack, ingredient.getAmount(), ingredient.getAmount()));
+                    materialRequests.add(createNewRequestForStack(manager, craftingHelperStack, ingredient.getAmount() * count, ingredient.getAmount() * minCount ));
                 }
             }
         }

--- a/src/main/java/com/minecolonies/coremod/colony/requestsystem/resolvers/core/AbstractCraftingProductionResolver.java
+++ b/src/main/java/com/minecolonies/coremod/colony/requestsystem/resolvers/core/AbstractCraftingProductionResolver.java
@@ -148,13 +148,13 @@ public abstract class AbstractCraftingProductionResolver<C extends AbstractCraft
                 {
                     materialRequests.add(createNewRequestForStack(manager, craftingHelperStack, ingredient.getAmount(), ingredient.getAmount()));
                 }
-                else if (!ItemStackUtils.isEmpty(container) && ItemStackUtils.compareItemStacksIgnoreStackSize(container, craftingHelperStack, false, true))
+                else if (ItemStackUtils.isEmpty(container) || ItemStackUtils.compareItemStacksIgnoreStackSize(container, craftingHelperStack, false, true))
                 {
-                    materialRequests.add(createNewRequestForStack(manager, craftingHelperStack, ingredient.getAmount(), ingredient.getAmount()));
+                    materialRequests.add(createNewRequestForStack(manager, craftingHelperStack, ingredient.getAmount() * count, ingredient.getAmount() * minCount ));
                 } 
                 else
                 {
-                    materialRequests.add(createNewRequestForStack(manager, craftingHelperStack, ingredient.getAmount() * count, ingredient.getAmount() * minCount));
+                    materialRequests.add(createNewRequestForStack(manager, craftingHelperStack, ingredient.getAmount(), ingredient.getAmount()));
                 }
             }
         }

--- a/src/main/java/com/minecolonies/coremod/datalistener/CrafterRecipeListener.java
+++ b/src/main/java/com/minecolonies/coremod/datalistener/CrafterRecipeListener.java
@@ -45,6 +45,11 @@ public class CrafterRecipeListener extends JsonReloadListener
                 recipeManager.addRecipe(recipeJson, key);
             }
 
+            if(recipeJson.has(RECIPE_TYPE_PROP) && recipeJson.get(RECIPE_TYPE_PROP).getAsString().equals(RECIPE_TYPE_RECIPE_MULT_OUT)) 
+            {
+                recipeManager.addRecipe(recipeJson, key);
+            }
+
             if(recipeJson.has(RECIPE_TYPE_PROP) && recipeJson.get(RECIPE_TYPE_PROP).getAsString().equals(RECIPE_TYPE_REMOVE)) 
             {
                 recipeManager.removeRecipe(recipeJson, key);

--- a/src/main/java/com/minecolonies/coremod/datalistener/CrafterRecipeListener.java
+++ b/src/main/java/com/minecolonies/coremod/datalistener/CrafterRecipeListener.java
@@ -1,7 +1,7 @@
 package com.minecolonies.coremod.datalistener;
 
 import com.google.gson.*;
-import com.ldtteam.blockout.Log;
+import com.minecolonies.api.util.Log;
 import com.minecolonies.coremod.colony.crafting.CustomRecipeManager;
 
 import net.minecraft.client.resources.JsonReloadListener;
@@ -55,5 +55,8 @@ public class CrafterRecipeListener extends JsonReloadListener
                 recipeManager.removeRecipe(recipeJson, key);
             }
         } 
+
+        final int totalRecipes = recipeManager.getAllRecipes().values().stream().mapToInt(x -> x.size()).sum();
+        Log.getLogger().info("Loaded " + totalRecipes + " recipes for " + recipeManager.getAllRecipes().size() + " crafters");
     }
 }

--- a/src/main/java/com/minecolonies/coremod/entity/ai/basic/AbstractEntityAIBasic.java
+++ b/src/main/java/com/minecolonies/coremod/entity/ai/basic/AbstractEntityAIBasic.java
@@ -1605,17 +1605,7 @@ public abstract class AbstractEntityAIBasic<J extends AbstractJob<?, J>, B exten
             return true; // has already needed transfers...
         }
 
-        int transferamount = 0;
-        int transferred;
-        do
-        {
-            transferamount = Math.min(amount, STACKSIZE);
-            transferred = InventoryUtils.transferXOfFirstSlotInProviderWithIntoNextFreeSlotInItemHandlerWithResult(entity, predicate.getA(), transferamount, worker.getInventoryCitizen());
-            amount -= transferred;
-        }
-        while (transferred > 0 && amount > 0);
-
-        return amount == 0;
+        return InventoryUtils.transferXOfFirstSlotInProviderWithIntoNextFreeSlotInItemHandlerWithResult(entity, predicate.getA(), amount, worker.getInventoryCitizen()) == 0;
     }
 
     /**

--- a/src/main/java/com/minecolonies/coremod/entity/ai/basic/AbstractEntityAIBasic.java
+++ b/src/main/java/com/minecolonies/coremod/entity/ai/basic/AbstractEntityAIBasic.java
@@ -1606,20 +1606,16 @@ public abstract class AbstractEntityAIBasic<J extends AbstractJob<?, J>, B exten
         }
 
         int transferamount = 0;
-
+        int transferred;
         do
         {
             transferamount = Math.min(amount, STACKSIZE);
-            amount -= transferamount;
-
-            if (!InventoryUtils.transferXOfFirstSlotInProviderWithIntoNextFreeSlotInItemHandler(entity, predicate.getA(), transferamount, worker.getInventoryCitizen()))
-            {
-                return false; // couldn't transfer
-            }
+            transferred = InventoryUtils.transferXOfFirstSlotInProviderWithIntoNextFreeSlotInItemHandlerWithResult(entity, predicate.getA(), transferamount, worker.getInventoryCitizen());
+            amount -= transferred;
         }
-        while (amount > 0);
+        while (transferred > 0 && amount > 0);
 
-        return true;
+        return amount == 0;
     }
 
     /**

--- a/src/main/java/com/minecolonies/coremod/entity/ai/basic/AbstractEntityAICrafting.java
+++ b/src/main/java/com/minecolonies/coremod/entity/ai/basic/AbstractEntityAICrafting.java
@@ -18,7 +18,9 @@ import com.minecolonies.api.util.Tuple;
 import com.minecolonies.coremod.colony.buildings.AbstractBuildingWorker;
 import com.minecolonies.coremod.colony.jobs.AbstractJobCrafter;
 
+import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
+import net.minecraft.item.Items;
 import net.minecraft.util.Hand;
 import org.jetbrains.annotations.NotNull;
 
@@ -173,13 +175,13 @@ public abstract class AbstractEntityAICrafting<J extends AbstractJobCrafter<?, J
             {
                 remaining = inputStorage.getAmount();
             }
-            else if (!ItemStackUtils.isEmpty(container) && ItemStackUtils.compareItemStacksIgnoreStackSize(inputStorage.getItemStack(), container , false, true))
+            else if (ItemStackUtils.isEmpty(container) || !ItemStackUtils.compareItemStacksIgnoreStackSize(inputStorage.getItemStack(), container , false, true))
             {
-                remaining = inputStorage.getAmount();
+                remaining = inputStorage.getAmount() * remainingOpsCount;
             }
             else
             {
-                remaining = inputStorage.getAmount() * remainingOpsCount;
+                remaining = inputStorage.getAmount();
             }
             if (InventoryUtils.getItemCountInProvider(getOwnBuilding(), itemStack -> itemStack.isItemEqual(inputStorage.getItemStack()))
                   + InventoryUtils.getItemCountInItemHandler(worker.getInventoryCitizen(), itemStack -> itemStack.isItemEqual(inputStorage.getItemStack()))
@@ -191,7 +193,7 @@ public abstract class AbstractEntityAICrafting<J extends AbstractJobCrafter<?, J
                 return START_WORKING;
             }
         }
-
+        
         job.setCraftCounter(doneOpsCount);
         return QUERY_ITEMS;
     }
@@ -251,13 +253,13 @@ public abstract class AbstractEntityAICrafting<J extends AbstractJobCrafter<?, J
             {
                 remaining = inputStorage.getAmount();
             }
-            else if(!ItemStackUtils.isEmpty(container) && ItemStackUtils.compareItemStacksIgnoreStackSize(inputStorage.getItemStack(), container , false, true))
+            else if(ItemStackUtils.isEmpty(container) || !ItemStackUtils.compareItemStacksIgnoreStackSize(inputStorage.getItemStack(), container , false, true))
             {
-                remaining = inputStorage.getAmount();
+                remaining = inputStorage.getAmount() * job.getMaxCraftingCount();
             }
             else
             {
-                remaining = inputStorage.getAmount() * job.getMaxCraftingCount();
+                remaining = inputStorage.getAmount();
             }
 
             if (invCount <= 0 || invCount + ((job.getCraftCounter() + progressOpsCount) * inputStorage.getAmount())

--- a/src/main/java/com/minecolonies/coremod/entity/ai/basic/AbstractEntityAICrafting.java
+++ b/src/main/java/com/minecolonies/coremod/entity/ai/basic/AbstractEntityAICrafting.java
@@ -175,13 +175,13 @@ public abstract class AbstractEntityAICrafting<J extends AbstractJobCrafter<?, J
             {
                 remaining = inputStorage.getAmount();
             }
-            else if (ItemStackUtils.isEmpty(container) || !ItemStackUtils.compareItemStacksIgnoreStackSize(inputStorage.getItemStack(), container , false, true))
+            else if (!ItemStackUtils.isEmpty(container) && ItemStackUtils.compareItemStacksIgnoreStackSize(inputStorage.getItemStack(), container , false, true))
             {
-                remaining = inputStorage.getAmount() * remainingOpsCount;
+                remaining = inputStorage.getAmount();
             }
             else
             {
-                remaining = inputStorage.getAmount();
+                remaining = inputStorage.getAmount() * remainingOpsCount;
             }
             if (InventoryUtils.getItemCountInProvider(getOwnBuilding(), itemStack -> itemStack.isItemEqual(inputStorage.getItemStack()))
                   + InventoryUtils.getItemCountInItemHandler(worker.getInventoryCitizen(), itemStack -> itemStack.isItemEqual(inputStorage.getItemStack()))
@@ -193,7 +193,7 @@ public abstract class AbstractEntityAICrafting<J extends AbstractJobCrafter<?, J
                 return START_WORKING;
             }
         }
-        
+
         job.setCraftCounter(doneOpsCount);
         return QUERY_ITEMS;
     }
@@ -253,13 +253,13 @@ public abstract class AbstractEntityAICrafting<J extends AbstractJobCrafter<?, J
             {
                 remaining = inputStorage.getAmount();
             }
-            else if(ItemStackUtils.isEmpty(container) || !ItemStackUtils.compareItemStacksIgnoreStackSize(inputStorage.getItemStack(), container , false, true))
+            else if(!ItemStackUtils.isEmpty(container) && ItemStackUtils.compareItemStacksIgnoreStackSize(inputStorage.getItemStack(), container , false, true))
             {
-                remaining = inputStorage.getAmount() * job.getMaxCraftingCount();
+                remaining = inputStorage.getAmount();
             }
             else
             {
-                remaining = inputStorage.getAmount();
+                remaining = inputStorage.getAmount() * job.getMaxCraftingCount();
             }
 
             if (invCount <= 0 || invCount + ((job.getCraftCounter() + progressOpsCount) * inputStorage.getAmount())

--- a/src/main/java/com/minecolonies/coremod/entity/ai/basic/AbstractEntityAICrafting.java
+++ b/src/main/java/com/minecolonies/coremod/entity/ai/basic/AbstractEntityAICrafting.java
@@ -169,13 +169,17 @@ public abstract class AbstractEntityAICrafting<J extends AbstractJobCrafter<?, J
         {
             final ItemStack container = inputStorage.getItem().getContainerItem(inputStorage.getItemStack());
             final int remaining;
-            if (ItemStackUtils.isEmpty(container) || !ItemStackUtils.compareItemStacksIgnoreStackSize(inputStorage.getItemStack(), container , false, true))
+            if(!currentRecipeStorage.getSecondaryOutputs().isEmpty() && ItemStackUtils.compareItemStackListIgnoreStackSize(currentRecipeStorage.getSecondaryOutputs(), inputStorage.getItemStack(), false, true))
             {
-                remaining = inputStorage.getAmount() * remainingOpsCount;
+                remaining = inputStorage.getAmount();
+            }
+            else if (!ItemStackUtils.isEmpty(container) && ItemStackUtils.compareItemStacksIgnoreStackSize(inputStorage.getItemStack(), container , false, true))
+            {
+                remaining = inputStorage.getAmount();
             }
             else
             {
-                remaining = inputStorage.getAmount();
+                remaining = inputStorage.getAmount() * remainingOpsCount;
             }
             if (InventoryUtils.getItemCountInProvider(getOwnBuilding(), itemStack -> itemStack.isItemEqual(inputStorage.getItemStack()))
                   + InventoryUtils.getItemCountInItemHandler(worker.getInventoryCitizen(), itemStack -> itemStack.isItemEqual(inputStorage.getItemStack()))
@@ -243,13 +247,17 @@ public abstract class AbstractEntityAICrafting<J extends AbstractJobCrafter<?, J
             final int invCount = InventoryUtils.getItemCountInItemHandler(worker.getInventoryCitizen(), predicate);
             final ItemStack container = inputStorage.getItem().getContainerItem(inputStorage.getItemStack());
             final int remaining;
-            if(ItemStackUtils.isEmpty(container) || !ItemStackUtils.compareItemStacksIgnoreStackSize(inputStorage.getItemStack(), container , false, true))
+            if(!currentRecipeStorage.getSecondaryOutputs().isEmpty() && ItemStackUtils.compareItemStackListIgnoreStackSize(currentRecipeStorage.getSecondaryOutputs(), inputStorage.getItemStack(), false, true))
             {
-                remaining = inputStorage.getAmount() * job.getMaxCraftingCount();
+                remaining = inputStorage.getAmount();
+            }
+            else if(!ItemStackUtils.isEmpty(container) && ItemStackUtils.compareItemStacksIgnoreStackSize(inputStorage.getItemStack(), container , false, true))
+            {
+                remaining = inputStorage.getAmount();
             }
             else
             {
-                remaining = inputStorage.getAmount();
+                remaining = inputStorage.getAmount() * job.getMaxCraftingCount();
             }
 
             if (invCount <= 0 || invCount + ((job.getCraftCounter() + progressOpsCount) * inputStorage.getAmount())

--- a/src/main/java/com/minecolonies/coremod/network/messages/server/colony/building/worker/AddRemoveRecipeMessage.java
+++ b/src/main/java/com/minecolonies/coremod/network/messages/server/colony/building/worker/AddRemoveRecipeMessage.java
@@ -70,7 +70,7 @@ public class AddRemoveRecipeMessage extends AbstractBuildingServerMessage<IBuild
      * @param remove        true if remove.
      * @param building      the building we're executing on.
      */
-    public AddRemoveRecipeMessage(final IBuildingView building, final List<ItemStack> input, final int gridSize, final ItemStack primaryOutput, final boolean remove)
+    public AddRemoveRecipeMessage(final IBuildingView building, final List<ItemStack> input, final int gridSize, final ItemStack primaryOutput, final List<ItemStack> additionalOutputs, final boolean remove)
     {
         super(building);
         this.remove = remove;
@@ -81,7 +81,7 @@ public class AddRemoveRecipeMessage extends AbstractBuildingServerMessage<IBuild
               StandardFactoryController.getInstance().getNewInstance(TypeConstants.ITOKEN),
               input,
               gridSize,
-              primaryOutput, Blocks.FURNACE);
+              primaryOutput, Blocks.FURNACE, null, null, null, null);
         }
         else
         {
@@ -90,7 +90,7 @@ public class AddRemoveRecipeMessage extends AbstractBuildingServerMessage<IBuild
               StandardFactoryController.getInstance().getNewInstance(TypeConstants.ITOKEN),
               input,
               gridSize,
-              primaryOutput);
+              primaryOutput, null, null, null, null, additionalOutputs);
         }
     }
 

--- a/src/main/java/com/minecolonies/coremod/network/messages/server/colony/building/worker/AddRemoveRecipeMessage.java
+++ b/src/main/java/com/minecolonies/coremod/network/messages/server/colony/building/worker/AddRemoveRecipeMessage.java
@@ -81,7 +81,7 @@ public class AddRemoveRecipeMessage extends AbstractBuildingServerMessage<IBuild
               StandardFactoryController.getInstance().getNewInstance(TypeConstants.ITOKEN),
               input,
               gridSize,
-              primaryOutput, Blocks.FURNACE, null, null, null, null);
+              primaryOutput, Blocks.FURNACE);
         }
         else
         {

--- a/src/main/java/com/minecolonies/coremod/proxy/CommonProxy.java
+++ b/src/main/java/com/minecolonies/coremod/proxy/CommonProxy.java
@@ -9,6 +9,7 @@ import com.minecolonies.api.colony.colonyEvents.registry.ColonyEventTypeRegistry
 import com.minecolonies.api.colony.guardtype.GuardType;
 import com.minecolonies.api.colony.interactionhandling.registry.InteractionResponseHandlerEntry;
 import com.minecolonies.api.colony.jobs.registry.JobEntry;
+import com.minecolonies.api.crafting.registry.RecipeTypeEntry;
 import com.minecolonies.api.util.constant.Constants;
 import com.minecolonies.apiimp.CommonMinecoloniesAPIImpl;
 import com.minecolonies.apiimp.initializer.*;
@@ -126,6 +127,12 @@ public abstract class CommonProxy implements IProxy
     public static void registerJobTypes(final RegistryEvent.Register<JobEntry> event)
     {
         ModJobsInitializer.init(event);
+    }
+
+    @SubscribeEvent
+    public static void registerRecipeTypes(final RegistryEvent.Register<RecipeTypeEntry> event)
+    {
+        ModRecipeTypesInitializer.init(event);
     }
 
     @Override

--- a/src/main/java/com/minecolonies/coremod/util/FurnaceRecipes.java
+++ b/src/main/java/com/minecolonies/coremod/util/FurnaceRecipes.java
@@ -1,12 +1,15 @@
 package com.minecolonies.coremod.util;
 
+
 import com.ldtteam.blockout.Log;
 import com.minecolonies.api.colony.requestsystem.token.StandardToken;
+import com.minecolonies.api.colony.requestsystem.StandardFactoryController;
 import com.minecolonies.api.compatibility.IFurnaceRecipes;
 import com.minecolonies.api.crafting.ItemStorage;
 import com.minecolonies.api.crafting.RecipeStorage;
 import com.minecolonies.api.util.ItemStackUtils;
 import com.minecolonies.api.util.constant.Constants;
+import com.minecolonies.api.util.constant.TypeConstants;
 import com.minecolonies.coremod.Network;
 import com.minecolonies.coremod.network.messages.client.UpdateClientWithRecipesMessage;
 import net.minecraft.block.Blocks;
@@ -54,7 +57,13 @@ public class FurnaceRecipes implements IFurnaceRecipes
             final NonNullList<Ingredient> list = recipe.getIngredients();
             if (list.size() == 1)
             {
-                final RecipeStorage storage = new RecipeStorage(new StandardToken(), Arrays.asList(list.get(0).getMatchingStacks()), 1, recipe.getRecipeOutput(), Blocks.FURNACE);
+                final RecipeStorage storage =StandardFactoryController.getInstance().getNewInstance(
+                    TypeConstants.RECIPE,
+                    StandardFactoryController.getInstance().getNewInstance(TypeConstants.ITOKEN), 
+                    Arrays.asList(list.get(0).getMatchingStacks()), 
+                    1, 
+                    recipe.getRecipeOutput(), 
+                    Blocks.FURNACE);
 
                 recipes.put(storage.getCleanedInput().get(0), storage);
 

--- a/src/main/resources/assets/minecolonies/lang/en_us.json
+++ b/src/main/resources/assets/minecolonies/lang/en_us.json
@@ -1807,5 +1807,7 @@
   "com.minecolonies.coremod.missingitems": "Awaiting Materials",
   "com.minecolonies.coremod.finished": "Finished!",
   "com.minecolonies.coremod.dist.blocks": "%d blocks",
-  "com.minecolonies.coremod.notresolved": "Awaiting Resolvers!"
+  "com.minecolonies.coremod.notresolved": "Awaiting Resolvers!",
+  "com.minecolonies.coremod.request.crafting.display": "%d * Recipe:%s"
+
 }

--- a/src/main/resources/assets/minecolonies/lang/en_us.json
+++ b/src/main/resources/assets/minecolonies/lang/en_us.json
@@ -480,6 +480,8 @@
   "com.minecolonies.coremod.job.miner": "Miner",
   "com.minecolonies.coremod.job.fisherman": "Fisher",
   "com.minecolonies.coremod.job.guard": "Guard",
+  "com.minecolonies.coremod.job.archertraining": "Archer Trainee",
+  "com.minecolonies.coremod.job.combattraining": "Combat Trainee",
 
   "com.minecolonies.coremod.error.supplychestalreadyplaced": "You have already placed a Supply Ship or Camp in this world!",
   "com.minecolonies.coremod.supplyneed": "Start off MineColonies by crafting a Supply Camp or Ship and placing it via right clicking the item on the ground!!",

--- a/src/main/resources/data/minecolonies/crafterrecipes/lumberjack/stripped_acacia_log.json
+++ b/src/main/resources/data/minecolonies/crafterrecipes/lumberjack/stripped_acacia_log.json
@@ -7,6 +7,16 @@
         "count": 1
     }
   ],
+  "alternate-output" : [
+    {
+        "item" : "minecraft:acacia_wood",
+        "count": 1
+    },
+    {
+        "item" : "minecraft:stripped_acacia_wood",
+        "count": 1
+    }
+  ],
   "result": "minecraft:stripped_acacia_log",
   "count": 1,
   "intermediate" : "minecraft:air"

--- a/src/main/resources/data/minecolonies/crafterrecipes/lumberjack/stripped_acacia_log2.json
+++ b/src/main/resources/data/minecolonies/crafterrecipes/lumberjack/stripped_acacia_log2.json
@@ -9,5 +9,6 @@
   ],
   "result": "minecraft:stripped_acacia_log",
   "count": 1,
-  "intermediate" : "minecraft:air"
+  "intermediate" : "minecraft:air",
+  "research-id" : "dummyresearch"
 }

--- a/src/main/resources/data/minecolonies/crafterrecipes/lumberjack/stripped_birch_log.json
+++ b/src/main/resources/data/minecolonies/crafterrecipes/lumberjack/stripped_birch_log.json
@@ -7,6 +7,16 @@
         "count": 1
     }
   ],
+  "alternate-output" : [
+    {
+        "item" : "minecraft:birch_wood",
+        "count": 1
+    },
+    {
+        "item" : "minecraft:stripped_birch_wood",
+        "count": 1
+    }
+  ],
   "result": "minecraft:stripped_birch_log",
   "count": 1,
   "intermediate" : "minecraft:air"

--- a/src/main/resources/data/minecolonies/crafterrecipes/lumberjack/stripped_birch_log2.json
+++ b/src/main/resources/data/minecolonies/crafterrecipes/lumberjack/stripped_birch_log2.json
@@ -9,5 +9,6 @@
   ],
   "result": "minecraft:stripped_birch_log",
   "count": 1,
-  "intermediate" : "minecraft:air"
+  "intermediate" : "minecraft:air",
+  "research-id" : "dummyresearch"
 }

--- a/src/main/resources/data/minecolonies/crafterrecipes/lumberjack/stripped_dark_oak_log.json
+++ b/src/main/resources/data/minecolonies/crafterrecipes/lumberjack/stripped_dark_oak_log.json
@@ -7,6 +7,16 @@
         "count": 1
     }
   ],
+  "alternate-output" : [
+    {
+        "item" : "minecraft:dark_oak_wood",
+        "count": 1
+    },
+    {
+        "item" : "minecraft:stripped_dark_oak_wood",
+        "count": 1
+    }
+  ],
   "result": "minecraft:stripped_dark_oak_log",
   "count": 1,
   "intermediate" : "minecraft:air"

--- a/src/main/resources/data/minecolonies/crafterrecipes/lumberjack/stripped_dark_oak_log2.json
+++ b/src/main/resources/data/minecolonies/crafterrecipes/lumberjack/stripped_dark_oak_log2.json
@@ -9,5 +9,6 @@
   ],
   "result": "minecraft:stripped_dark_oak_log",
   "count": 1,
-  "intermediate" : "minecraft:air"
+  "intermediate" : "minecraft:air",
+  "research-id" : "dummyresearch"
 }

--- a/src/main/resources/data/minecolonies/crafterrecipes/lumberjack/stripped_jungle_log.json
+++ b/src/main/resources/data/minecolonies/crafterrecipes/lumberjack/stripped_jungle_log.json
@@ -7,6 +7,16 @@
         "count": 1
     }
   ],
+  "alternate-output" : [
+    {
+        "item" : "minecraft:jungle_wood",
+        "count": 1
+    },
+    {
+        "item" : "minecraft:stripped_jungle_wood",
+        "count": 1
+    }
+  ],
   "result": "minecraft:stripped_jungle_log",
   "count": 1,
   "intermediate" : "minecraft:air"

--- a/src/main/resources/data/minecolonies/crafterrecipes/lumberjack/stripped_jungle_log2.json
+++ b/src/main/resources/data/minecolonies/crafterrecipes/lumberjack/stripped_jungle_log2.json
@@ -9,5 +9,6 @@
   ],
   "result": "minecraft:stripped_jungle_log",
   "count": 1,
-  "intermediate" : "minecraft:air"
+  "intermediate" : "minecraft:air",
+  "research-id" : "dummyresearch"
 }

--- a/src/main/resources/data/minecolonies/crafterrecipes/lumberjack/stripped_oak_log.json
+++ b/src/main/resources/data/minecolonies/crafterrecipes/lumberjack/stripped_oak_log.json
@@ -7,6 +7,16 @@
         "count": 1
     }
   ],
+  "alternate-output" : [
+    {
+        "item" : "minecraft:oak_wood",
+        "count": 1
+    },
+    {
+        "item" : "minecraft:stripped_oak_wood",
+        "count": 1
+    }
+  ],
   "result": "minecraft:stripped_oak_log",
   "count": 1,
   "intermediate" : "minecraft:air"

--- a/src/main/resources/data/minecolonies/crafterrecipes/lumberjack/stripped_oak_log2.json
+++ b/src/main/resources/data/minecolonies/crafterrecipes/lumberjack/stripped_oak_log2.json
@@ -9,5 +9,6 @@
   ],
   "result": "minecraft:stripped_oak_log",
   "count": 1,
-  "intermediate" : "minecraft:air"
+  "intermediate" : "minecraft:air",
+  "research-id" : "dummyresearch"
 }

--- a/src/main/resources/data/minecolonies/crafterrecipes/lumberjack/stripped_spruce_log.json
+++ b/src/main/resources/data/minecolonies/crafterrecipes/lumberjack/stripped_spruce_log.json
@@ -7,6 +7,16 @@
         "count": 1
     }
   ],
+  "alternate-output" : [
+    {
+        "item" : "minecraft:spruce_wood",
+        "count": 1
+    },
+    {
+        "item" : "minecraft:stripped_spruce_wood",
+        "count": 1
+    }
+  ],
   "result": "minecraft:stripped_spruce_log",
   "count": 1,
   "intermediate" : "minecraft:air"

--- a/src/main/resources/data/minecolonies/crafterrecipes/lumberjack/stripped_spruce_log2.json
+++ b/src/main/resources/data/minecolonies/crafterrecipes/lumberjack/stripped_spruce_log2.json
@@ -9,5 +9,6 @@
   ],
   "result": "minecraft:stripped_spruce_log",
   "count": 1,
-  "intermediate" : "minecraft:air"
+  "intermediate" : "minecraft:air",
+  "research-id" : "dummyresearch"
 }

--- a/src/main/resources/data/minecolonies/crafterrecipes/sawmill/acacia_acacia_timber_frame.json
+++ b/src/main/resources/data/minecolonies/crafterrecipes/sawmill/acacia_acacia_timber_frame.json
@@ -1,0 +1,60 @@
+{
+  "type" : "recipe",
+  "crafter": "sawmill",
+  "inputs": [
+    {
+        "item" : "minecraft:acacia_planks",
+        "count": 1
+    },
+    {
+        "item" : "minecraft:acacia_planks",
+        "count": 1
+    },
+    {
+        "item" : "structurize:sceptergold",
+        "count": 1
+    }
+  ],
+  "alternate-output" : [
+    {
+        "item" : "structurize:double_crossed_acacia_acacia_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:framed_acacia_acacia_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:side_framed_acacia_acacia_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:up_gated_acacia_acacia_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:down_gated_acacia_acacia_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:one_crossed_lr_acacia_acacia_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:one_crossed_rl_acacia_acacia_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:horizontal_plain_acacia_acacia_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:side_framed_horizontal_acacia_acacia_timber_frame",
+        "count": 4
+    }
+  ],
+  "result": "structurize:plain_acacia_acacia_timber_frame",
+  "count": 4,
+  "intermediate" : "minecraft:air",
+  "must-exist" : true
+}

--- a/src/main/resources/data/minecolonies/crafterrecipes/sawmill/acacia_birch_timber_frame.json
+++ b/src/main/resources/data/minecolonies/crafterrecipes/sawmill/acacia_birch_timber_frame.json
@@ -1,0 +1,60 @@
+{
+  "type" : "recipe",
+  "crafter": "sawmill",
+  "inputs": [
+    {
+        "item" : "minecraft:acacia_planks",
+        "count": 1
+    },
+    {
+        "item" : "minecraft:birch_planks",
+        "count": 1
+    },
+    {
+        "item" : "structurize:sceptergold",
+        "count": 1
+    }
+  ],
+  "alternate-output" : [
+    {
+        "item" : "structurize:double_crossed_acacia_birch_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:framed_acacia_birch_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:side_framed_acacia_birch_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:up_gated_acacia_birch_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:down_gated_acacia_birch_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:one_crossed_lr_acacia_birch_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:one_crossed_rl_acacia_birch_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:horizontal_plain_acacia_birch_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:side_framed_horizontal_acacia_birch_timber_frame",
+        "count": 4
+    }
+  ],
+  "result": "structurize:plain_acacia_birch_timber_frame",
+  "count": 4,
+  "intermediate" : "minecraft:air",
+  "must-exist" : true
+}

--- a/src/main/resources/data/minecolonies/crafterrecipes/sawmill/acacia_brick_timber_frame.json
+++ b/src/main/resources/data/minecolonies/crafterrecipes/sawmill/acacia_brick_timber_frame.json
@@ -1,0 +1,60 @@
+{
+  "type" : "recipe",
+  "crafter": "sawmill",
+  "inputs": [
+    {
+        "item" : "minecraft:acacia_planks",
+        "count": 1
+    },
+    {
+        "item" : "minecraft:brick",
+        "count": 1
+    },
+    {
+        "item" : "structurize:sceptergold",
+        "count": 1
+    }
+  ],
+  "alternate-output" : [
+    {
+        "item" : "structurize:double_crossed_acacia_brick_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:framed_acacia_brick_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:side_framed_acacia_brick_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:up_gated_acacia_brick_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:down_gated_acacia_brick_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:one_crossed_lr_acacia_brick_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:one_crossed_rl_acacia_brick_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:horizontal_plain_acacia_brick_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:side_framed_horizontal_acacia_brick_timber_frame",
+        "count": 4
+    }
+  ],
+  "result": "structurize:plain_acacia_brick_timber_frame",
+  "count": 4,
+  "intermediate" : "minecraft:air",
+  "must-exist" : true
+}

--- a/src/main/resources/data/minecolonies/crafterrecipes/sawmill/acacia_cactus_timber_frame.json
+++ b/src/main/resources/data/minecolonies/crafterrecipes/sawmill/acacia_cactus_timber_frame.json
@@ -1,0 +1,60 @@
+{
+  "type" : "recipe",
+  "crafter": "sawmill",
+  "inputs": [
+    {
+        "item" : "minecraft:acacia_planks",
+        "count": 1
+    },
+    {
+        "item" : "structurize:blockcactusplank",
+        "count": 1
+    },
+    {
+        "item" : "structurize:sceptergold",
+        "count": 1
+    }
+  ],
+  "alternate-output" : [
+    {
+        "item" : "structurize:double_crossed_acacia_cactus_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:framed_acacia_cactus_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:side_framed_acacia_cactus_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:up_gated_acacia_cactus_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:down_gated_acacia_cactus_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:one_crossed_lr_acacia_cactus_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:one_crossed_rl_acacia_cactus_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:horizontal_plain_acacia_cactus_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:side_framed_horizontal_acacia_cactus_timber_frame",
+        "count": 4
+    }
+  ],
+  "result": "structurize:plain_acacia_cactus_timber_frame",
+  "count": 4,
+  "intermediate" : "minecraft:air",
+  "must-exist" : true
+}

--- a/src/main/resources/data/minecolonies/crafterrecipes/sawmill/acacia_cobble_stone_timber_frame.json
+++ b/src/main/resources/data/minecolonies/crafterrecipes/sawmill/acacia_cobble_stone_timber_frame.json
@@ -1,0 +1,60 @@
+{
+  "type" : "recipe",
+  "crafter": "sawmill",
+  "inputs": [
+    {
+        "item" : "minecraft:acacia_planks",
+        "count": 1
+    },
+    {
+        "item" : "minecraft:cobblestone",
+        "count": 1
+    },
+    {
+        "item" : "structurize:sceptergold",
+        "count": 1
+    }
+  ],
+  "alternate-output" : [
+    {
+        "item" : "structurize:double_crossed_acacia_cobble_stone_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:framed_acacia_cobble_stone_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:side_framed_acacia_cobble_stone_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:up_gated_acacia_cobble_stone_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:down_gated_acacia_cobble_stone_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:one_crossed_lr_acacia_cobble_stone_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:one_crossed_rl_acacia_cobble_stone_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:horizontal_plain_acacia_cobble_stone_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:side_framed_horizontal_acacia_cobble_stone_timber_frame",
+        "count": 4
+    }
+  ],
+  "result": "structurize:plain_acacia_cobble_stone_timber_frame",
+  "count": 4,
+  "intermediate" : "minecraft:air",
+  "must-exist" : true
+}

--- a/src/main/resources/data/minecolonies/crafterrecipes/sawmill/acacia_dark_oak_timber_frame.json
+++ b/src/main/resources/data/minecolonies/crafterrecipes/sawmill/acacia_dark_oak_timber_frame.json
@@ -3,7 +3,7 @@
   "crafter": "sawmill",
   "inputs": [
     {
-        "item" : "minecraftacacia_planks",
+        "item" : "minecraft:acacia_planks",
         "count": 1
     },
     {

--- a/src/main/resources/data/minecolonies/crafterrecipes/sawmill/acacia_dark_oak_timber_frame.json
+++ b/src/main/resources/data/minecolonies/crafterrecipes/sawmill/acacia_dark_oak_timber_frame.json
@@ -1,0 +1,60 @@
+{
+  "type" : "recipe",
+  "crafter": "sawmill",
+  "inputs": [
+    {
+        "item" : "minecraftacacia_planks",
+        "count": 1
+    },
+    {
+        "item" : "minecraft:dark_oak_planks",
+        "count": 1
+    },
+    {
+        "item" : "structurize:sceptergold",
+        "count": 1
+    }
+  ],
+  "alternate-output" : [
+    {
+        "item" : "structurize:double_crossed_acacia_dark_oak_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:framed_acacia_dark_oak_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:side_framed_acacia_dark_oak_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:up_gated_acacia_dark_oak_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:down_gated_acacia_dark_oak_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:one_crossed_lr_acacia_dark_oak_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:one_crossed_rl_acacia_dark_oak_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:horizontal_plain_acacia_dark_oak_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:side_framed_horizontal_acacia_dark_oak_timber_frame",
+        "count": 4
+    }
+  ],
+  "result": "structurize:plain_acacia_dark_oak_timber_frame",
+  "count": 4,
+  "intermediate" : "minecraft:air",
+  "must-exist" : true
+}

--- a/src/main/resources/data/minecolonies/crafterrecipes/sawmill/acacia_jungle_timber_frame.json
+++ b/src/main/resources/data/minecolonies/crafterrecipes/sawmill/acacia_jungle_timber_frame.json
@@ -1,0 +1,60 @@
+{
+  "type" : "recipe",
+  "crafter": "sawmill",
+  "inputs": [
+    {
+        "item" : "minecraft:acacia_planks",
+        "count": 1
+    },
+    {
+        "item" : "minecraft:jungle_planks",
+        "count": 1
+    },
+    {
+        "item" : "structurize:sceptergold",
+        "count": 1
+    }
+  ],
+  "alternate-output" : [
+    {
+        "item" : "structurize:double_crossed_acacia_jungle_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:framed_acacia_jungle_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:side_framed_acacia_jungle_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:up_gated_acacia_jungle_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:down_gated_acacia_jungle_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:one_crossed_lr_acacia_jungle_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:one_crossed_rl_acacia_jungle_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:horizontal_plain_acacia_jungle_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:side_framed_horizontal_acacia_jungle_timber_frame",
+        "count": 4
+    }
+  ],
+  "result": "structurize:plain_acacia_jungle_timber_frame",
+  "count": 4,
+  "intermediate" : "minecraft:air",
+  "must-exist" : true
+}

--- a/src/main/resources/data/minecolonies/crafterrecipes/sawmill/acacia_oak_timber_frame.json
+++ b/src/main/resources/data/minecolonies/crafterrecipes/sawmill/acacia_oak_timber_frame.json
@@ -1,0 +1,60 @@
+{
+  "type" : "recipe",
+  "crafter": "sawmill",
+  "inputs": [
+    {
+        "item" : "minecraft:acacia_planks",
+        "count": 1
+    },
+    {
+        "item" : "minecraft:oak_planks",
+        "count": 1
+    },
+    {
+        "item" : "structurize:sceptergold",
+        "count": 1
+    }
+  ],
+  "alternate-output" : [
+    {
+        "item" : "structurize:double_crossed_acacia_oak_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:framed_acacia_oak_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:side_framed_acacia_oak_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:up_gated_acacia_oak_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:down_gated_acacia_oak_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:one_crossed_lr_acacia_oak_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:one_crossed_rl_acacia_oak_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:horizontal_plain_acacia_oak_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:side_framed_horizontal_acacia_oak_timber_frame",
+        "count": 4
+    }
+  ],
+  "result": "structurize:plain_acacia_oak_timber_frame",
+  "count": 4,
+  "intermediate" : "minecraft:air",
+  "must-exist" : true
+}

--- a/src/main/resources/data/minecolonies/crafterrecipes/sawmill/acacia_paper_timber_frame.json
+++ b/src/main/resources/data/minecolonies/crafterrecipes/sawmill/acacia_paper_timber_frame.json
@@ -1,0 +1,60 @@
+{
+  "type" : "recipe",
+  "crafter": "sawmill",
+  "inputs": [
+    {
+        "item" : "minecraft:acacia_planks",
+        "count": 1
+    },
+    {
+        "item" : "minecraft:paper",
+        "count": 1
+    },
+    {
+        "item" : "structurize:sceptergold",
+        "count": 1
+    }
+  ],
+  "alternate-output" : [
+    {
+        "item" : "structurize:double_crossed_acacia_paper_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:framed_acacia_paper_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:side_framed_acacia_paper_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:up_gated_acacia_paper_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:down_gated_acacia_paper_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:one_crossed_lr_acacia_paper_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:one_crossed_rl_acacia_paper_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:horizontal_plain_acacia_paper_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:side_framed_horizontal_acacia_paper_timber_frame",
+        "count": 4
+    }
+  ],
+  "result": "structurize:plain_acacia_paper_timber_frame",
+  "count": 4,
+  "intermediate" : "minecraft:air",
+  "must-exist" : true
+}

--- a/src/main/resources/data/minecolonies/crafterrecipes/sawmill/acacia_spruce_timber_frame.json
+++ b/src/main/resources/data/minecolonies/crafterrecipes/sawmill/acacia_spruce_timber_frame.json
@@ -1,0 +1,60 @@
+{
+  "type" : "recipe",
+  "crafter": "sawmill",
+  "inputs": [
+    {
+        "item" : "minecraft:acacia_planks",
+        "count": 1
+    },
+    {
+        "item" : "minecraft:spruce_planks",
+        "count": 1
+    },
+    {
+        "item" : "structurize:sceptergold",
+        "count": 1
+    }
+  ],
+  "alternate-output" : [
+    {
+        "item" : "structurize:double_crossed_acacia_spruce_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:framed_acacia_spruce_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:side_framed_acacia_spruce_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:up_gated_acacia_spruce_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:down_gated_acacia_spruce_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:one_crossed_lr_acacia_spruce_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:one_crossed_rl_acacia_spruce_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:horizontal_plain_acacia_spruce_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:side_framed_horizontal_acacia_spruce_timber_frame",
+        "count": 4
+    }
+  ],
+  "result": "structurize:plain_acacia_spruce_timber_frame",
+  "count": 4,
+  "intermediate" : "minecraft:air",
+  "must-exist" : true
+}

--- a/src/main/resources/data/minecolonies/crafterrecipes/sawmill/acacia_stone_timber_frame.json
+++ b/src/main/resources/data/minecolonies/crafterrecipes/sawmill/acacia_stone_timber_frame.json
@@ -1,0 +1,60 @@
+{
+  "type" : "recipe",
+  "crafter": "sawmill",
+  "inputs": [
+    {
+        "item" : "minecraft:acacia_planks",
+        "count": 1
+    },
+    {
+        "item" : "minecraft:stone",
+        "count": 1
+    },
+    {
+        "item" : "structurize:sceptergold",
+        "count": 1
+    }
+  ],
+  "alternate-output" : [
+    {
+        "item" : "structurize:double_crossed_acacia_stone_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:framed_acacia_stone_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:side_framed_acacia_stone_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:up_gated_acacia_stone_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:down_gated_acacia_stone_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:one_crossed_lr_acacia_stone_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:one_crossed_rl_acacia_stone_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:horizontal_plain_acacia_stone_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:side_framed_horizontal_acacia_stone_timber_frame",
+        "count": 4
+    }
+  ],
+  "result": "structurize:plain_acacia_stone_timber_frame",
+  "count": 4,
+  "intermediate" : "minecraft:air",
+  "must-exist" : true
+}

--- a/src/main/resources/data/minecolonies/crafterrecipes/sawmill/birch_acacia_timber_frame.json
+++ b/src/main/resources/data/minecolonies/crafterrecipes/sawmill/birch_acacia_timber_frame.json
@@ -1,0 +1,60 @@
+{
+  "type" : "recipe",
+  "crafter": "sawmill",
+  "inputs": [
+    {
+        "item" : "minecraft:birch_planks",
+        "count": 1
+    },
+    {
+        "item" : "minecraft:acacia_planks",
+        "count": 1
+    },
+    {
+        "item" : "structurize:sceptergold",
+        "count": 1
+    }
+  ],
+  "alternate-output" : [
+    {
+        "item" : "structurize:double_crossed_birch_acacia_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:framed_birch_acacia_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:side_framed_birch_acacia_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:up_gated_birch_acacia_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:down_gated_birch_acacia_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:one_crossed_lr_birch_acacia_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:one_crossed_rl_birch_acacia_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:horizontal_plain_birch_acacia_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:side_framed_horizontal_birch_acacia_timber_frame",
+        "count": 4
+    }
+  ],
+  "result": "structurize:plain_birch_acacia_timber_frame",
+  "count": 4,
+  "intermediate" : "minecraft:air",
+  "must-exist" : true
+}

--- a/src/main/resources/data/minecolonies/crafterrecipes/sawmill/birch_birch_timber_frame.json
+++ b/src/main/resources/data/minecolonies/crafterrecipes/sawmill/birch_birch_timber_frame.json
@@ -1,0 +1,60 @@
+{
+  "type" : "recipe",
+  "crafter": "sawmill",
+  "inputs": [
+    {
+        "item" : "minecraft:birch_planks",
+        "count": 1
+    },
+    {
+        "item" : "minecraft:birch_planks",
+        "count": 1
+    },
+    {
+        "item" : "structurize:sceptergold",
+        "count": 1
+    }
+  ],
+  "alternate-output" : [
+    {
+        "item" : "structurize:double_crossed_birch_birch_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:framed_birch_birch_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:side_framed_birch_birch_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:up_gated_birch_birch_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:down_gated_birch_birch_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:one_crossed_lr_birch_birch_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:one_crossed_rl_birch_birch_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:horizontal_plain_birch_birch_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:side_framed_horizontal_birch_birch_timber_frame",
+        "count": 4
+    }
+  ],
+  "result": "structurize:plain_birch_birch_timber_frame",
+  "count": 4,
+  "intermediate" : "minecraft:air",
+  "must-exist" : true
+}

--- a/src/main/resources/data/minecolonies/crafterrecipes/sawmill/birch_brick_timber_frame.json
+++ b/src/main/resources/data/minecolonies/crafterrecipes/sawmill/birch_brick_timber_frame.json
@@ -1,0 +1,60 @@
+{
+  "type" : "recipe",
+  "crafter": "sawmill",
+  "inputs": [
+    {
+        "item" : "minecraft:birch_planks",
+        "count": 1
+    },
+    {
+        "item" : "minecraft:brick",
+        "count": 1
+    },
+    {
+        "item" : "structurize:sceptergold",
+        "count": 1
+    }
+  ],
+  "alternate-output" : [
+    {
+        "item" : "structurize:double_crossed_birch_brick_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:framed_birch_brick_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:side_framed_birch_brick_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:up_gated_birch_brick_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:down_gated_birch_brick_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:one_crossed_lr_birch_brick_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:one_crossed_rl_birch_brick_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:horizontal_plain_birch_brick_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:side_framed_horizontal_birch_brick_timber_frame",
+        "count": 4
+    }
+  ],
+  "result": "structurize:plain_birch_brick_timber_frame",
+  "count": 4,
+  "intermediate" : "minecraft:air",
+  "must-exist" : true
+}

--- a/src/main/resources/data/minecolonies/crafterrecipes/sawmill/birch_cactus_timber_frame.json
+++ b/src/main/resources/data/minecolonies/crafterrecipes/sawmill/birch_cactus_timber_frame.json
@@ -1,0 +1,60 @@
+{
+  "type" : "recipe",
+  "crafter": "sawmill",
+  "inputs": [
+    {
+        "item" : "minecraft:birch_planks",
+        "count": 1
+    },
+    {
+        "item" : "structurize:blockcactusplank",
+        "count": 1
+    },
+    {
+        "item" : "structurize:sceptergold",
+        "count": 1
+    }
+  ],
+  "alternate-output" : [
+    {
+        "item" : "structurize:double_crossed_birch_cactus_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:framed_birch_cactus_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:side_framed_birch_cactus_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:up_gated_birch_cactus_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:down_gated_birch_cactus_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:one_crossed_lr_birch_cactus_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:one_crossed_rl_birch_cactus_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:horizontal_plain_birch_cactus_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:side_framed_horizontal_birch_cactus_timber_frame",
+        "count": 4
+    }
+  ],
+  "result": "structurize:plain_birch_cactus_timber_frame",
+  "count": 4,
+  "intermediate" : "minecraft:air",
+  "must-exist" : true
+}

--- a/src/main/resources/data/minecolonies/crafterrecipes/sawmill/birch_cobble_stone_timber_frame.json
+++ b/src/main/resources/data/minecolonies/crafterrecipes/sawmill/birch_cobble_stone_timber_frame.json
@@ -1,0 +1,60 @@
+{
+  "type" : "recipe",
+  "crafter": "sawmill",
+  "inputs": [
+    {
+        "item" : "minecraft:birch_planks",
+        "count": 1
+    },
+    {
+        "item" : "minecraft:cobblestone",
+        "count": 1
+    },
+    {
+        "item" : "structurize:sceptergold",
+        "count": 1
+    }
+  ],
+  "alternate-output" : [
+    {
+        "item" : "structurize:double_crossed_birch_cobble_stone_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:framed_birch_cobble_stone_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:side_framed_birch_cobble_stone_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:up_gated_birch_cobble_stone_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:down_gated_birch_cobble_stone_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:one_crossed_lr_birch_cobble_stone_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:one_crossed_rl_birch_cobble_stone_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:horizontal_plain_birch_cobble_stone_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:side_framed_horizontal_birch_cobble_stone_timber_frame",
+        "count": 4
+    }
+  ],
+  "result": "structurize:plain_birch_cobble_stone_timber_frame",
+  "count": 4,
+  "intermediate" : "minecraft:air",
+  "must-exist" : true
+}

--- a/src/main/resources/data/minecolonies/crafterrecipes/sawmill/birch_dark_oak_timber_frame.json
+++ b/src/main/resources/data/minecolonies/crafterrecipes/sawmill/birch_dark_oak_timber_frame.json
@@ -1,0 +1,60 @@
+{
+  "type" : "recipe",
+  "crafter": "sawmill",
+  "inputs": [
+    {
+        "item" : "minecraft:birch_planks",
+        "count": 1
+    },
+    {
+        "item" : "minecraft:dark_oak_planks",
+        "count": 1
+    },
+    {
+        "item" : "structurize:sceptergold",
+        "count": 1
+    }
+  ],
+  "alternate-output" : [
+    {
+        "item" : "structurize:double_crossed_birch_dark_oak_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:framed_birch_dark_oak_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:side_framed_birch_dark_oak_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:up_gated_birch_dark_oak_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:down_gated_birch_dark_oak_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:one_crossed_lr_birch_dark_oak_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:one_crossed_rl_birch_dark_oak_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:horizontal_plain_birch_dark_oak_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:side_framed_horizontal_birch_dark_oak_timber_frame",
+        "count": 4
+    }
+  ],
+  "result": "structurize:plain_birch_dark_oak_timber_frame",
+  "count": 4,
+  "intermediate" : "minecraft:air",
+  "must-exist" : true
+}

--- a/src/main/resources/data/minecolonies/crafterrecipes/sawmill/birch_jungle_timber_frame.json
+++ b/src/main/resources/data/minecolonies/crafterrecipes/sawmill/birch_jungle_timber_frame.json
@@ -1,0 +1,60 @@
+{
+  "type" : "recipe",
+  "crafter": "sawmill",
+  "inputs": [
+    {
+        "item" : "minecraft:birch_planks",
+        "count": 1
+    },
+    {
+        "item" : "minecraft:jungle_planks",
+        "count": 1
+    },
+    {
+        "item" : "structurize:sceptergold",
+        "count": 1
+    }
+  ],
+  "alternate-output" : [
+    {
+        "item" : "structurize:double_crossed_birch_jungle_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:framed_birch_jungle_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:side_framed_birch_jungle_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:up_gated_birch_jungle_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:down_gated_birch_jungle_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:one_crossed_lr_birch_jungle_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:one_crossed_rl_birch_jungle_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:horizontal_plain_birch_jungle_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:side_framed_horizontal_birch_jungle_timber_frame",
+        "count": 4
+    }
+  ],
+  "result": "structurize:plain_birch_jungle_timber_frame",
+  "count": 4,
+  "intermediate" : "minecraft:air",
+  "must-exist" : true
+}

--- a/src/main/resources/data/minecolonies/crafterrecipes/sawmill/birch_oak_timber_frame.json
+++ b/src/main/resources/data/minecolonies/crafterrecipes/sawmill/birch_oak_timber_frame.json
@@ -1,0 +1,60 @@
+{
+  "type" : "recipe",
+  "crafter": "sawmill",
+  "inputs": [
+    {
+        "item" : "minecraft:birch_planks",
+        "count": 1
+    },
+    {
+        "item" : "minecraft:oak_planks",
+        "count": 1
+    },
+    {
+        "item" : "structurize:sceptergold",
+        "count": 1
+    }
+  ],
+  "alternate-output" : [
+    {
+        "item" : "structurize:double_crossed_birch_oak_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:framed_birch_oak_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:side_framed_birch_oak_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:up_gated_birch_oak_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:down_gated_birch_oak_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:one_crossed_lr_birch_oak_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:one_crossed_rl_birch_oak_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:horizontal_plain_birch_oak_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:side_framed_horizontal_birch_oak_timber_frame",
+        "count": 4
+    }
+  ],
+  "result": "structurize:plain_birch_oak_timber_frame",
+  "count": 4,
+  "intermediate" : "minecraft:air",
+  "must-exist" : true
+}

--- a/src/main/resources/data/minecolonies/crafterrecipes/sawmill/birch_paper_timber_frame.json
+++ b/src/main/resources/data/minecolonies/crafterrecipes/sawmill/birch_paper_timber_frame.json
@@ -1,0 +1,60 @@
+{
+  "type" : "recipe",
+  "crafter": "sawmill",
+  "inputs": [
+    {
+        "item" : "minecraft:birch_planks",
+        "count": 1
+    },
+    {
+        "item" : "minecraft:paper",
+        "count": 1
+    },
+    {
+        "item" : "structurize:sceptergold",
+        "count": 1
+    }
+  ],
+  "alternate-output" : [
+    {
+        "item" : "structurize:double_crossed_birch_paper_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:framed_birch_paper_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:side_framed_birch_paper_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:up_gated_birch_paper_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:down_gated_birch_paper_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:one_crossed_lr_birch_paper_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:one_crossed_rl_birch_paper_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:horizontal_plain_birch_paper_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:side_framed_horizontal_birch_paper_timber_frame",
+        "count": 4
+    }
+  ],
+  "result": "structurize:plain_birch_paper_timber_frame",
+  "count": 4,
+  "intermediate" : "minecraft:air",
+  "must-exist" : true
+}

--- a/src/main/resources/data/minecolonies/crafterrecipes/sawmill/birch_spruce_timber_frame.json
+++ b/src/main/resources/data/minecolonies/crafterrecipes/sawmill/birch_spruce_timber_frame.json
@@ -1,0 +1,60 @@
+{
+  "type" : "recipe",
+  "crafter": "sawmill",
+  "inputs": [
+    {
+        "item" : "minecraft:birch_planks",
+        "count": 1
+    },
+    {
+        "item" : "minecraft:spruce_planks",
+        "count": 1
+    },
+    {
+        "item" : "structurize:sceptergold",
+        "count": 1
+    }
+  ],
+  "alternate-output" : [
+    {
+        "item" : "structurize:double_crossed_birch_spruce_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:framed_birch_spruce_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:side_framed_birch_spruce_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:up_gated_birch_spruce_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:down_gated_birch_spruce_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:one_crossed_lr_birch_spruce_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:one_crossed_rl_birch_spruce_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:horizontal_plain_birch_spruce_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:side_framed_horizontal_birch_spruce_timber_frame",
+        "count": 4
+    }
+  ],
+  "result": "structurize:plain_birch_spruce_timber_frame",
+  "count": 4,
+  "intermediate" : "minecraft:air",
+  "must-exist" : true
+}

--- a/src/main/resources/data/minecolonies/crafterrecipes/sawmill/birch_stone_timber_frame.json
+++ b/src/main/resources/data/minecolonies/crafterrecipes/sawmill/birch_stone_timber_frame.json
@@ -1,0 +1,60 @@
+{
+  "type" : "recipe",
+  "crafter": "sawmill",
+  "inputs": [
+    {
+        "item" : "minecraft:birch_planks",
+        "count": 1
+    },
+    {
+        "item" : "minecraft:stone",
+        "count": 1
+    },
+    {
+        "item" : "structurize:sceptergold",
+        "count": 1
+    }
+  ],
+  "alternate-output" : [
+    {
+        "item" : "structurize:double_crossed_birch_stone_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:framed_birch_stone_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:side_framed_birch_stone_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:up_gated_birch_stone_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:down_gated_birch_stone_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:one_crossed_lr_birch_stone_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:one_crossed_rl_birch_stone_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:horizontal_plain_birch_stone_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:side_framed_horizontal_birch_stone_timber_frame",
+        "count": 4
+    }
+  ],
+  "result": "structurize:plain_birch_stone_timber_frame",
+  "count": 4,
+  "intermediate" : "minecraft:air",
+  "must-exist" : true
+}

--- a/src/main/resources/data/minecolonies/crafterrecipes/sawmill/cactus_acacia_timber_frame.json
+++ b/src/main/resources/data/minecolonies/crafterrecipes/sawmill/cactus_acacia_timber_frame.json
@@ -1,0 +1,60 @@
+{
+  "type" : "recipe",
+  "crafter": "sawmill",
+  "inputs": [
+    {
+        "item" : "structurize:blockcactusplank",
+        "count": 1
+    },
+    {
+        "item" : "minecraft:acacia_planks",
+        "count": 1
+    },
+    {
+        "item" : "structurize:sceptergold",
+        "count": 1
+    }
+  ],
+  "alternate-output" : [
+    {
+        "item" : "structurize:double_crossed_cactus_acacia_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:framed_cactus_acacia_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:side_framed_cactus_acacia_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:up_gated_cactus_acacia_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:down_gated_cactus_acacia_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:one_crossed_lr_cactus_acacia_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:one_crossed_rl_cactus_acacia_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:horizontal_plain_cactus_acacia_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:side_framed_horizontal_cactus_acacia_timber_frame",
+        "count": 4
+    }
+  ],
+  "result": "structurize:plain_cactus_acacia_timber_frame",
+  "count": 4,
+  "intermediate" : "minecraft:air",
+  "must-exist" : true
+}

--- a/src/main/resources/data/minecolonies/crafterrecipes/sawmill/cactus_birch_timber_frame.json
+++ b/src/main/resources/data/minecolonies/crafterrecipes/sawmill/cactus_birch_timber_frame.json
@@ -1,0 +1,60 @@
+{
+  "type" : "recipe",
+  "crafter": "sawmill",
+  "inputs": [
+    {
+        "item" : "structurize:blockcactusplank",
+        "count": 1
+    },
+    {
+        "item" : "minecraft:birch_planks",
+        "count": 1
+    },
+    {
+        "item" : "structurize:sceptergold",
+        "count": 1
+    }
+  ],
+  "alternate-output" : [
+    {
+        "item" : "structurize:double_crossed_cactus_birch_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:framed_cactus_birch_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:side_framed_cactus_birch_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:up_gated_cactus_birch_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:down_gated_cactus_birch_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:one_crossed_lr_cactus_birch_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:one_crossed_rl_cactus_birch_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:horizontal_plain_cactus_birch_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:side_framed_horizontal_cactus_birch_timber_frame",
+        "count": 4
+    }
+  ],
+  "result": "structurize:plain_cactus_birch_timber_frame",
+  "count": 4,
+  "intermediate" : "minecraft:air",
+  "must-exist" : true
+}

--- a/src/main/resources/data/minecolonies/crafterrecipes/sawmill/cactus_brick_timber_frame.json
+++ b/src/main/resources/data/minecolonies/crafterrecipes/sawmill/cactus_brick_timber_frame.json
@@ -1,0 +1,60 @@
+{
+  "type" : "recipe",
+  "crafter": "sawmill",
+  "inputs": [
+    {
+        "item" : "structurize:blockcactusplank",
+        "count": 1
+    },
+    {
+        "item" : "minecraft:brick",
+        "count": 1
+    },
+    {
+        "item" : "structurize:sceptergold",
+        "count": 1
+    }
+  ],
+  "alternate-output" : [
+    {
+        "item" : "structurize:double_crossed_cactus_brick_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:framed_cactus_brick_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:side_framed_cactus_brick_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:up_gated_cactus_brick_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:down_gated_cactus_brick_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:one_crossed_lr_cactus_brick_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:one_crossed_rl_cactus_brick_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:horizontal_plain_cactus_brick_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:side_framed_horizontal_cactus_brick_timber_frame",
+        "count": 4
+    }
+  ],
+  "result": "structurize:plain_cactus_brick_timber_frame",
+  "count": 4,
+  "intermediate" : "minecraft:air",
+  "must-exist" : true
+}

--- a/src/main/resources/data/minecolonies/crafterrecipes/sawmill/cactus_cactus_timber_frame.json
+++ b/src/main/resources/data/minecolonies/crafterrecipes/sawmill/cactus_cactus_timber_frame.json
@@ -1,0 +1,60 @@
+{
+  "type" : "recipe",
+  "crafter": "sawmill",
+  "inputs": [
+    {
+        "item" : "structurize:blockcactusplank",
+        "count": 1
+    },
+    {
+        "item" : "structurize:blockcactusplank",
+        "count": 1
+    },
+    {
+        "item" : "structurize:sceptergold",
+        "count": 1
+    }
+  ],
+  "alternate-output" : [
+    {
+        "item" : "structurize:double_crossed_cactus_cactus_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:framed_cactus_cactus_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:side_framed_cactus_cactus_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:up_gated_cactus_cactus_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:down_gated_cactus_cactus_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:one_crossed_lr_cactus_cactus_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:one_crossed_rl_cactus_cactus_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:horizontal_plain_cactus_cactus_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:side_framed_horizontal_cactus_cactus_timber_frame",
+        "count": 4
+    }
+  ],
+  "result": "structurize:plain_cactus_cactus_timber_frame",
+  "count": 4,
+  "intermediate" : "minecraft:air",
+  "must-exist" : true
+}

--- a/src/main/resources/data/minecolonies/crafterrecipes/sawmill/cactus_cobble_stone_timber_frame.json
+++ b/src/main/resources/data/minecolonies/crafterrecipes/sawmill/cactus_cobble_stone_timber_frame.json
@@ -1,0 +1,60 @@
+{
+  "type" : "recipe",
+  "crafter": "sawmill",
+  "inputs": [
+    {
+        "item" : "structurize:blockcactusplank",
+        "count": 1
+    },
+    {
+        "item" : "minecraft:cobblestone",
+        "count": 1
+    },
+    {
+        "item" : "structurize:sceptergold",
+        "count": 1
+    }
+  ],
+  "alternate-output" : [
+    {
+        "item" : "structurize:double_crossed_cactus_cobble_stone_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:framed_cactus_cobble_stone_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:side_framed_cactus_cobble_stone_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:up_gated_cactus_cobble_stone_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:down_gated_cactus_cobble_stone_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:one_crossed_lr_cactus_cobble_stone_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:one_crossed_rl_cactus_cobble_stone_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:horizontal_plain_cactus_cobble_stone_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:side_framed_horizontal_cactus_cobble_stone_timber_frame",
+        "count": 4
+    }
+  ],
+  "result": "structurize:plain_cactus_cobble_stone_timber_frame",
+  "count": 4,
+  "intermediate" : "minecraft:air",
+  "must-exist" : true
+}

--- a/src/main/resources/data/minecolonies/crafterrecipes/sawmill/cactus_dark_oak_timber_frame.json
+++ b/src/main/resources/data/minecolonies/crafterrecipes/sawmill/cactus_dark_oak_timber_frame.json
@@ -1,0 +1,60 @@
+{
+  "type" : "recipe",
+  "crafter": "sawmill",
+  "inputs": [
+    {
+        "item" : "structurize:blockcactusplank",
+        "count": 1
+    },
+    {
+        "item" : "minecraft:dark_oak_planks",
+        "count": 1
+    },
+    {
+        "item" : "structurize:sceptergold",
+        "count": 1
+    }
+  ],
+  "alternate-output" : [
+    {
+        "item" : "structurize:double_crossed_cactus_dark_oak_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:framed_cactus_dark_oak_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:side_framed_cactus_dark_oak_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:up_gated_cactus_dark_oak_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:down_gated_cactus_dark_oak_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:one_crossed_lr_cactus_dark_oak_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:one_crossed_rl_cactus_dark_oak_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:horizontal_plain_cactus_dark_oak_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:side_framed_horizontal_cactus_dark_oak_timber_frame",
+        "count": 4
+    }
+  ],
+  "result": "structurize:plain_cactus_dark_oak_timber_frame",
+  "count": 4,
+  "intermediate" : "minecraft:air",
+  "must-exist" : true
+}

--- a/src/main/resources/data/minecolonies/crafterrecipes/sawmill/cactus_jungle_timber_frame.json
+++ b/src/main/resources/data/minecolonies/crafterrecipes/sawmill/cactus_jungle_timber_frame.json
@@ -1,0 +1,60 @@
+{
+  "type" : "recipe",
+  "crafter": "sawmill",
+  "inputs": [
+    {
+        "item" : "structurize:blockcactusplank",
+        "count": 1
+    },
+    {
+        "item" : "minecraft:jungle_planks",
+        "count": 1
+    },
+    {
+        "item" : "structurize:sceptergold",
+        "count": 1
+    }
+  ],
+  "alternate-output" : [
+    {
+        "item" : "structurize:double_crossed_cactus_jungle_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:framed_cactus_jungle_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:side_framed_cactus_jungle_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:up_gated_cactus_jungle_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:down_gated_cactus_jungle_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:one_crossed_lr_cactus_jungle_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:one_crossed_rl_cactus_jungle_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:horizontal_plain_cactus_jungle_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:side_framed_horizontal_cactus_jungle_timber_frame",
+        "count": 4
+    }
+  ],
+  "result": "structurize:plain_cactus_jungle_timber_frame",
+  "count": 4,
+  "intermediate" : "minecraft:air",
+  "must-exist" : true
+}

--- a/src/main/resources/data/minecolonies/crafterrecipes/sawmill/cactus_oak_timber_frame.json
+++ b/src/main/resources/data/minecolonies/crafterrecipes/sawmill/cactus_oak_timber_frame.json
@@ -1,0 +1,60 @@
+{
+  "type" : "recipe",
+  "crafter": "sawmill",
+  "inputs": [
+    {
+        "item" : "structurize:blockcactusplank",
+        "count": 1
+    },
+    {
+        "item" : "minecraft:oak_planks",
+        "count": 1
+    },
+    {
+        "item" : "structurize:sceptergold",
+        "count": 1
+    }
+  ],
+  "alternate-output" : [
+    {
+        "item" : "structurize:double_crossed_cactus_oak_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:framed_cactus_oak_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:side_framed_cactus_oak_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:up_gated_cactus_oak_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:down_gated_cactus_oak_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:one_crossed_lr_cactus_oak_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:one_crossed_rl_cactus_oak_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:horizontal_plain_cactus_oak_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:side_framed_horizontal_cactus_oak_timber_frame",
+        "count": 4
+    }
+  ],
+  "result": "structurize:plain_cactus_oak_timber_frame",
+  "count": 4,
+  "intermediate" : "minecraft:air",
+  "must-exist" : true
+}

--- a/src/main/resources/data/minecolonies/crafterrecipes/sawmill/cactus_paper_timber_frame.json
+++ b/src/main/resources/data/minecolonies/crafterrecipes/sawmill/cactus_paper_timber_frame.json
@@ -1,0 +1,60 @@
+{
+  "type" : "recipe",
+  "crafter": "sawmill",
+  "inputs": [
+    {
+        "item" : "structurize:blockcactusplank",
+        "count": 1
+    },
+    {
+        "item" : "minecraft:paper",
+        "count": 1
+    },
+    {
+        "item" : "structurize:sceptergold",
+        "count": 1
+    }
+  ],
+  "alternate-output" : [
+    {
+        "item" : "structurize:double_crossed_cactus_paper_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:framed_cactus_paper_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:side_framed_cactus_paper_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:up_gated_cactus_paper_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:down_gated_cactus_paper_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:one_crossed_lr_cactus_paper_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:one_crossed_rl_cactus_paper_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:horizontal_plain_cactus_paper_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:side_framed_horizontal_cactus_paper_timber_frame",
+        "count": 4
+    }
+  ],
+  "result": "structurize:plain_cactus_paper_timber_frame",
+  "count": 4,
+  "intermediate" : "minecraft:air",
+  "must-exist" : true
+}

--- a/src/main/resources/data/minecolonies/crafterrecipes/sawmill/cactus_spruce_timber_frame.json
+++ b/src/main/resources/data/minecolonies/crafterrecipes/sawmill/cactus_spruce_timber_frame.json
@@ -1,0 +1,60 @@
+{
+  "type" : "recipe",
+  "crafter": "sawmill",
+  "inputs": [
+    {
+        "item" : "structurize:blockcactusplank",
+        "count": 1
+    },
+    {
+        "item" : "minecraft:spruce_planks",
+        "count": 1
+    },
+    {
+        "item" : "structurize:sceptergold",
+        "count": 1
+    }
+  ],
+  "alternate-output" : [
+    {
+        "item" : "structurize:double_crossed_cactus_spruce_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:framed_cactus_spruce_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:side_framed_cactus_spruce_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:up_gated_cactus_spruce_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:down_gated_cactus_spruce_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:one_crossed_lr_cactus_spruce_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:one_crossed_rl_cactus_spruce_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:horizontal_plain_cactus_spruce_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:side_framed_horizontal_cactus_spruce_timber_frame",
+        "count": 4
+    }
+  ],
+  "result": "structurize:plain_cactus_spruce_timber_frame",
+  "count": 4,
+  "intermediate" : "minecraft:air",
+  "must-exist" : true
+}

--- a/src/main/resources/data/minecolonies/crafterrecipes/sawmill/cactus_stone_timber_frame.json
+++ b/src/main/resources/data/minecolonies/crafterrecipes/sawmill/cactus_stone_timber_frame.json
@@ -1,0 +1,60 @@
+{
+  "type" : "recipe",
+  "crafter": "sawmill",
+  "inputs": [
+    {
+        "item" : "structurize:blockcactusplank",
+        "count": 1
+    },
+    {
+        "item" : "minecraft:stone",
+        "count": 1
+    },
+    {
+        "item" : "structurize:sceptergold",
+        "count": 1
+    }
+  ],
+  "alternate-output" : [
+    {
+        "item" : "structurize:double_crossed_cactus_stone_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:framed_cactus_stone_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:side_framed_cactus_stone_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:up_gated_cactus_stone_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:down_gated_cactus_stone_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:one_crossed_lr_cactus_stone_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:one_crossed_rl_cactus_stone_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:horizontal_plain_cactus_stone_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:side_framed_horizontal_cactus_stone_timber_frame",
+        "count": 4
+    }
+  ],
+  "result": "structurize:plain_cactus_stone_timber_frame",
+  "count": 4,
+  "intermediate" : "minecraft:air",
+  "must-exist" : true
+}

--- a/src/main/resources/data/minecolonies/crafterrecipes/sawmill/dark_oak_acacia_timber_frame.json
+++ b/src/main/resources/data/minecolonies/crafterrecipes/sawmill/dark_oak_acacia_timber_frame.json
@@ -1,0 +1,60 @@
+{
+  "type" : "recipe",
+  "crafter": "sawmill",
+  "inputs": [
+    {
+        "item" : "minecraft:dark_oak_planks",
+        "count": 1
+    },
+    {
+        "item" : "minecraft:acacia_planks",
+        "count": 1
+    },
+    {
+        "item" : "structurize:sceptergold",
+        "count": 1
+    }
+  ],
+  "alternate-output" : [
+    {
+        "item" : "structurize:double_crossed_dark_oak_acacia_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:framed_dark_oak_acacia_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:side_framed_dark_oak_acacia_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:up_gated_dark_oak_acacia_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:down_gated_dark_oak_acacia_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:one_crossed_lr_dark_oak_acacia_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:one_crossed_rl_dark_oak_acacia_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:horizontal_plain_dark_oak_acacia_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:side_framed_horizontal_dark_oak_acacia_timber_frame",
+        "count": 4
+    }
+  ],
+  "result": "structurize:plain_dark_oak_acacia_timber_frame",
+  "count": 4,
+  "intermediate" : "minecraft:air",
+  "must-exist" : true
+}

--- a/src/main/resources/data/minecolonies/crafterrecipes/sawmill/dark_oak_birch_timber_frame.json
+++ b/src/main/resources/data/minecolonies/crafterrecipes/sawmill/dark_oak_birch_timber_frame.json
@@ -1,0 +1,60 @@
+{
+  "type" : "recipe",
+  "crafter": "sawmill",
+  "inputs": [
+    {
+        "item" : "minecraft:dark_oak_planks",
+        "count": 1
+    },
+    {
+        "item" : "minecraft:birch_planks",
+        "count": 1
+    },
+    {
+        "item" : "structurize:sceptergold",
+        "count": 1
+    }
+  ],
+  "alternate-output" : [
+    {
+        "item" : "structurize:double_crossed_dark_oak_birch_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:framed_dark_oak_birch_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:side_framed_dark_oak_birch_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:up_gated_dark_oak_birch_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:down_gated_dark_oak_birch_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:one_crossed_lr_dark_oak_birch_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:one_crossed_rl_dark_oak_birch_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:horizontal_plain_dark_oak_birch_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:side_framed_horizontal_dark_oak_birch_timber_frame",
+        "count": 4
+    }
+  ],
+  "result": "structurize:plain_dark_oak_birch_timber_frame",
+  "count": 4,
+  "intermediate" : "minecraft:air",
+  "must-exist" : true
+}

--- a/src/main/resources/data/minecolonies/crafterrecipes/sawmill/dark_oak_brick_timber_frame.json
+++ b/src/main/resources/data/minecolonies/crafterrecipes/sawmill/dark_oak_brick_timber_frame.json
@@ -1,0 +1,60 @@
+{
+  "type" : "recipe",
+  "crafter": "sawmill",
+  "inputs": [
+    {
+        "item" : "minecraft:dark_oak_planks",
+        "count": 1
+    },
+    {
+        "item" : "minecraft:brick",
+        "count": 1
+    },
+    {
+        "item" : "structurize:sceptergold",
+        "count": 1
+    }
+  ],
+  "alternate-output" : [
+    {
+        "item" : "structurize:double_crossed_dark_oak_brick_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:framed_dark_oak_brick_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:side_framed_dark_oak_brick_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:up_gated_dark_oak_brick_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:down_gated_dark_oak_brick_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:one_crossed_lr_dark_oak_brick_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:one_crossed_rl_dark_oak_brick_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:horizontal_plain_dark_oak_brick_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:side_framed_horizontal_dark_oak_brick_timber_frame",
+        "count": 4
+    }
+  ],
+  "result": "structurize:plain_dark_oak_brick_timber_frame",
+  "count": 4,
+  "intermediate" : "minecraft:air",
+  "must-exist" : true
+}

--- a/src/main/resources/data/minecolonies/crafterrecipes/sawmill/dark_oak_cactus_timber_frame.json
+++ b/src/main/resources/data/minecolonies/crafterrecipes/sawmill/dark_oak_cactus_timber_frame.json
@@ -1,0 +1,60 @@
+{
+  "type" : "recipe",
+  "crafter": "sawmill",
+  "inputs": [
+    {
+        "item" : "minecraft:dark_oak_planks",
+        "count": 1
+    },
+    {
+        "item" : "structurize:blockcactusplank",
+        "count": 1
+    },
+    {
+        "item" : "structurize:sceptergold",
+        "count": 1
+    }
+  ],
+  "alternate-output" : [
+    {
+        "item" : "structurize:double_crossed_dark_oak_cactus_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:framed_dark_oak_cactus_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:side_framed_dark_oak_cactus_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:up_gated_dark_oak_cactus_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:down_gated_dark_oak_cactus_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:one_crossed_lr_dark_oak_cactus_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:one_crossed_rl_dark_oak_cactus_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:horizontal_plain_dark_oak_cactus_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:side_framed_horizontal_dark_oak_cactus_timber_frame",
+        "count": 4
+    }
+  ],
+  "result": "structurize:plain_dark_oak_cactus_timber_frame",
+  "count": 4,
+  "intermediate" : "minecraft:air",
+  "must-exist" : true
+}

--- a/src/main/resources/data/minecolonies/crafterrecipes/sawmill/dark_oak_cobble_stone_timber_frame.json
+++ b/src/main/resources/data/minecolonies/crafterrecipes/sawmill/dark_oak_cobble_stone_timber_frame.json
@@ -1,0 +1,60 @@
+{
+  "type" : "recipe",
+  "crafter": "sawmill",
+  "inputs": [
+    {
+        "item" : "minecraft:dark_oak_planks",
+        "count": 1
+    },
+    {
+        "item" : "minecraft:cobblestone",
+        "count": 1
+    },
+    {
+        "item" : "structurize:sceptergold",
+        "count": 1
+    }
+  ],
+  "alternate-output" : [
+    {
+        "item" : "structurize:double_crossed_dark_oak_cobble_stone_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:framed_dark_oak_cobble_stone_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:side_framed_dark_oak_cobble_stone_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:up_gated_dark_oak_cobble_stone_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:down_gated_dark_oak_cobble_stone_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:one_crossed_lr_dark_oak_cobble_stone_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:one_crossed_rl_dark_oak_cobble_stone_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:horizontal_plain_dark_oak_cobble_stone_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:side_framed_horizontal_dark_oak_cobble_stone_timber_frame",
+        "count": 4
+    }
+  ],
+  "result": "structurize:plain_dark_oak_cobble_stone_timber_frame",
+  "count": 4,
+  "intermediate" : "minecraft:air",
+  "must-exist" : true
+}

--- a/src/main/resources/data/minecolonies/crafterrecipes/sawmill/dark_oak_dark_oak_timber_frame.json
+++ b/src/main/resources/data/minecolonies/crafterrecipes/sawmill/dark_oak_dark_oak_timber_frame.json
@@ -1,0 +1,60 @@
+{
+  "type" : "recipe",
+  "crafter": "sawmill",
+  "inputs": [
+    {
+        "item" : "minecraft:dark_oak_planks",
+        "count": 1
+    },
+    {
+        "item" : "minecraft:dark_oak_planks",
+        "count": 1
+    },
+    {
+        "item" : "structurize:sceptergold",
+        "count": 1
+    }
+  ],
+  "alternate-output" : [
+    {
+        "item" : "structurize:double_crossed_dark_oak_dark_oak_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:framed_dark_oak_dark_oak_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:side_framed_dark_oak_dark_oak_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:up_gated_dark_oak_dark_oak_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:down_gated_dark_oak_dark_oak_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:one_crossed_lr_dark_oak_dark_oak_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:one_crossed_rl_dark_oak_dark_oak_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:horizontal_plain_dark_oak_dark_oak_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:side_framed_horizontal_dark_oak_dark_oak_timber_frame",
+        "count": 4
+    }
+  ],
+  "result": "structurize:plain_dark_oak_dark_oak_timber_frame",
+  "count": 4,
+  "intermediate" : "minecraft:air",
+  "must-exist" : true
+}

--- a/src/main/resources/data/minecolonies/crafterrecipes/sawmill/dark_oak_jungle_timber_frame.json
+++ b/src/main/resources/data/minecolonies/crafterrecipes/sawmill/dark_oak_jungle_timber_frame.json
@@ -1,0 +1,60 @@
+{
+  "type" : "recipe",
+  "crafter": "sawmill",
+  "inputs": [
+    {
+        "item" : "minecraft:dark_oak_planks",
+        "count": 1
+    },
+    {
+        "item" : "minecraft:jungle_planks",
+        "count": 1
+    },
+    {
+        "item" : "structurize:sceptergold",
+        "count": 1
+    }
+  ],
+  "alternate-output" : [
+    {
+        "item" : "structurize:double_crossed_dark_oak_jungle_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:framed_dark_oak_jungle_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:side_framed_dark_oak_jungle_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:up_gated_dark_oak_jungle_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:down_gated_dark_oak_jungle_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:one_crossed_lr_dark_oak_jungle_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:one_crossed_rl_dark_oak_jungle_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:horizontal_plain_dark_oak_jungle_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:side_framed_horizontal_dark_oak_jungle_timber_frame",
+        "count": 4
+    }
+  ],
+  "result": "structurize:plain_dark_oak_jungle_timber_frame",
+  "count": 4,
+  "intermediate" : "minecraft:air",
+  "must-exist" : true
+}

--- a/src/main/resources/data/minecolonies/crafterrecipes/sawmill/dark_oak_oak_timber_frame.json
+++ b/src/main/resources/data/minecolonies/crafterrecipes/sawmill/dark_oak_oak_timber_frame.json
@@ -1,0 +1,60 @@
+{
+  "type" : "recipe",
+  "crafter": "sawmill",
+  "inputs": [
+    {
+        "item" : "minecraft:dark_oak_planks",
+        "count": 1
+    },
+    {
+        "item" : "minecraft:oak_planks",
+        "count": 1
+    },
+    {
+        "item" : "structurize:sceptergold",
+        "count": 1
+    }
+  ],
+  "alternate-output" : [
+    {
+        "item" : "structurize:double_crossed_dark_oak_oak_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:framed_dark_oak_oak_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:side_framed_dark_oak_oak_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:up_gated_dark_oak_oak_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:down_gated_dark_oak_oak_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:one_crossed_lr_dark_oak_oak_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:one_crossed_rl_dark_oak_oak_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:horizontal_plain_dark_oak_oak_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:side_framed_horizontal_dark_oak_oak_timber_frame",
+        "count": 4
+    }
+  ],
+  "result": "structurize:plain_dark_oak_oak_timber_frame",
+  "count": 4,
+  "intermediate" : "minecraft:air",
+  "must-exist" : true
+}

--- a/src/main/resources/data/minecolonies/crafterrecipes/sawmill/dark_oak_paper_timber_frame.json
+++ b/src/main/resources/data/minecolonies/crafterrecipes/sawmill/dark_oak_paper_timber_frame.json
@@ -1,0 +1,60 @@
+{
+  "type" : "recipe",
+  "crafter": "sawmill",
+  "inputs": [
+    {
+        "item" : "minecraft:dark_dark_oak_planks",
+        "count": 1
+    },
+    {
+        "item" : "minecraft:paper",
+        "count": 1
+    },
+    {
+        "item" : "structurize:sceptergold",
+        "count": 1
+    }
+  ],
+  "alternate-output" : [
+    {
+        "item" : "structurize:double_crossed_dark_dark_oak_paper_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:framed_dark_dark_oak_paper_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:side_framed_dark_dark_oak_paper_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:up_gated_dark_dark_oak_paper_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:down_gated_dark_dark_oak_paper_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:one_crossed_lr_dark_dark_oak_paper_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:one_crossed_rl_dark_dark_oak_paper_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:horizontal_plain_dark_dark_oak_paper_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:side_framed_horizontal_dark_dark_oak_paper_timber_frame",
+        "count": 4
+    }
+  ],
+  "result": "structurize:plain_dark_dark_oak_paper_timber_frame",
+  "count": 4,
+  "intermediate" : "minecraft:air",
+  "must-exist" : true
+}

--- a/src/main/resources/data/minecolonies/crafterrecipes/sawmill/dark_oak_paper_timber_frame.json
+++ b/src/main/resources/data/minecolonies/crafterrecipes/sawmill/dark_oak_paper_timber_frame.json
@@ -17,43 +17,43 @@
   ],
   "alternate-output" : [
     {
-        "item" : "structurize:double_crossed_dark_dark_oak_paper_timber_frame",
+        "item" : "structurize:double_crossed_dark_oak_paper_timber_frame",
         "count": 4
     },
     {
-        "item" : "structurize:framed_dark_dark_oak_paper_timber_frame",
+        "item" : "structurize:framed_dark_oak_paper_timber_frame",
         "count": 4
     },
     {
-        "item" : "structurize:side_framed_dark_dark_oak_paper_timber_frame",
+        "item" : "structurize:side_framed_dark_oak_paper_timber_frame",
         "count": 4
     },
     {
-        "item" : "structurize:up_gated_dark_dark_oak_paper_timber_frame",
+        "item" : "structurize:up_gated_dark_oak_paper_timber_frame",
         "count": 4
     },
     {
-        "item" : "structurize:down_gated_dark_dark_oak_paper_timber_frame",
+        "item" : "structurize:down_gated_dark_oak_paper_timber_frame",
         "count": 4
     },
     {
-        "item" : "structurize:one_crossed_lr_dark_dark_oak_paper_timber_frame",
+        "item" : "structurize:one_crossed_lr_dark_oak_paper_timber_frame",
         "count": 4
     },
     {
-        "item" : "structurize:one_crossed_rl_dark_dark_oak_paper_timber_frame",
+        "item" : "structurize:one_crossed_rl_dark_oak_paper_timber_frame",
         "count": 4
     },
     {
-        "item" : "structurize:horizontal_plain_dark_dark_oak_paper_timber_frame",
+        "item" : "structurize:horizontal_plain_dark_oak_paper_timber_frame",
         "count": 4
     },
     {
-        "item" : "structurize:side_framed_horizontal_dark_dark_oak_paper_timber_frame",
+        "item" : "structurize:side_framed_horizontal_dark_oak_paper_timber_frame",
         "count": 4
     }
   ],
-  "result": "structurize:plain_dark_dark_oak_paper_timber_frame",
+  "result": "structurize:plain_dark_oak_paper_timber_frame",
   "count": 4,
   "intermediate" : "minecraft:air",
   "must-exist" : true

--- a/src/main/resources/data/minecolonies/crafterrecipes/sawmill/dark_oak_paper_timber_frame.json
+++ b/src/main/resources/data/minecolonies/crafterrecipes/sawmill/dark_oak_paper_timber_frame.json
@@ -3,7 +3,7 @@
   "crafter": "sawmill",
   "inputs": [
     {
-        "item" : "minecraft:dark_dark_oak_planks",
+        "item" : "minecraft:dark_oak_planks",
         "count": 1
     },
     {

--- a/src/main/resources/data/minecolonies/crafterrecipes/sawmill/dark_oak_spruce_timber_frame.json
+++ b/src/main/resources/data/minecolonies/crafterrecipes/sawmill/dark_oak_spruce_timber_frame.json
@@ -1,0 +1,60 @@
+{
+  "type" : "recipe",
+  "crafter": "sawmill",
+  "inputs": [
+    {
+        "item" : "minecraft:dark_oak_planks",
+        "count": 1
+    },
+    {
+        "item" : "minecraft:spruce_planks",
+        "count": 1
+    },
+    {
+        "item" : "structurize:sceptergold",
+        "count": 1
+    }
+  ],
+  "alternate-output" : [
+    {
+        "item" : "structurize:double_crossed_dark_oak_spruce_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:framed_dark_oak_spruce_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:side_framed_dark_oak_spruce_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:up_gated_dark_oak_spruce_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:down_gated_dark_oak_spruce_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:one_crossed_lr_dark_oak_spruce_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:one_crossed_rl_dark_oak_spruce_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:horizontal_plain_dark_oak_spruce_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:side_framed_horizontal_dark_oak_spruce_timber_frame",
+        "count": 4
+    }
+  ],
+  "result": "structurize:plain_dark_oak_spruce_timber_frame",
+  "count": 4,
+  "intermediate" : "minecraft:air",
+  "must-exist" : true
+}

--- a/src/main/resources/data/minecolonies/crafterrecipes/sawmill/dark_oak_stone_timber_frame.json
+++ b/src/main/resources/data/minecolonies/crafterrecipes/sawmill/dark_oak_stone_timber_frame.json
@@ -1,0 +1,60 @@
+{
+  "type" : "recipe",
+  "crafter": "sawmill",
+  "inputs": [
+    {
+        "item" : "minecraft:dark_oak_planks",
+        "count": 1
+    },
+    {
+        "item" : "minecraft:stone",
+        "count": 1
+    },
+    {
+        "item" : "structurize:sceptergold",
+        "count": 1
+    }
+  ],
+  "alternate-output" : [
+    {
+        "item" : "structurize:double_crossed_dark_oak_stone_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:framed_dark_oak_stone_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:side_framed_dark_oak_stone_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:up_gated_dark_oak_stone_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:down_gated_dark_oak_stone_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:one_crossed_lr_dark_oak_stone_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:one_crossed_rl_dark_oak_stone_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:horizontal_plain_dark_oak_stone_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:side_framed_horizontal_dark_oak_stone_timber_frame",
+        "count": 4
+    }
+  ],
+  "result": "structurize:plain_dark_oak_stone_timber_frame",
+  "count": 4,
+  "intermediate" : "minecraft:air",
+  "must-exist" : true
+}

--- a/src/main/resources/data/minecolonies/crafterrecipes/sawmill/jungle_acacia_timber_frame.json
+++ b/src/main/resources/data/minecolonies/crafterrecipes/sawmill/jungle_acacia_timber_frame.json
@@ -1,0 +1,60 @@
+{
+  "type" : "recipe",
+  "crafter": "sawmill",
+  "inputs": [
+    {
+        "item" : "minecraft:jungle_planks",
+        "count": 1
+    },
+    {
+        "item" : "minecraft:acacia_planks",
+        "count": 1
+    },
+    {
+        "item" : "structurize:sceptergold",
+        "count": 1
+    }
+  ],
+  "alternate-output" : [
+    {
+        "item" : "structurize:double_crossed_jungle_acacia_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:framed_jungle_acacia_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:side_framed_jungle_acacia_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:up_gated_jungle_acacia_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:down_gated_jungle_acacia_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:one_crossed_lr_jungle_acacia_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:one_crossed_rl_jungle_acacia_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:horizontal_plain_jungle_acacia_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:side_framed_horizontal_jungle_acacia_timber_frame",
+        "count": 4
+    }
+  ],
+  "result": "structurize:plain_jungle_acacia_timber_frame",
+  "count": 4,
+  "intermediate" : "minecraft:air",
+  "must-exist" : true
+}

--- a/src/main/resources/data/minecolonies/crafterrecipes/sawmill/jungle_birch_timber_frame.json
+++ b/src/main/resources/data/minecolonies/crafterrecipes/sawmill/jungle_birch_timber_frame.json
@@ -1,0 +1,60 @@
+{
+  "type" : "recipe",
+  "crafter": "sawmill",
+  "inputs": [
+    {
+        "item" : "minecraft:jungle_planks",
+        "count": 1
+    },
+    {
+        "item" : "minecraft:birch_planks",
+        "count": 1
+    },
+    {
+        "item" : "structurize:sceptergold",
+        "count": 1
+    }
+  ],
+  "alternate-output" : [
+    {
+        "item" : "structurize:double_crossed_jungle_birch_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:framed_jungle_birch_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:side_framed_jungle_birch_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:up_gated_jungle_birch_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:down_gated_jungle_birch_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:one_crossed_lr_jungle_birch_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:one_crossed_rl_jungle_birch_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:horizontal_plain_jungle_birch_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:side_framed_horizontal_jungle_birch_timber_frame",
+        "count": 4
+    }
+  ],
+  "result": "structurize:plain_jungle_birch_timber_frame",
+  "count": 4,
+  "intermediate" : "minecraft:air",
+  "must-exist" : true
+}

--- a/src/main/resources/data/minecolonies/crafterrecipes/sawmill/jungle_brick_timber_frame.json
+++ b/src/main/resources/data/minecolonies/crafterrecipes/sawmill/jungle_brick_timber_frame.json
@@ -1,0 +1,60 @@
+{
+  "type" : "recipe",
+  "crafter": "sawmill",
+  "inputs": [
+    {
+        "item" : "minecraft:jungle_planks",
+        "count": 1
+    },
+    {
+        "item" : "minecraft:brick",
+        "count": 1
+    },
+    {
+        "item" : "structurize:sceptergold",
+        "count": 1
+    }
+  ],
+  "alternate-output" : [
+    {
+        "item" : "structurize:double_crossed_jungle_brick_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:framed_jungle_brick_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:side_framed_jungle_brick_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:up_gated_jungle_brick_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:down_gated_jungle_brick_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:one_crossed_lr_jungle_brick_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:one_crossed_rl_jungle_brick_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:horizontal_plain_jungle_brick_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:side_framed_horizontal_jungle_brick_timber_frame",
+        "count": 4
+    }
+  ],
+  "result": "structurize:plain_jungle_brick_timber_frame",
+  "count": 4,
+  "intermediate" : "minecraft:air",
+  "must-exist" : true
+}

--- a/src/main/resources/data/minecolonies/crafterrecipes/sawmill/jungle_cactus_timber_frame.json
+++ b/src/main/resources/data/minecolonies/crafterrecipes/sawmill/jungle_cactus_timber_frame.json
@@ -1,0 +1,60 @@
+{
+  "type" : "recipe",
+  "crafter": "sawmill",
+  "inputs": [
+    {
+        "item" : "minecraft:jungle_planks",
+        "count": 1
+    },
+    {
+        "item" : "structurize:blockcactusplank",
+        "count": 1
+    },
+    {
+        "item" : "structurize:sceptergold",
+        "count": 1
+    }
+  ],
+  "alternate-output" : [
+    {
+        "item" : "structurize:double_crossed_jungle_cactus_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:framed_jungle_cactus_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:side_framed_jungle_cactus_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:up_gated_jungle_cactus_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:down_gated_jungle_cactus_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:one_crossed_lr_jungle_cactus_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:one_crossed_rl_jungle_cactus_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:horizontal_plain_jungle_cactus_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:side_framed_horizontal_jungle_cactus_timber_frame",
+        "count": 4
+    }
+  ],
+  "result": "structurize:plain_jungle_cactus_timber_frame",
+  "count": 4,
+  "intermediate" : "minecraft:air",
+  "must-exist" : true
+}

--- a/src/main/resources/data/minecolonies/crafterrecipes/sawmill/jungle_cobble_stone_timber_frame.json
+++ b/src/main/resources/data/minecolonies/crafterrecipes/sawmill/jungle_cobble_stone_timber_frame.json
@@ -1,0 +1,60 @@
+{
+  "type" : "recipe",
+  "crafter": "sawmill",
+  "inputs": [
+    {
+        "item" : "minecraft:jungle_planks",
+        "count": 1
+    },
+    {
+        "item" : "minecraft:cobblestone",
+        "count": 1
+    },
+    {
+        "item" : "structurize:sceptergold",
+        "count": 1
+    }
+  ],
+  "alternate-output" : [
+    {
+        "item" : "structurize:double_crossed_jungle_cobble_stone_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:framed_jungle_cobble_stone_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:side_framed_jungle_cobble_stone_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:up_gated_jungle_cobble_stone_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:down_gated_jungle_cobble_stone_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:one_crossed_lr_jungle_cobble_stone_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:one_crossed_rl_jungle_cobble_stone_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:horizontal_plain_jungle_cobble_stone_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:side_framed_horizontal_jungle_cobble_stone_timber_frame",
+        "count": 4
+    }
+  ],
+  "result": "structurize:plain_jungle_cobble_stone_timber_frame",
+  "count": 4,
+  "intermediate" : "minecraft:air",
+  "must-exist" : true
+}

--- a/src/main/resources/data/minecolonies/crafterrecipes/sawmill/jungle_dark_oak_timber_frame.json
+++ b/src/main/resources/data/minecolonies/crafterrecipes/sawmill/jungle_dark_oak_timber_frame.json
@@ -1,0 +1,60 @@
+{
+  "type" : "recipe",
+  "crafter": "sawmill",
+  "inputs": [
+    {
+        "item" : "minecraft:jungle_planks",
+        "count": 1
+    },
+    {
+        "item" : "minecraft:dark_oak_planks",
+        "count": 1
+    },
+    {
+        "item" : "structurize:sceptergold",
+        "count": 1
+    }
+  ],
+  "alternate-output" : [
+    {
+        "item" : "structurize:double_crossed_jungle_dark_oak_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:framed_jungle_dark_oak_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:side_framed_jungle_dark_oak_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:up_gated_jungle_dark_oak_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:down_gated_jungle_dark_oak_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:one_crossed_lr_jungle_dark_oak_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:one_crossed_rl_jungle_dark_oak_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:horizontal_plain_jungle_dark_oak_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:side_framed_horizontal_jungle_dark_oak_timber_frame",
+        "count": 4
+    }
+  ],
+  "result": "structurize:plain_jungle_dark_oak_timber_frame",
+  "count": 4,
+  "intermediate" : "minecraft:air",
+  "must-exist" : true
+}

--- a/src/main/resources/data/minecolonies/crafterrecipes/sawmill/jungle_jungle_timber_frame.json
+++ b/src/main/resources/data/minecolonies/crafterrecipes/sawmill/jungle_jungle_timber_frame.json
@@ -1,0 +1,60 @@
+{
+  "type" : "recipe",
+  "crafter": "sawmill",
+  "inputs": [
+    {
+        "item" : "minecraft:jungle_planks",
+        "count": 1
+    },
+    {
+        "item" : "minecraft:jungle_planks",
+        "count": 1
+    },
+    {
+        "item" : "structurize:sceptergold",
+        "count": 1
+    }
+  ],
+  "alternate-output" : [
+    {
+        "item" : "structurize:double_crossed_jungle_jungle_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:framed_jungle_jungle_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:side_framed_jungle_jungle_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:up_gated_jungle_jungle_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:down_gated_jungle_jungle_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:one_crossed_lr_jungle_jungle_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:one_crossed_rl_jungle_jungle_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:horizontal_plain_jungle_jungle_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:side_framed_horizontal_jungle_jungle_timber_frame",
+        "count": 4
+    }
+  ],
+  "result": "structurize:plain_jungle_jungle_timber_frame",
+  "count": 4,
+  "intermediate" : "minecraft:air",
+  "must-exist" : true
+}

--- a/src/main/resources/data/minecolonies/crafterrecipes/sawmill/jungle_oak_timber_frame.json
+++ b/src/main/resources/data/minecolonies/crafterrecipes/sawmill/jungle_oak_timber_frame.json
@@ -1,0 +1,60 @@
+{
+  "type" : "recipe",
+  "crafter": "sawmill",
+  "inputs": [
+    {
+        "item" : "minecraft:jungle_planks",
+        "count": 1
+    },
+    {
+        "item" : "minecraft:oak_planks",
+        "count": 1
+    },
+    {
+        "item" : "structurize:sceptergold",
+        "count": 1
+    }
+  ],
+  "alternate-output" : [
+    {
+        "item" : "structurize:double_crossed_jungle_oak_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:framed_jungle_oak_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:side_framed_jungle_oak_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:up_gated_jungle_oak_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:down_gated_jungle_oak_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:one_crossed_lr_jungle_oak_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:one_crossed_rl_jungle_oak_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:horizontal_plain_jungle_oak_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:side_framed_horizontal_jungle_oak_timber_frame",
+        "count": 4
+    }
+  ],
+  "result": "structurize:plain_jungle_oak_timber_frame",
+  "count": 4,
+  "intermediate" : "minecraft:air",
+  "must-exist" : true
+}

--- a/src/main/resources/data/minecolonies/crafterrecipes/sawmill/jungle_paper_timber_frame.json
+++ b/src/main/resources/data/minecolonies/crafterrecipes/sawmill/jungle_paper_timber_frame.json
@@ -1,0 +1,60 @@
+{
+  "type" : "recipe",
+  "crafter": "sawmill",
+  "inputs": [
+    {
+        "item" : "minecraft:jungle_planks",
+        "count": 1
+    },
+    {
+        "item" : "minecraft:paper",
+        "count": 1
+    },
+    {
+        "item" : "structurize:sceptergold",
+        "count": 1
+    }
+  ],
+  "alternate-output" : [
+    {
+        "item" : "structurize:double_crossed_jungle_paper_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:framed_jungle_paper_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:side_framed_jungle_paper_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:up_gated_jungle_paper_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:down_gated_jungle_paper_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:one_crossed_lr_jungle_paper_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:one_crossed_rl_jungle_paper_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:horizontal_plain_jungle_paper_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:side_framed_horizontal_jungle_paper_timber_frame",
+        "count": 4
+    }
+  ],
+  "result": "structurize:plain_jungle_paper_timber_frame",
+  "count": 4,
+  "intermediate" : "minecraft:air",
+  "must-exist" : true
+}

--- a/src/main/resources/data/minecolonies/crafterrecipes/sawmill/jungle_spruce_timber_frame.json
+++ b/src/main/resources/data/minecolonies/crafterrecipes/sawmill/jungle_spruce_timber_frame.json
@@ -1,0 +1,60 @@
+{
+  "type" : "recipe",
+  "crafter": "sawmill",
+  "inputs": [
+    {
+        "item" : "minecraft:jungle_planks",
+        "count": 1
+    },
+    {
+        "item" : "minecraft:spruce_planks",
+        "count": 1
+    },
+    {
+        "item" : "structurize:sceptergold",
+        "count": 1
+    }
+  ],
+  "alternate-output" : [
+    {
+        "item" : "structurize:double_crossed_jungle_spruce_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:framed_jungle_spruce_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:side_framed_jungle_spruce_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:up_gated_jungle_spruce_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:down_gated_jungle_spruce_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:one_crossed_lr_jungle_spruce_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:one_crossed_rl_jungle_spruce_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:horizontal_plain_jungle_spruce_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:side_framed_horizontal_jungle_spruce_timber_frame",
+        "count": 4
+    }
+  ],
+  "result": "structurize:plain_jungle_spruce_timber_frame",
+  "count": 4,
+  "intermediate" : "minecraft:air",
+  "must-exist" : true
+}

--- a/src/main/resources/data/minecolonies/crafterrecipes/sawmill/jungle_stone_timber_frame.json
+++ b/src/main/resources/data/minecolonies/crafterrecipes/sawmill/jungle_stone_timber_frame.json
@@ -1,0 +1,60 @@
+{
+  "type" : "recipe",
+  "crafter": "sawmill",
+  "inputs": [
+    {
+        "item" : "minecraft:jungle_planks",
+        "count": 1
+    },
+    {
+        "item" : "minecraft:stone",
+        "count": 1
+    },
+    {
+        "item" : "structurize:sceptergold",
+        "count": 1
+    }
+  ],
+  "alternate-output" : [
+    {
+        "item" : "structurize:double_crossed_jungle_stone_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:framed_jungle_stone_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:side_framed_jungle_stone_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:up_gated_jungle_stone_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:down_gated_jungle_stone_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:one_crossed_lr_jungle_stone_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:one_crossed_rl_jungle_stone_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:horizontal_plain_jungle_stone_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:side_framed_horizontal_jungle_stone_timber_frame",
+        "count": 4
+    }
+  ],
+  "result": "structurize:plain_jungle_stone_timber_frame",
+  "count": 4,
+  "intermediate" : "minecraft:air",
+  "must-exist" : true
+}

--- a/src/main/resources/data/minecolonies/crafterrecipes/sawmill/oak_acacia_timber_frame.json
+++ b/src/main/resources/data/minecolonies/crafterrecipes/sawmill/oak_acacia_timber_frame.json
@@ -1,0 +1,60 @@
+{
+  "type" : "recipe",
+  "crafter": "sawmill",
+  "inputs": [
+    {
+        "item" : "minecraft:oak_planks",
+        "count": 1
+    },
+    {
+        "item" : "minecraft:acacia_planks",
+        "count": 1
+    },
+    {
+        "item" : "structurize:sceptergold",
+        "count": 1
+    }
+  ],
+  "alternate-output" : [
+    {
+        "item" : "structurize:double_crossed_oak_acacia_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:framed_oak_acacia_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:side_framed_oak_acacia_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:up_gated_oak_acacia_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:down_gated_oak_acacia_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:one_crossed_lr_oak_acacia_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:one_crossed_rl_oak_acacia_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:horizontal_plain_oak_acacia_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:side_framed_horizontal_oak_acacia_timber_frame",
+        "count": 4
+    }
+  ],
+  "result": "structurize:plain_oak_acacia_timber_frame",
+  "count": 4,
+  "intermediate" : "minecraft:air",
+  "must-exist" : true
+}

--- a/src/main/resources/data/minecolonies/crafterrecipes/sawmill/oak_birch_timber_frame.json
+++ b/src/main/resources/data/minecolonies/crafterrecipes/sawmill/oak_birch_timber_frame.json
@@ -1,0 +1,60 @@
+{
+  "type" : "recipe",
+  "crafter": "sawmill",
+  "inputs": [
+    {
+        "item" : "minecraft:oak_planks",
+        "count": 1
+    },
+    {
+        "item" : "minecraft:birch_planks",
+        "count": 1
+    },
+    {
+        "item" : "structurize:sceptergold",
+        "count": 1
+    }
+  ],
+  "alternate-output" : [
+    {
+        "item" : "structurize:double_crossed_oak_birch_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:framed_oak_birch_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:side_framed_oak_birch_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:up_gated_oak_birch_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:down_gated_oak_birch_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:one_crossed_lr_oak_birch_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:one_crossed_rl_oak_birch_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:horizontal_plain_oak_birch_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:side_framed_horizontal_oak_birch_timber_frame",
+        "count": 4
+    }
+  ],
+  "result": "structurize:plain_oak_birch_timber_frame",
+  "count": 4,
+  "intermediate" : "minecraft:air",
+  "must-exist" : true
+}

--- a/src/main/resources/data/minecolonies/crafterrecipes/sawmill/oak_brick_timber_frame.json
+++ b/src/main/resources/data/minecolonies/crafterrecipes/sawmill/oak_brick_timber_frame.json
@@ -1,0 +1,60 @@
+{
+  "type" : "recipe",
+  "crafter": "sawmill",
+  "inputs": [
+    {
+        "item" : "minecraft:oak_planks",
+        "count": 1
+    },
+    {
+        "item" : "minecraft:brick",
+        "count": 1
+    },
+    {
+        "item" : "structurize:sceptergold",
+        "count": 1
+    }
+  ],
+  "alternate-output" : [
+    {
+        "item" : "structurize:double_crossed_oak_brick_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:framed_oak_brick_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:side_framed_oak_brick_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:up_gated_oak_brick_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:down_gated_oak_brick_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:one_crossed_lr_oak_brick_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:one_crossed_rl_oak_brick_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:horizontal_plain_oak_brick_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:side_framed_horizontal_oak_brick_timber_frame",
+        "count": 4
+    }
+  ],
+  "result": "structurize:plain_oak_brick_timber_frame",
+  "count": 4,
+  "intermediate" : "minecraft:air",
+  "must-exist" : true
+}

--- a/src/main/resources/data/minecolonies/crafterrecipes/sawmill/oak_cactus_timber_frame.json
+++ b/src/main/resources/data/minecolonies/crafterrecipes/sawmill/oak_cactus_timber_frame.json
@@ -1,0 +1,60 @@
+{
+  "type" : "recipe",
+  "crafter": "sawmill",
+  "inputs": [
+    {
+        "item" : "minecraft:oak_planks",
+        "count": 1
+    },
+    {
+        "item" : "structurize:blockcactusplank",
+        "count": 1
+    },
+    {
+        "item" : "structurize:sceptergold",
+        "count": 1
+    }
+  ],
+  "alternate-output" : [
+    {
+        "item" : "structurize:double_crossed_oak_cactus_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:framed_oak_cactus_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:side_framed_oak_cactus_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:up_gated_oak_cactus_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:down_gated_oak_cactus_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:one_crossed_lr_oak_cactus_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:one_crossed_rl_oak_cactus_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:horizontal_plain_oak_cactus_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:side_framed_horizontal_oak_cactus_timber_frame",
+        "count": 4
+    }
+  ],
+  "result": "structurize:plain_oak_cactus_timber_frame",
+  "count": 4,
+  "intermediate" : "minecraft:air",
+  "must-exist" : true
+}

--- a/src/main/resources/data/minecolonies/crafterrecipes/sawmill/oak_cobble_stone_timber_frame.json
+++ b/src/main/resources/data/minecolonies/crafterrecipes/sawmill/oak_cobble_stone_timber_frame.json
@@ -1,0 +1,60 @@
+{
+  "type" : "recipe",
+  "crafter": "sawmill",
+  "inputs": [
+    {
+        "item" : "minecraft:oak_planks",
+        "count": 1
+    },
+    {
+        "item" : "minecraft:cobblestone",
+        "count": 1
+    },
+    {
+        "item" : "structurize:sceptergold",
+        "count": 1
+    }
+  ],
+  "alternate-output" : [
+    {
+        "item" : "structurize:double_crossed_oak_cobble_stone_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:framed_oak_cobble_stone_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:side_framed_oak_cobble_stone_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:up_gated_oak_cobble_stone_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:down_gated_oak_cobble_stone_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:one_crossed_lr_oak_cobble_stone_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:one_crossed_rl_oak_cobble_stone_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:horizontal_plain_oak_cobble_stone_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:side_framed_horizontal_oak_cobble_stone_timber_frame",
+        "count": 4
+    }
+  ],
+  "result": "structurize:plain_oak_cobble_stone_timber_frame",
+  "count": 4,
+  "intermediate" : "minecraft:air",
+  "must-exist" : true
+}

--- a/src/main/resources/data/minecolonies/crafterrecipes/sawmill/oak_dark_oak_timber_frame.json
+++ b/src/main/resources/data/minecolonies/crafterrecipes/sawmill/oak_dark_oak_timber_frame.json
@@ -1,0 +1,60 @@
+{
+  "type" : "recipe",
+  "crafter": "sawmill",
+  "inputs": [
+    {
+        "item" : "minecraft:oak_planks",
+        "count": 1
+    },
+    {
+        "item" : "minecraft:dark_oak_planks",
+        "count": 1
+    },
+    {
+        "item" : "structurize:sceptergold",
+        "count": 1
+    }
+  ],
+  "alternate-output" : [
+    {
+        "item" : "structurize:double_crossed_oak_dark_oak_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:framed_oak_dark_oak_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:side_framed_oak_dark_oak_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:up_gated_oak_dark_oak_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:down_gated_oak_dark_oak_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:one_crossed_lr_oak_dark_oak_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:one_crossed_rl_oak_dark_oak_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:horizontal_plain_oak_dark_oak_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:side_framed_horizontal_oak_dark_oak_timber_frame",
+        "count": 4
+    }
+  ],
+  "result": "structurize:plain_oak_dark_oak_timber_frame",
+  "count": 4,
+  "intermediate" : "minecraft:air",
+  "must-exist" : true
+}

--- a/src/main/resources/data/minecolonies/crafterrecipes/sawmill/oak_jungle_timber_frame.json
+++ b/src/main/resources/data/minecolonies/crafterrecipes/sawmill/oak_jungle_timber_frame.json
@@ -1,0 +1,60 @@
+{
+  "type" : "recipe",
+  "crafter": "sawmill",
+  "inputs": [
+    {
+        "item" : "minecraft:oak_planks",
+        "count": 1
+    },
+    {
+        "item" : "minecraft:jungle_planks",
+        "count": 1
+    },
+    {
+        "item" : "structurize:sceptergold",
+        "count": 1
+    }
+  ],
+  "alternate-output" : [
+    {
+        "item" : "structurize:double_crossed_oak_jungle_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:framed_oak_jungle_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:side_framed_oak_jungle_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:up_gated_oak_jungle_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:down_gated_oak_jungle_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:one_crossed_lr_oak_jungle_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:one_crossed_rl_oak_jungle_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:horizontal_plain_oak_jungle_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:side_framed_horizontal_oak_jungle_timber_frame",
+        "count": 4
+    }
+  ],
+  "result": "structurize:plain_oak_jungle_timber_frame",
+  "count": 4,
+  "intermediate" : "minecraft:air",
+  "must-exist" : true
+}

--- a/src/main/resources/data/minecolonies/crafterrecipes/sawmill/oak_oak_timber_frame.json
+++ b/src/main/resources/data/minecolonies/crafterrecipes/sawmill/oak_oak_timber_frame.json
@@ -1,0 +1,60 @@
+{
+  "type" : "recipe",
+  "crafter": "sawmill",
+  "inputs": [
+    {
+        "item" : "minecraft:oak_planks",
+        "count": 1
+    },
+    {
+        "item" : "minecraft:oak_planks",
+        "count": 1
+    },
+    {
+        "item" : "structurize:sceptergold",
+        "count": 1
+    }
+  ],
+  "alternate-output" : [
+    {
+        "item" : "structurize:double_crossed_oak_oak_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:framed_oak_oak_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:side_framed_oak_oak_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:up_gated_oak_oak_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:down_gated_oak_oak_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:one_crossed_lr_oak_oak_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:one_crossed_rl_oak_oak_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:horizontal_plain_oak_oak_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:side_framed_horizontal_oak_oak_timber_frame",
+        "count": 4
+    }
+  ],
+  "result": "structurize:plain_oak_oak_timber_frame",
+  "count": 4,
+  "intermediate" : "minecraft:air",
+  "must-exist" : true
+}

--- a/src/main/resources/data/minecolonies/crafterrecipes/sawmill/oak_paper_timber_frame.json
+++ b/src/main/resources/data/minecolonies/crafterrecipes/sawmill/oak_paper_timber_frame.json
@@ -1,0 +1,60 @@
+{
+  "type" : "recipe",
+  "crafter": "sawmill",
+  "inputs": [
+    {
+        "item" : "minecraft:oak_planks",
+        "count": 1
+    },
+    {
+        "item" : "minecraft:paper",
+        "count": 1
+    },
+    {
+        "item" : "structurize:sceptergold",
+        "count": 1
+    }
+  ],
+  "alternate-output" : [
+    {
+        "item" : "structurize:double_crossed_oak_paper_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:framed_oak_paper_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:side_framed_oak_paper_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:up_gated_oak_paper_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:down_gated_oak_paper_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:one_crossed_lr_oak_paper_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:one_crossed_rl_oak_paper_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:horizontal_plain_oak_paper_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:side_framed_horizontal_oak_paper_timber_frame",
+        "count": 4
+    }
+  ],
+  "result": "structurize:plain_oak_paper_timber_frame",
+  "count": 4,
+  "intermediate" : "minecraft:air",
+  "must-exist" : true
+}

--- a/src/main/resources/data/minecolonies/crafterrecipes/sawmill/oak_spruce_timber_frame.json
+++ b/src/main/resources/data/minecolonies/crafterrecipes/sawmill/oak_spruce_timber_frame.json
@@ -1,0 +1,60 @@
+{
+  "type" : "recipe",
+  "crafter": "sawmill",
+  "inputs": [
+    {
+        "item" : "minecraft:oak_planks",
+        "count": 1
+    },
+    {
+        "item" : "minecraft:spruce_planks",
+        "count": 1
+    },
+    {
+        "item" : "structurize:sceptergold",
+        "count": 1
+    }
+  ],
+  "alternate-output" : [
+    {
+        "item" : "structurize:double_crossed_oak_spruce_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:framed_oak_spruce_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:side_framed_oak_spruce_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:up_gated_oak_spruce_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:down_gated_oak_spruce_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:one_crossed_lr_oak_spruce_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:one_crossed_rl_oak_spruce_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:horizontal_plain_oak_spruce_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:side_framed_horizontal_oak_spruce_timber_frame",
+        "count": 4
+    }
+  ],
+  "result": "structurize:plain_oak_spruce_timber_frame",
+  "count": 4,
+  "intermediate" : "minecraft:air",
+  "must-exist" : true
+}

--- a/src/main/resources/data/minecolonies/crafterrecipes/sawmill/oak_stone_timber_frame.json
+++ b/src/main/resources/data/minecolonies/crafterrecipes/sawmill/oak_stone_timber_frame.json
@@ -1,0 +1,60 @@
+{
+  "type" : "recipe",
+  "crafter": "sawmill",
+  "inputs": [
+    {
+        "item" : "minecraft:oak_planks",
+        "count": 1
+    },
+    {
+        "item" : "minecraft:stone",
+        "count": 1
+    },
+    {
+        "item" : "structurize:sceptergold",
+        "count": 1
+    }
+  ],
+  "alternate-output" : [
+    {
+        "item" : "structurize:double_crossed_oak_stone_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:framed_oak_stone_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:side_framed_oak_stone_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:up_gated_oak_stone_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:down_gated_oak_stone_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:one_crossed_lr_oak_stone_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:one_crossed_rl_oak_stone_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:horizontal_plain_oak_stone_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:side_framed_horizontal_oak_stone_timber_frame",
+        "count": 4
+    }
+  ],
+  "result": "structurize:plain_oak_stone_timber_frame",
+  "count": 4,
+  "intermediate" : "minecraft:air",
+  "must-exist" : true
+}

--- a/src/main/resources/data/minecolonies/crafterrecipes/sawmill/spruce_acacia_timber_frame.json
+++ b/src/main/resources/data/minecolonies/crafterrecipes/sawmill/spruce_acacia_timber_frame.json
@@ -1,0 +1,60 @@
+{
+  "type" : "recipe",
+  "crafter": "sawmill",
+  "inputs": [
+    {
+        "item" : "minecraft:spruce_planks",
+        "count": 1
+    },
+    {
+        "item" : "minecraft:acacia_planks",
+        "count": 1
+    },
+    {
+        "item" : "structurize:sceptergold",
+        "count": 1
+    }
+  ],
+  "alternate-output" : [
+    {
+        "item" : "structurize:double_crossed_spruce_acacia_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:framed_spruce_acacia_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:side_framed_spruce_acacia_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:up_gated_spruce_acacia_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:down_gated_spruce_acacia_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:one_crossed_lr_spruce_acacia_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:one_crossed_rl_spruce_acacia_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:horizontal_plain_spruce_acacia_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:side_framed_horizontal_spruce_acacia_timber_frame",
+        "count": 4
+    }
+  ],
+  "result": "structurize:plain_spruce_acacia_timber_frame",
+  "count": 4,
+  "intermediate" : "minecraft:air",
+  "must-exist" : true
+}

--- a/src/main/resources/data/minecolonies/crafterrecipes/sawmill/spruce_birch_timber_frame.json
+++ b/src/main/resources/data/minecolonies/crafterrecipes/sawmill/spruce_birch_timber_frame.json
@@ -1,0 +1,60 @@
+{
+  "type" : "recipe",
+  "crafter": "sawmill",
+  "inputs": [
+    {
+        "item" : "minecraft:spruce_planks",
+        "count": 1
+    },
+    {
+        "item" : "minecraft:birch_planks",
+        "count": 1
+    },
+    {
+        "item" : "structurize:sceptergold",
+        "count": 1
+    }
+  ],
+  "alternate-output" : [
+    {
+        "item" : "structurize:double_crossed_spruce_birch_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:framed_spruce_birch_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:side_framed_spruce_birch_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:up_gated_spruce_birch_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:down_gated_spruce_birch_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:one_crossed_lr_spruce_birch_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:one_crossed_rl_spruce_birch_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:horizontal_plain_spruce_birch_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:side_framed_horizontal_spruce_birch_timber_frame",
+        "count": 4
+    }
+  ],
+  "result": "structurize:plain_spruce_birch_timber_frame",
+  "count": 4,
+  "intermediate" : "minecraft:air",
+  "must-exist" : true
+}

--- a/src/main/resources/data/minecolonies/crafterrecipes/sawmill/spruce_brick_timber_frame.json
+++ b/src/main/resources/data/minecolonies/crafterrecipes/sawmill/spruce_brick_timber_frame.json
@@ -1,0 +1,60 @@
+{
+  "type" : "recipe",
+  "crafter": "sawmill",
+  "inputs": [
+    {
+        "item" : "minecraft:spruce_planks",
+        "count": 1
+    },
+    {
+        "item" : "minecraft:brick",
+        "count": 1
+    },
+    {
+        "item" : "structurize:sceptergold",
+        "count": 1
+    }
+  ],
+  "alternate-output" : [
+    {
+        "item" : "structurize:double_crossed_spruce_brick_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:framed_spruce_brick_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:side_framed_spruce_brick_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:up_gated_spruce_brick_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:down_gated_spruce_brick_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:one_crossed_lr_spruce_brick_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:one_crossed_rl_spruce_brick_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:horizontal_plain_spruce_brick_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:side_framed_horizontal_spruce_brick_timber_frame",
+        "count": 4
+    }
+  ],
+  "result": "structurize:plain_spruce_brick_timber_frame",
+  "count": 4,
+  "intermediate" : "minecraft:air",
+  "must-exist" : true
+}

--- a/src/main/resources/data/minecolonies/crafterrecipes/sawmill/spruce_cactus_timber_frame.json
+++ b/src/main/resources/data/minecolonies/crafterrecipes/sawmill/spruce_cactus_timber_frame.json
@@ -1,0 +1,60 @@
+{
+  "type" : "recipe",
+  "crafter": "sawmill",
+  "inputs": [
+    {
+        "item" : "minecraft:spruce_planks",
+        "count": 1
+    },
+    {
+        "item" : "structurize:blockcactusplank",
+        "count": 1
+    },
+    {
+        "item" : "structurize:sceptergold",
+        "count": 1
+    }
+  ],
+  "alternate-output" : [
+    {
+        "item" : "structurize:double_crossed_spruce_cactus_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:framed_spruce_cactus_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:side_framed_spruce_cactus_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:up_gated_spruce_cactus_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:down_gated_spruce_cactus_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:one_crossed_lr_spruce_cactus_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:one_crossed_rl_spruce_cactus_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:horizontal_plain_spruce_cactus_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:side_framed_horizontal_spruce_cactus_timber_frame",
+        "count": 4
+    }
+  ],
+  "result": "structurize:plain_spruce_cactus_timber_frame",
+  "count": 4,
+  "intermediate" : "minecraft:air",
+  "must-exist" : true
+}

--- a/src/main/resources/data/minecolonies/crafterrecipes/sawmill/spruce_cobble_stone_timber_frame.json
+++ b/src/main/resources/data/minecolonies/crafterrecipes/sawmill/spruce_cobble_stone_timber_frame.json
@@ -1,0 +1,60 @@
+{
+  "type" : "recipe",
+  "crafter": "sawmill",
+  "inputs": [
+    {
+        "item" : "minecraft:spruce_planks",
+        "count": 1
+    },
+    {
+        "item" : "minecraft:cobblestone",
+        "count": 1
+    },
+    {
+        "item" : "structurize:sceptergold",
+        "count": 1
+    }
+  ],
+  "alternate-output" : [
+    {
+        "item" : "structurize:double_crossed_spruce_cobble_stone_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:framed_spruce_cobble_stone_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:side_framed_spruce_cobble_stone_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:up_gated_spruce_cobble_stone_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:down_gated_spruce_cobble_stone_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:one_crossed_lr_spruce_cobble_stone_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:one_crossed_rl_spruce_cobble_stone_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:horizontal_plain_spruce_cobble_stone_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:side_framed_horizontal_spruce_cobble_stone_timber_frame",
+        "count": 4
+    }
+  ],
+  "result": "structurize:plain_spruce_cobble_stone_timber_frame",
+  "count": 4,
+  "intermediate" : "minecraft:air",
+  "must-exist" : true
+}

--- a/src/main/resources/data/minecolonies/crafterrecipes/sawmill/spruce_dark_oak_timber_frame.json
+++ b/src/main/resources/data/minecolonies/crafterrecipes/sawmill/spruce_dark_oak_timber_frame.json
@@ -1,0 +1,60 @@
+{
+  "type" : "recipe",
+  "crafter": "sawmill",
+  "inputs": [
+    {
+        "item" : "minecraft:spruce_planks",
+        "count": 1
+    },
+    {
+        "item" : "minecraft:dark_oak_planks",
+        "count": 1
+    },
+    {
+        "item" : "structurize:sceptergold",
+        "count": 1
+    }
+  ],
+  "alternate-output" : [
+    {
+        "item" : "structurize:double_crossed_spruce_dark_oak_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:framed_spruce_dark_oak_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:side_framed_spruce_dark_oak_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:up_gated_spruce_dark_oak_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:down_gated_spruce_dark_oak_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:one_crossed_lr_spruce_dark_oak_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:one_crossed_rl_spruce_dark_oak_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:horizontal_plain_spruce_dark_oak_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:side_framed_horizontal_spruce_dark_oak_timber_frame",
+        "count": 4
+    }
+  ],
+  "result": "structurize:plain_spruce_dark_oak_timber_frame",
+  "count": 4,
+  "intermediate" : "minecraft:air",
+  "must-exist" : true
+}

--- a/src/main/resources/data/minecolonies/crafterrecipes/sawmill/spruce_jungle_timber_frame.json
+++ b/src/main/resources/data/minecolonies/crafterrecipes/sawmill/spruce_jungle_timber_frame.json
@@ -1,0 +1,60 @@
+{
+  "type" : "recipe",
+  "crafter": "sawmill",
+  "inputs": [
+    {
+        "item" : "minecraft:spruce_planks",
+        "count": 1
+    },
+    {
+        "item" : "minecraft:jungle_planks",
+        "count": 1
+    },
+    {
+        "item" : "structurize:sceptergold",
+        "count": 1
+    }
+  ],
+  "alternate-output" : [
+    {
+        "item" : "structurize:double_crossed_spruce_jungle_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:framed_spruce_jungle_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:side_framed_spruce_jungle_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:up_gated_spruce_jungle_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:down_gated_spruce_jungle_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:one_crossed_lr_spruce_jungle_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:one_crossed_rl_spruce_jungle_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:horizontal_plain_spruce_jungle_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:side_framed_horizontal_spruce_jungle_timber_frame",
+        "count": 4
+    }
+  ],
+  "result": "structurize:plain_spruce_jungle_timber_frame",
+  "count": 4,
+  "intermediate" : "minecraft:air",
+  "must-exist" : true
+}

--- a/src/main/resources/data/minecolonies/crafterrecipes/sawmill/spruce_oak_timber_frame.json
+++ b/src/main/resources/data/minecolonies/crafterrecipes/sawmill/spruce_oak_timber_frame.json
@@ -1,0 +1,60 @@
+{
+  "type" : "recipe",
+  "crafter": "sawmill",
+  "inputs": [
+    {
+        "item" : "minecraft:spruce_planks",
+        "count": 1
+    },
+    {
+        "item" : "minecraft:oak_planks",
+        "count": 1
+    },
+    {
+        "item" : "structurize:sceptergold",
+        "count": 1
+    }
+  ],
+  "alternate-output" : [
+    {
+        "item" : "structurize:double_crossed_spruce_oak_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:framed_spruce_oak_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:side_framed_spruce_oak_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:up_gated_spruce_oak_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:down_gated_spruce_oak_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:one_crossed_lr_spruce_oak_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:one_crossed_rl_spruce_oak_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:horizontal_plain_spruce_oak_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:side_framed_horizontal_spruce_oak_timber_frame",
+        "count": 4
+    }
+  ],
+  "result": "structurize:plain_spruce_oak_timber_frame",
+  "count": 4,
+  "intermediate" : "minecraft:air",
+  "must-exist" : true
+}

--- a/src/main/resources/data/minecolonies/crafterrecipes/sawmill/spruce_paper_timber_frame.json
+++ b/src/main/resources/data/minecolonies/crafterrecipes/sawmill/spruce_paper_timber_frame.json
@@ -1,0 +1,60 @@
+{
+  "type" : "recipe",
+  "crafter": "sawmill",
+  "inputs": [
+    {
+        "item" : "minecraft:spruce_planks",
+        "count": 1
+    },
+    {
+        "item" : "minecraft:paper",
+        "count": 1
+    },
+    {
+        "item" : "structurize:sceptergold",
+        "count": 1
+    }
+  ],
+  "alternate-output" : [
+    {
+        "item" : "structurize:double_crossed_spruce_paper_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:framed_spruce_paper_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:side_framed_spruce_paper_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:up_gated_spruce_paper_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:down_gated_spruce_paper_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:one_crossed_lr_spruce_paper_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:one_crossed_rl_spruce_paper_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:horizontal_plain_spruce_paper_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:side_framed_horizontal_spruce_paper_timber_frame",
+        "count": 4
+    }
+  ],
+  "result": "structurize:plain_spruce_paper_timber_frame",
+  "count": 4,
+  "intermediate" : "minecraft:air",
+  "must-exist" : true
+}

--- a/src/main/resources/data/minecolonies/crafterrecipes/sawmill/spruce_spruce_timber_frame.json
+++ b/src/main/resources/data/minecolonies/crafterrecipes/sawmill/spruce_spruce_timber_frame.json
@@ -1,0 +1,60 @@
+{
+  "type" : "recipe",
+  "crafter": "sawmill",
+  "inputs": [
+    {
+        "item" : "minecraft:spruce_planks",
+        "count": 1
+    },
+    {
+        "item" : "minecraft:spruce_planks",
+        "count": 1
+    },
+    {
+        "item" : "structurize:sceptergold",
+        "count": 1
+    }
+  ],
+  "alternate-output" : [
+    {
+        "item" : "structurize:double_crossed_spruce_spruce_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:framed_spruce_spruce_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:side_framed_spruce_spruce_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:up_gated_spruce_spruce_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:down_gated_spruce_spruce_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:one_crossed_lr_spruce_spruce_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:one_crossed_rl_spruce_spruce_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:horizontal_plain_spruce_spruce_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:side_framed_horizontal_spruce_spruce_timber_frame",
+        "count": 4
+    }
+  ],
+  "result": "structurize:plain_spruce_spruce_timber_frame",
+  "count": 4,
+  "intermediate" : "minecraft:air",
+  "must-exist" : true
+}

--- a/src/main/resources/data/minecolonies/crafterrecipes/sawmill/spruce_stone_timber_frame.json
+++ b/src/main/resources/data/minecolonies/crafterrecipes/sawmill/spruce_stone_timber_frame.json
@@ -1,0 +1,60 @@
+{
+  "type" : "recipe",
+  "crafter": "sawmill",
+  "inputs": [
+    {
+        "item" : "minecraft:spruce_planks",
+        "count": 1
+    },
+    {
+        "item" : "minecraft:stone",
+        "count": 1
+    },
+    {
+        "item" : "structurize:sceptergold",
+        "count": 1
+    }
+  ],
+  "alternate-output" : [
+    {
+        "item" : "structurize:double_crossed_spruce_stone_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:framed_spruce_stone_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:side_framed_spruce_stone_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:up_gated_spruce_stone_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:down_gated_spruce_stone_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:one_crossed_lr_spruce_stone_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:one_crossed_rl_spruce_stone_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:horizontal_plain_spruce_stone_timber_frame",
+        "count": 4
+    },
+    {
+        "item" : "structurize:side_framed_horizontal_spruce_stone_timber_frame",
+        "count": 4
+    }
+  ],
+  "result": "structurize:plain_spruce_stone_timber_frame",
+  "count": 4,
+  "intermediate" : "minecraft:air",
+  "must-exist" : true
+}


### PR DESCRIPTION
# Changes proposed in this pull request:
- Add support for multi-output recipes, so that one recipe can create all variants of one timber block
- Add support for custom recipes to require that the recipe 'exists' to be valid
  - This enables a multi-output recipe to replace a classic recipe in which the inputs match
  - When a multi-output replaces, it also looks for classic recipes who have outputs that are alternate in the multi-recipe and removes them
- Add support for multi-recipes to cycle through the outputs in the recipe list in buildings
- Add ability to capture actual secondary outputs (stay in grid) from recipes as they are being taught, This increases compatibility with many mod recipes, including aquaculture fish fillets.
- Some minor tweaks to display of the request tree in buildings, to make crafting jobs a bit clearer
- Fix Combat Academy and Archery to mark beds as unoccupied on wake up, letting the residents sleep the next night
- use Localizable strings for Combat Academy and Archery
- Ensure that multi recipes replace simple recipes, and that they update when they change
- Change all of the lumberjack recipes to be multi-recipes. They are now Log -> [Stripped Log, Wood, Stripped Wood]

Review please
