### PR TITLE
Fix duplicate tooltips in town hall GUI

### DIFF
--- a/src/main/resources/assets/minecolonies/gui/townhall/windowtownhall.xml
+++ b/src/main/resources/assets/minecolonies/gui/townhall/windowtownhall.xml
@@ -3,59 +3,58 @@
 
     <image source="minecolonies:textures/gui/townhall_book.png" pos="75 0" size="374 243"/>
 
-    <image id="infopage0" pos="56 73" size="31 14" source="minecolonies:textures/gui/bookmark_short_ribbon_01.png" tooltip="$(com.minecolonies.coremod.gui.townhalltab.information)"/>
-    <image id="actions0" pos="56 97" size="31 14" source="minecolonies:textures/gui/bookmark_short_ribbon_02.png" tooltip="$(com.minecolonies.coremod.gui.townhalltab.actions)"/>
-    <image id="permissions0" pos="56 121" size="31 15" source="minecolonies:textures/gui/bookmark_short_ribbon_03.png" tooltip="$(com.minecolonies.coremod.gui.townhalltab.permissions)"/>
-    <image id="citizens0" pos="56 145" size="31 14" source="minecolonies:textures/gui/bookmark_short_ribbon_04.png" tooltip="$(com.minecolonies.coremod.gui.townhalltab.citizens)"/>
-    <image id="settings0" pos="56 169" size="31 14" source="minecolonies:textures/gui/bookmark_short_ribbon_05.png" tooltip="$(com.minecolonies.coremod.gui.townhalltab.settings)"/>
-    <image id="workOrder0" pos="56 193" size="31 14" source="minecolonies:textures/gui/bookmark_short_ribbon_06.png" tooltip="$(com.minecolonies.coremod.gui.townhalltab.workorders)"/>
-    <image id="happiness0" pos="56 217" size="31 14" source="minecolonies:textures/gui/bookmark_short_ribbon_01.png" tooltip="$(com.minecolonies.coremod.gui.townhalltab.happiness)"/>
+    <image id="infopage0" pos="56 73" size="31 14" source="minecolonies:textures/gui/bookmark_short_ribbon_01.png"/>
+    <image id="actions0" pos="56 97" size="31 14" source="minecolonies:textures/gui/bookmark_short_ribbon_02.png"/>
+    <image id="permissions0" pos="56 121" size="31 15" source="minecolonies:textures/gui/bookmark_short_ribbon_03.png"/>
+    <image id="citizens0" pos="56 145" size="31 14" source="minecolonies:textures/gui/bookmark_short_ribbon_04.png"/>
+    <image id="settings0" pos="56 169" size="31 14" source="minecolonies:textures/gui/bookmark_short_ribbon_05.png"/>
+    <image id="workOrder0" pos="56 193" size="31 14" source="minecolonies:textures/gui/bookmark_short_ribbon_06.png"/>
+    <image id="happiness0" pos="56 217" size="31 14" source="minecolonies:textures/gui/bookmark_short_ribbon_01.png"/>
 
     <buttonimage id="infopage1" size="204 17" pos="58 43" source="minecolonies:textures/gui/bookmark_ribbon_01.png" visible="false"
-                 label="$(com.minecolonies.coremod.gui.workerhuts.information)"
+                 label="$(com.minecolonies.coremod.gui.townhalltab.information)"
                  textalign="MIDDLE_LEFT" textoffset="35 2" textcolor="White" textdisabledcolor="DarkGray"/>
     <buttonimage id="actions1" size="204 17" pos="58 43" source="minecolonies:textures/gui/bookmark_ribbon_02.png" visible="false"
-                 label="$(com.minecolonies.coremod.gui.townHall.actions)"
+                 label="$(com.minecolonies.coremod.gui.townhalltab.actions)"
                  textalign="MIDDLE_LEFT" textoffset="35 2" textcolor="White" textdisabledcolor="DarkGray"/>
     <buttonimage id="permissions1" size="204 17" pos="58 43" source="minecolonies:textures/gui/bookmark_ribbon_03.png" visible="false"
-                 label="$(com.minecolonies.coremod.gui.townHall.permissions)"
+                 label="$(com.minecolonies.coremod.gui.townhalltab.permissions)"
                  textalign="MIDDLE_LEFT" textoffset="35 2" textcolor="White" textdisabledcolor="DarkGray"/>
     <buttonimage id="citizens1" size="204 17" pos="58 43" source="minecolonies:textures/gui/bookmark_ribbon_04.png" visible="false"
-                 label="$(com.minecolonies.coremod.gui.townHall.citizens)"
+                 label="$(com.minecolonies.coremod.gui.townhalltab.citizens)"
                  textalign="MIDDLE_LEFT" textoffset="35 2" textcolor="White" textdisabledcolor="DarkGray"/>
     <buttonimage id="settings1" size="204 17" pos="58 43" source="minecolonies:textures/gui/bookmark_ribbon_05.png" visible="false"
-                 label="$(com.minecolonies.coremod.gui.workerhuts.settings)"
+                 label="$(com.minecolonies.coremod.gui.townhalltab.settings)"
                  textalign="MIDDLE_LEFT" textoffset="35 2" textcolor="White" textdisabledcolor="DarkGray"/>
     <buttonimage id="workOrder1" size="204 17" pos="58 43" source="minecolonies:textures/gui/bookmark_ribbon_06.png" visible="false"
-                 label="$(com.minecolonies.coremod.gui.workerhuts.workOrder)"
+                 label="$(com.minecolonies.coremod.gui.townhalltab.workorders)"
                  textalign="MIDDLE_LEFT" textoffset="35 2" textcolor="White" textdisabledcolor="DarkGray"/>
     <buttonimage id="happiness1" size="204 17" pos="58 43" source="minecolonies:textures/gui/bookmark_ribbon_01.png" visible="false"
-                 label="$(com.minecolonies.coremod.gui.workerhuts.happiness)"
+                 label="$(com.minecolonies.coremod.gui.townhalltab.happiness)"
                  textalign="MIDDLE_LEFT" textoffset="35 2" textcolor="White" textdisabledcolor="DarkGray"/>
 
     <buttonimage id="infoExt" pos="-17 73" size="104 14" source="minecolonies:textures/gui/bookmark_medium_ribbon_01.png" visible="false"
-                 label="$(com.minecolonies.coremod.gui.workerhuts.information)"
+                 label="$(com.minecolonies.coremod.gui.townhalltab.information)"
                  textalign="MIDDLE_LEFT" textcolor="White" textoffset="8 1"/>
     <buttonimage id="actionsExt" pos="-17 97" size="104 14" source="minecolonies:textures/gui/bookmark_medium_ribbon_02.png" visible="false"
-                 label="$(com.minecolonies.coremod.gui.townHall.actions)"
+                 label="$(com.minecolonies.coremod.gui.townhalltab.actions)"
                  textalign="MIDDLE_LEFT" textcolor="White" textoffset="8 1"/>
     <buttonimage id="permissionsExt" pos="-17 121" size="104 14" source="minecolonies:textures/gui/bookmark_medium_ribbon_03.png" visible="false"
-                 label="$(com.minecolonies.coremod.gui.townHall.permissions)"
+                 label="$(com.minecolonies.coremod.gui.townhalltab.permissions)"
                  textalign="MIDDLE_LEFT" textcolor="White" textoffset="8 1"/>
     <buttonimage id="citizensExt" pos="-17 145" size="104 14" source="minecolonies:textures/gui/bookmark_medium_ribbon_04.png" visible="false"
-                 label="$(com.minecolonies.coremod.gui.townHall.citizens)"
+                 label="$(com.minecolonies.coremod.gui.townhalltab.citizens)"
                  textalign="MIDDLE_LEFT" textcolor="White" textoffset="8 1"/>
     <buttonimage id="settingsExt" pos="-17 169" size="104 14" source="minecolonies:textures/gui/bookmark_medium_ribbon_05.png" visible="false"
-                 label="$(com.minecolonies.coremod.gui.workerhuts.settings)"
+                 label="$(com.minecolonies.coremod.gui.townhalltab.settings)"
                  textalign="MIDDLE_LEFT" textcolor="White" textoffset="8 1"/>
     <buttonimage id="workOrderExt" pos="-17 193" size="104 14" source="minecolonies:textures/gui/bookmark_medium_ribbon_06.png" visible="false"
-                 label="$(com.minecolonies.coremod.gui.workerhuts.workOrder)"
+                 label="$(com.minecolonies.coremod.gui.townhalltab.workorders)"
                  textalign="MIDDLE_LEFT" textcolor="White" textoffset="8 1"/>
     <buttonimage id="happinessExt" pos="-17 217" size="104 14" source="minecolonies:textures/gui/bookmark_medium_ribbon_01.png" visible="false"
-                 label="$(com.minecolonies.coremod.gui.workerhuts.happiness)"
+                 label="$(com.minecolonies.coremod.gui.townhalltab.happiness)"
                  textalign="MIDDLE_LEFT" textcolor="White" textoffset="8 1"/>
 
-    <!-- onHoverId="infoExt" onHoverId="actionsExt" onHoverId="permissionsExt" onHoverId="citizensExt" onHoverId="settingsExt" onHoverId="workOrderExt" onHoverId="happinessExt" -->
     <buttonimage id="infopage" size="17 17" pos="62 71" onHoverId="infoExt"
                  source="minecolonies:textures/gui/red_wax_information.png"/>
     <buttonimage id="actions" size="17 17" pos="62 95" onHoverId="actionsExt"
@@ -68,7 +67,7 @@
                  source="minecolonies:textures/gui/red_wax_settings.png"/>
     <buttonimage id="workOrder" size="17 17" pos="62 191" onHoverId="workOrderExt"
                  source="minecolonies:textures/gui/red_wax_work_orders.png"/>
-    <!-- todo Create the texture -->
+    <!-- TODO create the happiness texture -->
     <buttonimage id="happiness" size="17 17" pos="62 215" onHoverId="happinessExt"
                  source="minecolonies:textures/gui/red_wax_information.png"/>
 


### PR DESCRIPTION
Closes #
Closes #
Closes #

# Changes proposed in this pull request:
- the town hall tabs on the left had two tooltips, this fixes it
- tested and works
- Ray you pinged me on discord about this

Review please
