### PR TITLE
Serveral fixes

### DIFF
--- a/src/api/java/com/minecolonies/api/entity/ModEntities.java
+++ b/src/api/java/com/minecolonies/api/entity/ModEntities.java
@@ -11,6 +11,7 @@ import net.minecraft.entity.CreatureEntity;
 import net.minecraft.entity.Entity;
 import net.minecraft.entity.EntityType;
 import net.minecraft.entity.projectile.AbstractArrowEntity;
+import net.minecraft.entity.projectile.ArrowEntity;
 import net.minecraftforge.registries.ObjectHolder;
 
 @ObjectHolder(Constants.MOD_ID)
@@ -78,4 +79,6 @@ public class ModEntities
 
     @ObjectHolder("firearrow")
     public static EntityType<? extends AbstractArrowEntity> FIREARROW;
+
+    public static EntityType<? extends ArrowEntity> MC_NORMAL_ARROW;
 }

--- a/src/api/java/com/minecolonies/api/util/constant/RaiderConstants.java
+++ b/src/api/java/com/minecolonies/api/util/constant/RaiderConstants.java
@@ -89,10 +89,10 @@ public final class RaiderConstants
      */
     public static final double FOLLOW_RANGE                = 35.0D;
     public static final double MOVEMENT_SPEED              = 0.25D;
-    public static final double ARMOR                       = 2D;
+    public static final double ARMOR                       = 1D;
     public static final double CHIEF_BONUS_ARMOR           = 2D;
     public static final double BARBARIAN_BASE_HEALTH       = 10;
-    public static final double BARBARIAN_HEALTH_MULTIPLIER = 0.05;
+    public static final double BARBARIAN_HEALTH_MULTIPLIER = 0.025;
     public static final double ATTACK_SPEED_DIVIDER        = 3;
 
     /**

--- a/src/main/java/com/minecolonies/apiimp/initializer/EntityInitializer.java
+++ b/src/main/java/com/minecolonies/apiimp/initializer/EntityInitializer.java
@@ -3,6 +3,7 @@ package com.minecolonies.apiimp.initializer;
 import com.minecolonies.api.entity.MinecoloniesMinecart;
 import com.minecolonies.api.entity.ModEntities;
 import com.minecolonies.api.util.constant.Constants;
+import com.minecolonies.coremod.entity.CustomArrowEntity;
 import com.minecolonies.coremod.entity.FireArrowEntity;
 import com.minecolonies.coremod.entity.NewBobberEntity;
 import com.minecolonies.coremod.entity.SittingEntity;
@@ -154,7 +155,7 @@ public class EntityInitializer
             .setShouldReceiveVelocityUpdates(true));
 
         ModEntities.MC_NORMAL_ARROW = build("mcnormalarrow",
-          EntityType.Builder.create(FireArrowEntity::new, EntityClassification.MISC)
+          EntityType.Builder.create(CustomArrowEntity::new, EntityClassification.MISC)
             .setTrackingRange(ENTITY_TRACKING_RANGE)
             .setUpdateInterval(ENTITY_UPDATE_FREQUENCY_FISHHOOK)
             .size(0.5F, 0.5F)

--- a/src/main/java/com/minecolonies/apiimp/initializer/EntityInitializer.java
+++ b/src/main/java/com/minecolonies/apiimp/initializer/EntityInitializer.java
@@ -153,6 +153,13 @@ public class EntityInitializer
             .size(0.5F, 0.5F)
             .setShouldReceiveVelocityUpdates(true));
 
+        ModEntities.MC_NORMAL_ARROW = build("mcnormalarrow",
+          EntityType.Builder.create(FireArrowEntity::new, EntityClassification.MISC)
+            .setTrackingRange(ENTITY_TRACKING_RANGE)
+            .setUpdateInterval(ENTITY_UPDATE_FREQUENCY_FISHHOOK)
+            .size(0.5F, 0.5F)
+            .setShouldReceiveVelocityUpdates(true));
+
         ModEntities.SHIELDMAIDEN = build("shieldmaiden",
           EntityType.Builder.create(EntityShieldmaiden::new, EntityClassification.MONSTER)
             .setTrackingRange(ENTITY_TRACKING_RANGE)
@@ -202,6 +209,7 @@ public class EntityInitializer
             ModEntities.AMAZON,
             ModEntities.AMAZONCHIEF,
             ModEntities.FIREARROW,
+            ModEntities.MC_NORMAL_ARROW,
             ModEntities.SHIELDMAIDEN,
             ModEntities.NORSEMEN_ARCHER,
             ModEntities.NORSEMEN_CHIEF);

--- a/src/main/java/com/minecolonies/coremod/MineColonies.java
+++ b/src/main/java/com/minecolonies/coremod/MineColonies.java
@@ -42,6 +42,7 @@ import com.minecolonies.coremod.research.ResearchInitializer;
 import net.minecraft.client.renderer.RenderType;
 import net.minecraft.client.renderer.RenderTypeLookup;
 import net.minecraft.client.renderer.entity.MinecartRenderer;
+import net.minecraft.client.renderer.entity.TippedArrowRenderer;
 import net.minecraft.client.renderer.texture.AtlasTexture;
 import net.minecraft.util.ResourceLocation;
 import net.minecraft.util.SoundEvent;
@@ -175,6 +176,7 @@ public class MineColonies
         RenderingRegistry.registerEntityRenderingHandler(ModEntities.VISITOR, RenderBipedCitizen::new);
         RenderingRegistry.registerEntityRenderingHandler(ModEntities.FISHHOOK, RenderFishHook::new);
         RenderingRegistry.registerEntityRenderingHandler(ModEntities.FIREARROW, FireArrowRenderer::new);
+        RenderingRegistry.registerEntityRenderingHandler(ModEntities.MC_NORMAL_ARROW, TippedArrowRenderer::new);
 
         RenderingRegistry.registerEntityRenderingHandler(ModEntities.BARBARIAN, RendererBarbarian::new);
         RenderingRegistry.registerEntityRenderingHandler(ModEntities.ARCHERBARBARIAN, RendererBarbarian::new);

--- a/src/main/java/com/minecolonies/coremod/colony/colonyEvents/raidEvents/HordeRaidEvent.java
+++ b/src/main/java/com/minecolonies/coremod/colony/colonyEvents/raidEvents/HordeRaidEvent.java
@@ -34,9 +34,9 @@ import org.jetbrains.annotations.NotNull;
 
 import java.util.*;
 
-import static com.minecolonies.api.util.constant.NbtTagConstants.*;
 import static com.minecolonies.api.util.constant.ColonyConstants.SMALL_HORDE_SIZE;
 import static com.minecolonies.api.util.constant.Constants.TAG_COMPOUND;
+import static com.minecolonies.api.util.constant.NbtTagConstants.*;
 import static com.minecolonies.api.util.constant.TranslationConstants.*;
 import static com.minecolonies.coremod.colony.colonyEvents.raidEvents.pirateEvent.PirateRaidEvent.TAG_DAYS_LEFT;
 
@@ -259,7 +259,10 @@ public abstract class HordeRaidEvent implements IColonyRaidEvent, IColonyCampFir
         raidBar.setVisible(false);
         raidBar.removeAllPlayers();
 
-        colony.getRaiderManager().setNightsSinceLastRaid(0);
+        if (horde.hordeSize > 0)
+        {
+            LanguageHandler.sendPlayersMessage(colony.getImportantMessageEntityPlayers(), ALL_BARBARIANS_KILLED_MESSAGE);
+        }
     }
 
     @Override
@@ -391,6 +394,11 @@ public abstract class HordeRaidEvent implements IColonyRaidEvent, IColonyCampFir
             {
                 spawnHorde(spawnPos, colony, id, horde.numberOfBosses - boss.size(), horde.numberOfArchers - archers.size(), horde.numberOfRaiders - normal.size());
             }
+        }
+
+        if (horde.numberOfBosses + horde.numberOfRaiders + horde.numberOfArchers < horde.initialSize * 0.05)
+        {
+            status = EventStatus.DONE;
         }
 
         for (final Entity entity : getEntities())

--- a/src/main/java/com/minecolonies/coremod/colony/managers/RaidManager.java
+++ b/src/main/java/com/minecolonies/coremod/colony/managers/RaidManager.java
@@ -51,7 +51,7 @@ public class RaidManager implements IRaiderManager
     /**
      * Spawn modifier to decrease the spawn-rate.
      */
-    public static final double SPAWN_MODIFIER = 50;
+    public static final double SPAWN_MODIFIER = 60;
 
     /**
      * Min distance to keep while spawning near buildings
@@ -636,7 +636,7 @@ public class RaidManager implements IRaiderManager
 
         for (final IBuilding building : colony.getBuildingManager().getBuildings().values())
         {
-            levels += building.getBuildingLevel() * building.getBuildingLevel();
+            levels += building.getBuildingLevel() * 2;
         }
 
         return levels;

--- a/src/main/java/com/minecolonies/coremod/entity/CustomArrowEntity.java
+++ b/src/main/java/com/minecolonies/coremod/entity/CustomArrowEntity.java
@@ -1,0 +1,54 @@
+package com.minecolonies.coremod.entity;
+
+import net.minecraft.entity.EntityType;
+import net.minecraft.entity.LivingEntity;
+import net.minecraft.entity.projectile.ArrowEntity;
+import net.minecraft.util.math.EntityRayTraceResult;
+import net.minecraft.world.World;
+
+/**
+ * Custom arrow entity class which remove themselves when on the ground for a bit to not cause lag and they do not scale in damage with their motion.
+ */
+public class CustomArrowEntity extends ArrowEntity
+{
+    public CustomArrowEntity(final EntityType<? extends ArrowEntity> type, final World world)
+    {
+        super(type, world);
+    }
+
+    @Override
+    protected void arrowHit(LivingEntity target)
+    {
+        // TODO add enderman damage hit research here not that this is also used by mobs so check the shooter
+        super.arrowHit(target);
+    }
+
+    @Override
+    protected void onEntityHit(EntityRayTraceResult traceResult)
+    {
+        final double prevDamage = getDamage();
+
+        // Reduce damage by motion before vanilla increases it by the same factor, so our damage stays.
+        float f = (float) this.getMotion().length();
+        if (f != 0)
+        {
+            setDamage(prevDamage / f);
+        }
+
+        super.onEntityHit(traceResult);
+
+        // Set the old actual damage value back
+        setDamage(prevDamage);
+    }
+
+    @Override
+    public void tick()
+    {
+        super.tick();
+
+        if (this.timeInGround > 10)
+        {
+            remove();
+        }
+    }
+}

--- a/src/main/java/com/minecolonies/coremod/entity/CustomArrowEntity.java
+++ b/src/main/java/com/minecolonies/coremod/entity/CustomArrowEntity.java
@@ -3,14 +3,22 @@ package com.minecolonies.coremod.entity;
 import net.minecraft.entity.EntityType;
 import net.minecraft.entity.LivingEntity;
 import net.minecraft.entity.projectile.ArrowEntity;
+import net.minecraft.network.IPacket;
 import net.minecraft.util.math.EntityRayTraceResult;
 import net.minecraft.world.World;
+import net.minecraftforge.fml.network.NetworkHooks;
+import org.jetbrains.annotations.NotNull;
 
 /**
  * Custom arrow entity class which remove themselves when on the ground for a bit to not cause lag and they do not scale in damage with their motion.
  */
 public class CustomArrowEntity extends ArrowEntity
 {
+    /**
+     * Max time the arrow is stuck before removing it
+     */
+    private static final int MAX_TIME_IN_GROUND = 10;
+
     public CustomArrowEntity(final EntityType<? extends ArrowEntity> type, final World world)
     {
         super(type, world);
@@ -21,6 +29,13 @@ public class CustomArrowEntity extends ArrowEntity
     {
         // TODO add enderman damage hit research here not that this is also used by mobs so check the shooter
         super.arrowHit(target);
+    }
+
+    @Override
+    @NotNull
+    public IPacket<?> createSpawnPacket()
+    {
+        return NetworkHooks.getEntitySpawningPacket(this);
     }
 
     @Override
@@ -46,7 +61,7 @@ public class CustomArrowEntity extends ArrowEntity
     {
         super.tick();
 
-        if (this.timeInGround > 10)
+        if (this.timeInGround > MAX_TIME_IN_GROUND)
         {
             remove();
         }

--- a/src/main/java/com/minecolonies/coremod/entity/FireArrowEntity.java
+++ b/src/main/java/com/minecolonies/coremod/entity/FireArrowEntity.java
@@ -3,7 +3,7 @@ package com.minecolonies.coremod.entity;
 import com.minecolonies.api.items.ModItems;
 import net.minecraft.entity.Entity;
 import net.minecraft.entity.EntityType;
-import net.minecraft.entity.projectile.AbstractArrowEntity;
+import net.minecraft.entity.projectile.ArrowEntity;
 import net.minecraft.item.ItemStack;
 import net.minecraft.network.IPacket;
 import net.minecraft.world.World;
@@ -15,9 +15,9 @@ import javax.annotation.Nullable;
 /**
  * Custom arrow entity for the fire arrows.
  */
-public class FireArrowEntity extends AbstractArrowEntity
+public class FireArrowEntity extends CustomArrowEntity
 {
-    public FireArrowEntity(EntityType<? extends AbstractArrowEntity> entity, World world)
+    public FireArrowEntity(EntityType<? extends ArrowEntity> entity, World world)
     {
         super(entity, world);
     }

--- a/src/main/java/com/minecolonies/coremod/entity/FireArrowEntity.java
+++ b/src/main/java/com/minecolonies/coremod/entity/FireArrowEntity.java
@@ -5,9 +5,7 @@ import net.minecraft.entity.Entity;
 import net.minecraft.entity.EntityType;
 import net.minecraft.entity.projectile.ArrowEntity;
 import net.minecraft.item.ItemStack;
-import net.minecraft.network.IPacket;
 import net.minecraft.world.World;
-import net.minecraftforge.fml.network.NetworkHooks;
 import org.jetbrains.annotations.NotNull;
 
 import javax.annotation.Nullable;
@@ -20,13 +18,6 @@ public class FireArrowEntity extends CustomArrowEntity
     public FireArrowEntity(EntityType<? extends ArrowEntity> entity, World world)
     {
         super(entity, world);
-    }
-
-    @Override
-    @NotNull
-    public IPacket<?> createSpawnPacket()
-    {
-        return NetworkHooks.getEntitySpawningPacket(this);
     }
 
     @Override

--- a/src/main/java/com/minecolonies/coremod/entity/ai/citizen/guard/EntityAIRanger.java
+++ b/src/main/java/com/minecolonies/coremod/entity/ai/citizen/guard/EntityAIRanger.java
@@ -1,5 +1,6 @@
 package com.minecolonies.coremod.entity.ai.citizen.guard;
 
+import com.minecolonies.api.entity.ModEntities;
 import com.minecolonies.api.entity.ai.citizen.guards.GuardTask;
 import com.minecolonies.api.entity.ai.statemachine.AITarget;
 import com.minecolonies.api.entity.ai.statemachine.states.IAIState;
@@ -23,7 +24,6 @@ import com.minecolonies.coremod.research.MultiplierModifierResearchEffect;
 import com.minecolonies.coremod.research.UnlockAbilityResearchEffect;
 import net.minecraft.enchantment.EnchantmentHelper;
 import net.minecraft.enchantment.Enchantments;
-import net.minecraft.entity.EntityType;
 import net.minecraft.entity.MoverType;
 import net.minecraft.entity.projectile.ArrowEntity;
 import net.minecraft.item.ArrowItem;
@@ -353,7 +353,7 @@ public class EntityAIRanger extends AbstractEntityAIGuard<JobRanger, AbstractBui
 
                 for (int i = 0; i < amountOfArrows; i++)
                 {
-                    final ArrowEntity arrow = EntityType.ARROW.create(world);
+                    final ArrowEntity arrow = ModEntities.MC_NORMAL_ARROW.create(world);
                     arrow.setShooter(worker);
 
                     final UnlockAbilityResearchEffect arrowPierceEffect =

--- a/src/main/java/com/minecolonies/coremod/entity/ai/citizen/trainingcamps/EntityAIArcherTraining.java
+++ b/src/main/java/com/minecolonies/coremod/entity/ai/citizen/trainingcamps/EntityAIArcherTraining.java
@@ -1,5 +1,6 @@
 package com.minecolonies.coremod.entity.ai.citizen.trainingcamps;
 
+import com.minecolonies.api.entity.ModEntities;
 import com.minecolonies.api.entity.ai.statemachine.AITarget;
 import com.minecolonies.api.entity.ai.statemachine.states.IAIState;
 import com.minecolonies.api.entity.citizen.VisibleCitizenStatus;
@@ -10,7 +11,6 @@ import com.minecolonies.api.util.constant.ToolType;
 import com.minecolonies.coremod.colony.buildings.workerbuildings.BuildingArchery;
 import com.minecolonies.coremod.colony.jobs.JobArcherTraining;
 import com.minecolonies.coremod.util.WorkerUtil;
-import net.minecraft.entity.EntityType;
 import net.minecraft.entity.MoverType;
 import net.minecraft.entity.projectile.ArrowEntity;
 import net.minecraft.util.Hand;
@@ -163,7 +163,8 @@ public class EntityAIArcherTraining extends AbstractEntityAITraining<JobArcherTr
             WorkerUtil.faceBlock(currentShootingTarget, worker);
             worker.swingArm(Hand.MAIN_HAND);
 
-            final ArrowEntity arrow = EntityType.ARROW.create(world);
+            final ArrowEntity arrow = ModEntities.MC_NORMAL_ARROW.create(world);
+            arrow.setDamage(0);
             arrow.setShooter(worker);
             arrow.setPosition(worker.getPosX(), worker.getPosY() + 1, worker.getPosZ());
             final double xVector = currentShootingTarget.getX() - worker.getPosX();

--- a/src/main/java/com/minecolonies/coremod/entity/ai/registry/MobAIRegistry.java
+++ b/src/main/java/com/minecolonies/coremod/entity/ai/registry/MobAIRegistry.java
@@ -25,6 +25,8 @@ import java.util.function.Function;
 import java.util.function.Predicate;
 
 import static com.minecolonies.api.util.constant.RaiderConstants.*;
+import static com.minecolonies.coremod.entity.ai.minimal.EntityAIInteractToggleAble.FENCE_TOGGLE;
+import static com.minecolonies.coremod.entity.ai.minimal.EntityAIInteractToggleAble.TRAP_TOGGLE;
 
 public class MobAIRegistry implements IMobAIRegistry
 {
@@ -46,7 +48,7 @@ public class MobAIRegistry implements IMobAIRegistry
         registry
           .registerNewAiTaskForMobs(PRIORITY_ZERO, SwimGoal::new)
           .registerNewAiTaskForMobs(PRIORITY_FOUR, mob -> new EntityAIWalkToRandomHuts(mob, AI_MOVE_SPEED))
-          .registerNewAiTargetTaskForMobs(PRIORITY_THREE, mob -> new EntityAIInteractToggleAble(mob, EntityAIInteractToggleAble.GATE_TRAP))
+          .registerNewAiTargetTaskForMobs(PRIORITY_THREE, mob -> new EntityAIInteractToggleAble(mob, FENCE_TOGGLE, TRAP_TOGGLE))
           .registerNewAiTargetTaskForMobs(PRIORITY_THREE, mob -> new EntityAIBreakDoor(mob))
           .registerNewAiTargetTaskForMobs(PRIORITY_TWO, mob -> new NearestAttackableTargetGoal<>(mob, PlayerEntity.class, true, false))
           .registerNewAiTargetTaskForMobs(PRIORITY_THREE, mob -> new NearestAttackableTargetGoal<>(mob, EntityCitizen.class, true, false))

--- a/src/main/java/com/minecolonies/coremod/entity/citizen/EntityCitizen.java
+++ b/src/main/java/com/minecolonies/coremod/entity/citizen/EntityCitizen.java
@@ -96,6 +96,7 @@ import static com.minecolonies.api.util.constant.NbtTagConstants.*;
 import static com.minecolonies.api.util.constant.Suppression.INCREMENT_AND_DECREMENT_OPERATORS_SHOULD_NOT_BE_USED_IN_A_METHOD_CALL_OR_MIXED_WITH_OTHER_OPERATORS_IN_AN_EXPRESSION;
 import static com.minecolonies.api.util.constant.TranslationConstants.CITIZEN_RENAME_NOT_ALLOWED;
 import static com.minecolonies.api.util.constant.TranslationConstants.CITIZEN_RENAME_SAME;
+import static com.minecolonies.coremod.entity.ai.minimal.EntityAIInteractToggleAble.*;
 
 /**
  * The Class used to represent the citizen entities.
@@ -338,7 +339,7 @@ public class EntityCitizen extends AbstractEntityCitizen
         this.goalSelector.addGoal(++priority, new EntityAIEatTask(this));
         this.goalSelector.addGoal(++priority, new EntityAISickTask(this));
         this.goalSelector.addGoal(++priority, new EntityAISleep(this));
-        this.goalSelector.addGoal(priority, new EntityAIInteractToggleAble(this, EntityAIInteractToggleAble.GATE_DOOR_TRAP));
+        this.goalSelector.addGoal(priority, new EntityAIInteractToggleAble(this, FENCE_TOGGLE, TRAP_TOGGLE, DOOR_TOGGLE));
         this.goalSelector.addGoal(++priority, new LookAtWithoutMovingGoal(this, PlayerEntity.class, WATCH_CLOSEST2, 1.0F));
         this.goalSelector.addGoal(++priority, new LookAtWithoutMovingGoal(this, EntityCitizen.class, WATCH_CLOSEST2_FAR, WATCH_CLOSEST2_FAR_CHANCE));
         this.goalSelector.addGoal(++priority, new EntityAICitizenWander(this, DEFAULT_SPEED, 1.0D));

--- a/src/main/java/com/minecolonies/coremod/entity/citizen/VisitorCitizen.java
+++ b/src/main/java/com/minecolonies/coremod/entity/citizen/VisitorCitizen.java
@@ -51,6 +51,7 @@ import org.jetbrains.annotations.Nullable;
 import static com.minecolonies.api.util.constant.CitizenConstants.TICKS_20;
 import static com.minecolonies.api.util.constant.Constants.*;
 import static com.minecolonies.api.util.constant.NbtTagConstants.*;
+import static com.minecolonies.coremod.entity.ai.minimal.EntityAIInteractToggleAble.*;
 
 /**
  * Visitor citizen entity
@@ -155,7 +156,7 @@ public class VisitorCitizen extends AbstractEntityCitizen
         int priority = 0;
         this.goalSelector.addGoal(priority, new SwimGoal(this));
         this.goalSelector.addGoal(++priority, new OpenDoorGoal(this, true));
-        this.goalSelector.addGoal(priority, new EntityAIInteractToggleAble(this, EntityAIInteractToggleAble.GATE_DOOR_TRAP));
+        this.goalSelector.addGoal(priority, new EntityAIInteractToggleAble(this, FENCE_TOGGLE, TRAP_TOGGLE, DOOR_TOGGLE));
         this.goalSelector.addGoal(++priority, new LookAtWithoutMovingGoal(this, PlayerEntity.class, WATCH_CLOSEST2, 1.0F));
         this.goalSelector.addGoal(++priority, new LookAtWithoutMovingGoal(this, EntityCitizen.class, WATCH_CLOSEST2_FAR, WATCH_CLOSEST2_FAR_CHANCE));
         this.goalSelector.addGoal(++priority, new LookAtGoal(this, LivingEntity.class, WATCH_CLOSEST));

--- a/src/main/java/com/minecolonies/coremod/entity/mobs/EntityMercenary.java
+++ b/src/main/java/com/minecolonies/coremod/entity/mobs/EntityMercenary.java
@@ -52,6 +52,7 @@ import static com.minecolonies.api.util.constant.Constants.TICKS_FOURTY_MIN;
 import static com.minecolonies.api.util.constant.NbtTagConstants.TAG_COLONY_ID;
 import static com.minecolonies.api.util.constant.NbtTagConstants.TAG_TIME;
 import static com.minecolonies.api.util.constant.RaiderConstants.FOLLOW_RANGE;
+import static com.minecolonies.coremod.entity.ai.minimal.EntityAIInteractToggleAble.*;
 
 /**
  * Class for Mercenary entities, which can be spawned to protect the colony
@@ -134,7 +135,7 @@ public class EntityMercenary extends CreatureEntity implements INPC, IColonyRela
         this.targetSelector = new CustomGoalSelector(this.targetSelector);
         this.goalSelector.addGoal(0, new SwimGoal(this));
         this.goalSelector.addGoal(1, new EntityMercenaryAI(this));
-        this.goalSelector.addGoal(4, new EntityAIInteractToggleAble(this, EntityAIInteractToggleAble.GATE_DOOR_TRAP));
+        this.goalSelector.addGoal(4, new EntityAIInteractToggleAble(this, FENCE_TOGGLE, TRAP_TOGGLE, DOOR_TOGGLE));
         this.targetSelector.addGoal(5, new NearestAttackableTargetGoal<>(this, MonsterEntity.class, 10, true, false, e -> e instanceof IMob && !(e instanceof LlamaEntity)));
 
         this.forceSpawn = true;

--- a/src/main/java/com/minecolonies/coremod/entity/mobs/aitasks/EntityAIAttackArcher.java
+++ b/src/main/java/com/minecolonies/coremod/entity/mobs/aitasks/EntityAIAttackArcher.java
@@ -1,10 +1,10 @@
 package com.minecolonies.coremod.entity.mobs.aitasks;
 
+import com.minecolonies.api.entity.ModEntities;
 import com.minecolonies.api.entity.mobs.AbstractEntityMinecoloniesMob;
 import com.minecolonies.api.util.CompatibilityUtils;
 import com.minecolonies.api.util.EntityUtils;
 import com.minecolonies.coremod.MineColonies;
-import net.minecraft.entity.EntityType;
 import net.minecraft.entity.LivingEntity;
 import net.minecraft.entity.ai.goal.Goal;
 import net.minecraft.entity.projectile.AbstractArrowEntity;
@@ -128,7 +128,7 @@ public class EntityAIAttackArcher extends Goal
 
             if (lastAttack <= 0 && entity.canEntityBeSeen(target))
             {
-                AbstractArrowEntity arrowEntity = EntityType.ARROW.create(target.world);
+                AbstractArrowEntity arrowEntity = ModEntities.MC_NORMAL_ARROW.create(target.world);
                 arrowEntity.setShooter(entity);
 
                 final ItemStack bow = entity.getHeldItem(Hand.MAIN_HAND);

--- a/src/main/java/com/minecolonies/coremod/entity/pathfinding/pathjobs/PathJobWalkRandomEdge.java
+++ b/src/main/java/com/minecolonies/coremod/entity/pathfinding/pathjobs/PathJobWalkRandomEdge.java
@@ -21,7 +21,7 @@ public class PathJobWalkRandomEdge extends AbstractPathJob
       final World world,
       @NotNull final BlockPos start, final int range, final LivingEntity entity)
     {
-        super(world, start, start, range, entity);
+        super(world, AbstractPathJob.prepareStart(entity), start, range, entity);
     }
 
     @Override

--- a/src/main/java/com/minecolonies/coremod/event/EventHandler.java
+++ b/src/main/java/com/minecolonies/coremod/event/EventHandler.java
@@ -80,7 +80,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
-import static com.minecolonies.api.util.constant.NbtTagConstants.*;
+import static com.minecolonies.api.util.constant.NbtTagConstants.TAG_COLONY_ID;
+import static com.minecolonies.api.util.constant.NbtTagConstants.TAG_EVENT_ID;
 import static com.minecolonies.api.util.constant.TranslationConstants.CANT_PLACE_COLONY_IN_OTHER_DIM;
 import static com.minecolonies.coremod.MineColonies.CLOSE_COLONY_CAP;
 import static net.minecraftforge.eventbus.api.EventPriority.HIGHEST;
@@ -112,7 +113,8 @@ public class EventHandler
     {
         if (!event.getWorld().isRemote)
         {
-            if (MineColonies.getConfig().getCommon().mobAttackCitizens.get() && (event.getEntity() instanceof IMob) && !(event.getEntity() instanceof LlamaEntity) && !(event.getEntity() instanceof EndermanEntity))
+            if (MineColonies.getConfig().getCommon().mobAttackCitizens.get() && (event.getEntity() instanceof IMob) && !(event.getEntity() instanceof LlamaEntity)
+                  && !(event.getEntity() instanceof EndermanEntity))
             {
                 ((MobEntity) event.getEntity()).targetSelector.addGoal(6, new NearestAttackableTargetGoal<>((MobEntity) event.getEntity(), EntityCitizen.class, true));
                 ((MobEntity) event.getEntity()).targetSelector.addGoal(7, new NearestAttackableTargetGoal<>((MobEntity) event.getEntity(), EntityMercenary.class, true));
@@ -323,10 +325,13 @@ public class EventHandler
                     oldColony.removeVisitingPlayer(player);
                     oldColony.getPackageManager().removeCloseSubscriber(player);
                 }
+            }
 
-                // Add visiting/subscriber to new colony
+            // Add visiting/subscriber to new colony
+            if (newCloseColonies.getOwningColony() != 0)
+            {
                 final IColony newColony = IColonyManager.getInstance().getColonyByWorld(newCloseColonies.getOwningColony(), world);
-                if (newColony != null)
+                if (newColony != null && !newColony.getPackageManager().getCloseSubscribers().contains(player))
                 {
                     newColony.addVisitingPlayer(player);
                     newColony.getPackageManager().addCloseSubscriber(player);


### PR DESCRIPTION
Closes #5901
Closes #5929
Closes #5848

# Changes proposed in this pull request:
Adds Custom arrows for our entities, which do not scale in damage with movement and despawn quickly after beeing on the ground for a bit, avoiding fps lag from large battles with thousands of arrows.

Some raid balancing:
Raiders now have less armor and scale less in health
Colonies raidlevel grows more linearly than before and is a bit lower.
When less than 5% of raiders remain the raids now automatically end.

Fixes:
Training archers no longer deal damage when shooting
ToggleAI no longer toggles single blocks on doors and instead uses the doors own toggle functionality
Raiders no longer accidentally toggle doors
Fix guarding guards "Jiggling" because they didnt fix up their starting position for pathing
Fix pathing starting positions, now it checks for an existing collision box and if the citizen is actually within it so that e.g. standing next to a Trapdoor no longer assumes a pathing node above the trapdoor. Before it used entity positions which can vary too much, and caused some cases where citizens get stuck.
Fix players not always beeing added to the colony view subs after dim changes, they now check if they're added each time they enter a chunk claimed by a colony making it more resistant.

Review please
