### PR TITLE
Ignore consequences when visitors fall out of world

### DIFF
--- a/src/main/java/com/minecolonies/coremod/entity/citizen/VisitorCitizen.java
+++ b/src/main/java/com/minecolonies/coremod/entity/citizen/VisitorCitizen.java
@@ -660,6 +660,11 @@ public class VisitorCitizen extends AbstractEntityCitizen
             if (colony != null && getCitizenData() != null)
             {
                 colony.getVisitorManager().removeCivilian(getCitizenData());
+
+                if (cause == DamageSource.OUT_OF_WORLD) {
+                    return;
+                }
+
                 if (getCitizenData().getHomeBuilding() instanceof BuildingTavern)
                 {
                     BuildingTavern tavern = (BuildingTavern) getCitizenData().getHomeBuilding();


### PR DESCRIPTION
Quick fix for a problem I kept encountering. In singleplayer when I'm away from the colony, I'll often get messages saying all the visitors die from "outOfWorld". 

# Changes proposed in this pull request:
- When visitors fall out of the world (due to unloaded chunks, etc?), the consequences such as disabling visitors to your tavern and the death message sent to the player are ignored

Review please
