### PR TITLE
Fix deletion of all recipes

### DIFF
--- a/src/main/java/com/minecolonies/coremod/colony/buildings/AbstractBuildingWorker.java
+++ b/src/main/java/com/minecolonies/coremod/colony/buildings/AbstractBuildingWorker.java
@@ -577,7 +577,6 @@ public abstract class AbstractBuildingWorker extends AbstractBuilding implements
             final IToken<?> token = StandardFactoryController.getInstance().deserialize(recipesTags.getCompound(i));
             if (!recipes.contains(token)) 
             {
-                // We can't existance check with the global collection here, because it's often zero length when this code runs. 
                 recipes.add(token);
                 IColonyManager.getInstance().getRecipeManager().registerUse(token);
             }
@@ -745,10 +744,11 @@ public abstract class AbstractBuildingWorker extends AbstractBuilding implements
             buf.writeInt(data == null ? 0 : data.getId());
         }
         final List<IRecipeStorage> storages = new ArrayList<>();
+        Map<ResourceLocation, CustomRecipe> crafterRecipes = CustomRecipeManager.getInstance().getAllRecipes().get(getJobName());
         for (final IToken<?> token : new ArrayList<>(recipes))
         {
             final IRecipeStorage storage = IColonyManager.getInstance().getRecipeManager().getRecipes().get(token);
-            if (storage == null)
+            if (storage == null || (storage.getRecipeSource() != null && !crafterRecipes.containsKey(storage.getRecipeSource())))
             {
                 removeRecipe(token);
             }
@@ -956,16 +956,6 @@ public abstract class AbstractBuildingWorker extends AbstractBuilding implements
             }
         }
 
-        //Make a pass through our building recipes, and make sure the custom recipes still exist. 
-        Map<ResourceLocation, CustomRecipe> crafterRecipes = CustomRecipeManager.getInstance().getAllRecipes().get(getJobName());
-        for(IToken<?> token : ImmutableList.copyOf(recipes))
-        {
-            final IRecipeStorage recipe = IColonyManager.getInstance().getRecipeManager().getRecipes().get(token);
-            if (recipe != null && recipe.getRecipeSource() != null && !crafterRecipes.containsKey(recipe.getRecipeSource()))
-            {
-                removeRecipe(token);
-            }
-        }
         markDirty();
     }
 

--- a/src/main/java/com/minecolonies/coremod/colony/buildings/AbstractBuildingWorker.java
+++ b/src/main/java/com/minecolonies/coremod/colony/buildings/AbstractBuildingWorker.java
@@ -575,7 +575,7 @@ public abstract class AbstractBuildingWorker extends AbstractBuilding implements
         for (int i = 0; i < recipesTags.size(); i++)
         {
             final IToken<?> token = StandardFactoryController.getInstance().deserialize(recipesTags.getCompound(i));
-            if (!recipes.contains(token)) 
+            if (!recipes.contains(token))
             {
                 recipes.add(token);
                 IColonyManager.getInstance().getRecipeManager().registerUse(token);
@@ -955,7 +955,6 @@ public abstract class AbstractBuildingWorker extends AbstractBuilding implements
                 }
             }
         }
-
         markDirty();
     }
 


### PR DESCRIPTION
# Changes proposed in this pull request:
- Remove global existence check while deserializing buildings. The global collection is often empty at this stage
- Add code to remove no longer existing custom recipes from crafters

The second change I was testing when I fixed the first. Both are very simple. 

I'll do a follow up PR to re-instate the global existence check as a once-run during checkForCrafterSpecificRecipes, so it runs on the first colonytick handled by the building. 

Review please
