### PR TITLE
Invfixes

### DIFF
--- a/src/api/java/com/minecolonies/api/inventory/InventoryCitizen.java
+++ b/src/api/java/com/minecolonies/api/inventory/InventoryCitizen.java
@@ -263,6 +263,11 @@ public class InventoryCitizen implements IItemHandlerModifiable, INameable
         if (!ItemStackUtils.isEmpty(stack))
         {
             stack.getItem().damageItem(stack, amount, entityIn, onBroken);
+
+            if (ItemStackUtils.isEmpty(stack))
+            {
+                freeSlots++;
+            }
         }
 
         return ItemStackUtils.isEmpty(stack);
@@ -280,6 +285,11 @@ public class InventoryCitizen implements IItemHandlerModifiable, INameable
         if (!ItemStackUtils.isEmpty(stack))
         {
             stack.setCount(stack.getCount() - 1);
+
+            if (ItemStackUtils.isEmpty(stack))
+            {
+                freeSlots++;
+            }
         }
 
         return ItemStackUtils.isEmpty(stack);

--- a/src/api/java/com/minecolonies/api/inventory/api/CombinedItemHandler.java
+++ b/src/api/java/com/minecolonies/api/inventory/api/CombinedItemHandler.java
@@ -10,12 +10,10 @@ import net.minecraftforge.common.util.Constants;
 import net.minecraftforge.common.util.INBTSerializable;
 import net.minecraftforge.items.IItemHandler;
 import net.minecraftforge.items.IItemHandlerModifiable;
-import net.minecraftforge.items.wrapper.CombinedInvWrapper;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import javax.annotation.Nonnull;
-
 import java.util.Arrays;
 
 import static com.minecolonies.api.util.constant.Suppression.UNCHECKED;
@@ -305,6 +303,19 @@ public class CombinedItemHandler implements IItemHandlerModifiable, INBTSerializ
     @Override
     public boolean isItemValid(int slot, @Nonnull ItemStack stack)
     {
+        int slotIndex = slot;
+        for (final IItemHandlerModifiable modifiable : handlers)
+        {
+            if (slotIndex >= modifiable.getSlots())
+            {
+                slotIndex -= modifiable.getSlots();
+            }
+            else
+            {
+                return modifiable.isItemValid(slotIndex, stack);
+            }
+        }
+
         return false;
     }
 

--- a/src/api/java/com/minecolonies/api/tileentities/AbstractTileEntityRack.java
+++ b/src/api/java/com/minecolonies/api/tileentities/AbstractTileEntityRack.java
@@ -194,11 +194,11 @@ public abstract class AbstractTileEntityRack extends TileEntity implements IName
      */
     public void setBuildingPos(final BlockPos pos)
     {
-        this.buildingPos = pos;
-        if (world != null)
+        if (world != null && buildingPos != null && !buildingPos.equals(pos))
         {
             markDirty();
         }
+        this.buildingPos = pos;
     }
 
     /* Get the amount of items matching a predicate in the inventory.

--- a/src/api/java/com/minecolonies/api/tileentities/AbstractTileEntityRack.java
+++ b/src/api/java/com/minecolonies/api/tileentities/AbstractTileEntityRack.java
@@ -194,7 +194,7 @@ public abstract class AbstractTileEntityRack extends TileEntity implements IName
      */
     public void setBuildingPos(final BlockPos pos)
     {
-        if (world != null && buildingPos != null && !buildingPos.equals(pos))
+        if (world != null && (buildingPos == null || !buildingPos.equals(pos)))
         {
             markDirty();
         }

--- a/src/api/java/com/minecolonies/api/tileentities/TileEntityColonyBuilding.java
+++ b/src/api/java/com/minecolonies/api/tileentities/TileEntityColonyBuilding.java
@@ -37,9 +37,7 @@ import net.minecraftforge.items.IItemHandlerModifiable;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
-import java.util.ArrayList;
 import java.util.HashSet;
-import java.util.List;
 import java.util.Set;
 import java.util.function.Predicate;
 
@@ -470,7 +468,7 @@ public class TileEntityColonyBuilding extends AbstractTileEntityColonyBuilding i
     @Override
     public <T> LazyOptional<T> getCapability(@NotNull final Capability<T> capability, @Nullable final Direction side)
     {
-        if (capability == CapabilityItemHandler.ITEM_HANDLER_CAPABILITY && getBuilding() != null)
+        if (!removed && capability == CapabilityItemHandler.ITEM_HANDLER_CAPABILITY && getBuilding() != null)
         {
             if (combinedInv == null)
             {

--- a/src/api/java/com/minecolonies/api/tileentities/TileEntityEnchanter.java
+++ b/src/api/java/com/minecolonies/api/tileentities/TileEntityEnchanter.java
@@ -47,6 +47,13 @@ public class TileEntityEnchanter extends TileEntityColonyBuilding
     @Override
     public void tick()
     {
+        super.tick();
+
+        if (!world.isRemote)
+        {
+            return;
+        }
+
         this.bookSpreadPrev = this.bookSpread;
         this.bookRotationPrev = this.bookRotation;
         PlayerEntity player = this.world.getClosestPlayer(((float) this.pos.getX() + 0.5F), ((float) this.pos.getY() + 0.5F), ((float) this.pos.getZ() + 0.5F), 3.0D, false);

--- a/src/api/java/com/minecolonies/api/tileentities/TileEntityRack.java
+++ b/src/api/java/com/minecolonies/api/tileentities/TileEntityRack.java
@@ -447,6 +447,11 @@ public class TileEntityRack extends AbstractTileEntityRack
     {
         if (capability == CapabilityItemHandler.ITEM_HANDLER_CAPABILITY)
         {
+            if (lastOptional != null && lastOptional.isPresent())
+            {
+                return (LazyOptional<T>) lastOptional;
+            }
+
             if (single)
             {
                 lastOptional = LazyOptional.of(() -> inventory);
@@ -550,6 +555,7 @@ public class TileEntityRack extends AbstractTileEntityRack
             if (lastOptional != null)
             {
                 lastOptional.invalidate();
+                lastOptional = null;
             }
             super.setMain(main);
         }
@@ -563,6 +569,7 @@ public class TileEntityRack extends AbstractTileEntityRack
             if (lastOptional != null)
             {
                 lastOptional.invalidate();
+                lastOptional = null;
             }
             super.setSingle(single);
         }

--- a/src/api/java/com/minecolonies/api/tileentities/TileEntityRack.java
+++ b/src/api/java/com/minecolonies/api/tileentities/TileEntityRack.java
@@ -167,6 +167,7 @@ public class TileEntityRack extends AbstractTileEntityRack
         inventory = tempInventory;
         final BlockState state = world.getBlockState(pos);
         world.notifyBlockUpdate(pos, state, state, 0x03);
+        invalidateCap();
     }
 
     @Override
@@ -370,6 +371,8 @@ public class TileEntityRack extends AbstractTileEntityRack
         {
             this.buildingPos = BlockPosUtil.read(compound, TAG_POS);
         }
+
+        invalidateCap();
     }
 
     @NotNull
@@ -445,39 +448,45 @@ public class TileEntityRack extends AbstractTileEntityRack
     @Override
     public <T> LazyOptional<T> getCapability(@Nonnull final Capability<T> capability, final Direction dir)
     {
-        if (capability == CapabilityItemHandler.ITEM_HANDLER_CAPABILITY)
+        if (!removed && capability == CapabilityItemHandler.ITEM_HANDLER_CAPABILITY)
         {
             if (lastOptional != null && lastOptional.isPresent())
             {
-                return (LazyOptional<T>) lastOptional;
+                return lastOptional.cast();
             }
 
             if (single)
             {
-                lastOptional = LazyOptional.of(() -> inventory);
-                return (LazyOptional<T>) lastOptional;
+                lastOptional = LazyOptional.of(() ->
+                {
+                    if (this.isRemoved())
+                    {
+                        return new RackInventory(0);
+                    }
+
+                    return new CombinedItemHandler(RACK, getInventory());
+                });
+                return lastOptional.cast();
             }
-            else if (getOtherChest() != null)
+            else
             {
-                if (isMain())
+                lastOptional = LazyOptional.of(() ->
                 {
-                    lastOptional = LazyOptional.of(() -> new CombinedItemHandler(RACK, inventory, getOtherChest().getInventory()));
-                    return (LazyOptional<T>) lastOptional;
-                }
-                else
-                {
-                    if (getOtherChest().isMain())
+                    if (this.isRemoved())
                     {
-                        lastOptional = getOtherChest().getCapability(CapabilityItemHandler.ITEM_HANDLER_CAPABILITY);
-                        return (LazyOptional<T>) lastOptional;
+                        return new RackInventory(0);
                     }
-                    else
+
+                    final AbstractTileEntityRack other = getOtherChest();
+                    if (other == null)
                     {
-                        setMain(true);
-                        lastOptional = LazyOptional.of(() -> new CombinedItemHandler(RACK, inventory, getOtherChest().getInventory()));
-                        return (LazyOptional<T>) lastOptional;
+                        return new CombinedItemHandler(RACK, getInventory());
                     }
-                }
+
+                    return new CombinedItemHandler(RACK, getInventory(), other.getInventory());
+                });
+
+                return lastOptional.cast();
             }
         }
         return super.getCapability(capability, dir);
@@ -552,11 +561,7 @@ public class TileEntityRack extends AbstractTileEntityRack
     {
         if (main != this.main)
         {
-            if (lastOptional != null)
-            {
-                lastOptional.invalidate();
-                lastOptional = null;
-            }
+            invalidateCap();
             super.setMain(main);
         }
     }
@@ -566,12 +571,35 @@ public class TileEntityRack extends AbstractTileEntityRack
     {
         if (single != this.single)
         {
-            if (lastOptional != null)
-            {
-                lastOptional.invalidate();
-                lastOptional = null;
-            }
+            invalidateCap();
             super.setSingle(single);
         }
+    }
+
+    @Override
+    public void remove()
+    {
+        super.remove();
+        invalidateCap();
+    }
+
+    @Override
+    public void updateContainingBlockInfo()
+    {
+        super.updateContainingBlockInfo();
+        invalidateCap();
+    }
+
+    /**
+     * Invalidates the cap
+     */
+    private void invalidateCap()
+    {
+        if (lastOptional != null && lastOptional.isPresent())
+        {
+            lastOptional.invalidate();
+        }
+
+        lastOptional = null;
     }
 }

--- a/src/api/java/com/minecolonies/api/tileentities/TileEntityRack.java
+++ b/src/api/java/com/minecolonies/api/tileentities/TileEntityRack.java
@@ -3,14 +3,12 @@ package com.minecolonies.api.tileentities;
 import com.minecolonies.api.MinecoloniesAPIProxy;
 import com.minecolonies.api.blocks.AbstractBlockMinecoloniesRack;
 import com.minecolonies.api.blocks.types.RackType;
-import com.minecolonies.api.configuration.CommonConfiguration;
 import com.minecolonies.api.crafting.ItemStorage;
 import com.minecolonies.api.inventory.api.CombinedItemHandler;
 import com.minecolonies.api.inventory.container.ContainerRack;
 import com.minecolonies.api.util.BlockPosUtil;
 import com.minecolonies.api.util.ItemStackUtils;
 import com.minecolonies.api.util.WorldUtil;
-import com.minecolonies.api.util.constant.Constants;
 import io.netty.buffer.Unpooled;
 import net.minecraft.block.BlockState;
 import net.minecraft.entity.player.PlayerEntity;
@@ -234,7 +232,7 @@ public class TileEntityRack extends AbstractTileEntityRack
         {
             if (!main && !single && getOtherChest() != null && !getOtherChest().isMain())
             {
-                main = true;
+                setMain(true);
             }
 
             if (main || single)
@@ -447,11 +445,6 @@ public class TileEntityRack extends AbstractTileEntityRack
     @Override
     public <T> LazyOptional<T> getCapability(@Nonnull final Capability<T> capability, final Direction dir)
     {
-        if (lastOptional != null)
-        {
-            lastOptional.invalidate();
-        }
-
         if (capability == CapabilityItemHandler.ITEM_HANDLER_CAPABILITY)
         {
             if (single)
@@ -475,7 +468,7 @@ public class TileEntityRack extends AbstractTileEntityRack
                     }
                     else
                     {
-                        this.main = true;
+                        setMain(true);
                         lastOptional = LazyOptional.of(() -> new CombinedItemHandler(RACK, inventory, getOtherChest().getInventory()));
                         return (LazyOptional<T>) lastOptional;
                     }
@@ -547,5 +540,31 @@ public class TileEntityRack extends AbstractTileEntityRack
     public ITextComponent getDisplayName()
     {
         return new StringTextComponent("Rack");
+    }
+
+    @Override
+    public void setMain(final boolean main)
+    {
+        if (main != this.main)
+        {
+            if (lastOptional != null)
+            {
+                lastOptional.invalidate();
+            }
+            super.setMain(main);
+        }
+    }
+
+    @Override
+    public void setSingle(final boolean single)
+    {
+        if (single != this.single)
+        {
+            if (lastOptional != null)
+            {
+                lastOptional.invalidate();
+            }
+            super.setSingle(single);
+        }
     }
 }

--- a/src/main/java/com/minecolonies/coremod/entity/citizen/citizenhandlers/CitizenItemHandler.java
+++ b/src/main/java/com/minecolonies/coremod/entity/citizen/citizenhandlers/CitizenItemHandler.java
@@ -255,15 +255,19 @@ public class CitizenItemHandler implements ICitizenItemHandler
             return;
         }
 
-        heldItem.damageItem(damage, citizen, (i) -> {
-            i.sendBreakAnimation(Hand.MAIN_HAND);
-        });
-
         //check if tool breaks
-        if (ItemStackUtils.isEmpty(heldItem) && citizen.getInventoryCitizen().getHeldItemSlot(hand) != -1)
+        if (citizen.getCitizenData()
+              .getInventory()
+              .damageInventoryItem(citizen.getCitizenData().getInventory().getHeldItemSlot(hand), damage, citizen, item -> item.sendBreakAnimation(hand)))
         {
-            citizen.getInventoryCitizen().insertItem(citizen.getInventoryCitizen().getHeldItemSlot(hand), ItemStackUtils.EMPTY, false);
-            citizen.setItemStackToSlot(EquipmentSlotType.MAINHAND, ItemStackUtils.EMPTY);
+            if (hand == Hand.MAIN_HAND)
+            {
+                citizen.setItemStackToSlot(EquipmentSlotType.MAINHAND, ItemStackUtils.EMPTY);
+            }
+            else
+            {
+                citizen.setItemStackToSlot(EquipmentSlotType.OFFHAND, ItemStackUtils.EMPTY);
+            }
         }
     }
 


### PR DESCRIPTION
# Changes proposed in this pull request:
Improve citizen inventory free slots and stop damaging/modifying internal stacks from outside

Fix cap invalidate only upon change
Fix racks(and their chunk) beeing marked dirty from the buildings getCap call all the time
Fix capability invalidates to be like chests
Fix Building cap returning values when the TE was removed
Fix Enchanter doing animations serverside and not calling super tick
Fix CombinedHandler not having isItemValid implemented


Review please
