### PR TITLE
Fixes and pathing improvements

### DIFF
--- a/src/api/java/com/minecolonies/api/entity/ai/statemachine/basestatemachine/BasicStateMachine.java
+++ b/src/api/java/com/minecolonies/api/entity/ai/statemachine/basestatemachine/BasicStateMachine.java
@@ -92,15 +92,11 @@ public class BasicStateMachine<T extends IStateMachineTransition<S>, S extends I
     {
         if (transition instanceof IStateMachineEvent)
         {
-            final List<T> temp = new ArrayList<>(eventTransitionMap.get(((IStateMachineEvent<?>) transition).getEventType()));
-            temp.remove(transition);
-            eventTransitionMap.put(((IStateMachineEvent<?>) transition).getEventType(), temp);
+            eventTransitionMap.get(((IStateMachineEvent<?>) transition).getEventType()).removeIf(t -> t == transition);
         }
         else
         {
-            final List<T> temp = new ArrayList<>(transitionMap.get(transition.getState()));
-            temp.remove(transition);
-            transitionMap.put(transition.getState(), temp);
+            transitionMap.get(transition.getState()).removeIf(t -> t == transition);
         }
     }
 

--- a/src/api/java/com/minecolonies/api/entity/citizen/AbstractCivilianEntity.java
+++ b/src/api/java/com/minecolonies/api/entity/citizen/AbstractCivilianEntity.java
@@ -11,6 +11,11 @@ import org.jetbrains.annotations.Nullable;
 public abstract class AbstractCivilianEntity extends AgeableEntity implements INPC, IStuckHandlerEntity
 {
 
+    /**
+     * Whether this entity can be stuck for stuckhandling
+     */
+    private boolean canBeStuck = true;
+
     protected AbstractCivilianEntity(final EntityType<? extends AgeableEntity> type, final World worldIn)
     {
         super(type, worldIn);
@@ -41,4 +46,20 @@ public abstract class AbstractCivilianEntity extends AgeableEntity implements IN
      * @param id the id to set.
      */
     public abstract void setCitizenId(int id);
+
+    @Override
+    public boolean canBeStuck()
+    {
+        return canBeStuck;
+    }
+
+    /**
+     * Sets whether the entity currently can be stuck
+     *
+     * @param canBeStuck
+     */
+    public void setCanBeStuck(final boolean canBeStuck)
+    {
+        this.canBeStuck = canBeStuck;
+    }
 }

--- a/src/main/java/com/minecolonies/coremod/colony/managers/RaidManager.java
+++ b/src/main/java/com/minecolonies/coremod/colony/managers/RaidManager.java
@@ -91,7 +91,7 @@ public class RaidManager implements IRaiderManager
     /**
      * Min required raidlevel
      */
-    private static final int MIN_REQUIRED_RAIDLEVEL = 100;
+    private static final int MIN_REQUIRED_RAIDLEVEL = 75;
 
     /**
      * Percentage increased amount of spawns per player

--- a/src/main/java/com/minecolonies/coremod/colony/managers/RaidManager.java
+++ b/src/main/java/com/minecolonies/coremod/colony/managers/RaidManager.java
@@ -521,7 +521,7 @@ public class RaidManager implements IRaiderManager
     @Override
     public int calculateRaiderAmount(final int raidLevel)
     {
-        return Math.min(MineColonies.getConfig().getCommon().maxBarbarianSize.get(),
+        return 1 + Math.min(MineColonies.getConfig().getCommon().maxBarbarianSize.get(),
           (int) ((raidLevel / SPAWN_MODIFIER) * getRaidDifficultyModifier() * (1.0 + colony.getMessagePlayerEntities().size() * INCREASE_PER_PLAYER) * ((
             colony.getWorld().rand.nextDouble() * 0.5d) + 0.75)));
     }

--- a/src/main/java/com/minecolonies/coremod/entity/ai/citizen/guard/AbstractEntityAIGuard.java
+++ b/src/main/java/com/minecolonies/coremod/entity/ai/citizen/guard/AbstractEntityAIGuard.java
@@ -429,6 +429,8 @@ public abstract class AbstractEntityAIGuard<J extends AbstractJobGuard<J>, B ext
                 return START_WORKING;
             }
 
+            worker.setCanBeStuck(false);
+            worker.getNavigator().getPathingOptions().setCanUseRails(false);
             fighttimer = COMBAT_TIME;
             equipInventoryArmor();
             moveInAttackPosition();
@@ -438,6 +440,11 @@ public abstract class AbstractEntityAIGuard<J extends AbstractJobGuard<J>, B ext
         if (fighttimer > 0)
         {
             fighttimer--;
+            if (fighttimer == 0)
+            {
+                worker.getNavigator().getPathingOptions().setCanUseRails(((EntityCitizen) worker).canPathOnRails());
+                worker.setCanBeStuck(true);
+            }
         }
 
         return null;

--- a/src/main/java/com/minecolonies/coremod/entity/citizen/EntityCitizen.java
+++ b/src/main/java/com/minecolonies/coremod/entity/citizen/EntityCitizen.java
@@ -1637,12 +1637,7 @@ public class EntityCitizen extends AbstractEntityCitizen
             return world.getScoreboard().getTeam(this.cachedTeamName);
         }
 
-        if (getCitizenColonyHandler().getColony() != null)
-        {
-            return getCitizenColonyHandler().getColony().getTeam();
-        }
-
-        return null;
+        return world.getScoreboard().getTeam(getScoreboardName());
     }
 
     @Override

--- a/src/main/java/com/minecolonies/coremod/entity/citizen/VisitorCitizen.java
+++ b/src/main/java/com/minecolonies/coremod/entity/citizen/VisitorCitizen.java
@@ -697,6 +697,11 @@ public class VisitorCitizen extends AbstractEntityCitizen
     public void setRawPosition(double x, double y, double z)
     {
         super.setRawPosition(x, y, z);
+        if (world.isRemote)
+        {
+            return;
+        }
+
         if (citizenStatusHandler != null && x < 1 && x > -1 && z < 1 && z > -1)
         {
             Log.getLogger().error("Visitor entity set to zero pos, report to mod author:", new Exception());

--- a/src/main/java/com/minecolonies/coremod/entity/citizen/citizenhandlers/MovementHandler.java
+++ b/src/main/java/com/minecolonies/coremod/entity/citizen/citizenhandlers/MovementHandler.java
@@ -104,7 +104,7 @@ public class MovementHandler extends MovementController
         }
         else if (this.action == net.minecraft.entity.ai.controller.MovementController.Action.JUMPING)
         {
-            this.mob.setAIMoveSpeed((float) (this.speed * this.mob.getAttribute(SharedMonsterAttributes.MOVEMENT_SPEED).getValue()));
+            this.mob.setAIMoveSpeed((float) (this.speed * speedAtr.getValue()));
 
             // Avoid beeing stuck in jumping while in liquids
             final BlockPos blockpos = new BlockPos(this.mob);

--- a/src/main/java/com/minecolonies/coremod/entity/pathfinding/MinecoloniesAdvancedPathNavigate.java
+++ b/src/main/java/com/minecolonies/coremod/entity/pathfinding/MinecoloniesAdvancedPathNavigate.java
@@ -17,7 +17,6 @@ import com.minecolonies.coremod.util.WorkerUtil;
 import net.minecraft.block.AbstractRailBlock;
 import net.minecraft.block.BlockState;
 import net.minecraft.block.LadderBlock;
-import net.minecraft.block.VineBlock;
 import net.minecraft.entity.Entity;
 import net.minecraft.entity.MobEntity;
 import net.minecraft.entity.SharedMonsterAttributes;
@@ -225,6 +224,7 @@ public class MinecoloniesAdvancedPathNavigate extends AbstractAdvancedPathNaviga
         this.ourEntity.setMoveVertical(0);
         if (handleLadders(oldIndex))
         {
+            pathFollow();
             return;
         }
         if (handleRails())
@@ -531,9 +531,9 @@ public class MinecoloniesAdvancedPathNavigate extends AbstractAdvancedPathNaviga
      */
     private BlockPos findBlockUnderEntity(@NotNull final Entity parEntity)
     {
-        int blockX = (int)Math.round(parEntity.posX);
-        int blockY = MathHelper.floor(parEntity.posY-0.2D);
-        int blockZ = (int)Math.round(parEntity.posZ);
+        int blockX = (int) Math.round(parEntity.posX);
+        int blockY = MathHelper.floor(parEntity.posY - 0.2D);
+        int blockZ = (int) Math.round(parEntity.posZ);
         return new BlockPos(blockX, blockY, blockZ);
     }
 
@@ -698,7 +698,7 @@ public class MinecoloniesAdvancedPathNavigate extends AbstractAdvancedPathNaviga
                 }
                 else
                 {
-                    this.ourEntity.getNavigator().clearPath();
+                    return false;
                 }
                 return true;
             }
@@ -764,39 +764,38 @@ public class MinecoloniesAdvancedPathNavigate extends AbstractAdvancedPathNaviga
                 {
                     this.currentPath.setCurrentPathIndex(curNodeNext);
                 }
-
-                this.checkForStuck(vec3);
                 return;
             }
         }
 
         Vec3d vec3d = this.getEntityPosition();
-        this.maxDistanceToWaypoint = this.entity.getWidth() > 0.75F ? this.entity.getWidth() / 2.0F : 0.75F - this.entity.getWidth() / 2.0F;
-        Vec3d vec3d1 = this.currentPath.getVectorFromIndex(this.entity, this.currentPath.getCurrentPathIndex());
-        // Forge: fix MC-94054
-        if (Math.abs(this.entity.getPosX() - vec3d1.x) < (double) this.maxDistanceToWaypoint
-              && Math.abs(this.entity.getPosZ() - vec3d1.z) < (double) this.maxDistanceToWaypoint &&
-              Math.abs(this.entity.getPosY() - vec3d1.y) < 1.0D)
+        this.maxDistanceToWaypoint = 0.75F;
+
+        // Look at multiple points, incase we're too fast
+        for (int i = this.currentPath.getCurrentPathIndex(); i < Math.min(this.currentPath.getCurrentPathLength(), this.currentPath.getCurrentPathIndex() + 4); i++)
         {
-            this.currentPath.incrementPathIndex();
-        }
-        else
-        {
-            // Look ahead if we were too fast.
-            for (int i = this.currentPath.getCurrentPathIndex(); i < Math.min(this.currentPath.getCurrentPathLength(), this.currentPath.getCurrentPathIndex() + 4); i++)
+            Vec3d vec3d2 = this.currentPath.getVectorFromIndex(this.entity, i);
+            if (Math.abs(this.entity.getPosX() - vec3d2.x) < (double) this.maxDistanceToWaypoint - Math.abs(this.entity.getPosY() - (vec3d2.y)) * 0.1
+                  && Math.abs(this.entity.getPosZ() - vec3d2.z) < (double) this.maxDistanceToWaypoint - Math.abs(this.entity.getPosY() - (vec3d2.y)) * 0.1 &&
+                  Math.abs(this.entity.getPosY() - (vec3d2.y - 0.5f)) < 1.0D)
             {
-                Vec3d vec3d2 = this.currentPath.getVectorFromIndex(this.entity, i);
-                if (Math.abs(this.entity.getPosX() - vec3d2.x) < (double) this.maxDistanceToWaypoint
-                      && Math.abs(this.entity.getPosZ() - vec3d2.z) < (double) this.maxDistanceToWaypoint &&
-                      Math.abs(this.entity.getPosY() - vec3d2.y) < 1.0D)
+                this.currentPath.incrementPathIndex();
+                // Mark reached nodes for debug path drawing
+                if (AbstractPathJob.lastDebugNodesPath != null)
                 {
-                    this.currentPath.setCurrentPathIndex(i);
-                    break;
+                    final PathPoint point = currentPath.getPathPointFromIndex(i);
+                    final BlockPos pos = new BlockPos(point.x, point.y, point.z);
+                    for (final Node node : AbstractPathJob.lastDebugNodesPath)
+                    {
+                        if (node.pos.equals(pos))
+                        {
+                            node.setReachedByWorker();
+                            break;
+                        }
+                    }
                 }
             }
         }
-
-        this.checkForStuck(vec3d);
     }
 
     public void updatePath() {}

--- a/src/main/java/com/minecolonies/coremod/entity/pathfinding/Node.java
+++ b/src/main/java/com/minecolonies/coremod/entity/pathfinding/Node.java
@@ -84,6 +84,16 @@ public class Node implements Comparable<Node>
     private boolean isOnRails = false;
 
     /**
+     * Whether this is an air node
+     */
+    private boolean isCornerNode = false;
+
+    /**
+     * Wether this node got reached by an entity, for debug drawing
+     */
+    private boolean isReachedByWorker = false;
+
+    /**
      * Create initial Node.
      *
      * @param pos       coordinates of node.
@@ -354,5 +364,41 @@ public class Node implements Comparable<Node>
     public boolean isOnRails()
     {
         return isOnRails;
+    }
+
+    /**
+     * Marks the node as reached by the worker
+     */
+    public void setReachedByWorker()
+    {
+        isReachedByWorker = true;
+    }
+
+    /**
+     * Whether the node is reached by a worker
+     *
+     * @return reached
+     */
+    public boolean isReachedByWorker()
+    {
+        return isReachedByWorker;
+    }
+
+    /**
+     * Marks the node as reached by the worker
+     */
+    public void setCornerNode(boolean isCornerNode)
+    {
+        this.isCornerNode = isCornerNode;
+    }
+
+    /**
+     * Whether the node is reached by a worker
+     *
+     * @return reached
+     */
+    public boolean isCornerNode()
+    {
+        return isCornerNode;
     }
 }

--- a/src/main/java/com/minecolonies/coremod/entity/pathfinding/Pathfinding.java
+++ b/src/main/java/com/minecolonies/coremod/entity/pathfinding/Pathfinding.java
@@ -151,7 +151,14 @@ public final class Pathfinding
 
             for (@NotNull final Node n : debugNodesPath)
             {
-                debugDrawNode(n, 0F, 1.0F, 0F, matrixStack);
+                if (n.isReachedByWorker())
+                {
+                    debugDrawNode(n, 1F, 0.4F, 0F, matrixStack);
+                }
+                else
+                {
+                    debugDrawNode(n, 0F, 1.0F, 0F, matrixStack);
+                }
             }
         }
         catch (final ConcurrentModificationException exc)

--- a/src/main/java/com/minecolonies/coremod/entity/pathfinding/pathjobs/AbstractPathJob.java
+++ b/src/main/java/com/minecolonies/coremod/entity/pathfinding/pathjobs/AbstractPathJob.java
@@ -977,7 +977,7 @@ public abstract class AbstractPathJob implements Callable<Path>
     {
         final boolean canDrop = parent != null && !parent.isLadder();
         //  Nothing to stand on
-        if (!canDrop || isSwimming || (isPassable(parent.pos.down(), false)
+        if (!canDrop || isSwimming || ((parent.pos.getX() != pos.getX() || parent.pos.getZ() != pos.getZ()) && isPassable(parent.pos.down(), false)
                                          && isWalkableSurface(world.getBlockState(parent.pos.down()), parent.pos.down()) == SurfaceType.DROPABLE))
         {
             return -1;

--- a/src/main/java/com/minecolonies/coremod/entity/pathfinding/pathjobs/AbstractPathJob.java
+++ b/src/main/java/com/minecolonies/coremod/entity/pathfinding/pathjobs/AbstractPathJob.java
@@ -537,6 +537,19 @@ public abstract class AbstractPathJob implements Callable<Path>
             walk(currentNode, BLOCKPOS_DOWN);
         }
 
+        // Only explore downwards when dropping
+        if ((currentNode.parent == null || !currentNode.parent.pos.equals(currentNode.pos.down())) && currentNode.isCornerNode())
+        {
+            walk(currentNode, BLOCKPOS_DOWN);
+            return;
+        }
+
+        // Walk downwards node if passable
+        if (isPassable(currentNode.pos.down(), false))
+        {
+            walk(currentNode, BLOCKPOS_DOWN);
+        }
+
         // N
         if (dPos.getZ() <= 0)
         {
@@ -776,10 +789,30 @@ public abstract class AbstractPathJob implements Callable<Path>
             return false;
         }
 
+        boolean corner = false;
         if (pos.getY() != newY)
         {
-            dPos = dPos.add(0, newY - pos.getY(), 0);
-            pos = new BlockPos(pos.getX(), newY, pos.getZ());
+            // if the new position is above the current node, we're taking the node directly above
+            if (!parent.isCornerNode() && newY - pos.getY() > 0 && (parent.parent == null || !parent.parent.pos.equals(parent.pos.add(new BlockPos(0, newY - pos.getY(), 0)))))
+            {
+                dPos = new BlockPos(0, newY - pos.getY(), 0);
+                pos = parent.pos.add(dPos);
+                corner = true;
+            }
+            // If we're going down, take the air-corner before going to the lower node
+            else if (!parent.isCornerNode() && newY - pos.getY() < 0 && (dPos.getX() != 0 || dPos.getZ() != 0) && (parent.parent == null || !parent.pos.down()
+                                                                                                                                               .equals(parent.parent.pos)))
+            {
+                dPos = new BlockPos(dPos.getX(), 0, dPos.getZ());
+                pos = parent.pos.add(dPos);
+                corner = true;
+            }
+            // Fix up normal y
+            else
+            {
+                dPos = dPos.add(0, newY - pos.getY(), 0);
+                pos = new BlockPos(pos.getX(), newY, pos.getZ());
+            }
         }
 
         int nodeKey = computeNodeKey(pos);
@@ -811,6 +844,7 @@ public abstract class AbstractPathJob implements Callable<Path>
         {
             node = createNode(parent, pos, nodeKey, isSwimming, heuristic, cost, score);
             node.setOnRails(onRails);
+            node.setCornerNode(corner);
         }
         else if (updateCurrentNode(parent, node, heuristic, cost, score))
         {
@@ -943,7 +977,8 @@ public abstract class AbstractPathJob implements Callable<Path>
     {
         final boolean canDrop = parent != null && !parent.isLadder();
         //  Nothing to stand on
-        if (!canDrop || isSwimming)
+        if (!canDrop || isSwimming || (isPassable(parent.pos.down(), false)
+                                         && isWalkableSurface(world.getBlockState(parent.pos.down()), parent.pos.down()) == SurfaceType.DROPABLE))
         {
             return -1;
         }
@@ -1226,7 +1261,7 @@ public abstract class AbstractPathJob implements Callable<Path>
     /**
      * Check if we can walk on a surface, drop into, or neither.
      */
-    private enum SurfaceType
+    protected enum SurfaceType
     {
         WALKABLE,
         DROPABLE,

--- a/src/main/java/com/minecolonies/coremod/entity/pathfinding/pathjobs/PathJobRandomPos.java
+++ b/src/main/java/com/minecolonies/coremod/entity/pathfinding/pathjobs/PathJobRandomPos.java
@@ -91,7 +91,7 @@ public class PathJobRandomPos extends AbstractPathJob
     @Override
     protected boolean isAtDestination(@NotNull final Node n)
     {
-        if (Math.sqrt(start.distanceSq(n.pos)) > distance)
+        if (Math.sqrt(start.distanceSq(n.pos)) > distance && isWalkableSurface(world.getBlockState(n.pos.down()), n.pos.down()) == SurfaceType.WALKABLE)
         {
             getResult().randomPos = n.pos;
             return true;


### PR DESCRIPTION
Closes #6100
Closes #6193
Closes #6198
# Changes proposed in this pull request:

Pathing now also maps corner nodes when going upstairs or dropping down, giving our citizen a more smooth path to follow and fixing some corner cases, like in 6100 where without that node they jump down from a ladder since the next node is diagonal in the opposite direction on the next floor.

Pathing now considers going down through passable blocks, which previously did not work in cases where the passable block is also of walkable ground type, like trapdoors are.

Improved pathfollow, it is now better at recognizing arrival at a path point and also displays this during debug draw, reached nodes are displayed as orange:
![image](https://user-images.githubusercontent.com/38401808/101158386-ee091b80-362b-11eb-87d7-5e242c747151.png)

Adjust min raidlevel before the first raid to be a bit lower
Fix pathing trying to drop down from places where the previous block is passable and dropable, e.g. jumping down vines instead of going them down.
Fix random path generation beeing able to end up on blocks a citizen cannot stand upon.
Fix guards doing stuck teleport during combat
Fix guards using rails during combat
Fix visitor zero position check throwing errors on clientside, when some other mods are creating one at 0 0 for 
rendering
Fix raids not spawning at low levels
Fix AI getting stuck when removing tasks
Fix citizen loading the colony to find the team, when not needed to do so

Review please
