### PR TITLE
Do Not Merge

### DIFF
--- a/src/api/java/com/minecolonies/api/configuration/CommonConfiguration.java
+++ b/src/api/java/com/minecolonies/api/configuration/CommonConfiguration.java
@@ -26,7 +26,7 @@ public class CommonConfiguration extends AbstractConfiguration
     public final ForgeConfigSpec.BooleanValue allowOtherDimColonies;
     public final ForgeConfigSpec.IntValue     citizenRespawnInterval;
     public final ForgeConfigSpec.IntValue     maxCitizenPerColony;
-    public final ForgeConfigSpec.BooleanValue builderInfiniteResources;
+    public final ForgeConfigSpec.IntValue     builderInfiniteResourcesLevel;
     public final ForgeConfigSpec.BooleanValue limitToOneWareHousePerColony;
     public final ForgeConfigSpec.IntValue     builderBuildBlockDelay;
     public final ForgeConfigSpec.IntValue     blockMiningDelayModifier;
@@ -385,7 +385,7 @@ public class CommonConfiguration extends AbstractConfiguration
         allowOtherDimColonies = defineBoolean(builder, "allowotherdimcolonies", false);
         citizenRespawnInterval = defineInteger(builder, "citizenrespawninterval", 60, CITIZEN_RESPAWN_INTERVAL_MIN, CITIZEN_RESPAWN_INTERVAL_MAX);
         maxCitizenPerColony = defineInteger(builder, "maxcitizenpercolony", 150, 4, 500);
-        builderInfiniteResources = defineBoolean(builder, "builderinfiniteresources", false);
+        builderInfiniteResourcesLevel = defineInteger(builder, "builderinfiniteresources",0,0,5);
         limitToOneWareHousePerColony = defineBoolean(builder, "limittoonewarehousepercolony", true);
         builderBuildBlockDelay = defineInteger(builder, "builderbuildblockdelay", 15, 1, 500);
         blockMiningDelayModifier = defineInteger(builder, "blockminingdelaymodifier", 500, 1, 10000);

--- a/src/main/java/com/minecolonies/coremod/entity/ai/basic/AbstractEntityAIStructureWithWorkOrder.java
+++ b/src/main/java/com/minecolonies/coremod/entity/ai/basic/AbstractEntityAIStructureWithWorkOrder.java
@@ -173,25 +173,25 @@ public abstract class AbstractEntityAIStructureWithWorkOrder<J extends AbstractJ
     /**
      * State for material requesting.
      */
-    private void requestMaterialsState()
-    {
-        if (MineColonies.getConfig().getCommon().builderInfiniteResources.get() || job.getWorkOrder().isRequested() || job.getWorkOrder() instanceof WorkOrderBuildRemoval)
-        {
+    private void requestMaterialsState() {
+        if (job.getWorkOrder().isRequested() || job.getWorkOrder() instanceof WorkOrderBuildRemoval) {
             return;
         }
+        final int currentUpgradeLevel = ((WorkOrderBuild) job.getWorkOrder()).getUpgradeLevel();
+        if (MineColonies.getConfig().getCommon().builderInfiniteResourcesLevel.get() <= currentUpgradeLevel) {
 
-        if (requestMaterials())
-        {
-            final AbstractBuildingStructureBuilder buildingWorker = getOwnBuilding();
-            job.getWorkOrder().setRequested(true);
+            if (requestMaterials()) {
+                final AbstractBuildingStructureBuilder buildingWorker = getOwnBuilding();
+                job.getWorkOrder().setRequested(true);
 
-            int newQuantity = buildingWorker.getNeededResources().values().stream().mapToInt(ItemStorage::getAmount).sum();
-            if (job.getWorkOrder().getAmountOfRes() == 0 || newQuantity > job.getWorkOrder().getAmountOfRes())
-            {
-                job.getWorkOrder().setAmountOfRes(newQuantity);
+                int newQuantity = buildingWorker.getNeededResources().values().stream().mapToInt(ItemStorage::getAmount).sum();
+                if (job.getWorkOrder().getAmountOfRes() == 0 || newQuantity > job.getWorkOrder().getAmountOfRes()) {
+                    job.getWorkOrder().setAmountOfRes(newQuantity);
+                }
             }
         }
     }
+
 
     @Override
     public boolean requestMaterials()

--- a/src/main/java/com/minecolonies/coremod/entity/ai/util/BuildingStructureHandler.java
+++ b/src/main/java/com/minecolonies/coremod/entity/ai/util/BuildingStructureHandler.java
@@ -257,7 +257,7 @@ public class BuildingStructureHandler<J extends AbstractJobStructure<?, J>, B ex
     @Override
     public boolean isCreative()
     {
-        return MineColonies.getConfig().getCommon().builderInfiniteResources.get();
+        return MineColonies.getConfig().getCommon().builderInfiniteResourcesLevel.get()==5;
     }
 
     @Override


### PR DESCRIPTION
A little stuck here. Config control is implemented, but I can't figure out how the request system would handle this. We want to autofill the request if the config is higher than the building's upgrade level, but I don't see how we were doing that before. Any pointers?
Addresses https://github.com/ldtteam/minecolonies-features/projects/1#card-42629540

# Changes proposed in this pull request:
-Create a graded config for the Builder Infinite Resources key
-Allow instance admins to control what level of free resources a building level gets. 
-

Review please
