### PR TITLE
Explicitly allow fletcher to produce string too.

### DIFF
--- a/src/main/resources/data/minecolonies/tags/items/fletcher_product.json
+++ b/src/main/resources/data/minecolonies/tags/items/fletcher_product.json
@@ -1,4 +1,6 @@
 {
   "replace": false,
-  "values": []
+  "values": [
+    "#forge:string"
+  ]
 }


### PR DESCRIPTION
# Changes proposed in this pull request:
- Explicitly allow the fletcher to craft string as an output.

(Mod compatibility: while the custom wool -> string recipe is already allowed by the fletcher, several other mods add other ways to make string, which seem like they should probably be the fletcher's responsibility too.  Note that it's not safe to similarly add wool as an allowed output as [due to the order the tags are processed in] this would also add all the wool-dying recipes, which we don't want.)

Review please
