### PR TITLE
Add loot tables to customrecipes

### DIFF
--- a/src/api/java/com/minecolonies/api/crafting/IRecipeStorage.java
+++ b/src/api/java/com/minecolonies/api/crafting/IRecipeStorage.java
@@ -4,6 +4,7 @@ import com.minecolonies.api.colony.requestsystem.token.IToken;
 import net.minecraft.block.Block;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.ResourceLocation;
+import net.minecraft.world.World;
 import net.minecraftforge.items.IItemHandler;
 import org.jetbrains.annotations.NotNull;
 
@@ -64,9 +65,9 @@ public interface IRecipeStorage
      */
     boolean canFullFillRecipe(final int qty, final Map<ItemStorage, Integer> existingRequirements, @NotNull final IItemHandler... inventories);
 
-    default boolean fullFillRecipe(@NotNull final IItemHandler... inventories)
+    default boolean fullFillRecipe(@NotNull final World world, @NotNull final IItemHandler... inventories)
     {
-        return fullfillRecipe(Arrays.asList(inventories));
+        return fullfillRecipe(world, Arrays.asList(inventories));
     }
 
     /**
@@ -75,46 +76,52 @@ public interface IRecipeStorage
      * @param handlers the handlers to use.
      * @return true if succesful.
      */
-    boolean fullfillRecipe(final List<IItemHandler> handlers);
+    boolean fullfillRecipe(final World world, final List<IItemHandler> handlers);
 
     /**
      * Get which type this recipe is
      * This type comes from the RecipeTypes registry
      * @return The recipe type
      */
-    public AbstractRecipeType<IRecipeStorage> getRecipeType();
+    AbstractRecipeType<IRecipeStorage> getRecipeType();
 
     /**
      * Get a list of alternates to getPrimaryOutput
      * @return a list if Itemstacks that this recipe can produce instead of getPrimaryOutput
      */
-    public List<ItemStack> getAlternateOutputs();
+    List<ItemStack> getAlternateOutputs();
 
     /**
      * Get the classic version of this recipe with GetPrimaryOutput targetted correctly from the chosen alternate
      * @param requiredOutput Which output wanted
      * @return the RecipeStorage that is "right" for that output
      */
-    public RecipeStorage getClassicForMultiOutput(ItemStack requiredOutput);
+    RecipeStorage getClassicForMultiOutput(ItemStack requiredOutput);
 
     /**
      * Get the classic version of this recipe with GetPrimaryOutput targetted correctly from the chosen alternate
      * @param stackPredicate Predicate to select the right stack
      * @return the RecipeStorage that is "right" for that output
      */
-    public RecipeStorage getClassicForMultiOutput(final Predicate<ItemStack> stackPredicate);
+    RecipeStorage getClassicForMultiOutput(final Predicate<ItemStack> stackPredicate);
 
     /**
      * Source of the recipe, ie registry name.
      * @return
      */
-    public ResourceLocation getRecipeSource();
+    ResourceLocation getRecipeSource();
 
     /**
      * Get the secondary (leave behind in grid) outputs
      * @return list of items that weren't consumed during crafting
      */
-    public List<ItemStack> getSecondaryOutputs();
+    List<ItemStack> getSecondaryOutputs();
+
+    /** 
+     * Get the location/id of the Loot table used for optional outputs
+     * @return the resource location for the table
+    */
+    ResourceLocation getLootTable();
 
     /**
      * Get the unique token of the recipe.

--- a/src/api/java/com/minecolonies/api/crafting/IRecipeStorageFactory.java
+++ b/src/api/java/com/minecolonies/api/crafting/IRecipeStorageFactory.java
@@ -68,6 +68,11 @@ public interface IRecipeStorageFactory extends IFactory<IToken<?>, RecipeStorage
             throw new IllegalArgumentException("Eighth parameter is supposed to be a List<ItemStack> or Null!");
         }
 
+        if (context.length > MIN_PARAMS_IRECIPESTORAGE + 5 && context[8] != null && !(context[8] instanceof ResourceLocation))
+        {
+            throw new IllegalArgumentException("Eighth parameter is supposed to be a List<ItemStack> or Null!");
+        }
+
         final List<ItemStack> input = (List<ItemStack>) context[0];
         final int gridSize = (int) context[1];
         final ItemStack primaryOutput = (ItemStack) context[2];
@@ -76,7 +81,8 @@ public interface IRecipeStorageFactory extends IFactory<IToken<?>, RecipeStorage
         final ResourceLocation type  = context.length < 6 ? null : (ResourceLocation) context[5];
         final List<ItemStack> altOutputs = context.length < 7 ? null :  (List<ItemStack>) context[6];
         final List<ItemStack> secOutputs = context.length < 8 ? null :  (List<ItemStack>) context[7];
-        return getNewInstance(token, input, gridSize, primaryOutput, intermediate, source, type, altOutputs, secOutputs);
+        final ResourceLocation lootTable = context.length < 9 ? null : (ResourceLocation) context[8];
+        return getNewInstance(token, input, gridSize, primaryOutput, intermediate, source, type, altOutputs, secOutputs, lootTable);
     }
 
     /**
@@ -103,7 +109,8 @@ public interface IRecipeStorageFactory extends IFactory<IToken<?>, RecipeStorage
       @Nullable final ResourceLocation source,
       @Nullable final ResourceLocation type,
       @Nullable final List<ItemStack> altOutputs,
-      @Nullable final List<ItemStack> secOutputs
+      @Nullable final List<ItemStack> secOutputs,
+      @Nullable final ResourceLocation lootTable
       );
 }
 

--- a/src/api/java/com/minecolonies/api/crafting/IRecipeStorageFactory.java
+++ b/src/api/java/com/minecolonies/api/crafting/IRecipeStorageFactory.java
@@ -70,7 +70,7 @@ public interface IRecipeStorageFactory extends IFactory<IToken<?>, RecipeStorage
 
         if (context.length > MIN_PARAMS_IRECIPESTORAGE + 5 && context[8] != null && !(context[8] instanceof ResourceLocation))
         {
-            throw new IllegalArgumentException("Eighth parameter is supposed to be a List<ItemStack> or Null!");
+            throw new IllegalArgumentException("Ninth parameter is supposed to be a ResourceLocation or Null!");
         }
 
         final List<ItemStack> input = (List<ItemStack>) context[0];

--- a/src/api/java/com/minecolonies/api/crafting/RecipeStorage.java
+++ b/src/api/java/com/minecolonies/api/crafting/RecipeStorage.java
@@ -9,11 +9,21 @@ import com.minecolonies.api.crafting.registry.RecipeTypeEntry;
 import com.minecolonies.api.util.CraftingUtils;
 import com.minecolonies.api.util.InventoryUtils;
 import com.minecolonies.api.util.ItemStackUtils;
+import com.minecolonies.api.util.Log;
+import com.minecolonies.api.util.WorldUtil;
 import com.minecolonies.api.util.constant.TypeConstants;
-
 import net.minecraft.block.Block;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.ResourceLocation;
+import net.minecraft.world.World;
+import net.minecraft.world.server.ServerWorld;
+import net.minecraft.world.storage.loot.ILootGenerator;
+import net.minecraft.world.storage.loot.LootContext;
+import net.minecraft.world.storage.loot.LootParameterSets;
+import net.minecraft.world.storage.loot.LootTable;
+import net.minecraft.world.storage.loot.LootTableManager;
+import net.minecraft.world.storage.loot.LootTables;
+import net.minecraftforge.fml.server.ServerLifecycleHooks;
 import net.minecraftforge.items.IItemHandler;
 import net.minecraftforge.registries.IForgeRegistry;
 import org.jetbrains.annotations.NotNull;
@@ -85,6 +95,16 @@ public class RecipeStorage implements IRecipeStorage
     private final IToken<?> token;
 
     /**
+     * The Resource location of the Loot Table to use for possible outputs
+     */
+    private final ResourceLocation lootTable;
+
+    /**
+     * The cached loot table for possible outputs
+     */
+    private LootTable loot;
+
+    /**
      * Create an instance of the recipe storage.
      *
      * @param token         the token of the storage.
@@ -96,8 +116,9 @@ public class RecipeStorage implements IRecipeStorage
      * @param type          What type of recipe this is. (ie: minecolonies:classic)
      * @param altOutputs    List of alternate outputs for a multi-output recipe
      * @param secOutputs    List of secondary outputs for a recipe. this includes containers, etc. 
+     * @param lootTable     Loot table to use for possible alternate outputs
      */
-    public RecipeStorage(final IToken<?> token, final List<ItemStack> input, final int gridSize, @NotNull final ItemStack primaryOutput, final Block intermediate, final ResourceLocation source, final ResourceLocation type, final List<ItemStack> altOutputs, final List<ItemStack> secOutputs)
+    public RecipeStorage(final IToken<?> token, final List<ItemStack> input, final int gridSize, @NotNull final ItemStack primaryOutput, final Block intermediate, final ResourceLocation source, final ResourceLocation type, final List<ItemStack> altOutputs, final List<ItemStack> secOutputs, final ResourceLocation lootTable)
     {
         this.input = Collections.unmodifiableList(input);
         this.cleanedInput = new ArrayList<>();
@@ -118,6 +139,8 @@ public class RecipeStorage implements IRecipeStorage
         {
             this.recipeType = recipeTypes.getValue(recipeTypes.getDefaultKey()).getHandlerProducer().apply(this);
         }
+
+        this.lootTable = lootTable;
     }
 
     @Override
@@ -277,6 +300,16 @@ public class RecipeStorage implements IRecipeStorage
             return false; 
         }
 
+        if(this.lootTable != null && !this.lootTable.equals(that.lootTable))
+        {
+            return false;
+        }
+
+        if(this.lootTable == null && that.lootTable != null)
+        {
+            return false; 
+        }
+
         if(!this.recipeType.getId().equals(that.recipeType.getId()))
         {
             return false;
@@ -386,7 +419,7 @@ public class RecipeStorage implements IRecipeStorage
      * @return true if succesful.
      */
     @Override
-    public boolean fullfillRecipe(final List<IItemHandler> handlers)
+    public boolean fullfillRecipe(final World world, final List<IItemHandler> handlers)
     {
         if (!checkForFreeSpace(handlers) || !canFullFillRecipe(1, Collections.emptyMap(), handlers.toArray(new IItemHandler[0])))
         {
@@ -442,7 +475,7 @@ public class RecipeStorage implements IRecipeStorage
             }
         }
 
-        insertCraftedItems(handlers, getPrimaryOutput());
+        insertCraftedItems(handlers, getPrimaryOutput(), world);
         return true;
     }
 
@@ -457,7 +490,7 @@ public class RecipeStorage implements IRecipeStorage
      *
      * @param handlers the handlers.
      */
-    private void insertCraftedItems(final List<IItemHandler> handlers, ItemStack outputStack)
+    private void insertCraftedItems(final List<IItemHandler> handlers, ItemStack outputStack, World world)
     {
         for (final IItemHandler handler : handlers)
         {
@@ -467,7 +500,19 @@ public class RecipeStorage implements IRecipeStorage
             }
         }
 
+        if (loot == null && lootTable != null)
+        {
+            loot = world.getServer().getLootTableManager().getLootTableFromLocation(lootTable);
+        }
+        
         final List<ItemStack> secondaryStacks = new ArrayList<>();
+
+        if(loot != null)
+        {
+            Log.getLogger().info("Generating lootTable items");
+            secondaryStacks.addAll(loot.generate((new LootContext.Builder((ServerWorld) world)).build(LootParameterSets.EMPTY)));
+        }
+
         if(!secondaryOutputs.isEmpty())
         {
             secondaryStacks.addAll(secondaryOutputs);
@@ -512,8 +557,9 @@ public class RecipeStorage implements IRecipeStorage
             intermediate,
             this.recipeSource,
             ModRecipeTypes.CLASSIC_ID,
-            null, //alternate outputs
-            this.secondaryOutputs //secondary output
+            null,                   // alternate outputs
+            this.secondaryOutputs,  // secondary output
+            this.lootTable          // loot table
             );
 
     }
@@ -559,5 +605,11 @@ public class RecipeStorage implements IRecipeStorage
     public List<ItemStack> getSecondaryOutputs()
     {
         return secondaryOutputs;
+    }
+
+    @Override
+    public ResourceLocation getLootTable()
+    {
+        return lootTable;
     }
 }

--- a/src/api/java/com/minecolonies/api/crafting/RecipeStorage.java
+++ b/src/api/java/com/minecolonies/api/crafting/RecipeStorage.java
@@ -9,21 +9,15 @@ import com.minecolonies.api.crafting.registry.RecipeTypeEntry;
 import com.minecolonies.api.util.CraftingUtils;
 import com.minecolonies.api.util.InventoryUtils;
 import com.minecolonies.api.util.ItemStackUtils;
-import com.minecolonies.api.util.Log;
-import com.minecolonies.api.util.WorldUtil;
 import com.minecolonies.api.util.constant.TypeConstants;
 import net.minecraft.block.Block;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.ResourceLocation;
 import net.minecraft.world.World;
 import net.minecraft.world.server.ServerWorld;
-import net.minecraft.world.storage.loot.ILootGenerator;
 import net.minecraft.world.storage.loot.LootContext;
 import net.minecraft.world.storage.loot.LootParameterSets;
 import net.minecraft.world.storage.loot.LootTable;
-import net.minecraft.world.storage.loot.LootTableManager;
-import net.minecraft.world.storage.loot.LootTables;
-import net.minecraftforge.fml.server.ServerLifecycleHooks;
 import net.minecraftforge.items.IItemHandler;
 import net.minecraftforge.registries.IForgeRegistry;
 import org.jetbrains.annotations.NotNull;
@@ -509,7 +503,6 @@ public class RecipeStorage implements IRecipeStorage
 
         if(loot != null)
         {
-            Log.getLogger().info("Generating lootTable items");
             secondaryStacks.addAll(loot.generate((new LootContext.Builder((ServerWorld) world)).build(LootParameterSets.EMPTY)));
         }
 

--- a/src/api/java/com/minecolonies/api/util/constant/Constants.java
+++ b/src/api/java/com/minecolonies/api/util/constant/Constants.java
@@ -47,7 +47,7 @@ public final class Constants
     public static final int    UPDATE_FLAG                      = 0x03;
     public static final int    TICKS_HOUR                       = TICKS_SECOND * SECONDS_A_MINUTE * SECONDS_A_MINUTE;
     public static final int    TICKS_FOURTY_MIN                 = 48000;
-    public static final int    MAX_PARAMS_IRECIPESTORAGE        = 8;
+    public static final int    MAX_PARAMS_IRECIPESTORAGE        = 9;
     public static final int    MIN_PARAMS_IRECIPESTORAGE        = 3;
     public static final int    PARAMS_ITEMSTORAGE               = 2;
     public static final int    PARAMS_RESEARCH_EFFECT           = 2;

--- a/src/main/java/com/minecolonies/coremod/colony/buildings/AbstractBuildingWorker.java
+++ b/src/main/java/com/minecolonies/coremod/colony/buildings/AbstractBuildingWorker.java
@@ -268,7 +268,7 @@ public abstract class AbstractBuildingWorker extends AbstractBuilding implements
     public boolean fullFillRecipe(final IRecipeStorage storage)
     {
         final List<IItemHandler> handlers = getHandlers();
-        return storage.fullfillRecipe(handlers);
+        return storage.fullfillRecipe(this.getColony().getWorld(), handlers);
     }
 
     @Override

--- a/src/main/java/com/minecolonies/coremod/colony/crafting/CustomRecipe.java
+++ b/src/main/java/com/minecolonies/coremod/colony/crafting/CustomRecipe.java
@@ -470,7 +470,7 @@ public class CustomRecipe
                     this.getRecipeId(),
                     ModRecipeTypes.CLASSIC_ID,
                     null, //alternate outputs
-                    null, //secondary output
+                    secondary, //secondary output
                     lootTable
                     );
             }
@@ -486,7 +486,7 @@ public class CustomRecipe
                     this.getRecipeId(),
                     ModRecipeTypes.MULTI_OUTPUT_ID,
                     altOutputs, //alternate outputs
-                    null, //secondary output
+                    secondary, //secondary output
                     lootTable
                     );
             }

--- a/src/main/java/com/minecolonies/coremod/colony/crafting/RecipeStorageFactory.java
+++ b/src/main/java/com/minecolonies/coremod/colony/crafting/RecipeStorageFactory.java
@@ -63,6 +63,11 @@ public class RecipeStorageFactory implements IRecipeStorageFactory
      */
     private static final String TYPE_TAG = "type";
 
+    /**
+     * Compound tag for Loot Table
+     */
+    private static final String LOOT_TAG = "loot-table";
+
     @NotNull
     @Override
     public TypeToken<RecipeStorage> getFactoryOutputType()
@@ -88,9 +93,10 @@ public class RecipeStorageFactory implements IRecipeStorageFactory
       final ResourceLocation source,
       final ResourceLocation type,
       final List<ItemStack> altOutputs,
-      final List<ItemStack> secOutputs)
+      final List<ItemStack> secOutputs,
+      final ResourceLocation lootTable)
     {
-        return new RecipeStorage(token, input, gridSize, primaryOutput, intermediate, source, type, altOutputs, secOutputs);
+        return new RecipeStorage(token, input, gridSize, primaryOutput, intermediate, source, type, altOutputs, secOutputs, lootTable);
     }
 
     @NotNull
@@ -138,6 +144,10 @@ public class RecipeStorageFactory implements IRecipeStorageFactory
         }
         compound.put(SECOUTPUT_TAG, secOutputTagList);
 
+        if(recipeStorage.getLootTable() != null)
+        {
+            compound.putString(LOOT_TAG, recipeStorage.getLootTable().toString());
+        }
 
         return compound;
     }
@@ -181,7 +191,9 @@ public class RecipeStorageFactory implements IRecipeStorageFactory
             secOutputs.add(ItemStack.read(secOutputTag));
         }
 
-        return this.getNewInstance(token, input, gridSize, primaryOutput, intermediate, source, type, altOutputs.isEmpty() ? null : altOutputs, secOutputs.isEmpty() ? null : secOutputs);
+        final ResourceLocation lootTable = nbt.contains(LOOT_TAG) ? new ResourceLocation(nbt.getString(LOOT_TAG)) : null; 
+
+        return this.getNewInstance(token, input, gridSize, primaryOutput, intermediate, source, type, altOutputs.isEmpty() ? null : altOutputs, secOutputs.isEmpty() ? null : secOutputs, lootTable);
     }
 
     @Override
@@ -206,6 +218,8 @@ public class RecipeStorageFactory implements IRecipeStorageFactory
 
         packetBuffer.writeInt(input.getSecondaryOutputs().size());
         input.getSecondaryOutputs().forEach(stack -> packetBuffer.writeItemStack(stack));
+
+        packetBuffer.writeResourceLocation(input.getLootTable());
 
         controller.serialize(packetBuffer, input.getToken());
     }
@@ -239,9 +253,10 @@ public class RecipeStorageFactory implements IRecipeStorageFactory
             secOutputs.add(buffer.readItemStack());
         }
 
+        final ResourceLocation lootTable = buffer.readResourceLocation();
 
         final IToken<?> token = controller.deserialize(buffer);
-        return this.getNewInstance(token, input, gridSize, primaryOutput, intermediate, null, type, altOutputs.isEmpty() ? null : altOutputs, secOutputs.isEmpty() ? null : secOutputs);
+        return this.getNewInstance(token, input, gridSize, primaryOutput, intermediate, null, type, altOutputs.isEmpty() ? null : altOutputs, secOutputs.isEmpty() ? null : secOutputs, lootTable);
     }
 
     @Override

--- a/src/main/java/com/minecolonies/coremod/colony/crafting/RecipeStorageFactory.java
+++ b/src/main/java/com/minecolonies/coremod/colony/crafting/RecipeStorageFactory.java
@@ -219,7 +219,11 @@ public class RecipeStorageFactory implements IRecipeStorageFactory
         packetBuffer.writeInt(input.getSecondaryOutputs().size());
         input.getSecondaryOutputs().forEach(stack -> packetBuffer.writeItemStack(stack));
 
-        packetBuffer.writeResourceLocation(input.getLootTable());
+        packetBuffer.writeBoolean(input.getLootTable() != null);
+        if(input.getLootTable() != null)
+        {
+            packetBuffer.writeResourceLocation(input.getLootTable());
+        }
 
         controller.serialize(packetBuffer, input.getToken());
     }
@@ -253,7 +257,11 @@ public class RecipeStorageFactory implements IRecipeStorageFactory
             secOutputs.add(buffer.readItemStack());
         }
 
-        final ResourceLocation lootTable = buffer.readResourceLocation();
+        ResourceLocation lootTable = null;
+        if(buffer.readBoolean())
+        {
+            lootTable = buffer.readResourceLocation();
+        }
 
         final IToken<?> token = controller.deserialize(buffer);
         return this.getNewInstance(token, input, gridSize, primaryOutput, intermediate, null, type, altOutputs.isEmpty() ? null : altOutputs, secOutputs.isEmpty() ? null : secOutputs, lootTable);

--- a/src/main/java/com/minecolonies/coremod/entity/ai/basic/AbstractEntityAICrafting.java
+++ b/src/main/java/com/minecolonies/coremod/entity/ai/basic/AbstractEntityAICrafting.java
@@ -334,7 +334,7 @@ public abstract class AbstractEntityAICrafting<J extends AbstractJobCrafter<?, J
             final IAIState check = checkForItems(currentRecipeStorage);
             if (check == CRAFT)
             {
-                if (!currentRecipeStorage.fullFillRecipe(worker.getItemHandlerCitizen()))
+                if (!currentRecipeStorage.fullFillRecipe(worker.getEntityWorld(), worker.getItemHandlerCitizen()))
                 {
                     currentRequest = null;
                     incrementActionsDone(getActionRewardForCraftingSuccess());

--- a/src/main/java/com/minecolonies/coremod/entity/ai/citizen/crusher/EntityAIWorkCrusher.java
+++ b/src/main/java/com/minecolonies/coremod/entity/ai/citizen/crusher/EntityAIWorkCrusher.java
@@ -119,7 +119,7 @@ public class EntityAIWorkCrusher extends AbstractEntityAICrafting<JobCrusher, Bu
 
                 worker.swingArm(Hand.MAIN_HAND);
                 job.setCraftCounter(job.getCraftCounter() + 1);
-                currentRecipeStorage.fullFillRecipe(worker.getItemHandlerCitizen());
+                currentRecipeStorage.fullFillRecipe(worker.getEntityWorld(), worker.getItemHandlerCitizen());
 
                 worker.decreaseSaturationForContinuousAction();
                 worker.getCitizenExperienceHandler().addExperience(0.1);

--- a/src/main/resources/data/minecolonies/crafterrecipes/crusher/gravel1.json
+++ b/src/main/resources/data/minecolonies/crafterrecipes/crusher/gravel1.json
@@ -8,6 +8,7 @@
     }
   ],
   "result": "minecraft:gravel",
+  "loot-table": "minecolonies:recipes/gravel",
   "count": "1",
   "intermediate" : "minecraft:air",
   "not-research-id" : "gildedhammer"

--- a/src/main/resources/data/minecolonies/crafterrecipes/crusher/gravel2.json
+++ b/src/main/resources/data/minecolonies/crafterrecipes/crusher/gravel2.json
@@ -8,6 +8,7 @@
     }
   ],
   "result": "minecraft:gravel",
+  "loot-table": "minecolonies:recipes/gravel",
   "count": "1",
   "intermediate" : "minecraft:air",
   "research-id" : "gildedhammer"

--- a/src/main/resources/data/minecolonies/loot_tables/recipes/gravel.json
+++ b/src/main/resources/data/minecolonies/loot_tables/recipes/gravel.json
@@ -1,0 +1,20 @@
+{
+  "pools": [
+    {
+      "name": "minecolonies:barbarian",
+      "rolls": 1,
+      "bonus_rolls": 1,
+      "entries": [
+        {
+          "type": "empty",
+          "weight": 90
+        },
+        {
+          "type": "item",
+          "weight": 10,
+          "name": "minecraft:flint"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
# Changes proposed in this pull request:
- Add base functionality to recipestorage to store and generate loot from loot tables
- Add definition of loot tables & secondary outputs to custom recipes
- Add flint @ 10% rate to the Crusher's gravel recipes.

Review please
