### PR TITLE
Serveral fixes

### DIFF
--- a/src/api/java/com/minecolonies/api/entity/pathfinding/PathingOptions.java
+++ b/src/api/java/com/minecolonies/api/entity/pathfinding/PathingOptions.java
@@ -36,6 +36,11 @@ public class PathingOptions
     public double swimCostEnter = 25D;
 
     /**
+     * Cost to traverse trap doors
+     */
+    public double traverseToggleAbleCost = 2D;
+
+    /**
      * Whether to use minecart rail pathing
      */
     private boolean canUseRails  = false;
@@ -128,6 +133,12 @@ public class PathingOptions
     public PathingOptions withRailExitCost(final double railExitCost)
     {
         railsExitCost = railExitCost;
+        return this;
+    }
+
+    public PathingOptions withToggleCost(final double toggleCost)
+    {
+        traverseToggleAbleCost = toggleCost;
         return this;
     }
 }

--- a/src/api/java/com/minecolonies/api/util/WorldUtil.java
+++ b/src/api/java/com/minecolonies/api/util/WorldUtil.java
@@ -12,11 +12,7 @@ import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.math.ChunkPos;
 import net.minecraft.util.registry.DynamicRegistries;
 import net.minecraft.util.registry.Registry;
-import net.minecraft.world.Difficulty;
-import net.minecraft.world.DimensionType;
-import net.minecraft.world.GameRules;
-import net.minecraft.world.IWorld;
-import net.minecraft.world.World;
+import net.minecraft.world.*;
 import net.minecraft.world.chunk.AbstractChunkProvider;
 import net.minecraft.world.chunk.Chunk;
 import net.minecraft.world.chunk.ChunkStatus;
@@ -61,6 +57,7 @@ public class WorldUtil
 
     /**
      * Mark a chunk at a position dirty if loaded.
+     *
      * @param world the world to mark it dirty in.
      * @param pos   the position within the chunk.
      */
@@ -159,6 +156,7 @@ public class WorldUtil
 
     /**
      * Check if a world is of the overworld type.
+     *
      * @param world the world to check.
      * @return true if so.
      */
@@ -169,6 +167,7 @@ public class WorldUtil
 
     /**
      * Check if a world is of the nether type.
+     *
      * @param world the world to check.
      * @return true if so.
      */
@@ -179,8 +178,9 @@ public class WorldUtil
 
     /**
      * Check if a world has a specific dimension type.
+     *
      * @param world the world to check.
-     * @param type the type to compare.
+     * @param type  the type to compare.
      * @return true if it matches.
      */
     public static boolean isOfWorldType(@NotNull final World world, @NotNull final RegistryKey<DimensionType> type)
@@ -201,10 +201,10 @@ public class WorldUtil
     }
 
     /**
-     * Check to see if the world is peaceful. 
-     * 
-     * There are several checks performed here, currently both gamerule and difficulty. 
-     * 
+     * Check to see if the world is peaceful.
+     * <p>
+     * There are several checks performed here, currently both gamerule and difficulty.
+     *
      * @param world world to check
      * @return true if peaceful
      */
@@ -228,13 +228,7 @@ public class WorldUtil
             return world.setBlockState(pos, state, 3);
         }
 
-        final boolean result = world.setBlockState(pos, state, 1);
-        if (result)
-        {
-            ((ServerWorld) world).getChunkProvider().markBlockChanged(pos);
-        }
-
-        return result;
+        return setBlockState(world, pos, state, 3);
     }
 
     /**
@@ -255,13 +249,8 @@ public class WorldUtil
         if ((flags & 2) != 0)
         {
             flags -= 2;
-            final boolean result = world.setBlockState(pos, state, flags);
-            if (result)
-            {
-                ((ServerWorld) world).getChunkProvider().markBlockChanged(pos);
-            }
-
-            return result;
+            ((ServerWorld) world).getChunkProvider().markBlockChanged(pos);
+            return world.setBlockState(pos, state, flags);
         }
         else
         {
@@ -271,11 +260,12 @@ public class WorldUtil
 
     /**
      * Get all entities within a building.
-     * @param world the world to check this for.
-     * @param clazz the entity class.
-     * @param building the building to check the range for.
+     *
+     * @param world     the world to check this for.
+     * @param clazz     the entity class.
+     * @param building  the building to check the range for.
      * @param predicate the predicate to check
-     * @param <T> the type of the predicate.
+     * @param <T>       the type of the predicate.
      * @return a list of all within those borders.
      */
     public static <T extends Entity> List<T> getEntitiesWithinBuilding(
@@ -296,9 +286,9 @@ public class WorldUtil
         List<T> list = Lists.newArrayList();
         AbstractChunkProvider abstractchunkprovider = world.getChunkProvider();
 
-        for(int x = minX; x <= maxX; ++x)
+        for (int x = minX; x <= maxX; ++x)
         {
-            for(int z = minZ; z <= maxZ; ++z)
+            for (int z = minZ; z <= maxZ; ++z)
             {
                 if (isEntityChunkLoaded(world, x, z))
                 {

--- a/src/api/java/com/minecolonies/api/util/constant/ColonyManagerConstants.java
+++ b/src/api/java/com/minecolonies/api/util/constant/ColonyManagerConstants.java
@@ -55,12 +55,12 @@ public final class ColonyManagerConstants
     /**
      * Colony filename.
      */
-    public static final String FILENAME_COLONY = "colony%d_%s.dat";
+    public static final String FILENAME_COLONY = "colony%d.dat";
 
     /**
      * Colony filename deleted.
      */
-    public static final String FILENAME_COLONY_DELETED = "colony%d_%s.dat.deleted";
+    public static final String FILENAME_COLONY_DELETED = "colony%d.dat.deleted";
 
     /**
      * Colony filename.

--- a/src/main/java/com/minecolonies/coremod/client/gui/containers/WindowCrafting.java
+++ b/src/main/java/com/minecolonies/coremod/client/gui/containers/WindowCrafting.java
@@ -144,7 +144,6 @@ public class WindowCrafting extends ContainerScreen<ContainerCrafting>
                     Network.getNetwork().sendToServer(new AddRemoveRecipeMessage(building, input, completeCrafting ? 3 : 2, primaryOutput, secondaryOutputs, false));
                 }
             }
-            closeScreen();
         }
     }
 

--- a/src/main/java/com/minecolonies/coremod/colony/managers/CitizenManager.java
+++ b/src/main/java/com/minecolonies/coremod/colony/managers/CitizenManager.java
@@ -354,6 +354,7 @@ public class CitizenManager implements ICitizenManager
         }
 
         calculateMaxCitizens();
+        markDirty();
         colony.markDirty();
     }
 

--- a/src/main/java/com/minecolonies/coremod/colony/managers/RaidManager.java
+++ b/src/main/java/com/minecolonies/coremod/colony/managers/RaidManager.java
@@ -56,7 +56,7 @@ public class RaidManager implements IRaiderManager
     /**
      * Min distance to keep while spawning near buildings
      */
-    private static final int MIN_BUILDING_SPAWN_DIST = 25;
+    private static final int MIN_BUILDING_SPAWN_DIST = 35;
 
     /**
      * Different biome ids.
@@ -506,22 +506,18 @@ public class RaidManager implements IRaiderManager
             // Additional raid protection for certain buildings, towers can be used now to deal with unlucky - inwall spawns
             if (building instanceof BuildingGuardTower)
             {
-                // 32/39/48/55/62
                 minDist += building.getBuildingLevel() * 7;
             }
             else if (building.hasModule(LivingBuildingModule.class))
             {
-                // 39/43/47/51/55
                 minDist += building.getBuildingLevel() * 4;
             }
             else if (building instanceof BuildingTownHall)
             {
-                // 43/51/59/67/75
                 minDist += building.getBuildingLevel() * 8;
             }
             else
             {
-                // 37/39/41/43/45
                 minDist += building.getBuildingLevel() * 2;
             }
 

--- a/src/main/java/com/minecolonies/coremod/entity/ai/citizen/miner/EntityAIStructureMiner.java
+++ b/src/main/java/com/minecolonies/coremod/entity/ai/citizen/miner/EntityAIStructureMiner.java
@@ -350,8 +350,9 @@ public class EntityAIStructureMiner extends AbstractEntityAIStructureWithWorkOrd
                 return getState();
             }
             //Get ladder orientation
-            final BlockState metadata = getBlockState(safeStand);
-
+            final BlockState metadata = Blocks.LADDER.getDefaultState()
+                                          .with(HorizontalBlock.HORIZONTAL_FACING,
+                                            Direction.getFacingFromVector(nextLadder.getX() - nextCobble.getX(), 0, nextLadder.getZ() - nextCobble.getZ()));
             setBlockFromInventory(nextLadder, Blocks.LADDER, metadata);
             return getState();
         }
@@ -975,7 +976,7 @@ public class EntityAIStructureMiner extends AbstractEntityAIStructureWithWorkOrd
         {
             getInventory().extractItem(slot, 1, false);
             //Flag 1+2 is needed for updates
-            world.setBlockState(location, metadata, 0x03);
+            WorldUtil.setBlockState(world, location, metadata);
         }
     }
 

--- a/src/main/java/com/minecolonies/coremod/entity/ai/minimal/EntityAIInteractToggleAble.java
+++ b/src/main/java/com/minecolonies/coremod/entity/ai/minimal/EntityAIInteractToggleAble.java
@@ -2,6 +2,7 @@ package com.minecolonies.coremod.entity.ai.minimal;
 
 import com.minecolonies.api.util.WorldUtil;
 import net.minecraft.block.*;
+import net.minecraft.entity.Entity;
 import net.minecraft.entity.MobEntity;
 import net.minecraft.entity.ai.goal.Goal;
 import net.minecraft.pathfinding.GroundPathNavigator;
@@ -34,7 +35,7 @@ public class EntityAIInteractToggleAble extends Goal
     /**
      * The min distance the gate has to be from the citizen.
      */
-    private static final double MIN_DISTANCE = 2.25D;
+    private static final double MIN_DISTANCE = 4D;
 
     /**
      * The max distance the gate has to be from the citizen.
@@ -47,7 +48,6 @@ public class EntityAIInteractToggleAble extends Goal
     public static final ToggleAble FENCE_TOGGLE = new FenceToggle();
     public static final ToggleAble TRAP_TOGGLE  = new TrapToggle();
     public static final ToggleAble DOOR_TOGGLE  = new DoorToggle();
-
 
     /**
      * Our citizen.
@@ -143,45 +143,68 @@ public class EntityAIInteractToggleAble extends Goal
         }
 
         final int maxLengthToCheck = Math.min(path.getCurrentPathIndex() + LENGTH_TO_CHECK, path.getCurrentPathLength());
-        for (int i = Math.max(0, path.getCurrentPathIndex() - 1); i < maxLengthToCheck; ++i)
+        for (int i = Math.max(0, path.getCurrentPathIndex() - 1); i < maxLengthToCheck; i++)
         {
-            final PathPoint pathpoint = path.getPathPointFromIndex(i);
+            if (i == path.getCurrentPathLength() - 1)
+            {
+                // Reached path end
+                return;
+            }
 
+            // We need current + next to determine the move direction to find out whether sth is blocking in that way
+            final PathPoint current = path.getPathPointFromIndex(i);
+            final PathPoint next = path.getPathPointFromIndex(i + 1);
+
+            // Skip same nodes
+            if (next.x == current.x && next.y == current.y && next.z == current.z)
+            {
+                continue;
+            }
+
+            // Find the moving direction
+            final Direction dir;
+            if (current.x == next.x && current.z == next.z)
+            {
+                // Up/Down we just use east
+                dir = Direction.EAST;
+            }
+            else
+            {
+                dir = Direction.getFacingFromVector(next.x - current.x, 0, next.z - current.z);
+            }
+
+            // Check necessary height levels
             for (int level = 0; level < getHeightToCheck(path, i); level++)
             {
-                BlockPos pos = new BlockPos(pathpoint.x, pathpoint.y + level, pathpoint.z);
-                BlockState state = entity.world.getBlockState(pos);
-                if (this.entity.getDistanceSq(pos.getX(), this.entity.getPosY(), pos.getZ()) <= MIN_DISTANCE && isValidBlockState(state))
-                {
-                    if (i < path.getCurrentPathLength() - 1)
-                    {
-                        final PathPoint next = path.getPathPointFromIndex(i + 1);
+                checkPosAndAdd(entity, dir, new BlockPos(current.x, current.y + level, current.z));
+                checkPosAndAdd(entity, dir, new BlockPos(next.x, next.y + level, next.z));
+            }
+        }
+    }
 
-                        // Skip same nodes
-                        if (next.x == pathpoint.x && next.y == pathpoint.y && next.z == pathpoint.z)
-                        {
-                            continue;
-                        }
+    /**
+     * Checks if the pos has a toggleable hindering movement in the given direction and adds it to our toggle positions
+     *
+     * @param entity entity to check for
+     * @param dir    Direction to check in
+     * @param pos    position to check
+     */
+    private void checkPosAndAdd(final Entity entity, Direction dir, final BlockPos pos)
+    {
+        if (toggleAblePositions.containsKey(pos))
+        {
+            return;
+        }
 
-                        final Direction dir;
-                        if (pathpoint.x == next.x && pathpoint.z == next.z)
-                        {
-                            // Up/Down we just use east
-                            dir = Direction.EAST;
-                        }
-                        else
-                        {
-                            dir = Direction.getFacingFromVector(pathpoint.x - next.x, 0, pathpoint.z - next.z).rotateY();
-                        }
-
-                        // See if collision shape can fit our entity in
-                        final VoxelShape collisionShape = state.getCollisionShape(entity.world, pos);
-                        if (collisionShape.getStart(dir.getAxis()) + 0.1 < entity.getWidth() && collisionShape.getEnd(dir.getAxis()) + 0.1 + entity.getWidth() > 1)
-                        {
-                            toggleAblePositions.put(pos, state.get(BlockStateProperties.OPEN));
-                        }
-                    }
-                }
+        final BlockState state = entity.world.getBlockState(pos);
+        if (this.entity.getDistanceSq(pos.getX(), this.entity.getPosY(), pos.getZ()) <= MIN_DISTANCE && isValidBlockState(state))
+        {
+            // See if current pos collision shape can fit our entity in
+            final VoxelShape collisionShape = state.getCollisionShape(entity.world, pos);
+            dir = dir.rotateY();
+            if (collisionShape.getStart(dir.getAxis()) + 0.1 < entity.getWidth() && collisionShape.getEnd(dir.getAxis()) + 0.1 + entity.getWidth() > 1)
+            {
+                toggleAblePositions.put(pos, state.get(BlockStateProperties.OPEN));
             }
         }
     }
@@ -496,8 +519,7 @@ public class EntityAIInteractToggleAble extends Goal
         @Override
         public void toggleBlockClosed(final BlockState state, final World world, final BlockPos pos)
         {
-            ((DoorBlock) state.getBlock()).openDoor(world, state, pos,false);
+            ((DoorBlock) state.getBlock()).openDoor(world, state, pos, false);
         }
     }
-
 }

--- a/src/main/java/com/minecolonies/coremod/entity/pathfinding/pathjobs/AbstractPathJob.java
+++ b/src/main/java/com/minecolonies/coremod/entity/pathfinding/pathjobs/AbstractPathJob.java
@@ -19,10 +19,11 @@ import com.minecolonies.coremod.util.WorkerUtil;
 import net.minecraft.block.*;
 import net.minecraft.block.material.Material;
 import net.minecraft.entity.LivingEntity;
-import net.minecraft.fluid.Fluids;
 import net.minecraft.fluid.FluidState;
+import net.minecraft.fluid.Fluids;
 import net.minecraft.pathfinding.Path;
 import net.minecraft.pathfinding.PathPoint;
+import net.minecraft.state.properties.BlockStateProperties;
 import net.minecraft.state.properties.Half;
 import net.minecraft.util.Direction;
 import net.minecraft.util.math.AxisAlignedBB;
@@ -361,6 +362,11 @@ public abstract class AbstractPathJob implements Callable<Path>
         {
             //  Tax the cost for jumping, dropping
             cost *= pathingOptions.jumpDropCost * Math.abs(dPos.getY());
+        }
+
+        if (world.getBlockState(blockPos).hasProperty(BlockStateProperties.OPEN))
+        {
+            cost *= pathingOptions.traverseToggleAbleCost;
         }
 
         if (onPath)

--- a/src/main/java/com/minecolonies/coremod/items/ItemScrollBuff.java
+++ b/src/main/java/com/minecolonies/coremod/items/ItemScrollBuff.java
@@ -40,7 +40,6 @@ public class ItemScrollBuff extends AbstractItemScroll
     @Override
     protected ItemStack onItemUseSuccess(final ItemStack itemStack, final World world, final ServerPlayerEntity player)
     {
-        itemStack.shrink(1);
         if (world.rand.nextInt(8) > 0)
         {
             for (final LivingEntity entity : world.getLoadedEntitiesWithinAABB(EntityCitizen.class, player.getBoundingBox().grow(15, 2, 15)))
@@ -62,6 +61,7 @@ public class ItemScrollBuff extends AbstractItemScroll
             SoundUtils.playSoundForPlayer(player, SoundEvents.ITEM_TOTEM_USE, 0.04f, 1.0f);
         }
 
+        itemStack.shrink(1);
         return itemStack;
     }
 

--- a/src/main/java/com/minecolonies/coremod/items/ItemScrollColonyAreaTP.java
+++ b/src/main/java/com/minecolonies/coremod/items/ItemScrollColonyAreaTP.java
@@ -2,6 +2,7 @@ package com.minecolonies.coremod.items;
 
 import com.ldtteam.structurize.util.LanguageHandler;
 import com.minecolonies.api.colony.IColony;
+import com.minecolonies.api.util.ItemStackUtils;
 import com.minecolonies.api.util.SoundUtils;
 import com.minecolonies.coremod.Network;
 import com.minecolonies.coremod.network.messages.client.VanillaParticleMessage;
@@ -45,15 +46,19 @@ public class ItemScrollColonyAreaTP extends AbstractItemScroll
     @Override
     protected ItemStack onItemUseSuccess(final ItemStack itemStack, final World world, final ServerPlayerEntity player)
     {
-        itemStack.shrink(1);
-
         if (world.rand.nextInt(10) == 0)
         {
             // Fail chance
             player.sendStatusMessage(new TranslationTextComponent("minecolonies.scroll.failed" + (world.rand.nextInt(FAIL_RESPONSES_TOTAL) + 1)).setStyle(Style.EMPTY.setFormatting(
               TextFormatting.GOLD)), true);
-            player.dropItem(itemStack.copy(), true, false);
-            itemStack.setCount(0);
+
+            itemStack.shrink(1);
+            if (!ItemStackUtils.isEmpty(itemStack))
+            {
+                player.dropItem(itemStack.copy(), true, false);
+                itemStack.setCount(0);
+            }
+
             for (final ServerPlayerEntity sPlayer : getAffectedPlayers(player))
             {
                 SoundUtils.playSoundForPlayer(sPlayer, SoundEvents.ENTITY_EVOKER_PREPARE_SUMMON, 0.3f, 1.0f);
@@ -66,6 +71,8 @@ public class ItemScrollColonyAreaTP extends AbstractItemScroll
                 doTeleport(sPlayer, getColony(itemStack), itemStack);
                 SoundUtils.playSoundForPlayer(sPlayer, SoundEvents.UI_TOAST_CHALLENGE_COMPLETE, 0.1f, 1.0f);
             }
+
+            itemStack.shrink(1);
         }
 
         return itemStack;

--- a/src/main/java/com/minecolonies/coremod/items/ItemScrollColonyTP.java
+++ b/src/main/java/com/minecolonies/coremod/items/ItemScrollColonyTP.java
@@ -46,8 +46,6 @@ public class ItemScrollColonyTP extends AbstractItemScroll
     @Override
     protected ItemStack onItemUseSuccess(final ItemStack itemStack, final World world, final ServerPlayerEntity player)
     {
-        itemStack.shrink(1);
-
         if (world.rand.nextInt(10) == 0)
         {
             // Fail
@@ -79,6 +77,7 @@ public class ItemScrollColonyTP extends AbstractItemScroll
             SoundUtils.playSoundForPlayer(player, SoundEvents.BLOCK_ENCHANTMENT_TABLE_USE, 0.6f, 1.0f);
         }
 
+        itemStack.shrink(1);
         return itemStack;
     }
 

--- a/src/main/java/com/minecolonies/coremod/util/BackUpHelper.java
+++ b/src/main/java/com/minecolonies/coremod/util/BackUpHelper.java
@@ -10,6 +10,7 @@ import com.minecolonies.coremod.colony.Colony;
 import net.minecraft.nbt.CompoundNBT;
 import net.minecraft.nbt.CompressedStreamTools;
 import net.minecraft.util.RegistryKey;
+import net.minecraft.util.ResourceLocation;
 import net.minecraft.world.World;
 import net.minecraft.world.chunk.Chunk;
 import net.minecraft.world.server.ServerWorld;
@@ -62,31 +63,31 @@ public final class BackUpHelper
               new File(ServerLifecycleHooks.getCurrentServer().func_240776_a_(FolderName.DOT).toFile(), FILENAME_MINECOLONIES_PATH);
             final ZipOutputStream zos = new ZipOutputStream(fos);
 
-
-            ServerLifecycleHooks.getCurrentServer().worlds.keySet().forEach(dimensionType -> {
+            for (final RegistryKey<World> dimensionType : ServerLifecycleHooks.getCurrentServer().worlds.keySet())
+            {
                 for (int i = 1; i <= IColonyManager.getInstance().getTopColonyId() + 1; i++)
                 {
-                    @NotNull final File file = new File(saveDir, String.format(FILENAME_COLONY, i, dimensionType.getLocation()));
-                    @NotNull final File fileDeleted = new File(saveDir, String.format(FILENAME_COLONY_DELETED, i, dimensionType.getLocation()));
+                    @NotNull final File file = new File(saveDir, getFolderForDimension(dimensionType.getLocation()) + String.format(FILENAME_COLONY, i));
+                    @NotNull final File fileDeleted = new File(saveDir, getFolderForDimension(dimensionType.getLocation()) + String.format(FILENAME_COLONY_DELETED, i));
                     if (file.exists())
                     {
                         // mark existing files
                         if (IColonyManager.getInstance().getColonyByDimension(i, dimensionType) == null)
                         {
                             markColonyDeleted(i, dimensionType);
-                            addToZipFile(String.format(FILENAME_COLONY_DELETED, i, dimensionType.getLocation()), zos, saveDir);
+                            addToZipFile(getFolderForDimension(dimensionType.getLocation()) + String.format(FILENAME_COLONY_DELETED, i), zos, saveDir);
                         }
                         else
                         {
-                            addToZipFile(String.format(FILENAME_COLONY, i, dimensionType.getLocation()), zos, saveDir);
+                            addToZipFile(getFolderForDimension(dimensionType.getLocation()) + String.format(FILENAME_COLONY, i), zos, saveDir);
                         }
                     }
                     else if (fileDeleted.exists())
                     {
-                        addToZipFile(String.format(FILENAME_COLONY_DELETED, i, dimensionType.getLocation()), zos, saveDir);
+                        addToZipFile(getFolderForDimension(dimensionType.getLocation()) + String.format(FILENAME_COLONY_DELETED, i), zos, saveDir);
                     }
                 }
-            });
+            }
             addToZipFile(getSaveLocation().getName(), zos, saveDir);
             zos.close();
         }
@@ -109,12 +110,13 @@ public final class BackUpHelper
     {
         @NotNull final File saveDir = new File(ServerLifecycleHooks.getCurrentServer().func_240776_a_(FolderName.DOT).toFile(), FILENAME_MINECOLONIES_PATH);
 
-        ServerLifecycleHooks.getCurrentServer().worlds.keySet().forEach(dimensionType -> {
+        for (final RegistryKey<World> dimensionType : ServerLifecycleHooks.getCurrentServer().worlds.keySet())
+        {
             int missingFilesInRow = 0;
             for (int i = 1; i <= MAX_COLONY_LOAD && missingFilesInRow < 5; i++)
             {
                 // Check non-deleted files for colony id + dim
-                @NotNull final File file = new File(saveDir, String.format(FILENAME_COLONY, i, dimensionType.getLocation()));
+                @NotNull final File file = new File(saveDir, getFolderForDimension(dimensionType.getLocation()) + String.format(FILENAME_COLONY, i));
                 if (file.exists())
                 {
                     missingFilesInRow = 0;
@@ -129,7 +131,7 @@ public final class BackUpHelper
                     missingFilesInRow++;
                 }
             }
-        });
+        }
     }
 
     /**
@@ -254,7 +256,7 @@ public final class BackUpHelper
         {
             final CompoundNBT colonyCompound = new CompoundNBT();
             colony.write(colonyCompound);
-            saveNBTToPath(new File(saveDir, String.format(FILENAME_COLONY, colony.getID(), colony.getDimension().getLocation())), colonyCompound);
+            saveNBTToPath(new File(saveDir, getFolderForDimension(colony.getDimension().getLocation()) + String.format(FILENAME_COLONY, colony.getID())), colonyCompound);
         }
     }
 
@@ -268,10 +270,10 @@ public final class BackUpHelper
     {
         @NotNull final File saveDir =
           new File(ServerLifecycleHooks.getCurrentServer().func_240776_a_(FolderName.DOT).toFile(), FILENAME_MINECOLONIES_PATH);
-        final File toDelete = new File(saveDir, String.format(FILENAME_COLONY, colonyID, dimensionID.getLocation()));
+        final File toDelete = new File(saveDir, getFolderForDimension(dimensionID.getLocation()) + String.format(FILENAME_COLONY, colonyID));
         if (toDelete.exists())
         {
-            final String fileName =  String.format(FILENAME_COLONY_DELETED, colonyID, dimensionID.getLocation());
+            final String fileName = getFolderForDimension(dimensionID.getLocation()) + String.format(FILENAME_COLONY_DELETED, colonyID);
             new File(saveDir, fileName).delete();
             toDelete.renameTo(new File(saveDir, fileName));
         }
@@ -287,13 +289,24 @@ public final class BackUpHelper
         ServerLifecycleHooks.getCurrentServer().worlds.keySet().forEach(dimensionType -> {
             for (int i = 1; i <= IColonyManager.getInstance().getTopColonyId() + 1; i++)
             {
-                @NotNull final File file = new File(saveDir, String.format(FILENAME_COLONY, i, dimensionType.getLocation()));
+                @NotNull final File file = new File(saveDir, getFolderForDimension(dimensionType.getLocation()) + String.format(FILENAME_COLONY, i));
                 if (file.exists())
                 {
                     loadColonyBackup(i, dimensionType, false, false);
                 }
             }
         });
+    }
+
+    /**
+     * Resource location name to file name
+     *
+     * @param location resource location
+     * @return file name to look for
+     */
+    private static String getFolderForDimension(final ResourceLocation location)
+    {
+        return location.getNamespace() + "\\" + location.getPath() + "\\";
     }
 
     /**
@@ -307,13 +320,13 @@ public final class BackUpHelper
     public static void loadColonyBackup(final int colonyId, final RegistryKey<World> dimension, boolean loadDeleted, boolean claimChunks)
     {
         @NotNull final File saveDir = new File(ServerLifecycleHooks.getCurrentServer().func_240776_a_(FolderName.DOT).toFile(), FILENAME_MINECOLONIES_PATH);
-        @NotNull final File backupFile = new File(saveDir, String.format(FILENAME_COLONY, colonyId, dimension.getLocation()));
+        @NotNull final File backupFile = new File(saveDir, getFolderForDimension(dimension.getLocation()) + String.format(FILENAME_COLONY, colonyId));
         CompoundNBT compound = loadNBTFromPath(backupFile);
         if (compound == null)
         {
             if (loadDeleted)
             {
-                compound = loadNBTFromPath(new File(saveDir, String.format(FILENAME_COLONY_DELETED, colonyId, dimension.getLocation())));
+                compound = loadNBTFromPath(new File(saveDir, String.format(FILENAME_COLONY_DELETED, colonyId, getFolderForDimension(dimension.getLocation()))));
             }
             if (compound == null)
             {


### PR DESCRIPTION
Closes #6577
Closes #6526
Closes #6474
Closes #6436
Closes #6406
Closes #6576
Closes #6339

# Changes proposed in this pull request:
Mark citizen manager dirty on citizen death
Increase base raidable range of buildings
Fix miner's voiding ladders by placing air instead of a ladderblock
Fix ToggleAbleAI not considering all possible obstacles, it ignored those who were on the next block but did not block movement to next's next.
Citizens now prefer paths where they do not have to use many toggleable blocks.
Fix some scrolls crashing on getting the colony after shrinking its itemstack to zero.
Fix backups on windows filesystem, those were broken as the name there couldnt contain ":". Instead of using res locations as names, we now distribute colony data backup files into dimension folders.
Fix our util setblockstate, which had an issue with not always syncing changes to the client
Fix closing recipe UI after adding one recipe


Review please
