### PR TITLE
Add campfires to the deco phase

### DIFF
--- a/src/main/resources/data/minecolonies/tags/blocks/decoblocks.json
+++ b/src/main/resources/data/minecolonies/tags/blocks/decoblocks.json
@@ -13,6 +13,7 @@
     "minecraft:horn_coral_block",
     "minecraft:lantern",
     "#minecraft:banners",
-    "#minecraft:signs"
+    "#minecraft:signs",
+    "#minecraft:campfires"
   ]
 }


### PR DESCRIPTION
Adds campfires to the deco phase based on a Discord suggestion "Might I suggest in the 1.16 version to have the campfire inside upgraded building be placed last if there is a way to do so? So far I've had two buildings burn down lol" https://discord.com/channels/139070364159311872/240841248750043137/798652486075285566
Might also help with citizens getting caught on fire.

Review please