### PR TITLE
Change standardRequests hover label

### DIFF
--- a/src/api/java/com/minecolonies/api/util/constant/TranslationConstants.java
+++ b/src/api/java/com/minecolonies/api/util/constant/TranslationConstants.java
@@ -438,6 +438,8 @@ public final class TranslationConstants
     @NonNls
     public static final String IN_QUEUE                                                             = "com.minecolonies.coremod.listentry";
     @NonNls
+    public static final String IN_PROGRESS                                                          = "com.minecolonies.coremod.in_progrss";
+    @NonNls
     public static final String MISSING_DELIVERIES                                                   = "com.minecolonies.coremod.missingitems";
     @NonNls
     public static final String FINISHED                                                             = "com.minecolonies.coremod.finished";

--- a/src/api/java/com/minecolonies/api/util/constant/TranslationConstants.java
+++ b/src/api/java/com/minecolonies/api/util/constant/TranslationConstants.java
@@ -438,7 +438,7 @@ public final class TranslationConstants
     @NonNls
     public static final String IN_QUEUE                                                             = "com.minecolonies.coremod.listentry";
     @NonNls
-    public static final String IN_PROGRESS                                                          = "com.minecolonies.coremod.in_progrss";
+    public static final String IN_PROGRESS                                                          = "com.minecolonies.coremod.in_progress";
     @NonNls
     public static final String MISSING_DELIVERIES                                                   = "com.minecolonies.coremod.missingitems";
     @NonNls

--- a/src/main/java/com/minecolonies/coremod/colony/requestsystem/requests/StandardRequests.java
+++ b/src/main/java/com/minecolonies/coremod/colony/requestsystem/requests/StandardRequests.java
@@ -399,7 +399,7 @@ public final class StandardRequests
 
                 if (posInList >= 0)
                 {
-                	return posInList == 0 ? ImmutableList.of(new TranslationTextComponent(FROM, requester), new TranslationTextComponent(IN_PROGRESS)) : ImmutableList.of(new TranslationTextComponent(FROM, requester), new TranslationTextComponent(IN_QUEUE, posInList));
+                	return posInList == 0 ? ImmutableList.of(new TranslationTextComponent(AT, requester), new TranslationTextComponent(IN_PROGRESS)) : ImmutableList.of(new TranslationTextComponent(FROM, requester), new TranslationTextComponent(IN_QUEUE, posInList));
                 }
                 else if (getState() == RequestState.FOLLOWUP_IN_PROGRESS)
                 {

--- a/src/main/java/com/minecolonies/coremod/colony/requestsystem/requests/StandardRequests.java
+++ b/src/main/java/com/minecolonies/coremod/colony/requestsystem/requests/StandardRequests.java
@@ -275,7 +275,7 @@ public final class StandardRequests
 
             if (posInList >= 0)
             {
-                return ImmutableList.of(new TranslationTextComponent(FROM, requester), new TranslationTextComponent(IN_QUEUE, posInList));
+                return ImmutableList.of(new TranslationTextComponent(FROM, requester), new TranslationTextComponent(IN_QUEUE+1, posInList));
             }
             else
             {
@@ -399,7 +399,7 @@ public final class StandardRequests
 
                 if (posInList >= 0)
                 {
-                    return ImmutableList.of(new TranslationTextComponent(AT, requester), new TranslationTextComponent(IN_QUEUE, posInList));
+                    return ImmutableList.of(new TranslationTextComponent(AT, requester), new TranslationTextComponent(IN_QUEUE+1, posInList));
                 }
                 else if (getState() == RequestState.FOLLOWUP_IN_PROGRESS)
                 {

--- a/src/main/java/com/minecolonies/coremod/colony/requestsystem/requests/StandardRequests.java
+++ b/src/main/java/com/minecolonies/coremod/colony/requestsystem/requests/StandardRequests.java
@@ -275,7 +275,8 @@ public final class StandardRequests
 
             if (posInList >= 0)
             {
-                return ImmutableList.of(new TranslationTextComponent(FROM, requester), new TranslationTextComponent(IN_QUEUE+1, posInList));
+            	if(posInList == 0) 	return ImmutableList.of(new TranslationTextComponent(FROM, requester), new TranslationTextComponent(IN_PROGRESS, posInList+1));
+            	else				return ImmutableList.of(new TranslationTextComponent(FROM, requester), new TranslationTextComponent(IN_QUEUE, posInList+1));
             }
             else
             {
@@ -399,7 +400,8 @@ public final class StandardRequests
 
                 if (posInList >= 0)
                 {
-                    return ImmutableList.of(new TranslationTextComponent(AT, requester), new TranslationTextComponent(IN_QUEUE+1, posInList));
+                	if(posInList == 0) 	return ImmutableList.of(new TranslationTextComponent(AT, requester), new TranslationTextComponent(IN_PROGRESS, posInList+1));
+                	else				return ImmutableList.of(new TranslationTextComponent(AT, requester), new TranslationTextComponent(IN_QUEUE, posInList+1));
                 }
                 else if (getState() == RequestState.FOLLOWUP_IN_PROGRESS)
                 {

--- a/src/main/java/com/minecolonies/coremod/colony/requestsystem/requests/StandardRequests.java
+++ b/src/main/java/com/minecolonies/coremod/colony/requestsystem/requests/StandardRequests.java
@@ -275,8 +275,7 @@ public final class StandardRequests
 
             if (posInList >= 0)
             {
-            	if(posInList == 0) 	return ImmutableList.of(new TranslationTextComponent(FROM, requester), new TranslationTextComponent(IN_PROGRESS));
-            	else				return ImmutableList.of(new TranslationTextComponent(FROM, requester), new TranslationTextComponent(IN_QUEUE, posInList+1));
+            	return posInList == 0 ? ImmutableList.of(new TranslationTextComponent(FROM, requester), new TranslationTextComponent(IN_PROGRESS)) : ImmutableList.of(new TranslationTextComponent(FROM, requester), new TranslationTextComponent(IN_QUEUE, posInList+1));
             }
             else
             {
@@ -400,8 +399,7 @@ public final class StandardRequests
 
                 if (posInList >= 0)
                 {
-                	if(posInList == 0) 	return ImmutableList.of(new TranslationTextComponent(AT, requester), new TranslationTextComponent(IN_PROGRESS));
-                	else				return ImmutableList.of(new TranslationTextComponent(AT, requester), new TranslationTextComponent(IN_QUEUE, posInList+1));
+                	return posInList == 0 ? ImmutableList.of(new TranslationTextComponent(FROM, requester), new TranslationTextComponent(IN_PROGRESS)) : ImmutableList.of(new TranslationTextComponent(FROM, requester), new TranslationTextComponent(IN_QUEUE, posInList+1));
                 }
                 else if (getState() == RequestState.FOLLOWUP_IN_PROGRESS)
                 {

--- a/src/main/java/com/minecolonies/coremod/colony/requestsystem/requests/StandardRequests.java
+++ b/src/main/java/com/minecolonies/coremod/colony/requestsystem/requests/StandardRequests.java
@@ -275,7 +275,7 @@ public final class StandardRequests
 
             if (posInList >= 0)
             {
-            	return posInList == 0 ? ImmutableList.of(new TranslationTextComponent(FROM, requester), new TranslationTextComponent(IN_PROGRESS)) : ImmutableList.of(new TranslationTextComponent(FROM, requester), new TranslationTextComponent(IN_QUEUE, posInList+1));
+            	return posInList == 0 ? ImmutableList.of(new TranslationTextComponent(FROM, requester), new TranslationTextComponent(IN_PROGRESS)) : ImmutableList.of(new TranslationTextComponent(FROM, requester), new TranslationTextComponent(IN_QUEUE, posInList));
             }
             else
             {
@@ -399,7 +399,7 @@ public final class StandardRequests
 
                 if (posInList >= 0)
                 {
-                	return posInList == 0 ? ImmutableList.of(new TranslationTextComponent(FROM, requester), new TranslationTextComponent(IN_PROGRESS)) : ImmutableList.of(new TranslationTextComponent(FROM, requester), new TranslationTextComponent(IN_QUEUE, posInList+1));
+                	return posInList == 0 ? ImmutableList.of(new TranslationTextComponent(FROM, requester), new TranslationTextComponent(IN_PROGRESS)) : ImmutableList.of(new TranslationTextComponent(FROM, requester), new TranslationTextComponent(IN_QUEUE, posInList));
                 }
                 else if (getState() == RequestState.FOLLOWUP_IN_PROGRESS)
                 {

--- a/src/main/java/com/minecolonies/coremod/colony/requestsystem/requests/StandardRequests.java
+++ b/src/main/java/com/minecolonies/coremod/colony/requestsystem/requests/StandardRequests.java
@@ -275,7 +275,7 @@ public final class StandardRequests
 
             if (posInList >= 0)
             {
-            	if(posInList == 0) 	return ImmutableList.of(new TranslationTextComponent(FROM, requester), new TranslationTextComponent(IN_PROGRESS, posInList+1));
+            	if(posInList == 0) 	return ImmutableList.of(new TranslationTextComponent(FROM, requester), new TranslationTextComponent(IN_PROGRESS));
             	else				return ImmutableList.of(new TranslationTextComponent(FROM, requester), new TranslationTextComponent(IN_QUEUE, posInList+1));
             }
             else
@@ -400,7 +400,7 @@ public final class StandardRequests
 
                 if (posInList >= 0)
                 {
-                	if(posInList == 0) 	return ImmutableList.of(new TranslationTextComponent(AT, requester), new TranslationTextComponent(IN_PROGRESS, posInList+1));
+                	if(posInList == 0) 	return ImmutableList.of(new TranslationTextComponent(AT, requester), new TranslationTextComponent(IN_PROGRESS));
                 	else				return ImmutableList.of(new TranslationTextComponent(AT, requester), new TranslationTextComponent(IN_QUEUE, posInList+1));
                 }
                 else if (getState() == RequestState.FOLLOWUP_IN_PROGRESS)

--- a/src/main/resources/assets/minecolonies/lang/en_us.json
+++ b/src/main/resources/assets/minecolonies/lang/en_us.json
@@ -1734,6 +1734,7 @@
   "com.minecolonies.coremod.from": "From: %s",
   "com.minecolonies.coremod.at": "At: %s",
   "com.minecolonies.coremod.listentry": "#%d in queue",
+  "com.minecolonies.coremod.in_progrss": "In Progress",
   "com.minecolonies.coremod.missingitems": "Awaiting Materials",
   "com.minecolonies.coremod.finished": "Finished!",
   "com.minecolonies.coremod.dist.blocks": "%d blocks",

--- a/src/main/resources/assets/minecolonies/lang/en_us.json
+++ b/src/main/resources/assets/minecolonies/lang/en_us.json
@@ -1734,7 +1734,7 @@
   "com.minecolonies.coremod.from": "From: %s",
   "com.minecolonies.coremod.at": "At: %s",
   "com.minecolonies.coremod.listentry": "#%d in queue",
-  "com.minecolonies.coremod.in_progrss": "In Progress",
+  "com.minecolonies.coremod.in_progress": "In Progress",
   "com.minecolonies.coremod.missingitems": "Awaiting Materials",
   "com.minecolonies.coremod.finished": "Finished!",
   "com.minecolonies.coremod.dist.blocks": "%d blocks",


### PR DESCRIPTION
Closes https://github.com/ldtteam/minecolonies-features/issues/315

# Changes proposed in this pull request:
- Changed standard request list UI, hover text to be more human-readable
Change the hover text in the request lists such as in the postbox to be more human-readable. RN when a request is first in the queue it says "#0 in queue", which does not make sense. But in this commit, it adds 1 to that value. So when something is first in the request queue it says "#1 in queue".

Review please
