### PR TITLE
Fix guards requesting shields and pupils getting too much paper

### DIFF
--- a/src/main/java/com/minecolonies/coremod/entity/ai/basic/AbstractEntityAIFight.java
+++ b/src/main/java/com/minecolonies/coremod/entity/ai/basic/AbstractEntityAIFight.java
@@ -25,6 +25,7 @@ import java.util.List;
 import java.util.Map;
 
 import static com.minecolonies.api.entity.ai.statemachine.states.AIWorkerState.*;
+import static com.minecolonies.api.research.util.ResearchConstants.SHIELD_USAGE;
 import static com.minecolonies.api.util.constant.Constants.TICKS_SECOND;
 import static com.minecolonies.api.util.constant.GuardConstants.*;
 import static com.minecolonies.api.util.constant.ToolLevelConstants.*;
@@ -149,6 +150,10 @@ public abstract class AbstractEntityAIFight<J extends AbstractJobGuard<J>, B ext
             for (final GuardGear item : itemList)
             {
                 if (!(building.getBuildingLevel() >= item.getMinBuildingLevelRequired() && building.getBuildingLevel() <= item.getMaxBuildingLevelRequired()))
+                {
+                    continue;
+                }
+                if (item.getItemNeeded() == ToolType.SHIELD && worker.getCitizenColonyHandler().getColony().getResearchManager().getResearchEffects().getEffectStrength(SHIELD_USAGE) <= 0)
                 {
                     continue;
                 }

--- a/src/main/java/com/minecolonies/coremod/entity/ai/citizen/school/EntityAIWorkTeacher.java
+++ b/src/main/java/com/minecolonies/coremod/entity/ai/citizen/school/EntityAIWorkTeacher.java
@@ -145,7 +145,8 @@ public class EntityAIWorkTeacher extends AbstractEntityAIInteract<JobTeacher, Bu
         }
 
         final int slot = InventoryUtils.findFirstSlotInItemHandlerWith(worker.getInventoryCitizen(), PAPER);
-        if (slot != -1)
+        final int pupilSlot = InventoryUtils.findFirstSlotInItemHandlerWith(pupilToTeach.getInventoryCitizen(), PAPER);
+        if (slot != -1 && pupilSlot == -1)
         {
             InventoryUtils.transferXOfFirstSlotInItemHandlerWithIntoNextFreeSlotInItemHandler(
               worker.getInventoryCitizen(),


### PR DESCRIPTION
Closes #6590 
Closes #6544
Closes #

# Changes proposed in this pull request:
- Guards won't request shields before the research is completed
- Stop teachers from giving their pupils paper if they already have some in their inventory
-

Review please
