### PR TITLE
Archery works with both old and new schematics. (either using haybale…

### DIFF
--- a/src/main/java/com/minecolonies/coremod/colony/buildings/workerbuildings/BuildingArchery.java
+++ b/src/main/java/com/minecolonies/coremod/colony/buildings/workerbuildings/BuildingArchery.java
@@ -113,7 +113,7 @@ public class BuildingArchery extends AbstractBuildingWorker implements IBuilding
     @Override
     public void registerBlockPosition(@NotNull final Block block, @NotNull final BlockPos pos, @NotNull final World world)
     {
-        if (block == Blocks.TARGET)
+        if (block == Blocks.TARGET || (block == Blocks.HAY_BLOCK && world.getBlockState(pos.down()).getBlock() instanceof FenceBlock)
         {
             shootingTargets.add(pos);
         }

--- a/src/main/java/com/minecolonies/coremod/colony/buildings/workerbuildings/BuildingArchery.java
+++ b/src/main/java/com/minecolonies/coremod/colony/buildings/workerbuildings/BuildingArchery.java
@@ -113,7 +113,7 @@ public class BuildingArchery extends AbstractBuildingWorker implements IBuilding
     @Override
     public void registerBlockPosition(@NotNull final Block block, @NotNull final BlockPos pos, @NotNull final World world)
     {
-        if (block == Blocks.TARGET || (block == Blocks.HAY_BLOCK && world.getBlockState(pos.down()).getBlock() instanceof FenceBlock)
+        if (block == Blocks.TARGET || (block == Blocks.HAY_BLOCK && world.getBlockState(pos.down()).getBlock() instanceof FenceBlock))
         {
             shootingTargets.add(pos);
         }


### PR DESCRIPTION
Archery works with both old and new schematics. (either using haybale or target blocks as shooting targets).
Temporary fix for 1.16 until all schematics use target blocks.