### PR TITLE
Restaurant sitting and some fixes

### DIFF
--- a/src/api/java/com/minecolonies/api/blocks/decorative/AbstractBlockGate.java
+++ b/src/api/java/com/minecolonies/api/blocks/decorative/AbstractBlockGate.java
@@ -1,5 +1,6 @@
 package com.minecolonies.api.blocks.decorative;
 
+import com.minecolonies.api.util.WorldUtil;
 import net.minecraft.block.*;
 import net.minecraft.block.material.Material;
 import net.minecraft.entity.LivingEntity;
@@ -438,11 +439,11 @@ public abstract class AbstractBlockGate extends DoorBlock
                 // Set top blocks to spikes
                 if (world.getBlockState(worldPos.up()).getBlock() != this)
                 {
-                    world.setBlockState(worldPos, state.cycle(DoorBlock.HINGE), 2);
+                    WorldUtil.setBlockState(world, worldPos, state.cycle(DoorBlock.HINGE), 2);
                 }
                 else
                 {
-                    world.setBlockState(worldPos, state.cycle(BlockStateProperties.OPEN), 2);
+                    WorldUtil.setBlockState(world, worldPos, state.cycle(BlockStateProperties.OPEN), 2);
                 }
             }
         }

--- a/src/api/java/com/minecolonies/api/configuration/CommonConfiguration.java
+++ b/src/api/java/com/minecolonies/api/configuration/CommonConfiguration.java
@@ -450,7 +450,7 @@ public class CommonConfiguration extends AbstractConfiguration
         spawnBarbarianSize = defineInteger(builder, "spawnbarbariansize", 5, MIN_SPAWN_BARBARIAN_HORDE_SIZE, MAX_SPAWN_BARBARIAN_HORDE_SIZE);
         maxBarbarianSize = defineInteger(builder, "maxBarbarianSize", 80, MIN_BARBARIAN_HORDE_SIZE, MAX_BARBARIAN_HORDE_SIZE);
         doBarbariansBreakThroughWalls = defineBoolean(builder, "dobarbariansbreakthroughwalls", true);
-        averageNumberOfNightsBetweenRaids = defineInteger(builder, "averagenumberofnightsbetweenraids", 12, 1, 10);
+        averageNumberOfNightsBetweenRaids = defineInteger(builder, "averagenumberofnightsbetweenraids", 12, 1, 50);
         minimumNumberOfNightsBetweenRaids = defineInteger(builder, "minimumnumberofnightsbetweenraids", 8, 1, 30);
         mobAttackCitizens = defineBoolean(builder, "mobattackcitizens", true);
         shouldRaidersBreakDoors = defineBoolean(builder, "shouldraiderbreakdoors", true);

--- a/src/api/java/com/minecolonies/api/entity/citizen/AbstractEntityCitizen.java
+++ b/src/api/java/com/minecolonies/api/entity/citizen/AbstractEntityCitizen.java
@@ -148,10 +148,22 @@ public abstract class AbstractEntityCitizen extends AbstractCivilianEntity imple
         return new BlockPos(getPosX(), getPosY(), getPosZ());
     }
 
+    /**
+     * Disable vanilla's item picking stuff as we're doing it ourselves
+     */
     @Override
     public boolean canPickUpLoot()
     {
-        return true;
+        return false;
+    }
+
+    /**
+     * Disable vanilla steering logic for villagers
+     */
+    @Override
+    public boolean canPassengerSteer()
+    {
+        return false;
     }
 
     public float getPreviousRotationPitch()

--- a/src/api/java/com/minecolonies/api/util/WorldUtil.java
+++ b/src/api/java/com/minecolonies/api/util/WorldUtil.java
@@ -7,6 +7,7 @@ import net.minecraft.util.math.ChunkPos;
 import net.minecraft.world.IWorld;
 import net.minecraft.world.World;
 import net.minecraft.world.chunk.ChunkStatus;
+import net.minecraft.world.server.ServerWorld;
 
 import static com.minecolonies.api.util.constant.CitizenConstants.NIGHT;
 
@@ -43,7 +44,7 @@ public class WorldUtil
     /**
      * Mark a chunk at a position dirty if loaded.
      * @param world the world to mark it dirty in.
-     * @param pos the position within the chunk.
+     * @param pos   the position within the chunk.
      */
     public static void markChunkDirty(final World world, final BlockPos pos)
     {
@@ -136,5 +137,61 @@ public class WorldUtil
     public static boolean isPastTime(final World world, final int pastTime)
     {
         return world.getDayTime() % 24000 <= pastTime;
+    }
+
+    /**
+     * Custom set block state, with 1 instead of default flag 3, to skip vanilla's path notify upon block change, making setBlockState expensive. The state change still affects
+     * neighbours and is synced
+     *
+     * @param world world to use
+     * @param pos   position to set
+     * @param state state to set
+     */
+    public static boolean setBlockState(final IWorld world, final BlockPos pos, final BlockState state)
+    {
+        if (world.isRemote())
+        {
+            return world.setBlockState(pos, state, 3);
+        }
+
+        final boolean result = world.setBlockState(pos, state, 1);
+        if (result)
+        {
+            ((ServerWorld) world).getChunkProvider().markBlockChanged(pos);
+        }
+
+        return result;
+    }
+
+    /**
+     * Custom set block state, skips vanilla's path notify upon block change, making setBlockState expensive.
+     *
+     * @param world world to use
+     * @param pos   position to set
+     * @param state state to set
+     * @param flags flags to use
+     */
+    public static boolean setBlockState(final IWorld world, final BlockPos pos, final BlockState state, int flags)
+    {
+        if (world.isRemote())
+        {
+            return world.setBlockState(pos, state, flags);
+        }
+
+        if ((flags & 2) != 0)
+        {
+            flags -= 2;
+            final boolean result = world.setBlockState(pos, state, flags);
+            if (result)
+            {
+                ((ServerWorld) world).getChunkProvider().markBlockChanged(pos);
+            }
+
+            return result;
+        }
+        else
+        {
+            return world.setBlockState(pos, state, flags);
+        }
     }
 }

--- a/src/main/java/com/minecolonies/coremod/colony/buildings/workerbuildings/BuildingCook.java
+++ b/src/main/java/com/minecolonies/coremod/colony/buildings/workerbuildings/BuildingCook.java
@@ -121,6 +121,9 @@ public class BuildingCook extends AbstractBuildingSmelterCrafter
         keepX.put(stack -> !ItemStackUtils.isEmpty(stack.getContainerItem()) && !stack.getContainerItem().getItem().equals(Items.BUCKET), new Tuple<>(STACKSIZE, false));
     }
 
+    /**
+     * Reads the tag positions
+     */
     public void initTagPositions()
     {
         if (initTags)
@@ -141,6 +144,13 @@ public class BuildingCook extends AbstractBuildingSmelterCrafter
                 }
             }
         }
+    }
+
+    @Override
+    public void onUpgradeComplete(final int newLevel)
+    {
+        super.onUpgradeComplete(newLevel);
+        initTags = false;
     }
 
     /**

--- a/src/main/java/com/minecolonies/coremod/colony/buildings/workerbuildings/BuildingCook.java
+++ b/src/main/java/com/minecolonies/coremod/colony/buildings/workerbuildings/BuildingCook.java
@@ -3,6 +3,7 @@ package com.minecolonies.coremod.colony.buildings.workerbuildings;
 import com.google.common.collect.ImmutableCollection;
 import com.google.common.collect.ImmutableList;
 import com.ldtteam.blockout.views.Window;
+import com.ldtteam.structurize.blocks.interfaces.IBlueprintDataProvider;
 import com.minecolonies.api.colony.ICitizenData;
 import com.minecolonies.api.colony.IColony;
 import com.minecolonies.api.colony.IColonyManager;
@@ -55,6 +56,7 @@ import java.util.stream.Collectors;
 
 import static com.minecolonies.api.util.ItemStackUtils.ISFOOD;
 import static com.minecolonies.api.util.constant.Constants.STACKSIZE;
+import static com.minecolonies.api.util.constant.SchematicTagConstants.TAG_SITTING;
 import static com.minecolonies.api.util.constant.Suppression.OVERRIDE_EQUALS;
 
 /**
@@ -88,7 +90,22 @@ public class BuildingCook extends AbstractBuildingSmelterCrafter
      * Failsafe for isCooking. Number of Colony Ticks before setting isCooking false. 
      */
     private int isCookingTimeout = 0;
-    
+
+    /**
+     * Whether we did init tags
+     */
+    private boolean initTags = false;
+
+    /**
+     * Sitting positions
+     */
+    private List<BlockPos> sitPositions;
+
+    /**
+     * Current sitting index
+     */
+    private int lastSitting = 0;
+
     /**
      * Instantiates a new cook building.
      *
@@ -103,6 +120,53 @@ public class BuildingCook extends AbstractBuildingSmelterCrafter
         keepX.put(stack -> isAllowedFuel(stack), new Tuple<>(STACKSIZE, true));
         keepX.put(stack -> !ItemStackUtils.isEmpty(stack.getContainerItem()) && !stack.getContainerItem().getItem().equals(Items.BUCKET), new Tuple<>(STACKSIZE, false));
     }
+
+    public void initTagPositions()
+    {
+        if (initTags)
+        {
+            return;
+        }
+
+        final IBlueprintDataProvider te = getTileEntity();
+        if (te != null)
+        {
+            initTags = true;
+            sitPositions = new ArrayList<>();
+            for (final Map.Entry<BlockPos, List<String>> entry : te.getWorldTagPosMap().entrySet())
+            {
+                if (entry.getValue().contains(TAG_SITTING))
+                {
+                    sitPositions.add(entry.getKey());
+                }
+            }
+        }
+    }
+
+    /**
+     * Gets the next sitting position to use for eating, just keeps iterating the aviable positions, so we do not have to keep track of who is where.
+     *
+     * @return eating position to sit at
+     */
+    public BlockPos getNextSittingPosition()
+    {
+        initTagPositions();
+
+        if (sitPositions.isEmpty())
+        {
+            return null;
+        }
+
+        lastSitting++;
+
+        if (lastSitting >= sitPositions.size())
+        {
+            lastSitting = 0;
+        }
+
+        return sitPositions.get(lastSitting);
+    }
+
 
     /**
      * Get the status of the assistant processing requests

--- a/src/main/java/com/minecolonies/coremod/entity/ai/citizen/guard/AbstractEntityAIGuard.java
+++ b/src/main/java/com/minecolonies/coremod/entity/ai/citizen/guard/AbstractEntityAIGuard.java
@@ -290,7 +290,6 @@ public abstract class AbstractEntityAIGuard<J extends AbstractJobGuard<J>, B ext
         if (effect != null)
         {
             chance = 1 - effect.getEffect();
-            return true;
         }
 
         // Chance to fall asleep every 10sec, Chance is 1 in (10 + level/2) = 1 in Level1:5,Level2:6 Level6:8 Level 12:11 etc

--- a/src/main/java/com/minecolonies/coremod/entity/ai/citizen/guard/AbstractEntityAIGuard.java
+++ b/src/main/java/com/minecolonies/coremod/entity/ai/citizen/guard/AbstractEntityAIGuard.java
@@ -8,7 +8,6 @@ import com.minecolonies.api.colony.buildings.views.MobEntryView;
 import com.minecolonies.api.colony.guardtype.registry.ModGuardTypes;
 import com.minecolonies.api.colony.permissions.Action;
 import com.minecolonies.api.colony.requestsystem.location.ILocation;
-import com.minecolonies.api.entity.ModEntities;
 import com.minecolonies.api.entity.ai.citizen.guards.GuardTask;
 import com.minecolonies.api.entity.ai.statemachine.AIEventTarget;
 import com.minecolonies.api.entity.ai.statemachine.AIOneTimeEventTarget;
@@ -34,7 +33,6 @@ import com.minecolonies.coremod.research.UnlockAbilityResearchEffect;
 import com.minecolonies.coremod.util.NamedDamageSource;
 import com.minecolonies.coremod.util.TeleportHelper;
 import net.minecraft.entity.LivingEntity;
-import net.minecraft.entity.monster.IMob;
 import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.potion.EffectInstance;
 import net.minecraft.potion.Effects;
@@ -292,6 +290,7 @@ public abstract class AbstractEntityAIGuard<J extends AbstractJobGuard<J>, B ext
         if (effect != null)
         {
             chance = 1 - effect.getEffect();
+            return true;
         }
 
         // Chance to fall asleep every 10sec, Chance is 1 in (10 + level/2) = 1 in Level1:5,Level2:6 Level6:8 Level 12:11 etc
@@ -300,13 +299,7 @@ public abstract class AbstractEntityAIGuard<J extends AbstractJobGuard<J>, B ext
         {
             // Sleep for 2500-3000 ticks
             sleepTimer = worker.getRandom().nextInt(500) + 2500;
-
-            final SittingEntity entity = (SittingEntity) ModEntities.SITTINGENTITY.create(world);
-            entity.setPosition(worker.posX, worker.posY - 1f, worker.posZ);
-            entity.setMaxLifeTime(sleepTimer);
-            world.addEntity(entity);
-            worker.startRiding(entity);
-            worker.getNavigator().clearPath();
+            SittingEntity.sitDown(worker.getPosition(), worker, sleepTimer);
 
             return true;
         }

--- a/src/main/java/com/minecolonies/coremod/entity/ai/citizen/school/EntityAIWorkPupil.java
+++ b/src/main/java/com/minecolonies/coremod/entity/ai/citizen/school/EntityAIWorkPupil.java
@@ -1,11 +1,9 @@
 package com.minecolonies.coremod.entity.ai.citizen.school;
 
 import com.minecolonies.api.colony.interactionhandling.ChatPriority;
-import com.minecolonies.api.entity.ModEntities;
 import com.minecolonies.api.entity.ai.statemachine.AITarget;
 import com.minecolonies.api.entity.ai.statemachine.states.IAIState;
 import com.minecolonies.api.entity.citizen.Skill;
-import com.minecolonies.api.util.BlockPosUtil;
 import com.minecolonies.api.util.InventoryUtils;
 import com.minecolonies.coremod.Network;
 import com.minecolonies.coremod.colony.buildings.workerbuildings.BuildingSchool;
@@ -16,6 +14,7 @@ import com.minecolonies.coremod.entity.ai.basic.AbstractEntityAIInteract;
 import com.minecolonies.coremod.entity.citizen.EntityCitizen;
 import com.minecolonies.coremod.network.messages.client.CircleParticleEffectMessage;
 import com.minecolonies.coremod.research.MultiplierModifierResearchEffect;
+import net.minecraft.inventory.EquipmentSlotType;
 import net.minecraft.item.ItemStack;
 import net.minecraft.item.Items;
 import net.minecraft.particles.ParticleTypes;
@@ -159,23 +158,19 @@ public class EntityAIWorkPupil extends AbstractEntityAIInteract<JobPupil, Buildi
         {
             // Sit for 60-120 seconds.
             maxSittingTicks = worker.getRandom().nextInt(120 / 2) + 60;
-
-            final SittingEntity entity = (SittingEntity) ModEntities.SITTINGENTITY.create(world);
-            entity.setPosition(studyPos.getX(), studyPos.getY() - 0.6, studyPos.getZ());
-            entity.setMaxLifeTime(maxSittingTicks * 20);
-            world.addEntity(entity);
-            worker.startRiding(entity);
-            worker.getNavigator().clearPath();
+            SittingEntity.sitDown(studyPos, worker, maxSittingTicks * 20);
         }
 
         final int slot = InventoryUtils.findFirstSlotInItemHandlerWith(worker.getInventoryCitizen(), PAPER);
 
         if (slot != -1)
         {
+            worker.setItemStackToSlot(EquipmentSlotType.MAINHAND, worker.getInventoryCitizen().getStackInSlot(slot));
             Network.getNetwork().sendToTrackingEntity(new CircleParticleEffectMessage(worker.getPositionVector().add(0, 1, 0), ParticleTypes.ENCHANT, sittingTicks), worker);
         }
         else
         {
+            worker.setItemStackToSlot(EquipmentSlotType.MAINHAND, ItemStack.EMPTY);
             Network.getNetwork().sendToTrackingEntity(new CircleParticleEffectMessage(worker.getPositionVector().add(0, 1, 0), ParticleTypes.HAPPY_VILLAGER, sittingTicks), worker);
         }
 
@@ -185,6 +180,7 @@ public class EntityAIWorkPupil extends AbstractEntityAIInteract<JobPupil, Buildi
             return getState();
         }
 
+        worker.setItemStackToSlot(EquipmentSlotType.MAINHAND, ItemStack.EMPTY);
         if (worker.ridingEntity != null)
         {
             worker.stopRiding();

--- a/src/main/java/com/minecolonies/coremod/entity/ai/citizen/school/EntityAIWorkTeacher.java
+++ b/src/main/java/com/minecolonies/coremod/entity/ai/citizen/school/EntityAIWorkTeacher.java
@@ -135,12 +135,7 @@ public class EntityAIWorkTeacher extends AbstractEntityAIInteract<JobTeacher, Bu
             final int jobModifier = (int) (100 / Math.max(1, getSecondarySkillLevel() / 2.0));
             maxSittingTicks = worker.getRandom().nextInt(jobModifier / 2) + jobModifier / 2;
 
-            final SittingEntity entity = (SittingEntity) ModEntities.SITTINGENTITY.create(world);
-            entity.setPosition(worker.posX, worker.posY - 1f, worker.posZ);
-            entity.setMaxLifeTime(maxSittingTicks * 20);
-            world.addEntity(entity);
-            worker.startRiding(entity);
-            worker.getNavigator().clearPath();
+            SittingEntity.sitDown(worker.getPosition(), worker, maxSittingTicks * 20);
         }
 
         sittingTicks++;

--- a/src/main/java/com/minecolonies/coremod/entity/ai/minimal/EntityAIInteractToggleAble.java
+++ b/src/main/java/com/minecolonies/coremod/entity/ai/minimal/EntityAIInteractToggleAble.java
@@ -1,5 +1,6 @@
 package com.minecolonies.coremod.entity.ai.minimal;
 
+import com.minecolonies.api.util.WorldUtil;
 import net.minecraft.block.*;
 import net.minecraft.entity.MobEntity;
 import net.minecraft.entity.ai.goal.Goal;
@@ -442,13 +443,13 @@ public class EntityAIInteractToggleAble extends Goal
         @Override
         public void toggleBlock(final BlockState state, final World world, final BlockPos pos)
         {
-            world.setBlockState(pos, state.cycle(BlockStateProperties.OPEN));
+            WorldUtil.setBlockState(world, pos, state.cycle(BlockStateProperties.OPEN));
         }
 
         @Override
         public void toggleBlockClosed(final BlockState state, final World world, final BlockPos pos)
         {
-            world.setBlockState(pos, state.with(BlockStateProperties.OPEN, false));
+            WorldUtil.setBlockState(world, pos, state.with(BlockStateProperties.OPEN, false));
         }
     }
 
@@ -466,13 +467,13 @@ public class EntityAIInteractToggleAble extends Goal
         @Override
         public void toggleBlock(final BlockState state, final World world, final BlockPos pos)
         {
-            world.setBlockState(pos, state.cycle(BlockStateProperties.OPEN));
+            WorldUtil.setBlockState(world, pos, state.cycle(BlockStateProperties.OPEN));
         }
 
         @Override
         public void toggleBlockClosed(final BlockState state, final World world, final BlockPos pos)
         {
-            world.setBlockState(pos, state.with(BlockStateProperties.OPEN, false));
+            WorldUtil.setBlockState(world, pos, state.with(BlockStateProperties.OPEN, false));
         }
     }
 

--- a/src/main/java/com/minecolonies/coremod/entity/ai/minimal/EntityAIVisitor.java
+++ b/src/main/java/com/minecolonies/coremod/entity/ai/minimal/EntityAIVisitor.java
@@ -1,7 +1,6 @@
 package com.minecolonies.coremod.entity.ai.minimal;
 
 import com.minecolonies.api.colony.buildings.IBuilding;
-import com.minecolonies.api.entity.ModEntities;
 import com.minecolonies.api.entity.ai.statemachine.states.IState;
 import com.minecolonies.api.entity.ai.statemachine.tickratestatemachine.ITickRateStateMachine;
 import com.minecolonies.api.entity.ai.statemachine.tickratestatemachine.TickRateStateMachine;
@@ -218,12 +217,7 @@ public class EntityAIVisitor extends Goal
         {
             if (citizen.getRidingEntity() == null)
             {
-                final SittingEntity entity = (SittingEntity) ModEntities.SITTINGENTITY.create(citizen.world);
-                entity.setPosition(moveTo.getX() + 0.5, moveTo.getY() - 0.4, moveTo.getZ() + 0.5);
-                entity.setMaxLifeTime(actionTimeoutCounter);
-                citizen.world.addEntity(entity);
-                citizen.startRiding(entity);
-                citizen.getNavigator().clearPath();
+                SittingEntity.sitDown(moveTo, citizen, actionTimeoutCounter);
             }
         }
         return false;

--- a/src/main/java/com/minecolonies/coremod/entity/citizen/citizenhandlers/CitizenDiseaseHandler.java
+++ b/src/main/java/com/minecolonies/coremod/entity/citizen/citizenhandlers/CitizenDiseaseHandler.java
@@ -6,7 +6,6 @@ import com.minecolonies.api.colony.IColonyManager;
 import com.minecolonies.api.colony.buildings.IBuilding;
 import com.minecolonies.api.entity.citizen.AbstractEntityCitizen;
 import com.minecolonies.api.entity.citizen.citizenhandlers.ICitizenDiseaseHandler;
-import com.minecolonies.api.util.Log;
 import com.minecolonies.coremod.MineColonies;
 import com.minecolonies.coremod.colony.jobs.AbstractJobGuard;
 import com.minecolonies.coremod.colony.jobs.JobHealer;
@@ -54,6 +53,13 @@ public class CitizenDiseaseHandler implements ICitizenDiseaseHandler
     private int immunityTicks = 0;
 
     /**
+     * The initial citizen count
+     */
+    private static final int initialCitizenCount = IMinecoloniesAPI.getInstance()
+                                                     .getConfig()
+                                                     .getCommon().initialCitizenAmount.get();
+
+    /**
      * Constructor for the experience handler.
      *
      * @param citizen the citizen owning the handler.
@@ -95,9 +101,7 @@ public class CitizenDiseaseHandler implements ICitizenDiseaseHandler
              && citizen.getCitizenColonyHandler().getColony().isActive()
              && !(citizen.getCitizenJobHandler().getColonyJob() instanceof JobHealer)
              && immunityTicks <= 0
-             && citizen.getCitizenColonyHandler().getColony().getCitizenManager().getCurrentCitizenCount() > IMinecoloniesAPI.getInstance()
-                                                                                                               .getConfig()
-                                                                                                               .getCommon().initialCitizenAmount.get();
+                 && citizen.getCitizenColonyHandler().getColony().getCitizenManager().getCurrentCitizenCount() > initialCitizenCount;
     }
 
     @Override

--- a/src/main/java/com/minecolonies/coremod/entity/citizen/citizenhandlers/CitizenItemHandler.java
+++ b/src/main/java/com/minecolonies/coremod/entity/citizen/citizenhandlers/CitizenItemHandler.java
@@ -282,7 +282,7 @@ public class CitizenItemHandler implements ICitizenItemHandler
                                                                .expand(2.0F, 1.0F, 2.0F)
                                                                .expand(-2.0F, -1.0F, -2.0F)))
         {
-            if (item != null && citizen.canPickUpLoot() && item.isAlive())
+            if (item != null && item.isAlive())
             {
                 tryPickupItemEntity(item);
             }

--- a/src/main/java/com/minecolonies/coremod/placementhandlers/GeneralBlockPlacementHandler.java
+++ b/src/main/java/com/minecolonies/coremod/placementhandlers/GeneralBlockPlacementHandler.java
@@ -6,6 +6,7 @@ import com.ldtteam.structurize.util.BlockUtils;
 import com.ldtteam.structurize.util.PlacementSettings;
 import com.minecolonies.api.compatibility.candb.ChiselAndBitsCheck;
 import com.minecolonies.api.util.Log;
+import com.minecolonies.api.util.WorldUtil;
 import net.minecraft.block.BlockState;
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.CompoundNBT;
@@ -42,7 +43,7 @@ public class GeneralBlockPlacementHandler implements IPlacementHandler
             return ActionProcessingResult.PASS;
         }
 
-        if (!world.setBlockState(pos, blockState, com.ldtteam.structurize.api.util.constant.Constants.UPDATE_FLAG))
+        if (!WorldUtil.setBlockState(world, pos, blockState, com.ldtteam.structurize.api.util.constant.Constants.UPDATE_FLAG))
         {
             return ActionProcessingResult.PASS;
         }


### PR DESCRIPTION
Closes #6263

# Changes proposed in this pull request:
Adds sitting within restaurants, at predefined positions. Now citizens after receiving their food go to a sitting place, idle there for a bit and then eat. Also improved sitting logic a bit, now the entities take the shape of the block we want to sit on into consideration and adjust the Y level accordingly.

Studying childs now hold paper in their hands.
Improve set blockstate performance by bypassing vanilla's loop of all entity navigators, all other logic is done as usual, just that specific wont run.

Fix average raid config default

Review please
