### PR TITLE
Fix comment for neighbor building rendering option

### DIFF
--- a/src/api/java/com/minecolonies/api/configuration/ClientConfiguration.java
+++ b/src/api/java/com/minecolonies/api/configuration/ClientConfiguration.java
@@ -20,7 +20,7 @@ public class ClientConfiguration extends AbstractConfiguration
     {
         createCategory(builder, "gameplay");
         citizenVoices = defineBoolean(builder, "disablecitizenvoices", true);
-        neighborbuildingrendering = defineBoolean(builder, "blueprintrender", true);
+        neighborbuildingrendering = defineBoolean(builder, "neighborbuildingrendering", true);
 
         swapToCategory(builder, "pathfinding");
         pathfindingDebugDraw = defineBoolean(builder, "pathfindingdebugdraw", false);


### PR DESCRIPTION
Closes #
Closes #
Closes #

# Changes proposed in this pull request:
Fixes this:
![image](https://user-images.githubusercontent.com/63612548/110961383-5cd5cf00-8315-11eb-9c43-7421f3ed0ddf.png)

Review please
