### PR TITLE
Improve backup loading

### DIFF
--- a/src/api/java/com/minecolonies/api/colony/IColonyManager.java
+++ b/src/api/java/com/minecolonies/api/colony/IColonyManager.java
@@ -267,6 +267,11 @@ public interface IColonyManager
     void onWorldLoad(@NotNull World world);
 
     /**
+     * Sets the cap for this world to loaded
+     */
+    void setCapLoaded();
+
+    /**
      * Get the Universal Unique ID for the server.
      *
      * @return the server Universal Unique ID for ther

--- a/src/main/java/com/minecolonies/coremod/event/FMLEventHandler.java
+++ b/src/main/java/com/minecolonies/coremod/event/FMLEventHandler.java
@@ -12,6 +12,7 @@ import net.minecraftforge.event.AddReloadListenerEvent;
 import net.minecraftforge.event.TickEvent;
 import net.minecraftforge.event.entity.player.PlayerEvent;
 import net.minecraftforge.eventbus.api.SubscribeEvent;
+import net.minecraftforge.fml.event.server.FMLServerAboutToStartEvent;
 import net.minecraftforge.fml.event.server.FMLServerStoppingEvent;
 import org.jetbrains.annotations.NotNull;
 
@@ -53,10 +54,16 @@ public class FMLEventHandler
     }
 
     @SubscribeEvent
-    public static void onServerAboutToStart(@NotNull final AddReloadListenerEvent event)
+    public static void onAddReloadListenerEvent(@NotNull final AddReloadListenerEvent event)
     {
         event.addListener(new CrafterRecipeListener());
         event.addListener(new ResearchListener());
+    }
+
+    @SubscribeEvent
+    public static void onServerAboutToStart(@NotNull final FMLServerAboutToStartEvent event)
+    {
+        IColonyManager.getInstance().getRecipeManager().reset();
     }
 
     public static void onServerStopped(final FMLServerStoppingEvent event)

--- a/src/main/java/com/minecolonies/coremod/util/BackUpHelper.java
+++ b/src/main/java/com/minecolonies/coremod/util/BackUpHelper.java
@@ -13,7 +13,6 @@ import net.minecraft.util.RegistryKey;
 import net.minecraft.util.ResourceLocation;
 import net.minecraft.world.World;
 import net.minecraft.world.chunk.Chunk;
-import net.minecraft.world.server.ServerWorld;
 import net.minecraft.world.storage.FolderName;
 import net.minecraftforge.fml.server.ServerLifecycleHooks;
 import org.jetbrains.annotations.NotNull;
@@ -104,6 +103,28 @@ public final class BackUpHelper
     }
 
     /**
+     * Loads the colony managers backup file
+     */
+    public static void loadManagerBackup()
+    {
+        try
+        {
+            @NotNull final File file = BackUpHelper.getSaveLocation();
+            @Nullable final CompoundNBT data = BackUpHelper.loadNBTFromPath(file);
+            if (data != null)
+            {
+                Log.getLogger().info("Loading Minecolonies colony manager Backup Data");
+                IColonyManager.getInstance().read(data);
+                Log.getLogger().info("Backup Load Complete");
+            }
+        }
+        catch (Exception e)
+        {
+            Log.getLogger().error("Error during restoring colony manager:", e);
+        }
+    }
+
+    /**
      * Loads all colonies from backup files which the world cap is missing.
      */
     public static void loadMissingColonies()
@@ -181,19 +202,6 @@ public final class BackUpHelper
     public static File getSaveLocation()
     {
         @NotNull final File saveDir = new File(ServerLifecycleHooks.getCurrentServer().func_240776_a_(FolderName.DOT).toFile(), FILENAME_MINECOLONIES_PATH);
-        return new File(saveDir, FILENAME_MINECOLONIES);
-    }
-
-    /**
-     * Get save location for Minecolonies data, from the world/save directory.
-     *
-     * @param world the server world object to use.
-     * @return Save file for minecolonies.
-     */
-    @NotNull
-    public static File getSaveLocation(final ServerWorld world)
-    {
-        @NotNull final File saveDir = new File(world.getServer().func_240776_a_(FolderName.DOT).toFile(), FILENAME_MINECOLONIES_PATH);
         return new File(saveDir, FILENAME_MINECOLONIES);
     }
 


### PR DESCRIPTION
# Changes proposed in this pull request:

Backup loading is now done directly during cap load, if parts of it were missing. If no cap exists it gets triggered on world load later.

Fix colonymanager(recipes,compat) always beeing read from disk and overwriting values from cap
Fix recipes possibly getting lost on dim unloads.

Review please
