### PR TITLE
Resource scroll improvements

### DIFF
--- a/src/api/java/com/minecolonies/api/util/constant/WindowConstants.java
+++ b/src/api/java/com/minecolonies/api/util/constant/WindowConstants.java
@@ -469,13 +469,15 @@ public final class WindowConstants
     public static final String RESOURCE_NAME               = "resourceName";
     public static final String RESOURCE_AVAILABLE_NEEDED   = "resourceAvailableNeeded";
     public static final String RESOURCE_MISSING            = "resourceMissing";
-    public static final String RESOURCE_ADD                = "resourceAdd";
-    public static final String RESOURCE_ID                 = "resourceId";
-    public static final String RESOURCE_QUANTITY_MISSING   = "resourceQuantity";
-    public static final String RESOURCE_ICON               = "resourceIcon";
-    public static final String STOCK_ADD                   = "addStock";
-    public static final String STOCK_REMOVE                = "removeStock";
-    public static final String QUANTITY_LABEL              = "resourceQty";
+    public static final String RESOURCE_ADD              = "resourceAdd";
+    public static final String RESOURCE_ID               = "resourceId";
+    public static final String RESOURCE_QUANTITY_MISSING = "resourceQuantity";
+    public static final String RESOURCE_ICON             = "resourceIcon";
+    public static final String STOCK_ADD                 = "addStock";
+    public static final String STOCK_REMOVE              = "removeStock";
+    public static final String QUANTITY_LABEL            = "resourceQty";
+    public static final String IN_DELIVERY_ICON          = "indeliveryicon";
+    public static final String IN_DELIVERY_AMOUNT        = "indeliveryamount";
 
     public static final String GUIDE_RESOURCE_SUFFIX = ":gui/windowhutguide.xml";
     public static final String GUIDE_CONFIRM         = "confirm";

--- a/src/main/java/com/minecolonies/coremod/client/gui/WindowResourceList.java
+++ b/src/main/java/com/minecolonies/coremod/client/gui/WindowResourceList.java
@@ -1,6 +1,9 @@
 package com.minecolonies.coremod.client.gui;
 
+import com.google.common.collect.ImmutableCollection;
+import com.google.common.collect.ImmutableList;
 import com.ldtteam.blockout.Pane;
+import com.ldtteam.blockout.controls.Image;
 import com.ldtteam.blockout.controls.ItemIcon;
 import com.ldtteam.blockout.controls.Label;
 import com.ldtteam.blockout.views.ScrollingList;
@@ -8,6 +11,9 @@ import com.ldtteam.structurize.util.LanguageHandler;
 import com.minecolonies.api.colony.IColonyManager;
 import com.minecolonies.api.colony.IColonyView;
 import com.minecolonies.api.colony.buildings.views.IBuildingView;
+import com.minecolonies.api.colony.requestsystem.request.IRequest;
+import com.minecolonies.api.colony.requestsystem.requestable.deliveryman.Delivery;
+import com.minecolonies.api.colony.requestsystem.token.IToken;
 import com.minecolonies.api.util.InventoryUtils;
 import com.minecolonies.api.util.ItemStackUtils;
 import com.minecolonies.api.util.constant.Constants;
@@ -25,10 +31,13 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
+import java.util.Map;
 
 import static com.minecolonies.api.util.constant.WindowConstants.*;
 import static com.minecolonies.coremod.client.gui.WindowHutBuilder.*;
+import static com.minecolonies.coremod.colony.buildings.utils.BuildingBuilderResource.RessourceAvailability.*;
 
 /**
  * Window for the resource list item.
@@ -80,6 +89,12 @@ public class WindowResourceList extends AbstractWindowSkeleton
             final PlayerInventory inventory = this.mc.player.inventory;
             final boolean isCreative = this.mc.player.isCreative();
 
+            final List<Delivery> deliveries = new ArrayList<>();
+            for (Map.Entry<Integer, Collection<IToken<?>>> entry : builder.getOpenRequestsByCitizen().entrySet())
+            {
+                addDeliveryRequestsToList(deliveries, ImmutableList.copyOf(entry.getValue()));
+            }
+
             resources.clear();
             resources.addAll(updatedView.getResources().values());
             for (final BuildingBuilderResource resource : resources)
@@ -96,9 +111,41 @@ public class WindowResourceList extends AbstractWindowSkeleton
                         stack -> !ItemStackUtils.isEmpty(stack) && stack.isItemEqual(resource.getItemStack()));
                 }
                 resource.setPlayerAmount(amountToSet);
+
+                resource.setAmountInDelivery(0);
+                for (final Delivery delivery : deliveries)
+                {
+                    if (ItemStackUtils.compareItemStacksIgnoreStackSize(resource.getItemStack(), delivery.getStack(), false, false))
+                    {
+                        resource.setAmountInDelivery(resource.getAmountInDelivery() + delivery.getStack().getCount());
+                    }
+                }
             }
 
-            resources.sort(new BuildingBuilderResource.ResourceComparator());
+            resources.sort(new BuildingBuilderResource.ResourceComparator(NOT_NEEDED, HAVE_ENOUGH, IN_DELIVERY, NEED_MORE, DONT_HAVE));
+        }
+    }
+
+    /**
+     * Adds the deliveries of the given tokens to the list
+     *
+     * @param requestList   list to add to
+     * @param tokensToCheck tokens to check
+     */
+    private void addDeliveryRequestsToList(final List<Delivery> requestList, final ImmutableCollection<IToken<?>> tokensToCheck)
+    {
+        for (final IToken<?> token : tokensToCheck)
+        {
+            final IRequest<?> request = builder.getColony().getRequestManager().getRequestForToken(token);
+            if (request.getRequest() instanceof Delivery && ((Delivery) request.getRequest()).getTarget().getInDimensionLocation().equals(builder.getID()))
+            {
+                requestList.add((Delivery) request.getRequest());
+            }
+
+            if (request.hasChildren())
+            {
+                addDeliveryRequestsToList(requestList, request.getChildren());
+            }
         }
     }
 
@@ -157,6 +204,12 @@ public class WindowResourceList extends AbstractWindowSkeleton
         final Label resourceLabel = rowPane.findPaneOfTypeByID(RESOURCE_NAME, Label.class);
         final Label resourceMissingLabel = rowPane.findPaneOfTypeByID(RESOURCE_MISSING, Label.class);
         final Label neededLabel = rowPane.findPaneOfTypeByID(RESOURCE_AVAILABLE_NEEDED, Label.class);
+
+        if (resource.getAmountInDelivery() > 0)
+        {
+            rowPane.findPaneOfTypeByID(IN_DELIVERY_ICON, Image.class).setVisible(true);
+            rowPane.findPaneOfTypeByID(IN_DELIVERY_AMOUNT, Label.class).setLabelText("" + resource.getAmountInDelivery());
+        }
 
         switch (resource.getAvailabilityStatus())
         {

--- a/src/main/java/com/minecolonies/coremod/colony/buildings/utils/BuildingBuilderResource.java
+++ b/src/main/java/com/minecolonies/coremod/colony/buildings/utils/BuildingBuilderResource.java
@@ -7,6 +7,8 @@ import org.jetbrains.annotations.NotNull;
 
 import java.io.Serializable;
 import java.util.Comparator;
+import java.util.HashMap;
+import java.util.Map;
 
 /**
  * Information about a resource. - How many are needed to finish the build - How many are available to the builder - How many are in the player's inventory (client side only)
@@ -15,6 +17,11 @@ public class BuildingBuilderResource extends ItemStorage
 {
     private int amountAvailable;
     private int amountPlayer;
+
+    /**
+     * The amount currently beeing delivered
+     */
+    private int amountInDelivery = 0;
 
     /**
      * Constructor for a resource but with available items.
@@ -91,10 +98,18 @@ public class BuildingBuilderResource extends ItemStorage
         {
             if (amountPlayer == 0)
             {
+                if (amountInDelivery > 0)
+                {
+                    return RessourceAvailability.IN_DELIVERY;
+                }
                 return RessourceAvailability.DONT_HAVE;
             }
             if (amountPlayer < (getAmount() - amountAvailable))
             {
+                if (amountInDelivery > 0)
+                {
+                    return RessourceAvailability.IN_DELIVERY;
+                }
                 return RessourceAvailability.NEED_MORE;
             }
             return RessourceAvailability.HAVE_ENOUGH;
@@ -163,12 +178,23 @@ public class BuildingBuilderResource extends ItemStorage
         amountPlayer = amount;
     }
 
+    public int getAmountInDelivery()
+    {
+        return amountInDelivery;
+    }
+
+    public void setAmountInDelivery(final int amountInDelivery)
+    {
+        this.amountInDelivery = amountInDelivery;
+    }
+
     /**
      * Availability status of the resource. according to the builder's chest, inventory and the player's inventory
      */
     public enum RessourceAvailability
     {
         NOT_NEEDED,
+        IN_DELIVERY,
         DONT_HAVE,
         NEED_MORE,
         HAVE_ENOUGH
@@ -181,7 +207,16 @@ public class BuildingBuilderResource extends ItemStorage
      */
     public static class ResourceComparator implements Comparator<BuildingBuilderResource>, Serializable
     {
-        private static final long serialVersionUID = 1;
+        private static final long                                serialVersionUID = 1;
+        private static final Map<RessourceAvailability, Integer> order            = new HashMap<>();
+
+        public ResourceComparator(final RessourceAvailability... resourceOrder)
+        {
+            for (int i = 0; i < resourceOrder.length; i++)
+            {
+                order.put(resourceOrder[i], i);
+            }
+        }
 
         /**
          * Compare to resource together.
@@ -194,6 +229,11 @@ public class BuildingBuilderResource extends ItemStorage
             if (resource1.getAvailabilityStatus() == resource2.getAvailabilityStatus())
             {
                 return resource1.getName().compareTo(resource2.getName());
+            }
+
+            if (!order.isEmpty())
+            {
+                return order.get(resource2.getAvailabilityStatus()).compareTo(order.get(resource1.getAvailabilityStatus()));
             }
 
             return resource2.getAvailabilityStatus().compareTo(resource1.getAvailabilityStatus());

--- a/src/main/resources/assets/minecolonies/gui/windowresourcescroll.xml
+++ b/src/main/resources/assets/minecolonies/gui/windowresourcescroll.xml
@@ -20,6 +20,8 @@
     <list id="resources" size="164 71%" pos="13 60">
         <box size="100% 30" linewidth="2">
             <itemicon id="resourceIcon" size="16 16" pos="1 1"/>
+            <image id="indeliveryicon" source="minecolonies:textures/gui/citizen/delivery_16x16.png" size="16 16" pos="120 12" visible="false"/>
+            <label id="indeliveryamount" size="100% 12" pos="140 15" textalign="MIDDLE_LEFT" color="green"/>
             <label id="resourceName" size="100 12" pos="20 3" textalign="MIDDLE_LEFT" color="black"/>
             <label id="resourceMissing" size="50 12" pos="2 18" textalign="MIDDLE_LEFT" color="black"/>
             <label id="resourceAvailableNeeded" size="100% 12" pos="0 18" textalign="MIDDLE" color="black"/>


### PR DESCRIPTION
# Changes proposed in this pull request:
Improved ordering of resource in the resource scroll, now the needed resources are ontop as opposed to previously the fullfillable ones were so it is easier to see what else is needed without scrolling down.
Added a display of currently delivered resources as an icon indicator with amount.

![image](https://user-images.githubusercontent.com/38401808/97423369-67b43800-190f-11eb-8bd6-f27aa4d3ddb0.png)


Review please
