### PR TITLE
Improve compatibility with modded farmland blocks.

### DIFF
--- a/src/main/java/com/minecolonies/coremod/entity/ai/citizen/farmer/EntityAIWorkFarmer.java
+++ b/src/main/java/com/minecolonies/coremod/entity/ai/citizen/farmer/EntityAIWorkFarmer.java
@@ -643,7 +643,7 @@ public class EntityAIWorkFarmer extends AbstractEntityAICrafting<JobFarmer, Buil
     {
         return !field.isNoPartOfField(world, position) && !(world.getBlockState(position.up()).getBlock() instanceof CropsBlock)
                  && !(world.getBlockState(position.up()).getBlock() instanceof StemBlock)
-                 && !(world.getBlockState(position).getBlock() instanceof BlockScarecrow) && world.getBlockState(position).getBlock() == Blocks.FARMLAND;
+                 && !(world.getBlockState(position).getBlock() instanceof BlockScarecrow) && world.getBlockState(position).getBlock() instanceof FarmlandBlock;
     }
 
     /**


### PR DESCRIPTION
# Changes proposed in this pull request:
- Change the farmer's planting check from exactly vanilla farmland to include derived types possibly added by mods as well.

As requested by someone in #help116 for compatibility with the Farmer's Delight mod.  Note that **I HAVE NOT TESTED THIS** with that mod, just that it compiles and doesn't break vanilla.  (But I did check the code of that mod and it does indeed derive from `FarmlandBlock`, so this fix should work for that case, unless there's another issue elsewhere.)

Review please
