### PR TITLE
Fix private crafting fulfillment error (dyer)

### DIFF
--- a/src/api/java/com/minecolonies/api/crafting/RecipeStorage.java
+++ b/src/api/java/com/minecolonies/api/crafting/RecipeStorage.java
@@ -14,6 +14,7 @@ import com.minecolonies.api.util.constant.TypeConstants;
 import net.minecraft.block.Block;
 import net.minecraft.item.ItemStack;
 import net.minecraft.loot.LootContext;
+import net.minecraft.loot.LootParameterSet;
 import net.minecraft.loot.LootParameters;
 import net.minecraft.loot.LootTable;
 import net.minecraft.util.Hand;
@@ -100,6 +101,18 @@ public class RecipeStorage implements IRecipeStorage
      * The cached loot table for possible outputs
      */
     private LootTable loot;
+
+    /**
+     * The loot parameter set definition
+     */
+    public static final LootParameterSet recipeLootParameters = (new LootParameterSet.Builder())
+                .required(LootParameters.field_237457_g_)
+                .required(LootParameters.THIS_ENTITY)
+                .required(LootParameters.TOOL)
+                .optional(LootParameters.DAMAGE_SOURCE)
+                .optional(LootParameters.KILLER_ENTITY)
+                .optional(LootParameters.DIRECT_KILLER_ENTITY)
+                .build();
 
     /**
      * Create an instance of the recipe storage.

--- a/src/main/java/com/minecolonies/coremod/colony/buildings/AbstractBuildingWorker.java
+++ b/src/main/java/com/minecolonies/coremod/colony/buildings/AbstractBuildingWorker.java
@@ -17,6 +17,7 @@ import com.minecolonies.api.crafting.ClassicRecipe;
 import com.minecolonies.api.crafting.IRecipeStorage;
 import com.minecolonies.api.crafting.ItemStorage;
 import com.minecolonies.api.crafting.MultiOutputRecipe;
+import com.minecolonies.api.crafting.RecipeStorage;
 import com.minecolonies.api.entity.citizen.AbstractEntityCitizen;
 import com.minecolonies.api.entity.citizen.Skill;
 import com.minecolonies.api.inventory.container.ContainerCrafting;
@@ -43,8 +44,7 @@ import net.minecraft.inventory.container.Container;
 import net.minecraft.inventory.container.INamedContainerProvider;
 import net.minecraft.item.ItemStack;
 import net.minecraft.loot.LootContext;
-import net.minecraft.loot.LootParameterSet;
-import net.minecraft.loot.LootParameterSets;
+
 import net.minecraft.loot.LootParameters;
 import net.minecraft.nbt.CompoundNBT;
 import net.minecraft.nbt.ListNBT;
@@ -289,7 +289,7 @@ public abstract class AbstractBuildingWorker extends AbstractBuilding implements
         .withRandom(worker.getRandom())
         .withLuck((float) luck));
 
-        return storage.fullfillRecipe(builder.build(LootParameterSets.GIFT), handlers);
+        return storage.fullfillRecipe(builder.build(RecipeStorage.recipeLootParameters), handlers);
     }
 
     @Override

--- a/src/main/java/com/minecolonies/coremod/entity/ai/basic/AbstractEntityAICrafting.java
+++ b/src/main/java/com/minecolonies/coremod/entity/ai/basic/AbstractEntityAICrafting.java
@@ -9,6 +9,7 @@ import com.minecolonies.api.colony.requestsystem.requestable.Stack;
 import com.minecolonies.api.colony.requestsystem.requestable.crafting.PublicCrafting;
 import com.minecolonies.api.crafting.IRecipeStorage;
 import com.minecolonies.api.crafting.ItemStorage;
+import com.minecolonies.api.crafting.RecipeStorage;
 import com.minecolonies.api.entity.ai.statemachine.AITarget;
 import com.minecolonies.api.entity.ai.statemachine.states.IAIState;
 import com.minecolonies.api.entity.citizen.VisibleCitizenStatus;
@@ -67,18 +68,6 @@ public abstract class AbstractEntityAICrafting<J extends AbstractJobCrafter<?, J
      * The current recipe that is being crafted.
      */
     protected IRecipeStorage currentRecipeStorage;
-
-    /**
-     * The loot parameter set definition
-     */
-    private static final LootParameterSet recipeLootParameters = (new LootParameterSet.Builder())
-                .required(LootParameters.field_237457_g_)
-                .required(LootParameters.THIS_ENTITY)
-                .required(LootParameters.TOOL)
-                .optional(LootParameters.DAMAGE_SOURCE)
-                .optional(LootParameters.KILLER_ENTITY)
-                .optional(LootParameters.DIRECT_KILLER_ENTITY)
-                .build();
 
     private DamageSource playerDamageSource; 
 
@@ -492,6 +481,6 @@ public abstract class AbstractEntityAICrafting<J extends AbstractJobCrafter<?, J
                 .withParameter(LootParameters.DIRECT_KILLER_ENTITY, playerDamageSource.getImmediateSource());
             }
         
-        return builder.build(recipeLootParameters);
+        return builder.build(RecipeStorage.recipeLootParameters);
     }
 }


### PR DESCRIPTION
Closes #6690

This fixes the private recipe resolution. 

Common case: Dyer is dying something, and has to craft the dye first. 