### PR TITLE
Some more raid balance

### DIFF
--- a/src/api/java/com/minecolonies/api/configuration/CommonConfiguration.java
+++ b/src/api/java/com/minecolonies/api/configuration/CommonConfiguration.java
@@ -941,6 +941,7 @@ public class CommonConfiguration extends AbstractConfiguration
                      "3,minecraft:smite,3,15",
                      "3,minecraft:sweeping,3,15",
                      "3,minecraft:unbreaking,3,15",
+                     "3,minecolonies:raider_damage_enchant,1,15",
 
                      "4,minecraft:aqua_affinity,4,5",
                      "4,minecraft:bane_of_arthropods,4,5",
@@ -985,6 +986,7 @@ public class CommonConfiguration extends AbstractConfiguration
                      "5,minecraft:sharpness,5,1",
                      "5,minecraft:smite,5,1",
                      "5,minecraft:sweeping,5,1",
+                     "5,minecolonies:raider_damage_enchant,2,3",
                      "5,minecraft:unbreaking,5,1"
                    ),
           s -> s instanceof String);

--- a/src/api/java/com/minecolonies/api/enchants/ModEnchants.java
+++ b/src/api/java/com/minecolonies/api/enchants/ModEnchants.java
@@ -1,0 +1,19 @@
+package com.minecolonies.api.enchants;
+
+import net.minecraft.enchantment.Enchantment;
+
+/**
+ * All our mods renchants
+ */
+public class ModEnchants
+{
+    private ModEnchants()
+    {
+        // Intentionally left empty
+    }
+
+    /**
+     * Raider damage enchant, gives extra damage against raiders
+     */
+    public static Enchantment raiderDamage;
+}

--- a/src/main/java/com/minecolonies/apiimp/initializer/ModEnchantInitializer.java
+++ b/src/main/java/com/minecolonies/apiimp/initializer/ModEnchantInitializer.java
@@ -1,0 +1,24 @@
+package com.minecolonies.apiimp.initializer;
+
+import com.minecolonies.api.enchants.ModEnchants;
+import com.minecolonies.api.util.constant.Constants;
+import com.minecolonies.coremod.enchants.RaiderDamageEnchant;
+import net.minecraft.enchantment.Enchantment;
+import net.minecraft.inventory.EquipmentSlotType;
+import net.minecraftforge.event.RegistryEvent;
+import net.minecraftforge.eventbus.api.SubscribeEvent;
+import net.minecraftforge.fml.common.Mod;
+
+/**
+ * Enchants initializer
+ */
+@Mod.EventBusSubscriber(modid = Constants.MOD_ID, bus = Mod.EventBusSubscriber.Bus.MOD)
+public class ModEnchantInitializer
+{
+    @SubscribeEvent
+    public static void registerEnchants(final RegistryEvent.Register<Enchantment> event)
+    {
+        ModEnchants.raiderDamage = new RaiderDamageEnchant(Enchantment.Rarity.VERY_RARE, new EquipmentSlotType[] {EquipmentSlotType.MAINHAND});
+        event.getRegistry().register(ModEnchants.raiderDamage);
+    }
+}

--- a/src/main/java/com/minecolonies/coremod/colony/buildings/utils/BuildingBuilderResource.java
+++ b/src/main/java/com/minecolonies/coremod/colony/buildings/utils/BuildingBuilderResource.java
@@ -208,7 +208,7 @@ public class BuildingBuilderResource extends ItemStorage
     public static class ResourceComparator implements Comparator<BuildingBuilderResource>, Serializable
     {
         private static final long                                serialVersionUID = 1;
-        private static final Map<RessourceAvailability, Integer> order            = new HashMap<>();
+        private final        Map<RessourceAvailability, Integer> order            = new HashMap<>();
 
         public ResourceComparator(final RessourceAvailability... resourceOrder)
         {

--- a/src/main/java/com/minecolonies/coremod/enchants/RaiderDamageEnchant.java
+++ b/src/main/java/com/minecolonies/coremod/enchants/RaiderDamageEnchant.java
@@ -1,0 +1,47 @@
+package com.minecolonies.coremod.enchants;
+
+import net.minecraft.enchantment.Enchantment;
+import net.minecraft.inventory.EquipmentSlotType;
+
+import static net.minecraft.enchantment.EnchantmentType.WEAPON;
+
+/**
+ * Enchant for adding extra damage against raiders
+ */
+public class RaiderDamageEnchant extends Enchantment
+{
+    /**
+     * Enchant id
+     */
+    private final String NAME_ID = "raider_damage_enchant";
+
+    public RaiderDamageEnchant(final Rarity rarity, final EquipmentSlotType[] slotTypes)
+    {
+        super(rarity, WEAPON, slotTypes);
+        setRegistryName(NAME_ID);
+    }
+
+    @Override
+    public int getMinEnchantability(int enchantmentLevel)
+    {
+        return 10;
+    }
+
+    @Override
+    public int getMaxEnchantability(int enchantmentLevel)
+    {
+        return 50;
+    }
+
+    @Override
+    public int getMinLevel()
+    {
+        return 1;
+    }
+
+    @Override
+    public int getMaxLevel()
+    {
+        return 2;
+    }
+}

--- a/src/main/resources/assets/minecolonies/lang/en_us.json
+++ b/src/main/resources/assets/minecolonies/lang/en_us.json
@@ -886,6 +886,8 @@
   "com.minecolonies.coremod.item.bannerrallyguards.gui.error": "Error modifying banner. Please try again.",
   "block.minecolonies.blockpaperwall": "Paper Wall",
 
+  "enchantment.minecolonies.raider_damage_enchant": "Raider's Bane",
+
   "com.minecolonies.coremod.item.gate.craft": "Crafted by the Mechanic",
   "com.minecolonies.coremod.item.gate.place": "Autoplaces parts. The max size is 5x4 which needs a stack of 20.",
 


### PR DESCRIPTION
# Changes proposed in this pull request:
Balance player damage against raiders in a way where player attacks still matter, but modded opness is diminished and doesnt matter much.
Add an enchant  providing extra damage against raiders, made by the enchanter worker
Fix builder's resource list ordering beeing affected by the resourcescroll

Review please
