### PR TITLE
Small statemachine improvement

### DIFF
--- a/src/api/java/com/minecolonies/api/entity/ai/statemachine/basestatemachine/BasicStateMachine.java
+++ b/src/api/java/com/minecolonies/api/entity/ai/statemachine/basestatemachine/BasicStateMachine.java
@@ -27,6 +27,9 @@ public class BasicStateMachine<T extends IStateMachineTransition<S>, S extends I
     @NotNull
     protected final Map<IStateEventType, ArrayList<T>> eventTransitionMap;
 
+    /**
+     * The current states list of transitions
+     */
     protected ArrayList<T> currentStateTransitions;
 
     /**

--- a/src/api/java/com/minecolonies/api/entity/ai/statemachine/basestatemachine/BasicStateMachine.java
+++ b/src/api/java/com/minecolonies/api/entity/ai/statemachine/basestatemachine/BasicStateMachine.java
@@ -10,6 +10,7 @@ import org.jetbrains.annotations.NotNull;
 
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.function.Consumer;
 
@@ -23,14 +24,14 @@ public class BasicStateMachine<T extends IStateMachineTransition<S>, S extends I
      * The lists of transitions and events
      */
     @NotNull
-    protected final Map<S, ArrayList<T>>               transitionMap;
+    protected final Map<S, List<T>>               transitionMap;
     @NotNull
-    protected final Map<IStateEventType, ArrayList<T>> eventTransitionMap;
+    protected final Map<IStateEventType, List<T>> eventTransitionMap;
 
     /**
      * The current states list of transitions
      */
-    protected ArrayList<T> currentStateTransitions;
+    protected List<T> currentStateTransitions;
 
     /**
      * The current state we're in
@@ -91,13 +92,13 @@ public class BasicStateMachine<T extends IStateMachineTransition<S>, S extends I
     {
         if (transition instanceof IStateMachineEvent)
         {
-            final ArrayList<T> temp = new ArrayList<>(eventTransitionMap.get(((IStateMachineEvent<?>) transition).getEventType()));
+            final List<T> temp = new ArrayList<>(eventTransitionMap.get(((IStateMachineEvent<?>) transition).getEventType()));
             temp.remove(transition);
             eventTransitionMap.put(((IStateMachineEvent<?>) transition).getEventType(), temp);
         }
         else
         {
-            final ArrayList<T> temp = new ArrayList<>(transitionMap.get(transition.getState()));
+            final List<T> temp = new ArrayList<>(transitionMap.get(transition.getState()));
             temp.remove(transition);
             transitionMap.put(transition.getState(), temp);
         }
@@ -108,7 +109,7 @@ public class BasicStateMachine<T extends IStateMachineTransition<S>, S extends I
      */
     public void tick()
     {
-        for (final ArrayList<T> transitions : eventTransitionMap.values())
+        for (final List<T> transitions : eventTransitionMap.values())
         {
             for (final T transition : transitions)
             {

--- a/src/api/java/com/minecolonies/api/entity/ai/statemachine/basestatemachine/BasicStateMachine.java
+++ b/src/api/java/com/minecolonies/api/entity/ai/statemachine/basestatemachine/BasicStateMachine.java
@@ -27,6 +27,8 @@ public class BasicStateMachine<T extends IStateMachineTransition<S>, S extends I
     @NotNull
     protected final Map<IStateEventType, ArrayList<T>> eventTransitionMap;
 
+    protected ArrayList<T> currentStateTransitions;
+
     /**
      * The current state we're in
      */
@@ -57,7 +59,8 @@ public class BasicStateMachine<T extends IStateMachineTransition<S>, S extends I
         this.initState = initialState;
         this.exceptionHandler = exceptionHandler;
         this.transitionMap = new HashMap<>();
-        this.transitionMap.put(initialState, new ArrayList<>());
+        currentStateTransitions = new ArrayList<>();
+        this.transitionMap.put(initialState, currentStateTransitions);
         this.eventTransitionMap = new HashMap<>();
     }
 
@@ -102,11 +105,23 @@ public class BasicStateMachine<T extends IStateMachineTransition<S>, S extends I
      */
     public void tick()
     {
-        // Check if any Events happens before doing state transitions
-        if (!eventTransitionMap.values().stream().anyMatch(k -> k.stream().anyMatch(this::checkTransition)))
+        for (final ArrayList<T> transitions : eventTransitionMap.values())
         {
-            // State transitions
-            transitionMap.get(state).stream().anyMatch(this::checkTransition);
+            for (final T transition : transitions)
+            {
+                if (checkTransition(transition))
+                {
+                    return;
+                }
+            }
+        }
+
+        for (final T transition : currentStateTransitions)
+        {
+            if (checkTransition(transition))
+            {
+                return;
+            }
         }
     }
 
@@ -161,6 +176,19 @@ public class BasicStateMachine<T extends IStateMachineTransition<S>, S extends I
                 removeTransition(transition);
             }
 
+            if (newState != state)
+            {
+                currentStateTransitions = transitionMap.get(newState);
+
+                if (currentStateTransitions == null || currentStateTransitions.isEmpty())
+                {
+                    // Reached Trap/Sink state we cannot leave.
+                    onException(new RuntimeException("Missing AI transition for state: " + getState()));
+                    reset();
+                    return false;
+                }
+            }
+
             state = newState;
             return true;
         }
@@ -193,5 +221,6 @@ public class BasicStateMachine<T extends IStateMachineTransition<S>, S extends I
     public void reset()
     {
         state = initState;
+        currentStateTransitions = transitionMap.get(initState);
     }
 }

--- a/src/api/java/com/minecolonies/api/entity/ai/statemachine/tickratestatemachine/TickRateStateMachine.java
+++ b/src/api/java/com/minecolonies/api/entity/ai/statemachine/tickratestatemachine/TickRateStateMachine.java
@@ -6,6 +6,7 @@ import com.minecolonies.api.entity.ai.statemachine.states.IState;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.ArrayList;
+import java.util.List;
 import java.util.Random;
 import java.util.function.Consumer;
 
@@ -34,9 +35,9 @@ public class TickRateStateMachine<S extends IState> extends BasicStateMachine<IT
     /**
      * Reference to our used global transition lists
      */
-    private final ArrayList<ITickingTransition<S>> aiBlockingTransitions;
-    private final ArrayList<ITickingTransition<S>> stateBlockingTransitions;
-    private final ArrayList<ITickingTransition<S>> eventTransitions;
+    private final List<ITickingTransition<S>> aiBlockingTransitions;
+    private final List<ITickingTransition<S>> stateBlockingTransitions;
+    private final List<ITickingTransition<S>> eventTransitions;
 
     /**
      * Construct a new StateMachine


### PR DESCRIPTION
# Changes proposed in this pull request:
This changes the statemachine to no longer do hash lookups frequently when it already does know/has a reference to the result. Instead we do the lookup once the state changes and keep the reference to the current state's transitions.
Removed streams in the basic statemachine aswell.

Review please
