### PR TITLE
Improve Research Remove Support

### DIFF
--- a/src/api/java/com/minecolonies/api/research/AbstractResearchProvider.java
+++ b/src/api/java/com/minecolonies/api/research/AbstractResearchProvider.java
@@ -628,6 +628,46 @@ public abstract class AbstractResearchProvider implements IDataProvider
         }
 
         /**
+         * Sets the Research to be removed, for its own ResourceLocation.
+         * Prevents load (though not data gen) of all other settings.  Not compatible with other variants of setRemove.
+         * @return this
+         */
+        public Research setRemove()
+        {
+            this.json.addProperty("remove", true);
+            return this;
+        }
+
+        /**
+         * Sets the Research JSON to remove a different individual research, by ResourceLocation.
+         * Prevents load (though not data gen) of all other settings.  Not compatible with other variants of setRemove.
+         * @param researchId  The target research.
+         * @return this
+         */
+        public Research setRemove(final ResourceLocation researchId)
+        {
+            this.json.addProperty("remove", researchId.toString());
+            return this;
+        }
+
+        /**
+         * Sets the Research JSON to remove multiple individual research, by ResourceLocations.
+         * Prevents load (though not data gen) of all other settings.  Not compatible with other variants of setRemove.
+         * @param researchIds  The target research.
+         * @return this
+         */
+        public Research setRemove(final Collection<ResourceLocation> researchIds)
+        {
+            JsonArray removes = new JsonArray();
+            for(ResourceLocation rem : researchIds)
+            {
+                removes.add(rem.toString());
+            }
+            this.json.add("remove", removes);
+            return this;
+        }
+
+        /**
          * Add the Research to a collection, and return the same research.
          * essentially the same as List.add() with a useful return.
          * @param list      The list to add the Research onto.
@@ -876,6 +916,47 @@ public abstract class AbstractResearchProvider implements IDataProvider
         public ResearchBranch setHidden(final boolean hidden)
         {
             this.json.addProperty("hidden", hidden);
+            return this;
+        }
+
+        /**
+         * Sets the Research Branch JSON to remove all researches attached to its branch.
+         * Avoid use where stacking data packs are possible, as only last JSON for a ResourceLocation wins.
+         * Not compatible with other variants of setRemove.
+         * @return this
+         */
+        public ResearchBranch setRemove()
+        {
+            this.json.addProperty("remove", true);
+            return this;
+        }
+
+        /**
+         * Sets the Research Branch JSON to remove a different branch and all dependent researches, by ResourceLocation.
+         * Not compatible with other variants of setRemove.
+         * @param branchId  The target research branch.
+         * @return this
+         */
+        public ResearchBranch setRemove(final ResourceLocation branchId)
+        {
+            this.json.addProperty("remove", branchId.toString());
+            return this;
+        }
+
+        /**
+         * Sets the Research JSON to remove different branches and all dependent researches, by ResourceLocation.
+         * Not compatible with other variants of setRemove.
+         * @param branchIds  The target research branch.
+         * @return this
+         */
+        public ResearchBranch setRemove(final Collection<ResourceLocation> branchIds)
+        {
+            final JsonArray removes = new JsonArray();
+            for(ResourceLocation rem : branchIds)
+            {
+                removes.add(rem.toString());
+            }
+            this.json.add("remove", removes);
             return this;
         }
     }

--- a/src/api/java/com/minecolonies/api/research/AbstractResearchProvider.java
+++ b/src/api/java/com/minecolonies/api/research/AbstractResearchProvider.java
@@ -927,6 +927,7 @@ public abstract class AbstractResearchProvider implements IDataProvider
          */
         public ResearchBranch setRemove()
         {
+            this.json.addProperty("base-time", 1.0);
             this.json.addProperty("remove", true);
             return this;
         }
@@ -939,6 +940,7 @@ public abstract class AbstractResearchProvider implements IDataProvider
          */
         public ResearchBranch setRemove(final ResourceLocation branchId)
         {
+            this.json.addProperty("base-time", 1.0);
             this.json.addProperty("remove", branchId.toString());
             return this;
         }
@@ -951,6 +953,7 @@ public abstract class AbstractResearchProvider implements IDataProvider
          */
         public ResearchBranch setRemove(final Collection<ResourceLocation> branchIds)
         {
+            this.json.addProperty("base-time", 1.0);
             final JsonArray removes = new JsonArray();
             for(ResourceLocation rem : branchIds)
             {

--- a/src/main/java/com/minecolonies/coremod/datalistener/ResearchListener.java
+++ b/src/main/java/com/minecolonies/coremod/datalistener/ResearchListener.java
@@ -8,22 +8,23 @@ import com.minecolonies.api.research.IResearchRequirement;
 import com.minecolonies.api.research.effects.IResearchEffect;
 import com.minecolonies.api.util.Log;
 
+import com.minecolonies.api.util.Tuple;
 import com.minecolonies.coremod.research.GlobalResearch;
 import com.minecolonies.coremod.research.GlobalResearchBranch;
 import com.minecolonies.coremod.research.ResearchEffectCategory;
-import net.minecraft.client.MinecraftGame;
 import net.minecraft.client.resources.JsonReloadListener;
 import net.minecraft.entity.player.ServerPlayerEntity;
 import net.minecraft.profiler.IProfiler;
 import net.minecraft.resources.IResourceManager;
 import net.minecraft.server.MinecraftServer;
 import net.minecraft.server.dedicated.DedicatedServer;
-import net.minecraft.server.integrated.IntegratedServer;
 import net.minecraft.util.ResourceLocation;
 import net.minecraftforge.fml.server.ServerLifecycleHooks;
 import org.jetbrains.annotations.NotNull;
 
+import java.util.Collection;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Map;
 
 import static com.minecolonies.coremod.research.GlobalResearch.*;
@@ -61,16 +62,16 @@ public class ResearchListener extends JsonReloadListener
         // For now, we'll populate relative levels when doing so, but we probably want to do that dynamically.
         final Map<ResourceLocation, ResearchEffectCategory> effectCategories = parseResearchEffects(object);
 
+        // We /shouldn't/ get any removes before the Research they're trying to remove exists,
+        // but it can happen if multiple data packs affect each other.
+        // Instead, get lists of research locations for researches and branches to not load and quit their parsing early.
+        final Tuple<Collection<ResourceLocation>,Collection<ResourceLocation>> removeResearchesAndBranches = parseRemoveResearches(object);
+
         // Next, populate a new map of IGlobalResearches, identified by researchID.
         // This allows us to figure out root/branch relationships more sanely.
         // We need the effectCategories and levels to do this.
         MinecraftServer server = ServerLifecycleHooks.getCurrentServer();
-        final Map<ResourceLocation, GlobalResearch> researchMap = parseResearches(object, effectCategories, !(server instanceof DedicatedServer));
-
-        // We /shouldn't/ get any removes before the Research they're trying to remove exists,
-        // but it can happen if multiple data packs affect each other.
-        // So now that we've loaded everything, then we can start removes.
-        parseRemoveResearches(object, researchMap);
+        final Map<ResourceLocation, GlobalResearch> researchMap = parseResearches(object, effectCategories, removeResearchesAndBranches.getA(), removeResearchesAndBranches.getB(), !(server instanceof DedicatedServer));
 
         // After we've loaded all researches, we can then try to assign child relationships.
         // This is also the phase where we'd try to support back-calculating university levels for researches without them/with incorrect ones.
@@ -84,7 +85,7 @@ public class ResearchListener extends JsonReloadListener
         // For dedicated servers, send to any connected players.  On startup, this will be no-one.
         // But it is possible to reload data packs live, and while not supported it's something to handle.
         // This event fires early enough on the server start lifecycle that server isn't initialized.
-        // We only need to send to players during a datapack reload event during live play.
+        // We only need to send to players during a data pack reload event during live play.
         if(server != null)
         {
             for (ServerPlayerEntity player : server.getPlayerList().getPlayers())
@@ -156,14 +157,25 @@ public class ResearchListener extends JsonReloadListener
      *
      * @param object             A Map containing the resource location of each json file, and the element within that json file.
      * @param effectCategories   A Map containing the effect categories by effectId.
+     * @param removeResearches   A Collection of researches to remove, if present.
+     * @param removeBranches     A Collection of research branches to remove, including all component researches, if present.
      * @param checkResourceLoc   If the client should check resource locations at the time.  This can not be run on the server.
      * @return                   A Map containing the ResearchIds and the GlobalResearches each ID corresponds to.
      */
-    private Map<ResourceLocation, GlobalResearch> parseResearches(final Map<ResourceLocation, JsonElement> object, final Map<ResourceLocation, ResearchEffectCategory> effectCategories, boolean checkResourceLoc)
+    private Map<ResourceLocation, GlobalResearch> parseResearches(final Map<ResourceLocation, JsonElement> object, final Map<ResourceLocation, ResearchEffectCategory> effectCategories, final Collection<ResourceLocation> removeResearches, final Collection<ResourceLocation> removeBranches, boolean checkResourceLoc)
     {
         final Map<ResourceLocation, GlobalResearch> researchMap = new HashMap<>();
         for(final Map.Entry<ResourceLocation, JsonElement> entry : object.entrySet())
         {
+            // Cancel removed individual researches first, to save parsing time.
+            if(removeResearches.contains(entry.getKey()))
+            {
+                if(MinecoloniesAPIProxy.getInstance().getConfig().getServer().researchDebugLog.get())
+                {
+                    Log.getLogger().info(entry.getKey() + " was removed by data pack.");
+                }
+                continue;
+            }
             // Note that we don't actually use the resource folders or file names; those are only for organization purposes.
             final JsonObject researchJson = entry.getValue().getAsJsonObject();
 
@@ -182,17 +194,27 @@ public class ResearchListener extends JsonReloadListener
             //And same for research-branch-specific settings, to avoid extraneous warnings.
             if (researchJson.has(RESEARCH_BRANCH_NAME_PROP) || researchJson.has(RESEARCH_BASE_TIME_PROP) || researchJson.has(RESEARCH_BRANCH_TYPE_PROP))
             {
-                Log.getLogger().warn(entry.getKey() + " is a branch json.");
                 continue;
             }
 
-
             //Check for absolute minimum required types, and log as warning if malformed.
-            if (MinecoloniesAPIProxy.getInstance().getConfig().getServer().researchDebugLog.get() &&
-                  !(researchJson.has(RESEARCH_BRANCH_PROP) && researchJson.get(RESEARCH_BRANCH_PROP).isJsonPrimitive()
+            if (!(researchJson.has(RESEARCH_BRANCH_PROP) && researchJson.get(RESEARCH_BRANCH_PROP).isJsonPrimitive()
                          && researchJson.get(RESEARCH_BRANCH_PROP).getAsJsonPrimitive().isString()))
             {
-                Log.getLogger().warn(entry.getKey() + " is a Research , but does not contain all required fields.  Researches must have a branch:string properties.");
+                if(MinecoloniesAPIProxy.getInstance().getConfig().getServer().researchDebugLog.get())
+                {
+                    Log.getLogger().warn(entry.getKey() + " is a Research , but does not contain all required fields.  Researches must have a branch:string properties.");
+                }
+                continue;
+            }
+
+            // Now that we've confirmed a branch exists at all, cancel the add if it's from a removed branch.
+            else if(removeBranches.contains(new ResourceLocation(researchJson.get(RESEARCH_BRANCH_PROP).getAsString())))
+            {
+                if(MinecoloniesAPIProxy.getInstance().getConfig().getServer().researchDebugLog.get())
+                {
+                    Log.getLogger().info(entry.getKey() + " was removed, as its branch had been removed by data pack.");
+                }
                 continue;
             }
 
@@ -232,28 +254,82 @@ public class ResearchListener extends JsonReloadListener
      * Parses out a researches map for elements containing Remove properties, and applies those removals to the researchMap
      *
      * @param object        A Map containing the resource location of each json file, and the element within that json file.
-     * @param researchMap   A Map to apply those Research Removes against.
+     * @return              A Tuple containing resource locations of Researches (A) and Branches (B) to remove from the global research tree.
      */
-    private void parseRemoveResearches(final Map<ResourceLocation, JsonElement> object, final Map<ResourceLocation, GlobalResearch> researchMap)
+    private Tuple<Collection<ResourceLocation>, Collection<ResourceLocation>> parseRemoveResearches(final Map<ResourceLocation, JsonElement> object)
     {
-        for(final Map.Entry<ResourceLocation, JsonElement> entry : object.entrySet())
+        Collection<ResourceLocation> removeResearches = new HashSet<>();
+        Collection<ResourceLocation> removeBranches = new HashSet<>();
+        for (final Map.Entry<ResourceLocation, JsonElement> entry : object.entrySet())
         {
             final JsonObject researchJson = entry.getValue().getAsJsonObject();
 
-            // Users could plausibly want to remove a research json without depending on the Minecraft override behavior.
-            // This would mostly be relevant for multiple overlapping data packs, which may have unpredictable load orders.
-            // The json for such a removal can have an arbitrary filename, and the remove property points to the specific json to remove.
-            if (researchJson.has(RESEARCH_REMOVE_PROP) && researchJson.get(RESEARCH_REMOVE_PROP).getAsJsonPrimitive().isString())
+            if (researchJson.has(RESEARCH_REMOVE_PROP))
             {
-                //hashmap, so don't have to check presence.
-                researchMap.remove(new ResourceLocation(researchJson.get(RESEARCH_REMOVE_PROP).getAsString()));
-            }
-            // Files which declare remove:, but lack ID or have the wrong types are malformed.
-            else if (researchJson.has(RESEARCH_REMOVE_PROP))
-            {
-                Log.getLogger().error(entry.getKey() + " is a research remove, but does not contain all required fields.  Research Removes must have remove:boolean and id:string.");
+                // Removing an entire branch, and all research on that branch.
+                if(researchJson.has(RESEARCH_BRANCH_NAME_PROP) || researchJson.has(RESEARCH_BASE_TIME_PROP))
+                {
+                    // Accept arrays, if the data pack makers wants to remove multiple branches.
+                    if(researchJson.get(RESEARCH_REMOVE_PROP).isJsonArray())
+                    {
+                        for(final JsonElement remove : researchJson.get(RESEARCH_REMOVE_PROP).getAsJsonArray())
+                        {
+                            if(remove.isJsonPrimitive() && remove.getAsJsonPrimitive().isString())
+                            {
+                                removeBranches.add(new ResourceLocation(remove.getAsString()));
+                            }
+                        }
+                    }
+
+                    // Accept individual strings.
+                    // Users could plausibly want to remove a research json without depending on the Minecraft override behavior.
+                    // This would mostly be relevant for multiple overlapping data packs, which may have unpredictable load orders.
+                    // The json for such a removal can have an arbitrary filename, and the remove property points to the specific json to remove.
+                    else if(researchJson.get(RESEARCH_REMOVE_PROP).isJsonPrimitive() && researchJson.get(RESEARCH_REMOVE_PROP).getAsJsonPrimitive().isString())
+                    {
+                        removeBranches.add(new ResourceLocation(researchJson.get(RESEARCH_REMOVE_PROP).getAsJsonPrimitive().getAsString()));
+                    }
+                    // Lastly, accept just boolean true, for the simple case of removing this particular branch and all component researches.
+                    else if(researchJson.get(RESEARCH_REMOVE_PROP).isJsonPrimitive() && researchJson.get(RESEARCH_REMOVE_PROP).getAsJsonPrimitive().isBoolean()
+                              && researchJson.get(RESEARCH_REMOVE_PROP).getAsBoolean())
+                    {
+                        removeBranches.add(entry.getKey());
+                    }
+                }
+
+                // Users could plausibly want to remove a research json without depending on the Minecraft override behavior.
+                // This would mostly be relevant for multiple overlapping data packs, which may have unpredictable load orders.
+                // The json for such a removal can have an arbitrary filename, and the remove property points to the specific json to remove.
+                else if (researchJson.get(RESEARCH_REMOVE_PROP).isJsonArray())
+                {
+                    for (final JsonElement remove : researchJson.get(RESEARCH_REMOVE_PROP).getAsJsonArray())
+                    {
+                        if (remove.isJsonPrimitive() && remove.getAsJsonPrimitive().isString())
+                        {
+                            removeResearches.add(new ResourceLocation(remove.getAsString()));
+                        }
+                    }
+                }
+                // Removing individual researches by name.
+                else if (researchJson.get(RESEARCH_REMOVE_PROP).isJsonPrimitive() && researchJson.get(RESEARCH_REMOVE_PROP).getAsJsonPrimitive().isString())
+                {
+                    removeResearches.add(new ResourceLocation(researchJson.get(RESEARCH_REMOVE_PROP).getAsString()));
+                }
+                // Removes with a boolean true, but are not branch removes.
+                else if (researchJson.get(RESEARCH_REMOVE_PROP).isJsonPrimitive() && researchJson.get(RESEARCH_REMOVE_PROP).getAsJsonPrimitive().isBoolean()
+                           && researchJson.get(RESEARCH_REMOVE_PROP).getAsBoolean())
+                {
+                    removeResearches.add(entry.getKey());
+                }
+                // Files which declare remove, but are malformed should be reported to help diagnose the error.
+                else
+                {
+                    Log.getLogger()
+                      .error(entry.getKey() + " is a research remove, but does not contain all required fields.  Research Removes must have remove:boolean and id:string.");
+                }
             }
         }
+        return new Tuple<>(removeResearches, removeBranches);
     }
 
     /**
@@ -289,20 +365,20 @@ public class ResearchListener extends JsonReloadListener
                     }
                     else
                     {
-                        //For now, log and re-graft entries with inconsistent parent-child relationships to a separate branch.
-                        entry.setValue(new GlobalResearch(entry.getValue().getId(), entry.getValue().getBranch(), 1, entry.getValue().getEffects(),
-                          entry.getValue().getIconTextureResourceLocation(), entry.getValue().getIconItemStack(), entry.getValue().isImmutable()));
                         Log.getLogger()
                           .error(entry.getValue().getBranch() + "/" + entry.getKey() + "could not be attached to " + entry.getValue().getParent() + " on "
                                    + researchMap.get(entry.getValue().getParent()).getBranch());
+                        //For now, log and re-graft entries with inconsistent parent-child relationships as a separate primary research.
+                        entry.setValue(new GlobalResearch(entry.getValue().getId(), entry.getValue().getBranch(), 1, entry.getValue().getEffects(),
+                          entry.getValue().getIconTextureResourceLocation(), entry.getValue().getIconItemStack(), entry.getValue().isImmutable()));
                     }
                 }
                 else
                 {
-                    //For now, log and re-graft entries with inconsistent parent-child relationships to a separate branch.
+                    Log.getLogger().error(entry.getValue().getBranch() + "/" + entry.getKey() + " could not find parent " + entry.getValue().getParent());
+                    //For now, log and re-graft entries with inconsistent parent-child relationships as a separate primary research.
                     entry.setValue(new GlobalResearch(entry.getValue().getId(), entry.getValue().getBranch(), 1, entry.getValue().getEffects(),
                       entry.getValue().getIconTextureResourceLocation(), entry.getValue().getIconItemStack(), entry.getValue().isImmutable()));
-                    Log.getLogger().error(entry.getValue().getBranch() + "/" + entry.getKey() + " could not find parent " + entry.getValue().getParent());
                 }
             }
             researchTree.addResearch(entry.getValue().getBranch(), entry.getValue(), true);

--- a/src/main/java/com/minecolonies/coremod/research/GlobalResearch.java
+++ b/src/main/java/com/minecolonies/coremod/research/GlobalResearch.java
@@ -285,6 +285,7 @@ public class GlobalResearch implements IGlobalResearch
         this.id = id;
         final String autogenKey = "com." + this.id.getNamespace() + ".research." + this.id.getPath().replaceAll("[ /]",".");
         this.name = new TranslationTextComponent(autogenKey + ".name");
+        this.parent = new ResourceLocation("");
         this.subtitle = new TranslationTextComponent("");
         this.effects.addAll(effects);
         this.depth = universityLevel;


### PR DESCRIPTION
# Changes proposed in this pull request:
- Researches now support the `remove` tag in separate string (to remove a single other research), array-of-strings (to remove multiple other researches), and boolean (to remove themselves) modes.  All strings must be valid as resource locations, even if pointing to non-existent targets.
- Yes, boolean is kinda superfluous.  I'd also caution against it in a multi-data-pack environment, as there doesn't seem to be many guarantees for ordering if multiple file-based data packs effect the same (non-Tag) file.  But it's easy.
- Research branches (that is, files containing at least one of `base-time` or `branch-name`) now support the `remove` tag.  They support string (to remove a single other research branch), array-of-string (to remove a group of research branches), and boolean modes (to remove itself) modes.  Removing a research branch disables its from the University, and removes all researches on it from the GlobalResearchTree.  This should have all relevant effects act as if on default behavior -- effect strengths should act at zero, but huts will default to unlocked.
- Adds implementations for those settings into AbstractResearchProvider's internal classes, which probably won't have much use beyond testing or outside developer work.
- Switched up handling of removes into a more ordered approach in ResearchListener.  More a code cleanup thing than a performance improvement.
- Some fixes for inconsistent research trees, such as invalid parent-child relationships or incoherent researchLevels.  This should also improve stability for reloading research data packs on a live instance with `remove` effects, but there's still a bit to be done there, and even the final version probably won't be able to guarantee consistency or data retention in all cases.  On the other hand, don't expect people to be turning them on and off on a live world anyway.

Review please
