### PR TITLE
Fix builders in manual mode unable to select orders created for them

### DIFF
--- a/src/main/java/com/minecolonies/coremod/colony/buildings/workerbuildings/BuildingBuilder.java
+++ b/src/main/java/com/minecolonies/coremod/colony/buildings/workerbuildings/BuildingBuilder.java
@@ -153,9 +153,9 @@ public class BuildingBuilder extends AbstractBuildingStructureBuilder
             list.addAll(getColony().getWorkManager().getOrderedList(WorkOrderBuildDecoration.class, getPosition()));
 
             list.removeIf(order -> order instanceof WorkOrderBuildMiner);
-            list.removeIf(order -> order.isClaimed());
+            list.removeIf(order -> order.isClaimed() && !order.getClaimedBy().equals(getPosition()));
             list.removeIf(order -> order instanceof WorkOrderBuild && !(order instanceof WorkOrderBuildRemoval) &&
-                  !((WorkOrderBuild) order).canBuild(getMainCitizen()));
+                  !((WorkOrderBuild) order).canBuildIngoringDistance(getMainCitizen()));
 
             buf.writeInt(list.size());
 
@@ -328,7 +328,7 @@ public class BuildingBuilder extends AbstractBuildingStructureBuilder
         }
 
         IWorkOrder wo = getColony().getWorkManager().getWorkOrder(orderId);
-        if (wo == null || wo.getClaimedBy() != null)
+        if (wo == null || (wo.getClaimedBy() != null && !wo.getClaimedBy().equals(getPosition())))
         {
             return;
         }

--- a/src/main/java/com/minecolonies/coremod/colony/workorders/WorkOrderBuild.java
+++ b/src/main/java/com/minecolonies/coremod/colony/workorders/WorkOrderBuild.java
@@ -139,11 +139,8 @@ public class WorkOrderBuild extends WorkOrderBuildDecoration
         //  - OR the WorkOrder is for the TownHall
         //  - OR the WorkOrder is not farther away than 100 blocks from any builder
 
-        final int builderLevel = citizen.getWorkBuilding().getBuildingLevel();
-        return (builderLevel >= upgradeLevel || builderLevel == BuildingBuilder.MAX_BUILDING_LEVEL
-                  || (citizen.getWorkBuilding() != null && citizen.getWorkBuilding().getID().equals(buildingLocation))
-                  || isLocationTownhall(citizen.getColony(), buildingLocation)
-                       && citizen.getWorkBuilding().getPosition().distanceSq(this.getBuildingLocation()) <= MAX_DISTANCE_SQ);
+        return canBuildIngoringDistance(citizen)
+                       && citizen.getWorkBuilding().getPosition().distanceSq(this.getBuildingLocation()) <= MAX_DISTANCE_SQ;
     }
 
     /**

--- a/src/main/java/com/minecolonies/coremod/colony/workorders/WorkOrderBuild.java
+++ b/src/main/java/com/minecolonies/coremod/colony/workorders/WorkOrderBuild.java
@@ -146,6 +146,25 @@ public class WorkOrderBuild extends WorkOrderBuildDecoration
                        && citizen.getWorkBuilding().getPosition().distanceSq(this.getBuildingLocation()) <= MAX_DISTANCE_SQ);
     }
 
+    /**
+     * Checks if a builder may accept this workOrder while ignoring the distance to the builder.
+     * 
+     * @param citizen the builder who to check.
+     * @return Whether the builder may accept this workOrder.
+     */
+    public boolean canBuildIngoringDistance(@NotNull final ICitizenData citizen)
+    {
+        //  A Build WorkOrder may be fulfilled by a Builder as long as any ONE of the following is true:
+        //  - The Builder's Work AbstractBuilding is built
+        //  - OR the WorkOrder is for the Builder's Work AbstractBuilding
+        //  - OR the WorkOrder is for the TownHall
+
+        final int builderLevel = citizen.getWorkBuilding().getBuildingLevel();
+        return (builderLevel >= upgradeLevel || builderLevel == BuildingBuilder.MAX_BUILDING_LEVEL
+                  || (citizen.getWorkBuilding() != null && citizen.getWorkBuilding().getID().equals(buildingLocation))
+                  || isLocationTownhall(citizen.getColony(), buildingLocation));
+    }
+
     @Override
     public boolean tooFarFromAnyBuilder(final IColony colony, final int level)
     {


### PR DESCRIPTION
Closes #
Closes #
Closes #

# Changes proposed in this pull request:
- Fix builders in manual mode not showing build orders that are created with them selected, but outside the normal builder range.
-
-

It might make sense to add canBuildIngoringDistance to `WorkOrderBuildDecoration` too, instead of just `WorkOrderBuild`, but i didn't as it would never be called in any class besides `WorkOrderBuild`.

Review please
