### PR TITLE
Make building modules accessible by parent class/interface as well as exact interface

### DIFF
--- a/src/api/java/com/minecolonies/api/colony/buildings/IBuilding.java
+++ b/src/api/java/com/minecolonies/api/colony/buildings/IBuilding.java
@@ -37,18 +37,26 @@ public interface IBuilding extends IBuildingContainer, IRequestResolverProvider,
 {
     /**
      * Check if the building has a particular module.
-     * @param clazz the module of the class to check.
+     * @param clazz the class or interface of the module to check.
      * @return true if so.
      */
     boolean hasModule(final Class<? extends IBuildingModule> clazz);
 
     /**
-     * Get the module with a particular class.
-     * @param clazz the modules class.
-     * @return the module or null of not existant.
+     * Get the first module with a particular class or interface.
+     * @param clazz the module's class or interface.
+     * @return the module or empty if not existent.
      */
     @NotNull
     <T extends IBuildingModule> Optional<T> getModule(Class<T> clazz);
+
+    /**
+     * Get all modules with a particular class or interface.
+     * @param clazz the module's interface (or class, but prefer getModule in that case)
+     * @return the list of modules or empty if none match.
+     */
+    @NotNull
+    <T extends IBuildingModule> List<T> getModules(Class<T> clazz);
 
     /**
      * Register a specific module to the building.

--- a/src/main/java/com/minecolonies/coremod/colony/buildings/AbstractBuilding.java
+++ b/src/main/java/com/minecolonies/coremod/colony/buildings/AbstractBuilding.java
@@ -156,7 +156,7 @@ public abstract class AbstractBuilding extends AbstractBuildingContainer
     /**
      * Set of building modules this building has.
      */
-    protected Map<Class<? extends IBuildingModule>, IBuildingModule> modules = new LinkedHashMap<>();
+    protected List<IBuildingModule> modules = new ArrayList<>();
 
     /**
      * Constructor for a AbstractBuilding.
@@ -175,20 +175,30 @@ public abstract class AbstractBuilding extends AbstractBuildingContainer
     @Override
     public boolean hasModule(final Class<? extends IBuildingModule> clazz)
     {
-        return modules.containsKey(clazz);
+        return getModule(clazz).isPresent();
     }
 
     @NotNull
     @Override
     public <T extends IBuildingModule> Optional<T> getModule(final Class<T> clazz)
     {
-        return Optional.ofNullable((T) modules.get(clazz));
+        return getModules(clazz).stream().findFirst();
+    }
+
+    @NotNull
+    @Override
+    public <T extends IBuildingModule> List<T> getModules(final Class<T> clazz)
+    {
+        return this.modules.stream()
+                .filter(clazz::isInstance)
+                .map(c -> (T) c)
+                .collect(Collectors.toList());
     }
 
     @Override
     public void registerModule(@NotNull final IBuildingModule module)
     {
-        this.modules.put(module.getClass(), module);
+        this.modules.add(module);
     }
 
     /**
@@ -209,13 +219,7 @@ public abstract class AbstractBuilding extends AbstractBuildingContainer
     @Override
     public void onWakeUp()
     {
-        for (final IBuildingModule module : modules.values())
-        {
-            if (module instanceof IBuildingEventsModule)
-            {
-                ((IBuildingEventsModule) module).onWakeUp();
-            }
-        }
+        getModules(IBuildingEventsModule.class).forEach(IBuildingEventsModule::onWakeUp);
     }
 
     /**
@@ -245,25 +249,13 @@ public abstract class AbstractBuilding extends AbstractBuildingContainer
     @Override
     public void onBuildingMove(final IBuilding oldBuilding)
     {
-        for (final IBuildingModule module : modules.values())
-        {
-            if (module instanceof IBuildingEventsModule)
-            {
-                ((IBuildingEventsModule) module).onBuildingMove(oldBuilding);
-            }
-        }
+        getModules(IBuildingEventsModule.class).forEach(module -> module.onBuildingMove(oldBuilding));
     }
 
     @Override
     public void onPlayerEnterBuilding(final PlayerEntity player)
     {
-        for (final IBuildingModule module : modules.values())
-        {
-            if (module instanceof IBuildingEventsModule)
-            {
-                ((IBuildingEventsModule) module).onPlayerEnterBuilding(player);
-            }
-        }
+        getModules(IBuildingEventsModule.class).forEach(module -> module.onPlayerEnterBuilding(player));
     }
 
     @Override
@@ -336,13 +328,7 @@ public abstract class AbstractBuilding extends AbstractBuildingContainer
             minimumStock.put(new ItemStorage(ItemStack.read(compoundNBT)), compoundNBT.getInt(TAG_QUANTITY));
         }
 
-        for (final IBuildingModule module : modules.values())
-        {
-            if (module instanceof IPersistentModule)
-            {
-                ((IPersistentModule) module).deserializeNBT(compound);
-            }
-        }
+        getModules(IPersistentModule.class).forEach(module -> module.deserializeNBT(compound));
     }
 
     @Override
@@ -371,13 +357,7 @@ public abstract class AbstractBuilding extends AbstractBuildingContainer
         }
         compound.put(TAG_MINIMUM_STOCK, minimumStockTagList);
 
-        for (final IBuildingModule module : modules.values())
-        {
-            if (module instanceof IPersistentModule)
-            {
-                ((IPersistentModule) module).serializeNBT(compound);
-            }
-        }
+        getModules(IPersistentModule.class).forEach(module -> module.serializeNBT(compound));
         return compound;
     }
 
@@ -413,39 +393,24 @@ public abstract class AbstractBuilding extends AbstractBuildingContainer
         ChunkDataHelper.claimColonyChunks(colony, false, this.getID(), getClaimRadius(getBuildingLevel()));
         ConstructionTapeHelper.removeConstructionTape(getCorners(), world);
 
-        for (final IBuildingModule module : modules.values())
-        {
-            if (module instanceof IBuildingEventsModule)
-            {
-                ((IBuildingEventsModule) module).onDestroyed();
-            }
-        }
+        getModules(IBuildingEventsModule.class).forEach(IBuildingEventsModule::onDestroyed);
     }
 
     @Override
     public void removeCitizen(final ICitizenData citizen)
     {
-        for (final IBuildingModule module : modules.values())
-        {
-            if (module instanceof IAssignsCitizen)
-            {
-                ((IAssignsCitizen) module).removeCitizen(citizen);
-            }
-        }
+        getModules(IAssignsCitizen.class).forEach(module -> module.removeCitizen(citizen));
         super.removeCitizen(citizen);
     }
 
     @Override
     public boolean assignCitizen(final ICitizenData citizen)
     {
-        for (final IBuildingModule module : modules.values())
+        for (final IAssignsCitizen module : getModules(IAssignsCitizen.class))
         {
-            if (module instanceof IAssignsCitizen)
+            if (module.assignCitizen(citizen))
             {
-                if (((IAssignsCitizen) module).assignCitizen(citizen))
-                {
-                    return true;
-                }
+                return true;
             }
         }
         return super.assignCitizen(citizen);
@@ -455,12 +420,9 @@ public abstract class AbstractBuilding extends AbstractBuildingContainer
     public int getMaxInhabitants()
     {
         int current = -1;
-        for (final IBuildingModule module : modules.values())
+        for (final IDefinesCoreBuildingStatsModule module : getModules(IDefinesCoreBuildingStatsModule.class))
         {
-            if (module instanceof IDefinesCoreBuildingStatsModule)
-            {
-                current = ((IDefinesCoreBuildingStatsModule) module).getMaxInhabitants().apply(current);
-            }
+            current = module.getMaxInhabitants().apply(current);
         }
 
         if (current == -1)
@@ -587,7 +549,7 @@ public abstract class AbstractBuilding extends AbstractBuildingContainer
     @Override
     public final boolean isDirty()
     {
-        for (final IBuildingModule module : modules.values())
+        for (final IBuildingModule module : modules)
         {
             if (module.checkDirty())
             {
@@ -601,7 +563,7 @@ public abstract class AbstractBuilding extends AbstractBuildingContainer
     public final void clearDirty()
     {
         dirty = false;
-        for (final IBuildingModule module : modules.values())
+        for (final IBuildingModule module : modules)
         {
             module.clearDirty();
         }
@@ -746,13 +708,7 @@ public abstract class AbstractBuilding extends AbstractBuildingContainer
         buf.writeBoolean(minimumStock.size() >= minimumStockSize());
         buf.writeBoolean(isDeconstructed());
 
-        for (final IBuildingModule module : modules.values())
-        {
-            if (module instanceof IPersistentModule)
-            {
-                ((IPersistentModule) module).serializeToView(buf);
-            }
-        }
+        getModules(IPersistentModule.class).forEach(module -> module.serializeToView(buf));
     }
 
     /**
@@ -845,13 +801,7 @@ public abstract class AbstractBuilding extends AbstractBuildingContainer
             }
         }
 
-        for (final IBuildingModule module : modules.values())
-        {
-            if (module instanceof ITickingModule)
-            {
-                ((ITickingModule) module).onColonyTick(colony);
-            }
-        }
+        getModules(ITickingModule.class).forEach(module -> module.onColonyTick(colony));
     }
 
     /**
@@ -1067,13 +1017,7 @@ public abstract class AbstractBuilding extends AbstractBuildingContainer
             FireworkUtils.spawnFireworksAtAABBCorners(getCorners(), colony.getWorld(), newLevel);
         }
 
-        for (final IBuildingModule module : modules.values())
-        {
-            if (module instanceof IBuildingEventsModule)
-            {
-                ((IBuildingEventsModule) module).onUpgradeComplete(newLevel);
-            }
-        }
+        getModules(IBuildingEventsModule.class).forEach(module -> module.onUpgradeComplete(newLevel));
     }
 
     @Override
@@ -1394,13 +1338,7 @@ public abstract class AbstractBuilding extends AbstractBuildingContainer
     public void registerBlockPosition(@NotNull final BlockState blockState, @NotNull final BlockPos pos, @NotNull final World world)
     {
         super.registerBlockPosition(blockState, pos, world);
-        for (final IBuildingModule module : modules.values())
-        {
-            if (module instanceof IModuleWithExternalBlocks)
-            {
-                ((IModuleWithExternalBlocks) module).onBlockPlacedInBuilding(blockState, pos, world);
-            }
-        }
+        getModules(IModuleWithExternalBlocks.class).forEach(module -> module.onBlockPlacedInBuilding(blockState, pos, world));
     }
 
     /**


### PR DESCRIPTION
This is how everything inside AbstractBuilding was treating them anyway.

# Changes proposed in this pull request:
- Changes building module lookup so you can find modules by base class or interface as well as concrete class.

Review please
