### PR TITLE
Track recipe usage by token in the recipe  manager

### DIFF
--- a/src/api/java/com/minecolonies/api/crafting/IRecipeManager.java
+++ b/src/api/java/com/minecolonies/api/crafting/IRecipeManager.java
@@ -42,6 +42,13 @@ public interface IRecipeManager
     IToken<?> getRecipeId(final IRecipeStorage storage);
 
     /**
+     * Register the recipe as used with the recipe manager
+     * 
+     * @param token the recipe token
+     */
+    void registerUse(final IToken<?> token);
+
+    /**
      * Write colonies to NBT data for saving.
      *
      * @param compound NBT-Tag.
@@ -54,4 +61,9 @@ public interface IRecipeManager
      * @param compound NBT Tag.
      */
     void read(@NotNull final CompoundNBT compound);
+
+    /**
+     * Clear the recipe list (used during shutdown)
+     */
+    void reset();
 }

--- a/src/main/java/com/minecolonies/coremod/colony/ColonyManager.java
+++ b/src/main/java/com/minecolonies/coremod/colony/ColonyManager.java
@@ -796,7 +796,9 @@ public final class ColonyManager implements IColonyManager
                 @Nullable final CompoundNBT data = BackUpHelper.loadNBTFromPath(file);
                 if (data != null)
                 {
+                    Log.getLogger().info("Loading Minecolonies Data");
                     read(data);
+                    Log.getLogger().info("Load Complete");
                 }
 
                 if (serverUUID == null)
@@ -858,6 +860,7 @@ public final class ColonyManager implements IColonyManager
             if (loaded)
             {
                 BackUpHelper.backupColonyData();
+                recipeManager.reset();
                 loaded = false;
             }
         }

--- a/src/main/java/com/minecolonies/coremod/colony/buildings/AbstractBuildingWorker.java
+++ b/src/main/java/com/minecolonies/coremod/colony/buildings/AbstractBuildingWorker.java
@@ -555,6 +555,7 @@ public abstract class AbstractBuildingWorker extends AbstractBuilding implements
             if (!recipes.contains(token))
             {
                 recipes.add(token);
+                IColonyManager.getInstance().getRecipeManager().registerUse(token);
             }
         }
     }

--- a/src/main/java/com/minecolonies/coremod/colony/requestsystem/management/manager/StandardRecipeManager.java
+++ b/src/main/java/com/minecolonies/coremod/colony/requestsystem/management/manager/StandardRecipeManager.java
@@ -53,11 +53,8 @@ public class StandardRecipeManager implements IRecipeManager
     public IToken<?> addRecipe(final IRecipeStorage storage)
     {
         recipes.put(storage.getToken(), storage);
+        usedRecipes.add(storage.getToken());
         cache = null;
-        if(!usedRecipes.contains(storage.getToken()))
-        {
-            usedRecipes.add(storage.getToken());
-        }
         return storage.getToken();
     }
 
@@ -69,10 +66,7 @@ public class StandardRecipeManager implements IRecipeManager
         {
             return addRecipe(storage);
         }
-        if (!usedRecipes.contains(token))
-        {
-            usedRecipes.add(token);
-        }
+        usedRecipes.add(token);
         return token;
     }
 
@@ -122,9 +116,6 @@ public class StandardRecipeManager implements IRecipeManager
     @Override
     public void registerUse(final IToken<?> token)
     {
-        if(!usedRecipes.contains(token))
-        {
-            usedRecipes.add(token);
-        }
+        usedRecipes.add(token);
     }
 }


### PR DESCRIPTION
# Changes proposed in this pull request:
This enables tracking of all recipes used in the world, and filters the global recipe store by what is used during save. 

This will help keep colony.dat storage down to just what is necessary. 

This also clears the recipe list on world unload, so that the recipe list doesn't bleed over between worlds when switching between single player worlds. 

Review please
