### PR TITLE
Fix speed modifiers, fix raider damage scaling

### DIFF
--- a/src/api/java/com/minecolonies/api/entity/mobs/RaiderMobUtils.java
+++ b/src/api/java/com/minecolonies/api/entity/mobs/RaiderMobUtils.java
@@ -84,7 +84,7 @@ public final class RaiderMobUtils
      */
     public static void setMobAttributes(final AbstractEntityMinecoloniesMob mob, final IColony colony)
     {
-        final double difficultyModifier = 5.4;
+        final double difficultyModifier = colony.getRaiderManager().getRaidDifficultyModifier();
         mob.getAttribute(SharedMonsterAttributes.FOLLOW_RANGE).setBaseValue(FOLLOW_RANGE * 2);
         mob.getAttribute(SharedMonsterAttributes.MOVEMENT_SPEED).setBaseValue(difficultyModifier < 2.4 ? MOVEMENT_SPEED : MOVEMENT_SPEED * 1.2);
         final int raidLevel = colony.getRaiderManager().getColonyRaidLevel();

--- a/src/api/java/com/minecolonies/api/entity/mobs/RaiderMobUtils.java
+++ b/src/api/java/com/minecolonies/api/entity/mobs/RaiderMobUtils.java
@@ -50,7 +50,7 @@ public final class RaiderMobUtils
     /**
      * Damage increased by 1 for every 200 raid level difficulty
      */
-    public static int DAMAGE_PER_X_RAID_LEVEL = 200;
+    public static int DAMAGE_PER_X_RAID_LEVEL = 400;
 
     /**
      * Max damage from raidlevels
@@ -84,16 +84,16 @@ public final class RaiderMobUtils
      */
     public static void setMobAttributes(final AbstractEntityMinecoloniesMob mob, final IColony colony)
     {
-        final double difficultyModifier = colony.getRaiderManager().getRaidDifficultyModifier();
+        final double difficultyModifier = 5.4;
         mob.getAttribute(SharedMonsterAttributes.FOLLOW_RANGE).setBaseValue(FOLLOW_RANGE * 2);
-        mob.getAttribute(SharedMonsterAttributes.MOVEMENT_SPEED).setBaseValue(difficultyModifier < 2.4 ? MOVEMENT_SPEED : MOVEMENT_SPEED + 0.1);
+        mob.getAttribute(SharedMonsterAttributes.MOVEMENT_SPEED).setBaseValue(difficultyModifier < 2.4 ? MOVEMENT_SPEED : MOVEMENT_SPEED * 1.2);
         final int raidLevel = colony.getRaiderManager().getColonyRaidLevel();
 
         // Base damage
         final double attackDamage =
-          difficultyModifier * (ATTACK_DAMAGE + Math.min(
-            raidLevel / DAMAGE_PER_X_RAID_LEVEL,
-            MAX_RAID_LEVEL_DAMAGE));
+          ATTACK_DAMAGE +
+            difficultyModifier *
+              Math.min(raidLevel / DAMAGE_PER_X_RAID_LEVEL, MAX_RAID_LEVEL_DAMAGE);
 
         // Base health
         final double baseHealth = getHealthBasedOnRaidLevel(raidLevel) * difficultyModifier;

--- a/src/api/java/com/minecolonies/api/entity/pathfinding/AbstractAdvancedPathNavigate.java
+++ b/src/api/java/com/minecolonies/api/entity/pathfinding/AbstractAdvancedPathNavigate.java
@@ -21,7 +21,7 @@ public abstract class AbstractAdvancedPathNavigate extends GroundPathNavigator
     protected final MobEntity    ourEntity;
     @Nullable
     protected       BlockPos     destination;
-    protected       double       walkSpeed = 1.0D;
+    protected       double       walkSpeedFactor = 1.0D;
     @Nullable
     protected       BlockPos     originalDestination;
     @Nullable

--- a/src/api/java/com/minecolonies/api/util/EntityUtils.java
+++ b/src/api/java/com/minecolonies/api/util/EntityUtils.java
@@ -202,12 +202,12 @@ public final class EntityUtils
      * @param x      x-coordinate
      * @param y      y-coordinate
      * @param z      z-coordinate
-     * @param speed  Speed to move with
+     * @param speedFactor  Speedfactor to modify base speed with
      * @return True if the path is set to destination, otherwise false
      */
-    public static boolean tryMoveLivingToXYZ(@NotNull final MobEntity living, final int x, final int y, final int z, final double speed)
+    public static boolean tryMoveLivingToXYZ(@NotNull final MobEntity living, final int x, final int y, final int z, final double speedFactor)
     {
-        return living.getNavigator().tryMoveToXYZ(x, y, z, speed);
+        return living.getNavigator().tryMoveToXYZ(x, y, z, speedFactor);
     }
 
     /**

--- a/src/main/java/com/minecolonies/coremod/colony/CitizenData.java
+++ b/src/main/java/com/minecolonies/coremod/colony/CitizenData.java
@@ -1172,7 +1172,7 @@ public class CitizenData implements ICitizenData
               colony.getResearchManager().getResearchEffects().getEffect(WALKING, MultiplierModifierResearchEffect.class);
             if (speedEffect != null)
             {
-                final AttributeModifier speedModifier = new AttributeModifier(RESEARCH_BONUS_MULTIPLIER, 1.0 + speedEffect.getEffect(), AttributeModifier.Operation.MULTIPLY_TOTAL);
+                final AttributeModifier speedModifier = new AttributeModifier(RESEARCH_BONUS_MULTIPLIER, speedEffect.getEffect(), AttributeModifier.Operation.MULTIPLY_TOTAL);
                 AttributeModifierUtils.addModifier(citizen, speedModifier, SharedMonsterAttributes.MOVEMENT_SPEED);
             }
 

--- a/src/main/java/com/minecolonies/coremod/colony/managers/RaidManager.java
+++ b/src/main/java/com/minecolonies/coremod/colony/managers/RaidManager.java
@@ -479,8 +479,8 @@ public class RaidManager implements IRaiderManager
             // Additional raid protection for certain buildings, towers can be used now to deal with unlucky - inwall spawns
             if (building instanceof BuildingGuardTower)
             {
-                // 47/59/71/83/95
-                minDist += building.getBuildingLevel() * 12;
+                // 32/39/48/55/62
+                minDist += building.getBuildingLevel() * 7;
             }
             else if (building instanceof BuildingHome)
             {

--- a/src/main/java/com/minecolonies/coremod/entity/citizen/citizenhandlers/MovementHandler.java
+++ b/src/main/java/com/minecolonies/coremod/entity/citizen/citizenhandlers/MovementHandler.java
@@ -16,6 +16,7 @@ import net.minecraft.util.math.shapes.VoxelShape;
 
 /**
  * Custom movement handler for minecolonies citizens (avoid jumping so much).
+ * Note that the "speed" variable of the super is a speedFactor to our attributes base speed.
  */
 public class MovementHandler extends MovementController
 {
@@ -95,8 +96,7 @@ public class MovementHandler extends MovementController
         }
         else if (this.action == net.minecraft.entity.ai.controller.MovementController.Action.JUMPING)
         {
-            //TODO we're using setAIMoveSpeed manually which gets overridden here and above
-            this.mob.setAIMoveSpeed((float) (this.speed * this.mob.getAttribute(SharedMonsterAttributes.MOVEMENT_SPEED).getValue()));
+            this.mob.setAIMoveSpeed((float) (this.speed * speedAtr.getValue()));
 
             // Avoid beeing stuck in jumping while in liquids
             final BlockPos blockpos = new BlockPos(this.mob);

--- a/src/main/java/com/minecolonies/coremod/entity/citizen/citizenhandlers/MovementHandler.java
+++ b/src/main/java/com/minecolonies/coremod/entity/citizen/citizenhandlers/MovementHandler.java
@@ -96,7 +96,7 @@ public class MovementHandler extends MovementController
         }
         else if (this.action == net.minecraft.entity.ai.controller.MovementController.Action.JUMPING)
         {
-            this.mob.setAIMoveSpeed((float) (this.speed * speedAtr.getValue()));
+            this.mob.setAIMoveSpeed((float) (this.speed * this.mob.getAttribute(SharedMonsterAttributes.MOVEMENT_SPEED).getValue()));
 
             // Avoid beeing stuck in jumping while in liquids
             final BlockPos blockpos = new BlockPos(this.mob);

--- a/src/main/java/com/minecolonies/coremod/entity/mobs/aitasks/EntityAIAttackArcher.java
+++ b/src/main/java/com/minecolonies/coremod/entity/mobs/aitasks/EntityAIAttackArcher.java
@@ -33,15 +33,15 @@ public class EntityAIAttackArcher extends Goal
      */
     private static final double ARROW_PIERCE_DIFFICULTY = 3.0d;
 
-    private static final double                        PITCH_MULTIPLIER               = 0.4;
-    private static final double                        HALF_ROTATION                  = 180;
-    private static final double                        ATTACK_SPEED                   = 1.3;
-    private static final double                        AIM_HEIGHT                     = 2.0D;
-    private static final double                        ARROW_SPEED                    = 1.4D;
-    private static final double                        HIT_CHANCE                     = 10.0D;
-    private static final double                        AIM_SLIGHTLY_HIGHER_MULTIPLIER = 0.20000000298023224D;
-    private static final double                        BASE_PITCH                     = 0.8D;
-    private static final double                        PITCH_DIVIDER                  = 1.0D;
+    private static final double PITCH_MULTIPLIER               = 0.4;
+    private static final double HALF_ROTATION                  = 180;
+    private static final double ATTACK_SPEED                   = 1.1;
+    private static final double AIM_HEIGHT                     = 2.0D;
+    private static final double ARROW_SPEED                    = 1.4D;
+    private static final double HIT_CHANCE                     = 10.0D;
+    private static final double AIM_SLIGHTLY_HIGHER_MULTIPLIER = 0.20000000298023224D;
+    private static final double BASE_PITCH                     = 0.8D;
+    private static final double PITCH_DIVIDER                  = 1.0D;
     private static final double                        MAX_ATTACK_DISTANCE            = 20.0D;
     private static final double                        SPEED_FOR_DIST                 = 35;
     private final        AbstractEntityMinecoloniesMob entity;

--- a/src/main/java/com/minecolonies/coremod/entity/mobs/aitasks/EntityAIRaiderAttackMelee.java
+++ b/src/main/java/com/minecolonies/coremod/entity/mobs/aitasks/EntityAIRaiderAttackMelee.java
@@ -4,11 +4,12 @@ import com.minecolonies.api.entity.mobs.AbstractEntityMinecoloniesMob;
 import com.minecolonies.api.util.EntityUtils;
 import com.minecolonies.api.util.SoundUtils;
 import com.minecolonies.coremod.MineColonies;
+import com.minecolonies.coremod.util.NamedDamageSource;
 import net.minecraft.entity.LivingEntity;
 import net.minecraft.entity.ai.goal.Goal;
-import net.minecraft.util.EntityDamageSource;
 import net.minecraft.util.Hand;
 import net.minecraft.util.SoundEvents;
+import net.minecraft.util.text.TranslationTextComponent;
 
 import java.util.EnumSet;
 
@@ -20,11 +21,11 @@ import static com.minecolonies.api.entity.mobs.RaiderMobUtils.MOB_ATTACK_DAMAGE;
 public class EntityAIRaiderAttackMelee extends Goal
 {
 
-    private static final int                           MAX_ATTACK_DELAY        = 60;
-    private static final double                        HALF_ROTATION           = 180;
-    private static final double                        MIN_DISTANCE_FOR_ATTACK = 2.5;
-    private static final double                        ATTACK_SPEED            = 1.3;
-    public static final  int                           MUTEX_BITS              = 3;
+    private static final int    MAX_ATTACK_DELAY        = 60;
+    private static final double HALF_ROTATION           = 180;
+    private static final double MIN_DISTANCE_FOR_ATTACK = 2.5;
+    private static final double ATTACK_SPEED            = 1.2;
+    public static final  int    MUTEX_BITS              = 3;
 
     /**
      * Extended reach based on difficulty
@@ -36,7 +37,7 @@ public class EntityAIRaiderAttackMelee extends Goal
      * Additional movement speed difficulty
      */
     private static final double ADD_SPEED_DIFFICULTY = 2.3;
-    private static final double ADD_SPEED            = 0.3;
+    private static final double BONUS_SPEED          = 1.2;
 
     private final        AbstractEntityMinecoloniesMob entity;
     private              LivingEntity                  target;
@@ -115,7 +116,7 @@ public class EntityAIRaiderAttackMelee extends Goal
             if (entity.getDistance(target) <= (entity.getDifficulty() < EXTENDED_REACH_DIFFICUTLY ? MIN_DISTANCE_FOR_ATTACK : MIN_DISTANCE_FOR_ATTACK + EXTENDED_REACH)
                   && lastAttack <= 0 && entity.canEntityBeSeen(target))
             {
-                target.attackEntityFrom(new EntityDamageSource(entity.getType().getTranslationKey(), entity), (float) damageToBeDealt);
+                target.attackEntityFrom(new NamedDamageSource("death.attack." + ((TranslationTextComponent) entity.getName()).getKey(), entity), (float) damageToBeDealt);
                 entity.swingArm(Hand.MAIN_HAND);
                 entity.playSound(SoundEvents.ENTITY_PLAYER_ATTACK_SWEEP, (float) 1.0D, (float) SoundUtils.getRandomPitch(entity.getRNG()));
                 target.setRevengeTarget(entity);
@@ -129,7 +130,7 @@ public class EntityAIRaiderAttackMelee extends Goal
             entity.faceEntity(target, (float) HALF_ROTATION, (float) HALF_ROTATION);
             entity.getLookController().setLookPositionWithEntity(target, (float) HALF_ROTATION, (float) HALF_ROTATION);
 
-            entity.getNavigator().tryMoveToEntityLiving(target, entity.getDifficulty() < ADD_SPEED_DIFFICULTY ? ATTACK_SPEED : ATTACK_SPEED + ADD_SPEED);
+            entity.getNavigator().tryMoveToEntityLiving(target, entity.getDifficulty() < ADD_SPEED_DIFFICULTY ? ATTACK_SPEED : ATTACK_SPEED * BONUS_SPEED);
         }
     }
 

--- a/src/main/java/com/minecolonies/coremod/entity/pathfinding/MinecoloniesAdvancedPathNavigate.java
+++ b/src/main/java/com/minecolonies/coremod/entity/pathfinding/MinecoloniesAdvancedPathNavigate.java
@@ -43,11 +43,12 @@ import java.util.concurrent.ExecutionException;
 public class MinecoloniesAdvancedPathNavigate extends AbstractAdvancedPathNavigate
 {
     private static final double ON_PATH_SPEED_MULTIPLIER = 1.3D;
-    private static final double PIRATE_SWIM_BONUS        = 30;
-    private static final double BARBARIAN_SWIM_BONUS     = 15;
-    private static final double CITIZEN_SWIM_BONUS       = 10;
+    private static final double PIRATE_SWIM_BONUS        = 1.5;
+    private static final double BARBARIAN_SWIM_BONUS     = 1.2;
+    private static final double CITIZEN_SWIM_BONUS       = 1.1;
     public static final  double MIN_Y_DISTANCE           = 0.001;
-    public static final  int    MAX_SPEED_ALLOWED        = 100;
+    public static final  int    MAX_SPEED_ALLOWED        = 2;
+    public static final  double MIN_SPEED_ALLOWED        = 0.1;
 
     @Nullable
     private PathResult pathResult;
@@ -105,7 +106,7 @@ public class MinecoloniesAdvancedPathNavigate extends AbstractAdvancedPathNaviga
     }
 
     @Nullable
-    public PathResult moveAwayFromXYZ(final BlockPos avoid, final double range, final double speed)
+    public PathResult moveAwayFromXYZ(final BlockPos avoid, final double range, final double speedFactor)
     {
         @NotNull final BlockPos start = AbstractPathJob.prepareStart(ourEntity);
 
@@ -114,11 +115,11 @@ public class MinecoloniesAdvancedPathNavigate extends AbstractAdvancedPathNaviga
           avoid,
           (int) range,
           (int) ourEntity.getAttribute(SharedMonsterAttributes.FOLLOW_RANGE).getValue(),
-          ourEntity), null, speed);
+          ourEntity), null, speedFactor);
     }
 
     @Nullable
-    public RandomPathResult moveToRandomPos(final double range, final double speed)
+    public RandomPathResult moveToRandomPos(final double range, final double speedFactor)
     {
         if (pathResult instanceof RandomPathResult && pathResult.isComputing())
         {
@@ -132,14 +133,14 @@ public class MinecoloniesAdvancedPathNavigate extends AbstractAdvancedPathNaviga
           start,
           theRange,
           (int) ourEntity.getAttribute(SharedMonsterAttributes.FOLLOW_RANGE).getValue(),
-          ourEntity), null, speed);
+          ourEntity), null, speedFactor);
     }
 
     @Nullable
     public PathResult setPathJob(
       @NotNull final AbstractPathJob job,
       final BlockPos dest,
-      final double speed)
+      final double speedFactor)
     {
         if (dest != null && dest.equals(desiredPos) && calculationFuture != null && pathResult != null)
         {
@@ -155,11 +156,11 @@ public class MinecoloniesAdvancedPathNavigate extends AbstractAdvancedPathNaviga
             desiredPos = dest;
             desiredPosTimeout = 50 * 20;
         }
-        this.walkSpeed = speed;
+        this.walkSpeedFactor = speedFactor;
 
-        if (speed > MAX_SPEED_ALLOWED)
+        if (speedFactor > MAX_SPEED_ALLOWED || speedFactor < MIN_SPEED_ALLOWED)
         {
-            Log.getLogger().error("Tried to set a too high speed for entity:" + ourEntity, new Exception());
+            Log.getLogger().error("Tried to set a bad speed:" + speedFactor + " for entity:" + ourEntity, new Exception());
             return null;
         }
 
@@ -232,7 +233,7 @@ public class MinecoloniesAdvancedPathNavigate extends AbstractAdvancedPathNaviga
     }
 
     @Nullable
-    public PathResult moveToXYZ(final double x, final double y, final double z, final double speed)
+    public PathResult moveToXYZ(final double x, final double y, final double z, final double speedFactor)
     {
         final int newX = MathHelper.floor(x);
         final int newY = (int) y;
@@ -258,13 +259,13 @@ public class MinecoloniesAdvancedPathNavigate extends AbstractAdvancedPathNaviga
             desiredPos,
             (int) ourEntity.getAttribute(SharedMonsterAttributes.FOLLOW_RANGE).getValue(),
             ourEntity),
-          desiredPos, speed);
+          desiredPos, speedFactor);
     }
 
     @Override
-    public boolean tryMoveToBlockPos(final BlockPos pos, final double speed)
+    public boolean tryMoveToBlockPos(final BlockPos pos, final double speedFactor)
     {
-        moveToXYZ(pos.getX(), pos.getY(), pos.getZ(), speed);
+        moveToXYZ(pos.getX(), pos.getY(), pos.getZ(), speedFactor);
         return true;
     }
 
@@ -332,58 +333,58 @@ public class MinecoloniesAdvancedPathNavigate extends AbstractAdvancedPathNaviga
                  && super.isDirectPathBetweenPoints(start, end, sizeX, sizeY, sizeZ);
     }
 
-    public double getSpeed()
+    public double getSpeedFactor()
     {
         if (ourEntity instanceof AbstractEntityPirate && ourEntity.isInWater())
         {
-            speed = walkSpeed * PIRATE_SWIM_BONUS;
+            speed = walkSpeedFactor * PIRATE_SWIM_BONUS;
             return speed;
         }
         else if (ourEntity instanceof AbstractEntityBarbarian && ourEntity.isInWater())
         {
-            speed = walkSpeed * BARBARIAN_SWIM_BONUS;
+            speed = walkSpeedFactor * BARBARIAN_SWIM_BONUS;
             return speed;
         }
         else if (ourEntity instanceof AbstractEntityCitizen && ourEntity.isInWater())
         {
-            speed = walkSpeed * CITIZEN_SWIM_BONUS;
+            speed = walkSpeedFactor * CITIZEN_SWIM_BONUS;
             return speed;
         }
 
-        speed = walkSpeed;
-        return walkSpeed;
+        speed = walkSpeedFactor;
+        return walkSpeedFactor;
     }
 
     @Override
-    public void setSpeed(final double d)
+    public void setSpeed(final double speedFactor)
     {
-        if (d > MAX_SPEED_ALLOWED)
+        if (speedFactor > MAX_SPEED_ALLOWED || speedFactor < MIN_SPEED_ALLOWED)
         {
-            Log.getLogger().error("Tried to set a too high speed for entity:" + ourEntity, new Exception());
+            Log.getLogger().error("Tried to set a bad speed:" + speedFactor + " for entity:" + ourEntity, new Exception());
             return;
         }
-        walkSpeed = d;
+        walkSpeedFactor = speedFactor;
     }
 
     /**
      * Deprecated - try to use BlockPos instead
      */
     @Override
-    public boolean tryMoveToXYZ(final double x, final double y, final double z, final double speed)
+    public boolean tryMoveToXYZ(final double x, final double y, final double z, final double speedFactor)
     {
         if (x == 0 && y == 0 && z == 0)
         {
             return false;
         }
 
-        moveToXYZ(x, y, z, speed);
+        moveToXYZ(x, y, z, speedFactor);
         return true;
     }
 
     @Override
-    public boolean tryMoveToEntityLiving(final Entity entityIn, final double speedIn)
+    public boolean tryMoveToEntityLiving(final Entity entityIn, final double speedFactor)
     {
-        return tryMoveToBlockPos(entityIn.getPosition(), speedIn);
+        return tryMoveToBlockPos(entityIn.getPosition(), speedFactor);
     }
 
     // Removes stupid vanilla stuff, causing our pathpoints to occasionally be replaced by vanilla ones.
@@ -391,7 +392,7 @@ public class MinecoloniesAdvancedPathNavigate extends AbstractAdvancedPathNaviga
     protected void trimPath() {}
 
     @Override
-    public boolean setPath(@Nullable final Path path, final double speed)
+    public boolean setPath(@Nullable final Path path, final double speedFactor)
     {
         if (path == null)
         {
@@ -399,7 +400,7 @@ public class MinecoloniesAdvancedPathNavigate extends AbstractAdvancedPathNaviga
             return false;
         }
         pathStartTime = world.getGameTime();
-        return super.setPath(convertPath(path), speed);
+        return super.setPath(convertPath(path), speedFactor);
     }
 
     /**
@@ -447,7 +448,7 @@ public class MinecoloniesAdvancedPathNavigate extends AbstractAdvancedPathNaviga
             return true;
         }
 
-        setPath(calculationFuture.get(), getSpeed());
+        setPath(calculationFuture.get(), getSpeedFactor());
 
         pathResult.setPathLength(getPath().getCurrentPathLength());
         pathResult.setStatus(PathFindingStatus.IN_PROGRESS_FOLLOWING);
@@ -501,11 +502,11 @@ public class MinecoloniesAdvancedPathNavigate extends AbstractAdvancedPathNaviga
             {
                 if (WorkerUtil.isPathBlock(world.getBlockState(findBlockUnderEntity(ourEntity)).getBlock()))
                 {
-                    speed = ON_PATH_SPEED_MULTIPLIER * getSpeed();
+                    speed = ON_PATH_SPEED_MULTIPLIER * getSpeedFactor();
                 }
                 else
                 {
-                    speed = getSpeed();
+                    speed = getSpeedFactor();
                 }
             }
         }
@@ -644,7 +645,7 @@ public class MinecoloniesAdvancedPathNavigate extends AbstractAdvancedPathNaviga
         if (vec3.squareDistanceTo(ourEntity.posX, vec3.y, ourEntity.posZ) < Math.random() * 0.1)
         {
             //This way he is less nervous and gets up the ladder
-            double newSpeed = 0.05;
+            double newSpeed = 0.3;
             switch (pEx.getLadderFacing())
             {
                 //  Any of these values is climbing, so adjust our direction of travel towards the ladder
@@ -722,15 +723,14 @@ public class MinecoloniesAdvancedPathNavigate extends AbstractAdvancedPathNaviga
             vec3d = this.getPath().getPosition(this.ourEntity);
         }
 
-        ourEntity.setAIMoveSpeed((float) getSpeed());
-        this.ourEntity.getMoveHelper().setMoveTo(vec3d.x, vec3d.y, vec3d.z, getSpeed());
+        this.ourEntity.getMoveHelper().setMoveTo(vec3d.x, vec3d.y, vec3d.z, getSpeedFactor());
         return false;
     }
 
     @Override
     protected void pathFollow()
     {
-        getSpeed();
+        getSpeedFactor();
         final int curNode = currentPath.getCurrentPathIndex();
         final int curNodeNext = curNode + 1;
         if (curNodeNext < currentPath.getCurrentPathLength())

--- a/src/main/java/com/minecolonies/coremod/research/ResearchInitializer.java
+++ b/src/main/java/com/minecolonies/coremod/research/ResearchInitializer.java
@@ -455,10 +455,10 @@ public class ResearchInitializer
         final GlobalResearch agile = new GlobalResearch("agile", "civilian", "Agile", 4, new MultiplierModifierResearchEffect("Walking", 0.1));
         agile.setRequirement(new BuildingResearchRequirement(4, "townhall"));
 
-        final GlobalResearch swift = new GlobalResearch("swift", "civilian", "Swift", 5, new MultiplierModifierResearchEffect("Walking", 0.25));
+        final GlobalResearch swift = new GlobalResearch("swift", "civilian", "Swift", 5, new MultiplierModifierResearchEffect("Walking", 0.15));
         swift.setRequirement(new BuildingResearchRequirement(5, "townhall"));
 
-        final GlobalResearch athlete = new GlobalResearch("athlete", "civilian", "Athlete", 6, new MultiplierModifierResearchEffect("Walking", 1.0));
+        final GlobalResearch athlete = new GlobalResearch("athlete", "civilian", "Athlete", 6, new MultiplierModifierResearchEffect("Walking", 0.25));
 
         keen.addChild(rails);
         rails.addChild(nimble);

--- a/src/main/java/com/minecolonies/coremod/util/NamedDamageSource.java
+++ b/src/main/java/com/minecolonies/coremod/util/NamedDamageSource.java
@@ -4,7 +4,7 @@ import net.minecraft.entity.Entity;
 import net.minecraft.entity.LivingEntity;
 import net.minecraft.util.EntityDamageSource;
 import net.minecraft.util.text.ITextComponent;
-import net.minecraft.util.text.StringTextComponent;
+import net.minecraft.util.text.TranslationTextComponent;
 import org.jetbrains.annotations.NotNull;
 
 import javax.annotation.Nullable;
@@ -29,6 +29,11 @@ public class NamedDamageSource extends EntityDamageSource
     @Override
     public ITextComponent getDeathMessage(LivingEntity entityLivingBaseIn)
     {
-        return new StringTextComponent(this.damageType);
+        return new TranslationTextComponent(this.damageType, entityLivingBaseIn.getName());
+    }
+
+    public boolean isDifficultyScaled()
+    {
+        return false;
     }
 }

--- a/src/main/java/com/minecolonies/coremod/util/NamedDamageSource.java
+++ b/src/main/java/com/minecolonies/coremod/util/NamedDamageSource.java
@@ -32,6 +32,11 @@ public class NamedDamageSource extends EntityDamageSource
         return new TranslationTextComponent(this.damageType, entityLivingBaseIn.getName());
     }
 
+    /**
+     * World difficulty scaling of damage against players, disabled as we already do take world difficulty into account.
+     *
+     * @return false
+     */
     public boolean isDifficultyScaled()
     {
         return false;


### PR DESCRIPTION
# Changes proposed in this pull request:
Reworked a bit how we handle our entities speed a bit, we use the entities movement speed attribute as base speed, and any speedvalues passed along for certain pathing/move to operations are speedFactors multiplied ontop. In some cases we already use speed like this, in other cases we treated the given speedFactors as basespeed and caused issues. I've also renamed all the speed parameters to speedFactor for clarity.

Fixed raider difficulty scaling, it no longer scales base + scaling damage by difficulty, and also changed their damage to our custom damage source, which does not do additional world difficulty scaling with damage against players, as our raiders already do scale with world difficulty.

Review please
