### PR TITLE
fix fishman Keep looking for the pond

### DIFF
--- a/src/main/java/com/minecolonies/coremod/entity/ai/citizen/fisherman/EntityAIWorkFisherman.java
+++ b/src/main/java/com/minecolonies/coremod/entity/ai/citizen/fisherman/EntityAIWorkFisherman.java
@@ -327,7 +327,8 @@ public class EntityAIWorkFisherman extends AbstractEntityAISkill<JobFisherman, B
         executedRotations = 0;
         //If he can't find any pond, tell that to the player
         //If 20 ponds are already stored, take a random stored location
-        if (job.getPonds().size() >= MAX_PONDS)
+        //the fishman should not go to find water when fishman can find water but cant find pond
+        if (job.getPonds().size() >= MAX_PONDS||(lastPathResult!=null&&lastPathResult.pond==null&&job.getPonds().size()>0))
         {
             return setRandomWater();
         }

--- a/src/main/java/com/minecolonies/coremod/entity/ai/citizen/fisherman/EntityAIWorkFisherman.java
+++ b/src/main/java/com/minecolonies/coremod/entity/ai/citizen/fisherman/EntityAIWorkFisherman.java
@@ -328,7 +328,7 @@ public class EntityAIWorkFisherman extends AbstractEntityAISkill<JobFisherman, B
         //If he can't find any pond, tell that to the player
         //If 20 ponds are already stored, take a random stored location
         //the fishman should not go to find water when fishman can find water but cant find pond
-        if (job.getPonds().size() >= MAX_PONDS||(lastPathResult!=null&&lastPathResult.pond==null&&job.getPonds().size()>0))
+        if (job.getPonds().size() >= MAX_PONDS || (lastPathResult != null && lastPathResult.pond == null && job.getPonds().size() > 0))
         {
             return setRandomWater();
         }


### PR DESCRIPTION

Closes #
Closes #
Closes #

# Changes proposed in this pull request:
-the fishman should not go to find pond when fishman can find water but cant find pond. Maybe it's a problem with the ponds finding algorithm. Anyway, my fisherman found 18 ponds, and if he go down, he get a result but the pond =null.then he get stuck in an endless loop
-
-

Review please
