### PR TITLE
Add config option to disable supply loot

### DIFF
--- a/src/api/java/com/minecolonies/api/configuration/ServerConfiguration.java
+++ b/src/api/java/com/minecolonies/api/configuration/ServerConfiguration.java
@@ -1,10 +1,12 @@
 package com.minecolonies.api.configuration;
 
+import com.minecolonies.api.util.constant.NameConstants;
+import net.minecraftforge.common.ForgeConfigSpec;
+
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
-import com.minecolonies.api.util.constant.NameConstants;
-import net.minecraftforge.common.ForgeConfigSpec;
+
 import static com.minecolonies.api.util.constant.Constants.*;
 
 /**
@@ -57,6 +59,7 @@ public class ServerConfiguration extends AbstractConfiguration
     public final ForgeConfigSpec.IntValue     diseaseModifier;
     public final ForgeConfigSpec.BooleanValue forceLoadColony;
     public final ForgeConfigSpec.IntValue     badVisitorsChance;
+    public final ForgeConfigSpec.BooleanValue generateSupplyLoot;
 
     /*  --------------------------------------------------------------------------- *
      *  ------------------- ######## Command settings ######## ------------------- *
@@ -410,6 +413,7 @@ public class ServerConfiguration extends AbstractConfiguration
         diseaseModifier = defineInteger(builder, "diseasemodifier", 5, 1, 100);
         forceLoadColony = defineBoolean(builder, "forceloadcolony", false);
         badVisitorsChance = defineInteger(builder, "badvisitorchance", 2, 1, 100);
+        generateSupplyLoot = defineBoolean(builder, "generatesupplyloot", true);
 
         swapToCategory(builder, "commands");
         

--- a/src/main/java/com/minecolonies/coremod/loot/SupplyLoot.java
+++ b/src/main/java/com/minecolonies/coremod/loot/SupplyLoot.java
@@ -87,6 +87,9 @@ public class SupplyLoot
      */
     public void addLootToEvent(LootTableLoadEvent event)
     {
-        event.getTable().addPool(LootPool.builder().addEntry(TableLootEntry.builder(lootTables.get(event.getName()))).name(MOD_ID + ":loot:" + event.getName()).build());
+        if (MineColonies.getConfig().getServer().generateSupplyLoot.get())
+        {
+            event.getTable().addPool(LootPool.builder().addEntry(TableLootEntry.builder(lootTables.get(event.getName()))).name(MOD_ID + ":loot:" + event.getName()).build());
+        }
     }
 }

--- a/src/main/resources/assets/minecolonies/lang/en_us.json
+++ b/src/main/resources/assets/minecolonies/lang/en_us.json
@@ -31,8 +31,8 @@
   "minecolonies.config.configliststudyitems": "List of Study Items",
   "minecolonies.config.configliststudyitems.comment": "Items consumed by citizens in the Library.",
 
-  "minecolonies.config.generatesupplyloot": "Supply loot",
-  "minecolonies.config.generatesupplyloot.comment": "Whether to generate supply ship/camps in chests occasionally.",
+  "minecolonies.config.generatesupplyloot": "Supply Loot",
+  "minecolonies.config.generatesupplyloot.comment": "Whether to generate supply ships and camps in loot chests.",
 
   "minecolonies.config.forceloadcolony": "Force Load Colony",
   "minecolonies.config.forceloadcolony.comment": "If part of the colony is loaded by an owner/officer, the entire colony should be kept loaded.",


### PR DESCRIPTION
Closes https://github.com/ldtteam/minecolonies-features/issues/302
Closes #
Closes #

# Changes proposed in this pull request:
- Was already added in https://github.com/ldtteam/minecolonies/pull/4472, but seems it got removed. Readded it the same way so should Just Work:tm:
-
-

Review please
