### PR TITLE
Fix 6244: Update BuildingGuards to use short ResourceKey.Location text.

### DIFF
--- a/src/main/java/com/minecolonies/coremod/colony/buildings/AbstractBuildingGuards.java
+++ b/src/main/java/com/minecolonies/coremod/colony/buildings/AbstractBuildingGuards.java
@@ -1217,7 +1217,7 @@ public abstract class AbstractBuildingGuards extends AbstractBuildingWorker impl
             {
                 for (final String location : MineColonies.getConfig().getServer().guardResourceLocations.get())
                 {
-                    if (entry.getKey() != null && entry.getKey().toString().equals(location))
+                    if (entry.getKey() != null && entry.getKey().getLocation().toString().equals(location))
                     {
                         i++;
                         mobsToAttack.put(entry.getKey().getLocation(), new MobEntryView(entry.getKey().getLocation(), true, i));


### PR DESCRIPTION
Fix for configuration-related issues on Guard Tower enemy checklists, checking the config file against long ResourceKey rather than ResourceKey.location.

Closes #6244 

# Changes proposed in this pull request:
- Check against ResourceKey.location.

Review please
