### PR TITLE
Misc. Crafter fixes

### DIFF
--- a/src/main/java/com/minecolonies/coremod/colony/buildings/workerbuildings/BuildingConcreteMixer.java
+++ b/src/main/java/com/minecolonies/coremod/colony/buildings/workerbuildings/BuildingConcreteMixer.java
@@ -16,7 +16,6 @@ import com.minecolonies.api.util.ItemStackUtils;
 import com.minecolonies.api.util.constant.ToolType;
 import com.minecolonies.api.util.constant.TypeConstants;
 import com.minecolonies.coremod.client.gui.WindowHutCrafter;
-import com.minecolonies.coremod.client.gui.WindowHutWorkerPlaceholder;
 import com.minecolonies.coremod.colony.buildings.AbstractBuildingCrafter;
 import com.minecolonies.coremod.colony.jobs.JobConcreteMixer;
 import com.minecolonies.coremod.research.ResearchInitializer;
@@ -68,12 +67,17 @@ public class BuildingConcreteMixer extends AbstractBuildingCrafter
     /**
      * How deep the water can max be to place concrete in it.
      */
-    private static final int WATER_DEPTH_SUPPORT = 3;
+    private static final int WATER_DEPTH_SUPPORT = 5;
 
     /**
      * Water position list.
      */
     private final Map<Integer, List<BlockPos>> waterPos = new HashMap<>();
+
+    /**
+     * The minimum found water level
+     */
+    private int minWaterLevel = WATER_DEPTH_SUPPORT;
 
     /**
      * Instantiates a new concrete mason building.
@@ -141,6 +145,7 @@ public class BuildingConcreteMixer extends AbstractBuildingCrafter
                     fluidPos.add(pos);
                 }
                 waterPos.put(blockState.getFluidState().getLevel(), fluidPos);
+                minWaterLevel = Math.min(minWaterLevel, blockState.getFluidState().getLevel());
             }
         }
 
@@ -182,6 +187,7 @@ public class BuildingConcreteMixer extends AbstractBuildingCrafter
         {
             final CompoundNBT waterCompound = waterMapList.getCompound(i);
             final int level = waterCompound.getInt(TAG_LEVEL);
+            minWaterLevel = Math.min(minWaterLevel, level);
 
             final ListNBT waterTagList = waterCompound.getList(TAG_WATER, Constants.NBT.TAG_COMPOUND);
             final List<BlockPos> water = new ArrayList<>();
@@ -272,7 +278,7 @@ public class BuildingConcreteMixer extends AbstractBuildingCrafter
     @Nullable
     public BlockPos getBlockToMine()
     {
-        for (int i = 1; i <= WATER_DEPTH_SUPPORT; i++)
+        for (int i = 1; i <= minWaterLevel; i++)
         {
             for (final BlockPos pos : waterPos.getOrDefault(i, Collections.emptyList()))
             {
@@ -282,19 +288,19 @@ public class BuildingConcreteMixer extends AbstractBuildingCrafter
                 }
             }
         }
-
+        
         return null;
     }
 
     /**
-     * Check if there are open positions to mine.
+     * Check if there are open positions to place.
      *
      * @return the open position if so.
      */
     @Nullable
     public BlockPos getBlockToPlace()
     {
-        for (int i = 1; i <= WATER_DEPTH_SUPPORT; i++)
+        for (int i = 1; i <= minWaterLevel; i++)
         {
             for (final BlockPos pos : waterPos.getOrDefault(i, Collections.emptyList()))
             {
@@ -304,7 +310,7 @@ public class BuildingConcreteMixer extends AbstractBuildingCrafter
                 }
             }
         }
-
+ 
         return null;
     }
 
@@ -319,7 +325,7 @@ public class BuildingConcreteMixer extends AbstractBuildingCrafter
         int count = 0;
         if (primaryOutput.getItem() instanceof BlockItem)
         {
-            for (int i = 1; i <= WATER_DEPTH_SUPPORT; i++)
+            for (int i = 1; i <= minWaterLevel; i++)
             {
                 for (final BlockPos pos : waterPos.getOrDefault(i, Collections.emptyList()))
                 {

--- a/src/main/java/com/minecolonies/coremod/colony/buildings/workerbuildings/BuildingCook.java
+++ b/src/main/java/com/minecolonies/coremod/colony/buildings/workerbuildings/BuildingCook.java
@@ -305,6 +305,34 @@ public class BuildingCook extends AbstractBuildingSmelterCrafter
         return storage;
     }
 
+    /**
+     * Get the list of items that the assistant needs to craft the currently queued tasks
+     */
+    public Set<ItemStack> getAssistantItems()
+    {
+        final Set<ItemStack> recipeOutputs = new HashSet<>();
+        for (final ICitizenData citizen : getAssignedCitizen())
+        {
+            if (citizen.getJob() instanceof AbstractJobCrafter)
+            {
+                final List<IToken<?>> assignedTasks = citizen.getJob(AbstractJobCrafter.class).getAssignedTasks();
+                for (final IToken<?> taskToken : assignedTasks)
+                {
+                    final IRequest<? extends PublicCrafting> request = (IRequest<? extends PublicCrafting>) colony.getRequestManager().getRequestForToken(taskToken);
+                    final IRecipeStorage recipeStorage = getFirstRecipe(request.getRequest().getStack());
+                    if (recipeStorage != null)
+                    {
+                        for (final ItemStorage itemStorage : recipeStorage.getCleanedInput())
+                        {
+                            recipeOutputs.add(itemStorage.getItemStack());
+                        }
+                    }
+                }
+            }
+        }
+        return recipeOutputs;
+    }
+
     @Override
     public Map<Predicate<ItemStack>, Tuple<Integer, Boolean>> getRequiredItemsAndAmount()
     {

--- a/src/main/java/com/minecolonies/coremod/entity/ai/basic/AbstractEntityAIRequestSmelter.java
+++ b/src/main/java/com/minecolonies/coremod/entity/ai/basic/AbstractEntityAIRequestSmelter.java
@@ -75,11 +75,11 @@ public abstract class AbstractEntityAIRequestSmelter<J extends AbstractJobCrafte
           /*
            * Check if tasks should be executed.
            */
+          new AIEventTarget(AIBlockingEventType.STATE_BLOCKING, this::isFuelNeeded, this::checkFurnaceFuel, TICKS_SECOND * 10),
+          new AIEventTarget(AIBlockingEventType.EVENT, this::accelerateFurnaces, this::getState, TICKS_SECOND),
           new AITarget(START_USING_FURNACE, this::fillUpFurnace, TICKS_SECOND),
           new AITarget(RETRIEVING_END_PRODUCT_FROM_FURNACE, this::retrieveSmeltableFromFurnace, TICKS_SECOND),
-          new AITarget(ADD_FUEL_TO_FURNACE, this::addFuelToFurnace, TICKS_SECOND),
-          new AIEventTarget(AIBlockingEventType.STATE_BLOCKING, this::isFuelNeeded, this::checkFurnaceFuel, TICKS_SECOND),
-          new AIEventTarget(AIBlockingEventType.STATE_BLOCKING, this::accelerateFurnaces, TICKS_SECOND)
+          new AITarget(ADD_FUEL_TO_FURNACE, this::addFuelToFurnace, TICKS_SECOND)
         );
     }
 
@@ -198,7 +198,7 @@ public abstract class AbstractEntityAIRequestSmelter<J extends AbstractJobCrafte
     /**
      * Actually accelerate the furnaces
      */
-    private IAIState accelerateFurnaces()
+    private boolean accelerateFurnaces()
     {
         final int accelerationTicks = (worker.getCitizenData().getCitizenSkillHandler().getLevel(getOwnBuilding().getSecondarySkill()) / 10) * 2;
         final World world = getOwnBuilding().getColony().getWorld();
@@ -220,7 +220,7 @@ public abstract class AbstractEntityAIRequestSmelter<J extends AbstractJobCrafte
                 }
             }
         }
-        return getState();
+        return false;
     }
 
     /**
@@ -265,7 +265,8 @@ public abstract class AbstractEntityAIRequestSmelter<J extends AbstractJobCrafte
                 final FurnaceTileEntity furnace = (FurnaceTileEntity) entity;
                 if (!furnace.isBurning() && (hasSmeltableInFurnaceAndNoFuel(furnace) || hasNeitherFuelNorSmeltAble(furnace)) && currentRecipeStorage != null && currentRecipeStorage.getIntermediate() == Blocks.FURNACE) 
                 {
-                    return true;
+                    //We only want to return true if we're not already gathering materials.
+                    return getState() != GATHERING_REQUIRED_MATERIALS;
                 }
             }
         }

--- a/src/main/java/com/minecolonies/coremod/entity/ai/citizen/concrete/EntityAIConcreteMixer.java
+++ b/src/main/java/com/minecolonies/coremod/entity/ai/citizen/concrete/EntityAIConcreteMixer.java
@@ -72,7 +72,7 @@ public class EntityAIConcreteMixer extends AbstractEntityAICrafting<JobConcreteM
             return START_WORKING;
         }
 
-        if (walkToBuilding())
+        if (walkTo == null && walkToBuilding())
         {
             return START_WORKING;
         }
@@ -132,9 +132,10 @@ public class EntityAIConcreteMixer extends AbstractEntityAICrafting<JobConcreteM
             {
                 if (walkToBlock(posToPlace))
                 {
+                    walkTo = posToPlace;
                     return START_WORKING;
                 }
-
+                walkTo = null; 
                 if (InventoryUtils.attemptReduceStackInItemHandler(worker.getInventoryCitizen(), stack, 1))
                 {
                     world.setBlockState(posToPlace, block.getDefaultState().updatePostPlacement(Direction.DOWN, block.getDefaultState(), world, posToPlace, posToPlace), 0x03);
@@ -148,9 +149,10 @@ public class EntityAIConcreteMixer extends AbstractEntityAICrafting<JobConcreteM
         {
             if (walkToBlock(pos))
             {
+                walkTo = pos;
                 return START_WORKING;
             }
-
+            walkTo = null;
             if (mineBlock(pos))
             {
                 this.resetActionsDone();
@@ -185,7 +187,7 @@ public class EntityAIConcreteMixer extends AbstractEntityAICrafting<JobConcreteM
             return GET_RECIPE;
         }
 
-        if (walkToBuilding())
+        if (walkTo == null && walkToBuilding())
         {
             return getState();
         }


### PR DESCRIPTION
Closes #5948 

# Changes proposed in this pull request:
- Concrete Mixer now calculates better the right place to convert concrete powder to concrete
  - This fixes several styles, including birch and spacewars
  - This also surfaced a bug with not letting the walk to the mix point finish before walking to hut, blocking the transform to concrete. That is now fixed.
- Improve the logic that the cook uses to avoid things needed by the assistant.
  - This makes the assistant far more reliable in producing what is asked for. 
- Smelter crafters were waiting for all furnaces to quit burning before refueling. Tweaked the AI events to better handle this.

Review please
