### PR TITLE
Add formatting to AllInventory quantities

### DIFF
--- a/src/api/java/com/minecolonies/api/util/Utils.java
+++ b/src/api/java/com/minecolonies/api/util/Utils.java
@@ -6,15 +6,29 @@ import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.World;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
-
 import java.io.File;
+import java.util.NavigableMap;
 import java.util.Objects;
+import java.util.TreeMap;
+import java.util.Map.Entry;
 
 /**
  * General purpose utilities class. todo: split up into logically distinct parts
  */
 public final class Utils
 {
+    private static final NavigableMap<Long, String> suffixes = new TreeMap<> ();
+    
+    static
+    {
+    suffixes.put(1_000L, "k");
+    suffixes.put(1_000_000L, "M");
+    suffixes.put(1_000_000_000L, "G");
+    suffixes.put(1_000_000_000_000L, "T");
+    suffixes.put(1_000_000_000_000_000L, "P");
+    suffixes.put(1_000_000_000_000_000_000L, "E");
+    }
+
     /**
      * Private constructor to hide the implicit public one.
      */
@@ -216,5 +230,26 @@ public final class Utils
         {
             Log.getLogger().error("Directory doesn't exist and failed to be created: " + directory.toString());
         }
+    }
+    
+    /**
+     * Formats a long value into a abbreviated string, ie: 1000->1k, 1200->1.2k, 13000->13k
+     * @param value to format
+     * @return string version of the value
+     */
+    public static String format(long value)
+    {
+        //Long.MIN_VALUE == -Long.MIN_VALUE so we need an adjustment here
+        if (value == Long.MIN_VALUE) return format(Long.MIN_VALUE + 1);
+        if (value < 0) return "-" + format(-value);
+        if (value < 1000) return Long.toString(value); //deal with easy case
+
+        Entry<Long, String> e = suffixes.floorEntry(value);
+        Long divideBy = e.getKey();
+        String suffix = e.getValue();
+
+        long truncated = value / (divideBy / 10); //the number part of the output times 10
+        boolean hasDecimal = truncated < 100 && (truncated / 10d) != (truncated / 10);
+        return hasDecimal ? (truncated / 10d) + suffix : (truncated / 10) + suffix;
     }
 }

--- a/src/main/java/com/minecolonies/coremod/client/gui/WindowHutAllInventory.java
+++ b/src/main/java/com/minecolonies/coremod/client/gui/WindowHutAllInventory.java
@@ -1,22 +1,19 @@
 package com.minecolonies.coremod.client.gui;
 
-import com.google.common.collect.ImmutableCollection;
-import com.google.common.collect.ImmutableList;
 import com.ldtteam.blockout.Pane;
 import com.ldtteam.blockout.controls.*;
 import com.ldtteam.blockout.views.ScrollingList;
 import com.ldtteam.blockout.views.Window;
-import com.ldtteam.structurize.util.LanguageHandler;
 import com.minecolonies.api.colony.buildings.views.IBuildingView;
 import com.minecolonies.api.crafting.ItemStorage;
 import com.minecolonies.api.tileentities.TileEntityRack;
 import com.minecolonies.api.util.Tuple;
+import com.minecolonies.api.util.Utils;
 import com.minecolonies.api.util.constant.Constants;
 import com.minecolonies.coremod.colony.buildings.AbstractBuilding;
-import com.minecolonies.coremod.event.ClientEventHandler;
 import com.minecolonies.coremod.event.HighlightManager;
 import net.minecraft.client.Minecraft;
-import net.minecraft.client.gui.AbstractGui;
+import net.minecraft.client.gui.screen.Screen;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
 import net.minecraft.tileentity.TileEntity;
@@ -270,7 +267,14 @@ public class WindowHutAllInventory extends AbstractWindowSkeleton
                 final String name = resource.getItemStack().getDisplayName().getFormattedText();
                 resourceLabel.setLabelText(name.substring(0, Math.min(17, name.length())));
                 final Label qtys = rowPane.findPaneOfTypeByID("quantities", Label.class);
-                qtys.setLabelText(Integer.toString(resource.getAmount()));
+                if(!Screen.hasShiftDown())
+                {
+                    qtys.setLabelText(Utils.format(resource.getAmount()));
+                }
+                else
+                {
+                    qtys.setLabelText(Integer.toString(resource.getAmount()));
+                }
                 final Item imagesrc = resource.getItemStack().getItem();
                 final ItemStack image = new ItemStack(imagesrc, 1);
                 image.setTag(resource.getItemStack().getTag());


### PR DESCRIPTION
# Changes proposed in this pull request:
- Now in the allinventory display (chest in the lower corner of huts) numbers will display like 1.5k, 18k, etc. 

Review please
