### PR TITLE
Chest Resource search UI fix

### DIFF
--- a/src/api/java/com/minecolonies/api/tileentities/TileEntityColonyBuilding.java
+++ b/src/api/java/com/minecolonies/api/tileentities/TileEntityColonyBuilding.java
@@ -36,7 +36,7 @@ import net.minecraftforge.items.IItemHandlerModifiable;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
-import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.Set;
 import java.util.function.Predicate;
 
@@ -472,7 +472,7 @@ public class TileEntityColonyBuilding extends AbstractTileEntityColonyBuilding i
             if (combinedInv == null)
             {
                 //Add additional containers
-                final Set<IItemHandlerModifiable> handlers = new HashSet<>();
+                final Set<IItemHandlerModifiable> handlers = new LinkedHashSet<>();
                 final World world = colony.getWorld();
                 if (world != null)
                 {

--- a/src/main/java/com/minecolonies/coremod/client/gui/WindowHutAllInventory.java
+++ b/src/main/java/com/minecolonies/coremod/client/gui/WindowHutAllInventory.java
@@ -86,7 +86,8 @@ public class WindowHutAllInventory extends AbstractWindowSkeleton
     {
         final int row = stackList.getListElementIndexByPane(button);
         final ItemStorage storage = allItems.get(row);
-        final List<BlockPos> containerList = building.getContainerList();
+        final Set<BlockPos> containerList = new HashSet<>(building.getContainerList());
+        containerList.add(building.getID());
 
         for (BlockPos blockPos : containerList)
         {
@@ -158,7 +159,7 @@ public class WindowHutAllInventory extends AbstractWindowSkeleton
      */
     private void updateResources()
     {
-        final List<BlockPos> containerList = building.getContainerList();
+        final Set<BlockPos> containerList = new HashSet<>(building.getContainerList());
 
         final Map<ItemStorage, Integer> storedItems = new HashMap<>();
         final World world = building.getColony().getWorld();
@@ -169,8 +170,7 @@ public class WindowHutAllInventory extends AbstractWindowSkeleton
             final TileEntity rack = world.getTileEntity(blockPos);
             if (rack instanceof TileEntityRack)
             {
-
-                Map<ItemStorage, Integer> rackStorage = ((TileEntityRack) rack).getAllContent();
+                final Map<ItemStorage, Integer> rackStorage = ((TileEntityRack) rack).getAllContent();
 
                 for (final Map.Entry<ItemStorage, Integer> entry : rackStorage.entrySet())
                 {


### PR DESCRIPTION
# Changes proposed in this pull request:
Fix resource search not considering hutblock
Make sure that containers are only counted once
Fix cap's not keeping container order, making e.g. warehouse sort less deterministic and shuffling more stuff around

Review please
