### PR TITLE
Sort items by activeness making it easier to see selected items

### DIFF
--- a/src/main/java/com/minecolonies/coremod/client/gui/ViewFilterableList.java
+++ b/src/main/java/com/minecolonies/coremod/client/gui/ViewFilterableList.java
@@ -185,6 +185,26 @@ public class ViewFilterableList
         allItems.clear();
         allItems.addAll(getBlockList(filterPredicate));
         allItems.addAll(getExceptions().stream().filter(storage -> filterPredicate.test(storage.getItemStack())).collect(Collectors.toList()));
+
+        allItems.sort((o1, o2) -> {
+
+            boolean o1Allowed = building.isAllowedItem(id, new ItemStorage(o1.getItemStack()));
+            boolean o2Allowed = building.isAllowedItem(id, new ItemStorage(o2.getItemStack()));
+
+            if(!o1Allowed && o2Allowed)
+            {
+                return 1;
+            }
+            else if(o1Allowed && !o2Allowed)
+            {
+                return -1;
+            }
+            else
+            {
+                return 0;
+            }
+        });
+
         updateResourceList();
     }
 


### PR DESCRIPTION

# Changes proposed in this pull request:
- Sorting filterable items by active items. In practice this will for instance sort the fuel page of the restaurant or the baker to show the enabled items at the top, this gives a quick overview of what items are active.

New pull request to fix broken local config

Review please
