### PR TITLE
Improve food pick up

### DIFF
--- a/src/main/java/com/minecolonies/coremod/colony/buildings/AbstractBuilding.java
+++ b/src/main/java/com/minecolonies/coremod/colony/buildings/AbstractBuilding.java
@@ -1176,7 +1176,7 @@ public abstract class AbstractBuilding extends AbstractBuildingContainer
         final Map<Predicate<ItemStack>, Tuple<Integer, Boolean>> toKeep = new HashMap<>(keepX);
         if (keepFood())
         {
-            toKeep.put(ItemStackUtils.CAN_EAT, new Tuple<>(getBuildingLevel() * 2, true));
+            toKeep.put(stack -> ItemStackUtils.CAN_EAT.test(stack) && (this instanceof AbstractBuildingWorker ? ((AbstractBuildingWorker) this).canEat(stack) : true), new Tuple<>(getBuildingLevel() * 2, true));
         }
 
         final Map<ItemStorage, Tuple<Integer, Boolean>> requiredItems = new HashMap<>();

--- a/src/main/java/com/minecolonies/coremod/colony/buildings/AbstractBuilding.java
+++ b/src/main/java/com/minecolonies/coremod/colony/buildings/AbstractBuilding.java
@@ -1174,10 +1174,6 @@ public abstract class AbstractBuilding extends AbstractBuildingContainer
     public Map<Predicate<ItemStack>, Tuple<Integer, Boolean>> getRequiredItemsAndAmount()
     {
         final Map<Predicate<ItemStack>, Tuple<Integer, Boolean>> toKeep = new HashMap<>(keepX);
-        if (keepFood())
-        {
-            toKeep.put(stack -> ItemStackUtils.CAN_EAT.test(stack) && (this instanceof AbstractBuildingWorker ? ((AbstractBuildingWorker) this).canEat(stack) : true), new Tuple<>(getBuildingLevel() * 2, true));
-        }
 
         final Map<ItemStorage, Tuple<Integer, Boolean>> requiredItems = new HashMap<>();
         final Collection<IRequestResolver<?>> resolvers = getResolvers();

--- a/src/main/java/com/minecolonies/coremod/colony/buildings/AbstractBuildingWorker.java
+++ b/src/main/java/com/minecolonies/coremod/colony/buildings/AbstractBuildingWorker.java
@@ -162,7 +162,10 @@ public abstract class AbstractBuildingWorker extends AbstractBuilding implements
     public Map<Predicate<ItemStack>, Tuple<Integer, Boolean>> getRequiredItemsAndAmount()
     {
         final Map<Predicate<ItemStack>, Tuple<Integer, Boolean>> toKeep = new HashMap<>(super.getRequiredItemsAndAmount());
-        toKeep.put(ItemStackUtils.CAN_EAT, new Tuple<>(getBuildingLevel() * 2, true));
+        if (keepFood())
+        {
+            toKeep.put(stack -> ItemStackUtils.CAN_EAT.test(stack) && canEat(stack), new Tuple<>(getBuildingLevel() * 2, true));
+        }
         return toKeep;
     }
 

--- a/src/main/java/com/minecolonies/coremod/colony/buildings/workerbuildings/BuildingCook.java
+++ b/src/main/java/com/minecolonies/coremod/colony/buildings/workerbuildings/BuildingCook.java
@@ -472,7 +472,7 @@ public class BuildingCook extends AbstractBuildingSmelterCrafter
             return stack.getCount();
         }
 
-        if (ISFOOD.test(stack) && (localAlreadyKept.stream().filter(storage -> ISFOOD.test(storage.getItemStack())).mapToInt(ItemStorage::getAmount).sum() < STACKSIZE || !inventory))
+        if (ISFOOD.test(stack) && !isAllowedItem("food", new ItemStorage(stack)) && (localAlreadyKept.stream().filter(storage -> ISFOOD.test(storage.getItemStack())).mapToInt(ItemStorage::getAmount).sum() < STACKSIZE || !inventory))
         {
             final ItemStorage kept = new ItemStorage(stack);
             if (localAlreadyKept.contains(kept))

--- a/src/main/java/com/minecolonies/coremod/entity/ai/citizen/deliveryman/EntityAIWorkDeliveryman.java
+++ b/src/main/java/com/minecolonies/coremod/entity/ai/citizen/deliveryman/EntityAIWorkDeliveryman.java
@@ -229,8 +229,7 @@ public class EntityAIWorkDeliveryman extends AbstractEntityAIInteract<JobDeliver
         }
 
         final int amount = workerRequiresItem(building, stack, alreadyKept);
-        if (amount <= 0
-              || (building instanceof BuildingCook && CAN_EAT.test(stack)))
+        if (amount <= 0)
         {
             return false;
         }


### PR DESCRIPTION
Closes #
Closes #
Closes #

# Changes proposed in this pull request:
- Allow courier to pick up food from the cook if it's turned off
- Allow courier to pick up food from worker buildings that's not good enough for the worker to eat
- Make cook ignore food in the citizen's inventory they won't eat
- Make cook hand out food the citizen will eat

Review please
