### PR TITLE
Use correct Java source encoding

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -46,6 +46,8 @@ apply plugin: 'idea'
 apply plugin: 'eclipse'
 apply plugin: 'maven'
 
+compileJava.options.encoding = "UTF-8"
+
 jacocoTestReport {
     reports {
         xml.enabled true


### PR DESCRIPTION
# Changes proposed in this pull request:
- Fixes encoding used when compiling Java source on Windows.  (This fixes UI corruption and other string derps from constant Unicode strings in the Java code.)

Review please
