### PR TITLE
Simplify crushing.

### DIFF
--- a/src/api/java/com/minecolonies/api/compatibility/CompatibilityManager.java
+++ b/src/api/java/com/minecolonies/api/compatibility/CompatibilityManager.java
@@ -110,11 +110,6 @@ public class CompatibilityManager implements ICompatibilityManager
     private final List<ItemStorage> luckyOres = new ArrayList<>();
 
     /**
-     * What the crusher can work on.
-     */
-    private final Map<ItemStorage, ItemStorage> crusherModes = new HashMap<>();
-
-    /**
      * The items and weights of the recruitment.
      */
     private final List<Tuple<Item, Integer>> recruitmentCostsWeights = new ArrayList<>();
@@ -182,7 +177,6 @@ public class CompatibilityManager implements ICompatibilityManager
         discoverLuckyOres();
         discoverRecruitCosts();
         discoverDiseases();
-        discoverCrusherModes();
         discoverSifting();
         discoverFood();
         discoverFuel();
@@ -402,17 +396,6 @@ public class CompatibilityManager implements ICompatibilityManager
         }
 
         return false;
-    }
-
-    /**
-     * Getter for all the crusher modes.
-     *
-     * @return an immutable copy of the map.
-     */
-    @Override
-    public Map<ItemStorage, ItemStorage> getCrusherModes()
-    {
-        return ImmutableMap.<ItemStorage, ItemStorage>builder().putAll(this.crusherModes).build();
     }
 
     @Override
@@ -784,45 +767,6 @@ public class CompatibilityManager implements ICompatibilityManager
             catch (final NumberFormatException ex)
             {
                 Log.getLogger().warn("Invalid integer at pos 1, 3 or 4");
-            }
-        }
-    }
-
-    /**
-     * Calculate the crusher modes from the config file.
-     */
-    private void discoverCrusherModes()
-    {
-        for (final String string : MinecoloniesAPIProxy.getInstance().getConfig().getServer().crusherProduction.get())
-        {
-            final String[] split = string.split("!");
-            if (split.length != 2)
-            {
-                Log.getLogger().warn("Invalid crusher mode setting: " + string);
-                continue;
-            }
-
-            final String[] firstItem = split[0].split(":");
-            final String[] secondItem = split[1].split(":");
-
-            final Item item1 = ForgeRegistries.ITEMS.getValue(new ResourceLocation(firstItem[0], firstItem[1]));
-            final Item item2 = ForgeRegistries.ITEMS.getValue(new ResourceLocation(secondItem[0], secondItem[1]));
-
-            try
-            {
-                if (item1 == null || item2 == null)
-                {
-                    Log.getLogger().warn("Invalid crusher mode setting: " + string);
-                    continue;
-                }
-
-                final ItemStorage storage1 = new ItemStorage(new ItemStack(item1, 2));
-                final ItemStorage storage2 = new ItemStorage(new ItemStack(item2, 1));
-                crusherModes.put(storage1, storage2);
-            }
-            catch (final NumberFormatException ex)
-            {
-                Log.getLogger().warn("Error getting metaData", ex);
             }
         }
     }

--- a/src/api/java/com/minecolonies/api/compatibility/ICompatibilityManager.java
+++ b/src/api/java/com/minecolonies/api/compatibility/ICompatibilityManager.java
@@ -154,13 +154,6 @@ public interface ICompatibilityManager
     boolean isCompost(ItemStack stack);
 
     /**
-     * Get a map of all the crusher modes.
-     *
-     * @return the modes.
-     */
-    Map<ItemStorage, ItemStorage> getCrusherModes();
-
-    /**
      * Write colonies to NBT data for saving.
      *
      * @param compound NBT-Tag.

--- a/src/api/java/com/minecolonies/api/configuration/ServerConfiguration.java
+++ b/src/api/java/com/minecolonies/api/configuration/ServerConfiguration.java
@@ -135,7 +135,6 @@ public class ServerConfiguration extends AbstractConfiguration
     public final ForgeConfigSpec.ConfigValue<List<? extends String>> configListStudyItems;
     public final ForgeConfigSpec.ConfigValue<List<? extends String>> configListRecruitmentItems;
     public final ForgeConfigSpec.ConfigValue<List<? extends String>> luckyOres;
-    public final ForgeConfigSpec.ConfigValue<List<? extends String>> crusherProduction;
     public final ForgeConfigSpec.ConfigValue<List<? extends String>> sifterMeshes;
     public final ForgeConfigSpec.ConfigValue<List<? extends String>> listOfPlantables;
     public final ForgeConfigSpec.ConfigValue<List<? extends String>> enchantments;
@@ -478,12 +477,6 @@ public class ServerConfiguration extends AbstractConfiguration
                      "minecraft:lapis_ore!4",
                      "minecraft:diamond_ore!2",
                      "minecraft:emerald_ore!1"),
-          s -> s instanceof String);
-        crusherProduction = defineList(builder, "crusherproduction",
-          Arrays.asList
-                   ("minecraft:cobblestone!minecraft:gravel",
-                     "minecraft:gravel!minecraft:sand",
-                     "minecraft:sand!minecraft:clay"),
           s -> s instanceof String);
         sifterMeshes = defineList(builder, "siftermeshes",
           Arrays.asList

--- a/src/main/java/com/minecolonies/coremod/colony/buildings/workerbuildings/BuildingCrusher.java
+++ b/src/main/java/com/minecolonies/coremod/colony/buildings/workerbuildings/BuildingCrusher.java
@@ -1,7 +1,7 @@
 package com.minecolonies.coremod.colony.buildings.workerbuildings;
 
+import com.google.common.collect.ImmutableMap;
 import com.ldtteam.blockout.views.Window;
-import com.minecolonies.api.blocks.ModBlocks;
 import com.minecolonies.api.colony.ICitizenData;
 import com.minecolonies.api.colony.IColony;
 import com.minecolonies.api.colony.IColonyManager;
@@ -9,17 +9,15 @@ import com.minecolonies.api.colony.IColonyView;
 import com.minecolonies.api.colony.buildings.ModBuildings;
 import com.minecolonies.api.colony.buildings.registry.BuildingEntry;
 import com.minecolonies.api.colony.jobs.IJob;
-import com.minecolonies.api.colony.requestsystem.StandardFactoryController;
+import com.minecolonies.api.colony.requestsystem.token.IToken;
 import com.minecolonies.api.crafting.IRecipeStorage;
 import com.minecolonies.api.crafting.ItemStorage;
 import com.minecolonies.api.entity.citizen.Skill;
-import com.minecolonies.api.util.constant.TypeConstants;
 import com.minecolonies.coremod.Network;
 import com.minecolonies.coremod.client.gui.WindowHutCrusher;
 import com.minecolonies.coremod.colony.buildings.AbstractBuildingCrafter;
 import com.minecolonies.coremod.colony.jobs.JobCrusher;
 import com.minecolonies.coremod.network.messages.server.colony.building.crusher.CrusherSetModeMessage;
-
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.CompoundNBT;
 import net.minecraft.network.PacketBuffer;
@@ -27,7 +25,10 @@ import net.minecraft.util.Tuple;
 import net.minecraft.util.math.BlockPos;
 import org.jetbrains.annotations.NotNull;
 
-import java.util.*;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
 import static com.minecolonies.api.research.util.ResearchConstants.CRUSHING_11;
 import static com.minecolonies.api.util.constant.NbtTagConstants.*;
@@ -94,25 +95,23 @@ public class BuildingCrusher extends AbstractBuildingCrafter
      */
     private void loadCrusherMode()
     {
+        this.recipes.clear();
+        checkForWorkerSpecificRecipes();
+
         this.crusherRecipes.clear();
 
-        oneByOne = getColony().getResearchManager().getResearchEffects().getEffectStrength(CRUSHING_11) > 0;
-        for (final Map.Entry<ItemStorage, ItemStorage> mode : IColonyManager.getInstance().getCompatibilityManager().getCrusherModes().entrySet())
+        final ImmutableMap<IToken<?>, IRecipeStorage> recipes = IColonyManager.getInstance().getRecipeManager().getRecipes();
+        for (final IToken<?> token : this.recipes)
         {
+            final IRecipeStorage storage = recipes.get(token);
+            if (storage == null) continue; //wat
+            
+            final ItemStorage key = storage.getCleanedInput().get(0);
             if (this.crusherMode == null)
             {
-                this.crusherMode = mode.getKey();
+                this.crusherMode = key;
             }
-            final ItemStack input = mode.getKey().getItemStack();
-            if (oneByOne)
-            {
-                input.setCount(1);
-            }
-            final IRecipeStorage recipe = StandardFactoryController.getInstance().getNewInstance(
-              TypeConstants.RECIPE,
-              StandardFactoryController.getInstance().getNewInstance(TypeConstants.ITOKEN),
-              Collections.singletonList(input), 2, mode.getValue().getItemStack(), ModBlocks.blockHutCrusher);
-            crusherRecipes.put(mode.getKey(), recipe);
+            this.crusherRecipes.put(key, storage);
         }
     }
 
@@ -152,6 +151,9 @@ public class BuildingCrusher extends AbstractBuildingCrafter
     {
         return CRUSHER_DESC;
     }
+
+    @Override
+    public boolean isRecipeAlterationAllowed() { return false; }
 
     @Override
     public boolean canCraftComplexRecipes()
@@ -250,6 +252,8 @@ public class BuildingCrusher extends AbstractBuildingCrafter
         }
 
         this.oneByOne = compound.getBoolean(TAG_CRUSHER_RATIO);
+
+        loadCrusherMode();
     }
 
     @Override
@@ -274,7 +278,8 @@ public class BuildingCrusher extends AbstractBuildingCrafter
     {
         super.serializeToView(buf);
 
-        if (crusherRecipes.isEmpty() || !oneByOne && getColony().getResearchManager().getResearchEffects().getEffectStrength(CRUSHING_11) > 0)
+        final boolean oneOne = getColony().getResearchManager().getResearchEffects().getEffectStrength(CRUSHING_11) > 0;
+        if (crusherRecipes.isEmpty() || oneByOne != oneOne)
         {
             loadCrusherMode();
         }


### PR DESCRIPTION
Another bite-size piece extracted from the JEI PR.  This simplifies the crusher mode calculation, since it already has all the data in the crafterrecipes anyway.  (Possibly as a future extension this could get a similar treatment as #6687 and just craft automatically without mode selection, although that has some downsides too.)

# Changes proposed in this pull request:
- Calculates crusher modes automatically from datapack recipes instead of config.

Review please
