### PR TITLE
Builder resources orange

### DIFF
--- a/src/main/java/com/minecolonies/coremod/client/gui/WindowHutBuilder.java
+++ b/src/main/java/com/minecolonies/coremod/client/gui/WindowHutBuilder.java
@@ -44,6 +44,7 @@ public class WindowHutBuilder extends AbstractWindowWorkerBuilding<BuildingBuild
     public static final int RED       = Color.getByName("red", 0);
     public static final int DARKGREEN = Color.getByName("darkgreen", 0);
     public static final int BLACK     = Color.getByName("black", 0);
+    public static final int YELLOW    = Color.getByName("yellow", 0);
 
     /**
      * The advancement location.
@@ -214,9 +215,9 @@ public class WindowHutBuilder extends AbstractWindowWorkerBuilding<BuildingBuild
                 break;
             case NEED_MORE:
                 addButton.enable();
-                resourceLabel.setColor(RED, RED);
-                resourceMissingLabel.setColor(RED, RED);
-                neededLabel.setColor(RED, RED);
+                resourceLabel.setColor(YELLOW, YELLOW);
+                resourceMissingLabel.setColor(YELLOW, YELLOW);
+                neededLabel.setColor(YELLOW, YELLOW);
                 break;
             case HAVE_ENOUGH:
                 addButton.enable();

--- a/src/main/java/com/minecolonies/coremod/client/gui/WindowHutBuilder.java
+++ b/src/main/java/com/minecolonies/coremod/client/gui/WindowHutBuilder.java
@@ -44,7 +44,7 @@ public class WindowHutBuilder extends AbstractWindowWorkerBuilding<BuildingBuild
     public static final int RED       = Color.getByName("red", 0);
     public static final int DARKGREEN = Color.getByName("darkgreen", 0);
     public static final int BLACK     = Color.getByName("black", 0);
-    public static final int YELLOW    = Color.getByName("yellow", 0);
+    public static final int ORANGE    = Color.getByName("orange", 0);
 
     /**
      * The advancement location.
@@ -215,9 +215,9 @@ public class WindowHutBuilder extends AbstractWindowWorkerBuilding<BuildingBuild
                 break;
             case NEED_MORE:
                 addButton.enable();
-                resourceLabel.setColor(YELLOW, YELLOW);
-                resourceMissingLabel.setColor(YELLOW, YELLOW);
-                neededLabel.setColor(YELLOW, YELLOW);
+                resourceLabel.setColor(ORANGE, ORANGE);
+                resourceMissingLabel.setColor(ORANGE, ORANGE);
+                neededLabel.setColor(ORANGE, ORANGE);
                 break;
             case HAVE_ENOUGH:
                 addButton.enable();

--- a/src/main/java/com/minecolonies/coremod/client/gui/WindowResourceList.java
+++ b/src/main/java/com/minecolonies/coremod/client/gui/WindowResourceList.java
@@ -219,9 +219,9 @@ public class WindowResourceList extends AbstractWindowSkeleton
                 neededLabel.setColor(RED, RED);
                 break;
             case NEED_MORE:
-                resourceLabel.setColor(RED, RED);
-                resourceMissingLabel.setColor(RED, RED);
-                neededLabel.setColor(RED, RED);
+                resourceLabel.setColor(YELLOW, YELLOW);
+                resourceMissingLabel.setColor(YELLOW, YELLOW);
+                neededLabel.setColor(YELLOW, YELLOW);
                 break;
             case HAVE_ENOUGH:
                 resourceLabel.setColor(DARKGREEN, DARKGREEN);

--- a/src/main/java/com/minecolonies/coremod/client/gui/WindowResourceList.java
+++ b/src/main/java/com/minecolonies/coremod/client/gui/WindowResourceList.java
@@ -219,9 +219,9 @@ public class WindowResourceList extends AbstractWindowSkeleton
                 neededLabel.setColor(RED, RED);
                 break;
             case NEED_MORE:
-                resourceLabel.setColor(YELLOW, YELLOW);
-                resourceMissingLabel.setColor(YELLOW, YELLOW);
-                neededLabel.setColor(YELLOW, YELLOW);
+                resourceLabel.setColor(ORANGE, ORANGE);
+                resourceMissingLabel.setColor(ORANGE, ORANGE);
+                neededLabel.setColor(ORANGE, ORANGE);
                 break;
             case HAVE_ENOUGH:
                 resourceLabel.setColor(DARKGREEN, DARKGREEN);


### PR DESCRIPTION
Closes #
Closes #
Closes #

# Changes proposed in this pull request:
- On the resource scroll and the second page of the builder hut GUI, if you have some of the needed items but not all, this'll make it orange instead of red. Probably.
- On the resource scroll (but not the builder hut) the red comes before the orange, idk how to fix this
- Screenshot of the builder hut gui (I have 32 shingles):
![image](https://user-images.githubusercontent.com/63612548/102832491-2f335680-43b4-11eb-835b-6f6d0a0c84e7.png)


Review please
