### PR TITLE
Fix tags

### DIFF
--- a/src/main/resources/data/minecolonies/tags/blocks/pathblocks.json
+++ b/src/main/resources/data/minecolonies/tags/blocks/pathblocks.json
@@ -45,14 +45,14 @@
     "minecraft:polished_blackstone_brick_stairs",
     "minecraft:chiseled_sandstone",
     "minecraft:chiseled_red_sandstone",
-    "structurize:cream_bricks",
-    "structurize:brown_bricks",
-    "structurize:beige_bricks",
-    "structurize:cream_brick_stairs",
-    "structurize:brown_brick_stairs",
-    "structurize:beige_brick_stairs",
-    "structurize:cream_brick_slab",
-    "structurize:brown_brick_slab",
-    "structurize:beige_brick_slab"
+    "structurize:blockcreambricks",
+    "structurize:blockbrownbricks",
+    "structurize:blockbeigebricks",
+    "structurize:blockcreambrickstairs",
+    "structurize:blockbrownbrickstairs",
+    "structurize:blockbeigebrickstairs",
+    "structurize:blockcreambrickslab",
+    "structurize:blockbrownbrickslab",
+    "structurize:blockbeigebrickslab"
   ]
 }

--- a/src/main/resources/data/minecolonies/tags/items/florist_flowers_excluded.json
+++ b/src/main/resources/data/minecolonies/tags/items/florist_flowers_excluded.json
@@ -1,8 +1,8 @@
 {
   "replace": false,
   "values": [
-    "#botania:mystical_flowers",
-    "#botania:special_flowers",
+    {"id": "#botania:mystical_flowers", "required": false},
+    {"id": "#botania:special_flowers", "required": false},
     "minecraft:wither_rose"
   ]
 }


### PR DESCRIPTION
Closes #
Closes #
Closes #

# Changes proposed in this pull request:
- The protection block tag had a different way of getting blocks from other mods. This PR changes the florist_flowers_excluded tag to also use that way. Removes 2 (iirc) lines of log spam 😛 
- Also fixes the brick references in the pathblocks tag
-

Review please
