### PR TITLE
Minor Config change

### DIFF
--- a/build.properties
+++ b/build.properties
@@ -7,5 +7,5 @@ forge_version=31.2.33
 mappings=20200606-1.15.1
 # Dependencies
 structurize_version=0.13.94-ALPHA
-jei_version=6.0.0.2
+jei_version=6.0.3.15
 

--- a/src/api/java/com/minecolonies/api/configuration/CommonConfiguration.java
+++ b/src/api/java/com/minecolonies/api/configuration/CommonConfiguration.java
@@ -26,7 +26,6 @@ public class CommonConfiguration extends AbstractConfiguration
     public final ForgeConfigSpec.BooleanValue allowOtherDimColonies;
     public final ForgeConfigSpec.IntValue     citizenRespawnInterval;
     public final ForgeConfigSpec.IntValue     maxCitizenPerColony;
-    public final ForgeConfigSpec.BooleanValue builderInfiniteResources;
     public final ForgeConfigSpec.BooleanValue limitToOneWareHousePerColony;
     public final ForgeConfigSpec.IntValue     builderBuildBlockDelay;
     public final ForgeConfigSpec.IntValue     blockMiningDelayModifier;
@@ -384,7 +383,6 @@ public class CommonConfiguration extends AbstractConfiguration
         allowOtherDimColonies = defineBoolean(builder, "allowotherdimcolonies", false);
         citizenRespawnInterval = defineInteger(builder, "citizenrespawninterval", 60, CITIZEN_RESPAWN_INTERVAL_MIN, CITIZEN_RESPAWN_INTERVAL_MAX);
         maxCitizenPerColony = defineInteger(builder, "maxcitizenpercolony", 150, 4, 500);
-        builderInfiniteResources = defineBoolean(builder, "builderinfiniteresources", false);
         limitToOneWareHousePerColony = defineBoolean(builder, "limittoonewarehousepercolony", true);
         builderBuildBlockDelay = defineInteger(builder, "builderbuildblockdelay", 15, 1, 500);
         blockMiningDelayModifier = defineInteger(builder, "blockminingdelaymodifier", 500, 1, 10000);

--- a/src/api/java/com/minecolonies/api/configuration/ServerConfiguration.java
+++ b/src/api/java/com/minecolonies/api/configuration/ServerConfiguration.java
@@ -15,6 +15,7 @@ public class ServerConfiguration extends AbstractConfiguration
     public final ForgeConfigSpec.ConfigValue<List<? extends String>> maleFirstNames;
     public final ForgeConfigSpec.ConfigValue<List<? extends String>> femaleFirstNames;
     public final ForgeConfigSpec.ConfigValue<List<? extends String>> lastNames;
+    public final ForgeConfigSpec.BooleanValue builderInfiniteResources;
 
     /**
      * Builds server configuration.
@@ -33,6 +34,9 @@ public class ServerConfiguration extends AbstractConfiguration
 
         lastNames = defineList(builder, "lastnames", Arrays.asList(NameConstants.lastNames), s -> s instanceof String);
 
+        swapToCategory(builder, "Debug Tools");
+
+        builderInfiniteResources = defineBoolean(builder, "builderinfiniteresources", false);
         finishCategory(builder);
     }
 }

--- a/src/main/java/com/minecolonies/coremod/entity/ai/basic/AbstractEntityAIStructureWithWorkOrder.java
+++ b/src/main/java/com/minecolonies/coremod/entity/ai/basic/AbstractEntityAIStructureWithWorkOrder.java
@@ -174,7 +174,7 @@ public abstract class AbstractEntityAIStructureWithWorkOrder<J extends AbstractJ
      */
     private void requestMaterialsState()
     {
-        if (MineColonies.getConfig().getCommon().builderInfiniteResources.get() || job.getWorkOrder().isRequested() || job.getWorkOrder() instanceof WorkOrderBuildRemoval)
+        if (MineColonies.getConfig().getServer().builderInfiniteResources.get() || job.getWorkOrder().isRequested() || job.getWorkOrder() instanceof WorkOrderBuildRemoval)
         {
             return;
         }

--- a/src/main/java/com/minecolonies/coremod/entity/ai/util/BuildingStructureHandler.java
+++ b/src/main/java/com/minecolonies/coremod/entity/ai/util/BuildingStructureHandler.java
@@ -257,7 +257,7 @@ public class BuildingStructureHandler<J extends AbstractJobStructure<?, J>, B ex
     @Override
     public boolean isCreative()
     {
-        return MineColonies.getConfig().getCommon().builderInfiniteResources.get();
+        return MineColonies.getConfig().getServer().builderInfiniteResources.get();
     }
 
     @Override


### PR DESCRIPTION
# Changes proposed in this pull request:
- Refactor BuilderInfiniteResources key to Server Config
- Update JEI dependency, was three minor releases behind.

Intention: moving the debug and other such keys to the server config ought to reduce user confusion as to what the key is used for. 
I'm running into a runtime error from the JEI dependency while trying to build against minecolonies for some compatibility additions. I'm hoping that it is a mapping conflict, but I'm not sure. In any case, the JEI dependency runs fine at this level. 
Review please
