### PR TITLE
Various Research-Related Fixes : tooltips, emerald costs, max-citizens, Durability, Saturation Limit

### DIFF
--- a/src/api/java/com/minecolonies/api/configuration/ServerConfiguration.java
+++ b/src/api/java/com/minecolonies/api/configuration/ServerConfiguration.java
@@ -1335,13 +1335,13 @@ public class ServerConfiguration extends AbstractConfiguration
           s -> s instanceof String);
 
         this.loaded = defineList(builder, "loaded",
-          Collections.singletonList("minecraft:emerald*64"),
-          s -> s instanceof String);
-        this.heavilyloaded = defineList(builder, "heavilyloaded",
           Collections.singletonList("minecraft:emerald*128"),
           s -> s instanceof String);
-        this.deeppockets = defineList(builder, "deeppockets",
+        this.heavilyloaded = defineList(builder, "heavilyloaded",
           Collections.singletonList("minecraft:emerald*256"),
+          s -> s instanceof String);
+        this.deeppockets = defineList(builder, "deeppockets",
+          Collections.singletonList("minecraft:emerald*64"),
           s -> s instanceof String);
 
         taunt = defineList(builder, "taunt",

--- a/src/api/java/com/minecolonies/api/items/ItemBlockHut.java
+++ b/src/api/java/com/minecolonies/api/items/ItemBlockHut.java
@@ -47,8 +47,8 @@ public class ItemBlockHut extends BlockItem
         super.addInformation(stack, worldIn, tooltip, flagIn);
         if (block.needsResearch())
         {
-            tooltip.add(new TranslationTextComponent(TranslationConstants.HUT_NEEDS_RESEARCH_TOOLTIP_1, block.getName()));
-            tooltip.add(new TranslationTextComponent(TranslationConstants.HUT_NEEDS_RESEARCH_TOOLTIP_2, block.getName()));
+            tooltip.add(new TranslationTextComponent(TranslationConstants.HUT_NEEDS_RESEARCH_TOOLTIP_1, block.getTranslatedName(), block.getName()));
+            tooltip.add(new TranslationTextComponent(TranslationConstants.HUT_NEEDS_RESEARCH_TOOLTIP_2, block.getTranslatedName(), block.getName()));
         }
     }
 

--- a/src/api/java/com/minecolonies/api/research/util/ResearchConstants.java
+++ b/src/api/java/com/minecolonies/api/research/util/ResearchConstants.java
@@ -67,14 +67,14 @@ public final class ResearchConstants
     public static final String RETREAT          = "Retreat";
     public static final String NONE             = "None";
     public static final String SHIELD_USAGE     = "Shield Usage";
-    public static final String KNIGHT_TAUNT     = "Knight taunt mobs";
+    public static final String KNIGHT_TAUNT     = "Knights Taunt Mobs";
     public static final String DOUBLE_ARROWS    = "Double Arrows";
     public static final String ARROW_ITEMS      = "Consume Arrows";
     public static final String ARROW_PIERCE     = "Piercing Arrows";
-    public static final String KNIGHT_WHIRLWIND = "Whirldwind ability";
+    public static final String KNIGHT_WHIRLWIND = "Whirlwind Ability";
     public static final String BLOCK_ATTACKS    = "Block Attacks";
     public static final String SLEEP_LESS       = "Sleep Less";
-    public static final String WORK_LONGER      = "Working day h";
+    public static final String WORK_LONGER      = "Working Day h";
 
     public static final String TEACHING = "Teaching";
     public static final String GROWTH   = "Growth";
@@ -104,7 +104,7 @@ public final class ResearchConstants
     public static final String FIRE_RES    = "Miner Fire Res";
 
     public static final String END_KNOWLEGE = "Knowledge of The End";
-    public static final String MORE_SCROLLS = "more scroll recipes";
+    public static final String MORE_SCROLLS = "More Scroll Recipes";
 
     /**
      * Private constructor to hide implicit public one.

--- a/src/main/java/com/minecolonies/coremod/colony/managers/CitizenManager.java
+++ b/src/main/java/com/minecolonies/coremod/colony/managers/CitizenManager.java
@@ -469,9 +469,9 @@ public class CitizenManager implements ICitizenManager
         {
             max += effect.getEffect();
             // TODO research data rework
-            if (max >= 200)
+            if (max >= MineColonies.getConfig().getServer().maxCitizenPerColony.get())
             {
-                return MineColonies.getConfig().getServer().maxCitizenPerColony.get() - 25;
+                return MineColonies.getConfig().getServer().maxCitizenPerColony.get();
             }
         }
         return max;

--- a/src/main/java/com/minecolonies/coremod/entity/ai/citizen/school/EntityAIWorkTeacher.java
+++ b/src/main/java/com/minecolonies/coremod/entity/ai/citizen/school/EntityAIWorkTeacher.java
@@ -164,8 +164,8 @@ public class EntityAIWorkTeacher extends AbstractEntityAIInteract<JobTeacher, Bu
         if (effect != null)
         {
             xp *= (1 + effect.getEffect());
-            xp *= (1 + (getPrimarySkillLevel() / 10.0));
         }
+        xp *= (1 + (getPrimarySkillLevel() / 10.0));
 
         pupilToTeach.getCitizenData().getCitizenSkillHandler().addXpToSkill(Skill.Intelligence, xp, pupilToTeach.getCitizenData());
 

--- a/src/main/java/com/minecolonies/coremod/entity/citizen/EntityCitizen.java
+++ b/src/main/java/com/minecolonies/coremod/entity/citizen/EntityCitizen.java
@@ -623,7 +623,7 @@ public class EntityCitizen extends AbstractEntityCitizen
             }
 
             double healAmount = 1;
-            if (citizenData.getSaturation() >= FULL_SATURATION - limitDecrease)
+            if (citizenData.getSaturation() >= FULL_SATURATION + limitDecrease)
             {
                 healAmount += 1;
             }

--- a/src/main/java/com/minecolonies/coremod/entity/citizen/citizenhandlers/CitizenItemHandler.java
+++ b/src/main/java/com/minecolonies/coremod/entity/citizen/citizenhandlers/CitizenItemHandler.java
@@ -242,17 +242,14 @@ public class CitizenItemHandler implements ICitizenItemHandler
             return;
         }
 
-        double chance = 0;
         final MultiplierModifierResearchEffect effect =
           citizen.getCitizenColonyHandler().getColony().getResearchManager().getResearchEffects().getEffect(TOOL_DURABILITY, MultiplierModifierResearchEffect.class);
         if (effect != null)
         {
-            chance = effect.getEffect();
-        }
-
-        if (citizen.getRandom().nextDouble() < chance)
-        {
-            return;
+            if (citizen.getRandom().nextDouble() > (1 / (1 + effect.getEffect())))
+            {
+                return;
+            }
         }
 
         //check if tool breaks
@@ -333,15 +330,18 @@ public class CitizenItemHandler implements ICitizenItemHandler
                 continue;
             }
 
-            double armorDamage = damage;
             final MultiplierModifierResearchEffect
               effect = citizen.getCitizenColonyHandler().getColony().getResearchManager().getResearchEffects().getEffect(ARMOR_DURABILITY, MultiplierModifierResearchEffect.class);
-            if (effect != null)
+
+            if(effect != null)
             {
-                armorDamage *= 1 - effect.getEffect();
+                if (citizen.getRandom().nextDouble() > (1 / (1 + effect.getEffect())))
+                {
+                    return;
+                }
             }
 
-            stack.damageItem(Math.max(1, (int) (armorDamage / 4)), citizen, (i) -> {
+            stack.damageItem(Math.max(1, (int) (damage / 4)), citizen, (i) -> {
                 i.sendBreakAnimation(Hand.MAIN_HAND);
             });
         }

--- a/src/main/java/com/minecolonies/coremod/research/ResearchInitializer.java
+++ b/src/main/java/com/minecolonies/coremod/research/ResearchInitializer.java
@@ -165,7 +165,7 @@ public class ResearchInitializer
         final GlobalResearch cheatsheet = new GlobalResearch("cheatsheet", "technology", "Cheat Sheet", 3, new MultiplierModifierResearchEffect(RECIPES, 0.5));
         cheatsheet.setRequirement(new BuildingResearchRequirement(2, "sawmill"));
 
-        final GlobalResearch recipebook = new GlobalResearch("recipebook", "technology", "Recipe book", 4, new MultiplierModifierResearchEffect(RECIPES, 1.0));
+        final GlobalResearch recipebook = new GlobalResearch("recipebook", "technology", "Recipe Book", 4, new MultiplierModifierResearchEffect(RECIPES, 1.0));
         recipebook.setRequirement(new BuildingResearchRequirement(3, "sawmill"));
 
         final GlobalResearch rtm = new GlobalResearch("rtm", "technology", "RTM", 5, new MultiplierModifierResearchEffect(RECIPES, 2.0));
@@ -288,7 +288,7 @@ public class ResearchInitializer
         knowtheend.setRequirement(new BuildingResearchRequirement(3, "baker"));
         theflintstones.addChild(knowtheend);
 
-        final GlobalResearch morescrolls = new GlobalResearch("morescrolls", "technology", "More scrolls", 1, new UnlockAbilityResearchEffect(MORE_SCROLLS, true));
+        final GlobalResearch morescrolls = new GlobalResearch("morescrolls", "technology", "More Scrolls", 1, new UnlockAbilityResearchEffect(MORE_SCROLLS, true));
         morescrolls.setRequirement(new BuildingResearchRequirement(3, "enchanter"));
 
         researchTree.addResearch(pavetheroad.getBranch(), pavetheroad);


### PR DESCRIPTION
Closes #6300
Closes #6424

# Changes proposed in this pull request:
- Fixes display of tooltips for hut blocks that require research to build.

- MaxCitizens research will now go up to the maxCitizenPerColony limit, instead of 25 below, when at max level.  This will also allow very low levels of maxCitizensPerColony (below 100) to apply at all.  The higher ranks won't be able to adjust to match the server config settings yet, though, as remote clients don't get that information, but the workarounds to do so are very ugly and I don't want to mess with config file ranges for behavior that'll change again with the research data pack.

- Changes TOOL_DURABILITY and ARMOR_DURABILITY modifiers to act as `random > (1 / (1 + effectVal))`, as discussed with someaddons in the #getting_started chat.  This is effectively a small nerf to the Diamond-Coated research chain and a large buff to the Diamond Skin research chain (whose highest two tiers would only really show up if you tried to zerg rush a Wither with guards).  May eventually be worth doing a more focused balance pass.

- Allows teachers to apply their PrimarySkill (Knowledge) to XP gain of pupils regardless of "More Books" research status.

- Fixes SATLIMIT research to reduce the saturation required for citizens to get double healing, instead of increasing it above the possible range.

- Fixes costs of the Deep Pockets- Loaded - Heavily Loaded research, at least for new worlds or when a config file is rebuilt.

- Cleans up a few effect spelling or capitalization oddities, where doing so is non-breaking.

Review please