### PR TITLE
hotfix building access too early

### DIFF
--- a/src/main/java/com/minecolonies/coremod/entity/ai/basic/AbstractEntityAIBasic.java
+++ b/src/main/java/com/minecolonies/coremod/entity/ai/basic/AbstractEntityAIBasic.java
@@ -416,6 +416,7 @@ public abstract class AbstractEntityAIBasic<J extends AbstractJob<?, J>, B exten
 
         if (getState() == INIT)
         {
+            this.getOwnBuilding().setJobDisplayName(job.getName());
             return IDLE;
         }
 

--- a/src/main/java/com/minecolonies/coremod/entity/ai/basic/AbstractEntityAIInteract.java
+++ b/src/main/java/com/minecolonies/coremod/entity/ai/basic/AbstractEntityAIInteract.java
@@ -1,21 +1,14 @@
 package com.minecolonies.coremod.entity.ai.basic;
 
-import com.minecolonies.api.colony.buildings.IBuilding;
-import com.minecolonies.api.crafting.ItemStorage;
 import com.minecolonies.api.entity.ai.citizen.builder.IBuilderUndestroyable;
-import com.minecolonies.api.entity.ai.statemachine.states.IAIState;
-import com.minecolonies.api.entity.pathfinding.PathResult;
 import com.minecolonies.api.entity.pathfinding.RandomPathResult;
-import com.minecolonies.api.entity.pathfinding.TreePathResult;
 import com.minecolonies.api.util.BlockPosUtil;
 import com.minecolonies.api.util.InventoryUtils;
 import com.minecolonies.api.util.ItemStackUtils;
 import com.minecolonies.api.util.MathUtils;
 import com.minecolonies.coremod.MineColonies;
 import com.minecolonies.coremod.colony.buildings.AbstractBuildingWorker;
-import com.minecolonies.coremod.colony.buildings.workerbuildings.BuildingLumberjack;
 import com.minecolonies.coremod.colony.jobs.AbstractJob;
-import com.minecolonies.coremod.entity.ai.citizen.lumberjack.Tree;
 import com.minecolonies.coremod.research.MultiplierModifierResearchEffect;
 import net.minecraft.block.AirBlock;
 import net.minecraft.block.Block;
@@ -30,14 +23,10 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
-import java.util.Map;
 import java.util.stream.Collectors;
 
-import static com.minecolonies.api.entity.ai.statemachine.states.AIWorkerState.*;
 import static com.minecolonies.api.research.util.ResearchConstants.BLOCK_BREAK_SPEED;
-import static com.minecolonies.api.util.constant.Constants.TICKS_SECOND;
 
 /**
  * This is the base class of all worker AIs. Every AI implements this class with it's job type. There are some utilities within the class: - The AI will clear a full inventory at
@@ -114,7 +103,6 @@ public abstract class AbstractEntityAIInteract<J extends AbstractJob<?, J>, B ex
         super.registerTargets(
           //no new targets for now
         );
-        this.getOwnBuilding().setJobDisplayName(job.getName());
     }
 
     /**


### PR DESCRIPTION
# Changes proposed in this pull request:
AI now sets the job name to the building when it passed the safety checks of building exists etc. No longer does that in the constructor

Review please
