### PR TITLE
Make certain blocks not replacable and indestructible by raiders

### DIFF
--- a/src/api/java/com/minecolonies/api/entity/pathfinding/PathingStuckHandler.java
+++ b/src/api/java/com/minecolonies/api/entity/pathfinding/PathingStuckHandler.java
@@ -398,8 +398,9 @@ public class PathingStuckHandler implements IStuckHandler
         final Block blockAtPos = world.getBlockState(pos).getBlock();
         if (blockAtPos instanceof IBuilderUndestroyable || ModTags.indestructible.contains(blockAtPos))
         {
-            world.setBlockState(pos, Blocks.AIR.getDefaultState());
+            return;
         }
+        world.setBlockState(pos, Blocks.AIR.getDefaultState());
     }
 
     /**

--- a/src/api/java/com/minecolonies/api/entity/pathfinding/PathingStuckHandler.java
+++ b/src/api/java/com/minecolonies/api/entity/pathfinding/PathingStuckHandler.java
@@ -1,6 +1,9 @@
 package com.minecolonies.api.entity.pathfinding;
 
+import com.minecolonies.api.entity.ai.citizen.builder.IBuilderUndestroyable;
+import com.minecolonies.api.items.ModTags;
 import com.minecolonies.api.util.BlockPosUtil;
+import net.minecraft.block.Block;
 import net.minecraft.block.BlockState;
 import net.minecraft.block.Blocks;
 import net.minecraft.block.LadderBlock;
@@ -356,24 +359,46 @@ public class PathingStuckHandler implements IStuckHandler
         stuckLevel = 0;
     }
 
+    /**
+     * Attempt to break blocks that are blocking the entity to reach its destination.
+     * @param world the world it is in.
+     * @param start the position the entity is at.
+     * @param facing the direction the goal is in.
+     */
     private void breakBlocksAhead(final World world, final BlockPos start, final Direction facing)
     {
         // Above entity
         if (!world.isAirBlock(start.up(3)))
         {
-            world.setBlockState(start.up(3), Blocks.AIR.getDefaultState());
+            setAirIfPossible(world, start.up(3));
+            return;
         }
 
         // In goal direction
         if (!world.isAirBlock(start.offset(facing)))
         {
-            world.setBlockState(start.offset(facing), Blocks.AIR.getDefaultState());
+            setAirIfPossible(world, start.offset(facing));
+            return;
         }
 
         // Goal direction up
         if (!world.isAirBlock(start.up().offset(facing)))
         {
-            world.setBlockState(start.up().offset(facing), Blocks.AIR.getDefaultState());
+            setAirIfPossible(world, start.up().offset(facing));
+        }
+    }
+
+    /**
+     * Check if the block at the position is indestructible, if not, attempt to break it.
+     * @param world the world the block is in.
+     * @param pos the pos the block is at.
+     */
+    private void setAirIfPossible(final World world, final BlockPos pos)
+    {
+        final Block blockAtPos = world.getBlockState(pos).getBlock();
+        if (blockAtPos instanceof IBuilderUndestroyable || ModTags.indestructible.contains(blockAtPos))
+        {
+            world.setBlockState(pos, Blocks.AIR.getDefaultState());
         }
     }
 

--- a/src/api/java/com/minecolonies/api/items/ModTags.java
+++ b/src/api/java/com/minecolonies/api/items/ModTags.java
@@ -16,18 +16,20 @@ public class ModTags
 
     public static ITag<Block> decorationItems;
     public static ITag<Item>  concretePowder;
-    public static ITag<Block>    concreteBlock;
-    public static ITag<Block>    pathingBlocks;
+    public static ITag<Block> concreteBlock;
+    public static ITag<Block> pathingBlocks;
 
-    public static ITag<Block>    colonyProtectionException;
+    public static ITag<Block> colonyProtectionException;
+    public static ITag<Block> indestructible;
 
-    public static ITag<Block>    oreChanceBlocks;
-    public static ITag<Item>     compostables;
+    public static ITag<Block> oreChanceBlocks;
+    public static ITag<Item>  compostables;
 
     public static ITag<Item> fungi;
 
-    public static final Map<String, ITag<Item>> crafterProduct = new HashMap<>();
-    public static final Map<String, ITag<Item>> crafterProductExclusions = new HashMap<>();
-    public static final Map<String, ITag<Item>> crafterIngredient = new HashMap<>();
+
+    public static final Map<String, ITag<Item>> crafterProduct              = new HashMap<>();
+    public static final Map<String, ITag<Item>> crafterProductExclusions    = new HashMap<>();
+    public static final Map<String, ITag<Item>> crafterIngredient           = new HashMap<>();
     public static final Map<String, ITag<Item>> crafterIngredientExclusions = new HashMap<>();
 }

--- a/src/main/java/com/minecolonies/apiimp/initializer/ModTagsInitializer.java
+++ b/src/main/java/com/minecolonies/apiimp/initializer/ModTagsInitializer.java
@@ -46,6 +46,7 @@ public class ModTagsInitializer
     private static final ResourceLocation ORECHANCEBLOCKS = new ResourceLocation(MOD_ID, "orechanceblocks");
     private static final ResourceLocation COLONYPROTECTIONEXCEPTION = new ResourceLocation(MOD_ID, "protectionexception");
     private static final ResourceLocation FUNGI = new ResourceLocation(MOD_ID, "fungi");
+    private static final ResourceLocation INDESTRUCTIBLE = new ResourceLocation(MOD_ID, "indestructible");
 
     private static boolean loaded = false;
 
@@ -65,6 +66,7 @@ public class ModTagsInitializer
         ModTags.fungi = getItemTags(FUNGI);
         ModTags.oreChanceBlocks = getBlockTags(ORECHANCEBLOCKS);
         ModTags.colonyProtectionException = getBlockTags(COLONYPROTECTIONEXCEPTION);
+        ModTags.indestructible = getBlockTags(INDESTRUCTIBLE);
 
         initCrafterRules("baker");
         initCrafterRules("blacksmith");

--- a/src/main/java/com/minecolonies/coremod/network/messages/server/BuildToolPlaceMessage.java
+++ b/src/main/java/com/minecolonies/coremod/network/messages/server/BuildToolPlaceMessage.java
@@ -11,6 +11,8 @@ import com.minecolonies.api.colony.buildings.IBuilding;
 import com.minecolonies.api.colony.buildings.IRSComponent;
 import com.minecolonies.api.colony.buildings.ModBuildings;
 import com.minecolonies.api.colony.permissions.Action;
+import com.minecolonies.api.entity.ai.citizen.builder.IBuilderUndestroyable;
+import com.minecolonies.api.items.ModTags;
 import com.minecolonies.api.network.IMessage;
 import com.minecolonies.api.util.*;
 import com.minecolonies.coremod.blocks.huts.BlockHutTownHall;
@@ -51,6 +53,7 @@ public class BuildToolPlaceMessage implements IMessage
      */
     private static final String NO_HUT_IN_INVENTORY = "com.minecolonies.coremod.gui.buildtool.nohutininventory";
     private static final String WRONG_COLONY        = "com.minecolonies.coremod.gui.buildtool.wrongcolony";
+    private static final String IMMUTABLE_BLOCK_AT_POS = "com.minecolonies.coremod.buildtool.indestructible";
 
     /**
      * The state at the offset position.
@@ -200,6 +203,14 @@ public class BuildToolPlaceMessage implements IMessage
       final boolean mirror,
       final BlockState state)
     {
+        final Block blockAtPos = world.getBlockState(buildPos).getBlock();
+        if (blockAtPos instanceof IBuilderUndestroyable || ModTags.indestructible.contains(blockAtPos))
+        {
+            LanguageHandler.sendPlayerMessage(player, IMMUTABLE_BLOCK_AT_POS);
+            SoundUtils.playErrorSound(player, buildPos);
+            return;
+        }
+
         final String hut = sn.getSection();
         final ItemStack stack = BuildingUtils.getItemStackForHutFromInventory(player.inventory, hut);
         final Block block = stack.getItem() instanceof BlockItem ? ((BlockItem) stack.getItem()).getBlock() : null;

--- a/src/main/java/com/minecolonies/coremod/network/messages/server/BuildToolPlaceMessage.java
+++ b/src/main/java/com/minecolonies/coremod/network/messages/server/BuildToolPlaceMessage.java
@@ -52,8 +52,8 @@ public class BuildToolPlaceMessage implements IMessage
      * Language key for missing hut
      */
     private static final String NO_HUT_IN_INVENTORY = "com.minecolonies.coremod.gui.buildtool.nohutininventory";
-    private static final String WRONG_COLONY        = "com.minecolonies.coremod.gui.buildtool.wrongcolony";
-    private static final String IMMUTABLE_BLOCK_AT_POS = "com.minecolonies.coremod.buildtool.indestructible";
+    private static final String WRONG_COLONY                = "com.minecolonies.coremod.gui.buildtool.wrongcolony";
+    private static final String INDESTRUCTIBLE_BLOCK_AT_POS = "com.minecolonies.coremod.buildtool.indestructible";
 
     /**
      * The state at the offset position.
@@ -206,7 +206,7 @@ public class BuildToolPlaceMessage implements IMessage
         final Block blockAtPos = world.getBlockState(buildPos).getBlock();
         if (blockAtPos instanceof IBuilderUndestroyable || ModTags.indestructible.contains(blockAtPos))
         {
-            LanguageHandler.sendPlayerMessage(player, IMMUTABLE_BLOCK_AT_POS);
+            LanguageHandler.sendPlayerMessage(player, INDESTRUCTIBLE_BLOCK_AT_POS);
             SoundUtils.playErrorSound(player, buildPos);
             return;
         }

--- a/src/main/resources/assets/minecolonies/lang/en_us.json
+++ b/src/main/resources/assets/minecolonies/lang/en_us.json
@@ -1935,6 +1935,6 @@
   "com.minecolonies.coremod.gui.townhalltab.citizens": "Citizens",
   "com.minecolonies.coremod.gui.townhalltab.settings": "Settings",
   "com.minecolonies.coremod.gui.townhalltab.workorders": "Work Orders",
-  "com.minecolonies.coremod.gui.townhalltab.happiness": "Happiness"
-
+  "com.minecolonies.coremod.gui.townhalltab.happiness": "Happiness",
+  "com.minecolonies.coremod.buildtool.indestructible": "Failed to place hut block, block at pos is indestructible!"
 }

--- a/src/main/resources/assets/minecolonies/lang/en_us.json
+++ b/src/main/resources/assets/minecolonies/lang/en_us.json
@@ -1936,5 +1936,5 @@
   "com.minecolonies.coremod.gui.townhalltab.settings": "Settings",
   "com.minecolonies.coremod.gui.townhalltab.workorders": "Work Orders",
   "com.minecolonies.coremod.gui.townhalltab.happiness": "Happiness",
-  "com.minecolonies.coremod.buildtool.indestructible": "Failed to place hut block, block at pos is indestructible!"
+  "com.minecolonies.coremod.buildtool.indestructible": "Failed to place the hut block! The block at its intended position is indestructible!"
 }

--- a/src/main/resources/data/minecolonies/tags/blocks/indestructible.json
+++ b/src/main/resources/data/minecolonies/tags/blocks/indestructible.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "minecraft:bedrock"
+  ]
+}


### PR DESCRIPTION


# Changes proposed in this pull request:
- Fixes raiders able to break bedrock or hut blocks
- Fixes players being able to do so by placing hut blocks into bedrock
-

Review please
