### PR TITLE
Fix miner crash

### DIFF
--- a/src/main/java/com/minecolonies/coremod/client/gui/WindowHutMinerModule.java
+++ b/src/main/java/com/minecolonies/coremod/client/gui/WindowHutMinerModule.java
@@ -148,6 +148,11 @@ public class WindowHutMinerModule extends AbstractWindowWorkerModuleBuilding<Bui
                         }
                     }
                 }
+                else
+                {
+                    final Button button = pane.findPaneOfTypeByID("assignGuard", Button.class);
+                    button.setEnabled(false);
+                }
             }
         });
     }
@@ -193,23 +198,26 @@ public class WindowHutMinerModule extends AbstractWindowWorkerModuleBuilding<Bui
             case BUTTON_ASSIGNGUARD:
                 final int guardRow = guardsList.getListElementIndexByPane(button);
                 final ICitizenDataView guard = guardsInfo.get(guardRow);
-                final AbstractBuildingGuards.View guardbuilding = (AbstractBuildingGuards.View) miner.getColony().getBuilding(guard.getWorkBuilding());
-                if (guardbuilding.getMinePos() == null)
+                if (guard != null)
                 {
-                    if (miner.assignedGuards < miner.getMaxGuards())
+                    final AbstractBuildingGuards.View guardbuilding = (AbstractBuildingGuards.View) miner.getColony().getBuilding(guard.getWorkBuilding());
+                    if (guardbuilding.getMinePos() == null)
                     {
-                        Network.getNetwork().sendToServer(new GuardSetMinePosMessage(guardbuilding, miner.getPosition()));
-                        button.setText(new TranslationTextComponent("com.minecolonies.coremod.gui.hiring.buttonunassign"));
-                        guardbuilding.setMinePos(miner.getPosition());
-                        miner.assignedGuards++;
+                        if (miner.assignedGuards < miner.getMaxGuards())
+                        {
+                            Network.getNetwork().sendToServer(new GuardSetMinePosMessage(guardbuilding, miner.getPosition()));
+                            button.setText(new TranslationTextComponent("com.minecolonies.coremod.gui.hiring.buttonunassign"));
+                            guardbuilding.setMinePos(miner.getPosition());
+                            miner.assignedGuards++;
+                        }
                     }
-                }
-                else if (guardbuilding.getMinePos().equals(miner.getPosition()))
-                {
-                    Network.getNetwork().sendToServer(new GuardSetMinePosMessage(guardbuilding));
-                    button.setText(new TranslationTextComponent("com.minecolonies.coremod.gui.hiring.buttonassign"));
-                    guardbuilding.setMinePos(null);
-                    miner.assignedGuards--;
+                    else if (guardbuilding.getMinePos().equals(miner.getPosition()))
+                    {
+                        Network.getNetwork().sendToServer(new GuardSetMinePosMessage(guardbuilding));
+                        button.setText(new TranslationTextComponent("com.minecolonies.coremod.gui.hiring.buttonassign"));
+                        guardbuilding.setMinePos(null);
+                        miner.assignedGuards--;
+                    }
                 }
                 pullGuardsFromHut();
                 break;

--- a/src/main/java/com/minecolonies/coremod/client/gui/WindowHutMinerModule.java
+++ b/src/main/java/com/minecolonies/coremod/client/gui/WindowHutMinerModule.java
@@ -9,6 +9,7 @@ import com.ldtteam.blockout.views.SwitchView;
 import com.ldtteam.structurize.util.LanguageHandler;
 import com.minecolonies.api.colony.ICitizenDataView;
 import com.minecolonies.api.colony.buildings.views.IBuildingView;
+import com.minecolonies.api.util.Log;
 import com.minecolonies.api.util.constant.Constants;
 import com.minecolonies.coremod.Network;
 import com.minecolonies.coremod.colony.buildings.AbstractBuildingGuards;
@@ -116,32 +117,35 @@ public class WindowHutMinerModule extends AbstractWindowWorkerModuleBuilding<Bui
             public void updateElement(final int i, final Pane pane)
             {
                 final ICitizenDataView citizen = guardsInfo.get(i);
-                pane.findPaneOfTypeByID("guardName", Text.class).setText(citizen.getName());
-                final IBuildingView building = miner.getColony().getBuilding(citizen.getWorkBuilding());
-                if (building instanceof AbstractBuildingGuards.View)
+                if (citizen != null)
                 {
-                    final AbstractBuildingGuards.View guardbuilding = (AbstractBuildingGuards.View) building;
-                    final Button button = pane.findPaneOfTypeByID("assignGuard", Button.class);
-                    if (guardbuilding.getMinePos() == null)
+                    final IBuildingView building = miner.getColony().getBuilding(citizen.getWorkBuilding());
+                    if (building instanceof AbstractBuildingGuards.View)
                     {
-                        button.setText(new TranslationTextComponent("com.minecolonies.coremod.gui.hiring.buttonassign"));
-                        if (miner.assignedGuards >= miner.getMaxGuards())
+                        pane.findPaneOfTypeByID("guardName", Text.class).setText(citizen.getName());
+                        final AbstractBuildingGuards.View guardbuilding = (AbstractBuildingGuards.View) building;
+                        final Button button = pane.findPaneOfTypeByID("assignGuard", Button.class);
+                        if (guardbuilding.getMinePos() == null)
                         {
-                            button.setEnabled(false);
+                            button.setText(new TranslationTextComponent("com.minecolonies.coremod.gui.hiring.buttonassign"));
+                            if (miner.assignedGuards >= miner.getMaxGuards())
+                            {
+                                button.setEnabled(false);
+                            }
+                            else
+                            {
+                                button.setEnabled(true);
+                            }
+                        }
+                        else if (guardbuilding.getMinePos().equals(miner.getPosition()))
+                        {
+                            button.setText(new TranslationTextComponent("com.minecolonies.coremod.gui.hiring.buttonunassign"));
                         }
                         else
                         {
-                            button.setEnabled(true);
+                            button.setText(new TranslationTextComponent("com.minecolonies.coremod.gui.hiring.buttonassign"));
+                            button.setEnabled(false);
                         }
-                    }
-                    else if (guardbuilding.getMinePos().equals(miner.getPosition()))
-                    {
-                        button.setText(new TranslationTextComponent("com.minecolonies.coremod.gui.hiring.buttonunassign"));
-                    }
-                    else
-                    {
-                        button.setText(new TranslationTextComponent("com.minecolonies.coremod.gui.hiring.buttonassign"));
-                        button.setEnabled(false);
                     }
                 }
             }


### PR DESCRIPTION
Closes #6783
Closes #
Closes #

# Changes proposed in this pull request:
- Adds a null check to the guards list
- Don't try to display a not yet loaded guard
- Disable button on unloaded guard
- Don't try to assign/unassign unloaded guard
- I don't know, why it can take a few seconds to load the guards, maybe some of you have an idea

Review please
