### PR TITLE
Cook and mechanic can craft dried kelp blocks

### DIFF
--- a/src/main/resources/data/minecolonies/tags/items/cook_ingredient.json
+++ b/src/main/resources/data/minecolonies/tags/items/cook_ingredient.json
@@ -7,6 +7,8 @@
       "minecraft:chicken",
       "minecraft:porkchop",
       "minecraft:rabbit",
-      "minecraft:potato"
+      "minecraft:potato",
+      "minecraft:kelp",
+      "minecraft:dried_kelp"
   ]
 }

--- a/src/main/resources/data/minecolonies/tags/items/cook_ingredient.json
+++ b/src/main/resources/data/minecolonies/tags/items/cook_ingredient.json
@@ -9,6 +9,7 @@
       "minecraft:rabbit",
       "minecraft:potato",
       "minecraft:kelp",
-      "minecraft:dried_kelp"
+      "minecraft:dried_kelp",
+      "minecraft:dried_kelp_block"
   ]
 }

--- a/src/main/resources/data/minecolonies/tags/items/mechanic_ingredient.json
+++ b/src/main/resources/data/minecolonies/tags/items/mechanic_ingredient.json
@@ -8,6 +8,7 @@
     "minecraft:ender_pearl",
     "minecraft:ender_eye",
     "minecraft:redstone_torch",
-    "minecraft:glowstone_dust"
+    "minecraft:glowstone_dust",
+    "minecraft:dried_kelp_block"
   ]
 }

--- a/src/main/resources/data/minecolonies/tags/items/mechanic_product.json
+++ b/src/main/resources/data/minecolonies/tags/items/mechanic_product.json
@@ -19,6 +19,7 @@
     "minecraft:trapped_chest",
     "minecraft:ender_chest",
     "minecraft:lever",
-    "minecraft:daylight_detector"
+    "minecraft:daylight_detector",
+    "minecraft:dried_kelp_block"
   ]
 }


### PR DESCRIPTION
Closes https://github.com/ldtteam/minecolonies-features/issues/73
Closes #
Closes #

# Changes proposed in this pull request:
- Lets the Cook craft things with kelp and dried kelp, including dried kelp blocks
- Lets the Mechanic craft dried kelp blocks (they _are_ a storage block after all)
-

Review please
