### PR TITLE
Fix for Pupil Display, Baker/Bakery on Chorus Bread

### DIFF
--- a/src/main/java/com/minecolonies/coremod/client/gui/WindowTownHall.java
+++ b/src/main/java/com/minecolonies/coremod/client/gui/WindowTownHall.java
@@ -650,7 +650,10 @@ public class WindowTownHall extends AbstractWindowBuilding<ITownHallView>
 
                 if (building instanceof BuildingSchool.View)
                 {
-                    String teacherJobName = "com.minecolonies.coremod.job.teacher";
+                    // For schools, getJobDisplayName will always be the teacher's key, as it's derived from createJob(null),
+                    // while getJobName will always be the pupil, as it's derived from the hardcoded job name for the school.
+                    final String teacherJobName = jobName;
+                    final String pupilJobName = ((BuildingSchool.View) building).getJobName();
 
                     int maxTeachers = 1;
                     max = max - 1;
@@ -669,8 +672,8 @@ public class WindowTownHall extends AbstractWindowBuilding<ITownHallView>
                     }
                     final Tuple<Integer, Integer> teacherTuple = jobMaxCountMap.getOrDefault(teacherJobName, new Tuple<>(0, 0));
                     jobMaxCountMap.put(teacherJobName, new Tuple<>(teacherTuple.getA() + teachers, teacherTuple.getB() + maxTeachers));
-                    final Tuple<Integer, Integer> tuple = jobMaxCountMap.getOrDefault(jobName, new Tuple<>(0, 0));
-                    jobMaxCountMap.put(jobName, new Tuple<>(tuple.getA() + workers, tuple.getB() + max));
+                    final Tuple<Integer, Integer> pupilTuple = jobMaxCountMap.getOrDefault(pupilJobName, new Tuple<>(0, 0));
+                    jobMaxCountMap.put(pupilJobName, new Tuple<>(pupilTuple.getA() + workers, pupilTuple.getB() + max));
                 }
                 else
                 {

--- a/src/main/java/com/minecolonies/coremod/research/ResearchInitializer.java
+++ b/src/main/java/com/minecolonies/coremod/research/ResearchInitializer.java
@@ -285,7 +285,7 @@ public class ResearchInitializer
         enhanced_gates1.addChild(enhanced_gates2);
 
         final GlobalResearch knowtheend = new GlobalResearch("knowtheend", "technology", "Know the End?", 3, new UnlockAbilityResearchEffect(END_KNOWLEGE, true));
-        knowtheend.setRequirement(new BuildingResearchRequirement(3, "bakery"));
+        knowtheend.setRequirement(new BuildingResearchRequirement(3, "baker"));
         theflintstones.addChild(knowtheend);
 
         final GlobalResearch morescrolls = new GlobalResearch("morescrolls", "technology", "More scrolls", 1, new UnlockAbilityResearchEffect(MORE_SCROLLS, true));


### PR DESCRIPTION
Closes #6358 
Closes #6337 

# Changes proposed in this pull request:
- Changing counting approach for School-related workers (pupils and teachers) to avoid possible double-counting.  Adds comments to improve clarity. 
- Changes the building research requirement for "Know The End" from "bakery" to "baker", to match the getSchematicName for the baker hut ("bakery" is only used in translation files).  This'll be obviated with the research data pack, but this fix solves the problem for the meantime, and won't interfere with that PR.

Review please
