### PR TITLE
Fix a couple mods.toml issues

### DIFF
--- a/src/main/resources/META-INF/mods.toml
+++ b/src/main/resources/META-INF/mods.toml
@@ -6,12 +6,12 @@
 # The name of the mod loader type to load - for regular FML @Mod mods it should be javafml
 modLoader="javafml" #mandatory
 # A version range to match for said mod loader - for regular FML @Mod it will be the forge version
-loaderVersion="[31,)" #mandatory (27 is current forge version)
+loaderVersion="[33,)" #mandatory (27 is current forge version)
 # The license for you mod. This is mandatory metadata and allows for easier comprehension of your redistributive properties.
 # Review your options at https://choosealicense.com/. All rights reserved is the default copyright stance, and is thus the default here.
 license="GPL 3.0"
 # A URL to refer people to when problems occur with this mod
-issueTrackerURL="https://github.com/ldtteam/minecolonies/issues/new" #optional
+issueTrackerURL="https://github.com/ldtteam/minecolonies/issues/new/choose" #optional
 # A list of mods - how many allowed here is determined by the individual mod loader
 [[mods]] #mandatory
 # The modid of the mod


### PR DESCRIPTION
Closes #
Closes #
Closes #

# Changes proposed in this pull request:
- The issue link in mods.toml was going to https://github.com/ldtteam/minecolonies/issues/new/, but that goes to a blank issue (no templates). It should be https://github.com/ldtteam/minecolonies/issues/new/choose.
- The loaderVersion was set to 31 and above, but the dependency was set to 33.0.5 and above - this fixes it 
-

Review please
