### PR TITLE
Update Gentoo specific java installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ The Java JDK is used to compile MineColonies.
 1. Download and install the Java JDK 8.
     * [Windows](https://adoptopenjdk.net/): Choose OpenJDK 8 (LTS) version and HotSpot JVM, then click the `latest release` button. After the download is complete, open the file, accept the license agreement, and in a custom setup make sure that `Add to Path` and `Set JAVA_HOME` are set to `Entire feature will be installed on your local hard drive`. Then choose `Install` and wait for the installation to finish.
     * Linux: Installation methods for certain popular flavors of Linux are listed below. If your distribution is not listed, follow the instructions specific to your package manager or install it manually [here](http://www.oracle.com/technetwork/java/javase/downloads/jdk8-downloads-2133151.html).
-		* Gentoo: `emerge dev-java/oracle-jdk-bin`
+		* Gentoo: `emerge dev-java/openjdk-bin:8`
 		* Archlinux: `pacman -S jdk8-openjdk`
 		* Ubuntu/Debian: `apt-get install openjdk-8-jdk`
 		* Fedora: `yum install java-1.8.0-openjdk`


### PR DESCRIPTION
dev-java/oracle-jdk-bin was removed 18.9.2020 from the Gentoo repo:
https://gitweb.gentoo.org/repo/gentoo.git/commit/?id=6a7faaad2f8c5312dfb8d6e539b5a7346652e98b

Use dev-java/openjdk-bin instead:
https://packages.gentoo.org/packages/dev-java/openjdk-bin

`:8` is to specify openjdk-8 in the slot system.

# Changes proposed in this pull request:
- Update Gentoo specific java installation instructions

Review please
