### PR TITLE
Stop monsters spawn, mark dirty on change, buildingmanager cleanup

### DIFF
--- a/src/api/java/com/minecolonies/api/colony/buildings/IBuilding.java
+++ b/src/api/java/com/minecolonies/api/colony/buildings/IBuilding.java
@@ -396,10 +396,10 @@ public interface IBuilding extends IBuildingContainer, IRequestResolverProvider,
 
     /**
      * Check if a certain vec is within this building.
-     * @param positionVec the vec to check.
+     * @param pos the pos to check.
      * @return true if so.
      */
-    boolean isInBuilding(Vector3d positionVec);
+    boolean isInBuilding(@NotNull final BlockPos pos);
 
     /**
      * Get a map of all open requests by type.

--- a/src/api/java/com/minecolonies/api/colony/managers/interfaces/IBuildingManager.java
+++ b/src/api/java/com/minecolonies/api/colony/managers/interfaces/IBuildingManager.java
@@ -86,6 +86,13 @@ public interface IBuildingManager
     IWareHouse getClosestWarehouseInColony(BlockPos pos);
 
     /**
+     * check fi a position is inside one of the buildings.
+     * @param pos the position to check.
+     * @return true if so.
+     */
+    boolean isInsideBuilding(@NotNull final BlockPos pos);
+
+    /**
      * Returns a map with all buildings within the colony. Key is ID (Coordinates), value is building object.
      *
      * @return Map with ID (coordinates) as key, and buildings as value.

--- a/src/api/java/com/minecolonies/api/colony/managers/interfaces/IBuildingManager.java
+++ b/src/api/java/com/minecolonies/api/colony/managers/interfaces/IBuildingManager.java
@@ -86,13 +86,6 @@ public interface IBuildingManager
     IWareHouse getClosestWarehouseInColony(BlockPos pos);
 
     /**
-     * check fi a position is inside one of the buildings.
-     * @param pos the position to check.
-     * @return true if so.
-     */
-    boolean isInsideBuilding(@NotNull final BlockPos pos);
-
-    /**
      * Returns a map with all buildings within the colony. Key is ID (Coordinates), value is building object.
      *
      * @return Map with ID (coordinates) as key, and buildings as value.

--- a/src/api/java/com/minecolonies/api/util/WorldUtil.java
+++ b/src/api/java/com/minecolonies/api/util/WorldUtil.java
@@ -314,7 +314,7 @@ public class WorldUtil
                         {
                             for (final T entity : chunk.getEntityLists()[y].getByClass(clazz))
                             {
-                                if (building.isInBuilding(entity.getPositionVec()) && (predicate == null || predicate.test(entity)))
+                                if (building.isInBuilding(entity.getPosition()) && (predicate == null || predicate.test(entity)))
                                 {
                                     list.add(entity);
                                 }

--- a/src/main/java/com/minecolonies/coremod/colony/buildings/AbstractBuildingWorker.java
+++ b/src/main/java/com/minecolonies/coremod/colony/buildings/AbstractBuildingWorker.java
@@ -927,6 +927,7 @@ public abstract class AbstractBuildingWorker extends AbstractBuilding implements
                 {
                     addRecipeToList(recipeToken, true);
                     colony.getRequestManager().onColonyUpdate(request -> request.getRequest() instanceof IDeliverable && ((IDeliverable) request.getRequest()).matches(recipeStorage.getPrimaryOutput()));
+                    markDirty();
                 }
                 else if((forceReplace || newRecipe.getMustExist()) && !(duplicateFound.equals(recipeToken)))
                 {
@@ -945,6 +946,7 @@ public abstract class AbstractBuildingWorker extends AbstractBuilding implements
                         }
                     }
                     colony.getRequestManager().onColonyUpdate(request -> request.getRequest() instanceof IDeliverable && recipeStorage.getAlternateOutputs().stream().anyMatch(i -> ((IDeliverable) request.getRequest()).matches(i)));
+                    markDirty();
                 }
             }
             else
@@ -952,10 +954,10 @@ public abstract class AbstractBuildingWorker extends AbstractBuilding implements
                 if(recipes.contains(recipeToken))
                 {
                     removeRecipe(recipeToken);
+                    markDirty();
                 }
             }
         }
-        markDirty();
     }
 
 

--- a/src/main/java/com/minecolonies/coremod/colony/buildings/AbstractSchematicProvider.java
+++ b/src/main/java/com/minecolonies/coremod/colony/buildings/AbstractSchematicProvider.java
@@ -17,6 +17,7 @@ import net.minecraft.util.Tuple;
 import net.minecraft.util.math.AxisAlignedBB;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.math.vector.Vector3d;
+import org.jetbrains.annotations.NotNull;
 
 import static com.minecolonies.api.util.constant.NbtTagConstants.*;
 
@@ -322,7 +323,7 @@ public abstract class AbstractSchematicProvider implements ISchematicProvider, I
     }
 
     @Override
-    public boolean isInBuilding(final Vector3d positionVec)
+    public boolean isInBuilding(@NotNull final BlockPos positionVec)
     {
         final Tuple<BlockPos, BlockPos> corners = getCorners();
         return positionVec.getX() >= corners.getA().getX() - 1 && positionVec.getX() <= corners.getB().getX() + 1

--- a/src/main/java/com/minecolonies/coremod/colony/managers/BuildingManager.java
+++ b/src/main/java/com/minecolonies/coremod/colony/managers/BuildingManager.java
@@ -38,7 +38,6 @@ import net.minecraft.nbt.CompoundNBT;
 import net.minecraft.nbt.ListNBT;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.math.BlockPos;
-import net.minecraft.util.math.vector.Vector3d;
 import net.minecraft.world.World;
 import net.minecraft.world.chunk.Chunk;
 import net.minecraftforge.common.util.Constants;
@@ -335,19 +334,6 @@ public class BuildingManager implements IBuildingManager
             return capList != null && capList.size() >= MineColonies.getConfig().getServer().colonyLoadStrictness.get();
         }
 
-        return false;
-    }
-
-    @Override
-    public boolean isInsideBuilding(@NotNull final BlockPos pos)
-    {
-        for (final IBuilding building : buildings.values())
-        {
-            if (building.isInBuilding(new Vector3d(pos.getX(), pos.getY(), pos.getZ())))
-            {
-                return true;
-            }
-        }
         return false;
     }
 

--- a/src/main/java/com/minecolonies/coremod/event/EventHandler.java
+++ b/src/main/java/com/minecolonies/coremod/event/EventHandler.java
@@ -390,18 +390,18 @@ public class EventHandler
             return;
         }
 
-        final IColonyTagCapability newCloseColonies = ((World) event.getWorld()).getChunkAt(pos).getCapability(CLOSE_COLONY_CAP, null).resolve().orElse(null);
-        if (newCloseColonies == null || newCloseColonies.getOwningColony() == 0)
+        final IColonyTagCapability closeColonyCap = ((World) event.getWorld()).getChunkAt(pos).getCapability(CLOSE_COLONY_CAP, null).resolve().orElse(null);
+        if (closeColonyCap == null || closeColonyCap.getOwningColony() == 0)
         {
             return;
         }
-        final IColony newColony = IColonyManager.getInstance().getColonyByWorld(newCloseColonies.getOwningColony(), (World) event.getWorld());
+        final IColony newColony = IColonyManager.getInstance().getColonyByWorld(closeColonyCap.getOwningColony(), (World) event.getWorld());
         if (newColony == null)
         {
             return;
         }
 
-        for (final BlockPos buildingPos : newCloseColonies.getAllClaimingBuildings().getOrDefault(newCloseColonies.getOwningColony(), Collections.emptySet()))
+        for (final BlockPos buildingPos : closeColonyCap.getAllClaimingBuildings().getOrDefault(closeColonyCap.getOwningColony(), Collections.emptySet()))
         {
             final IBuilding building = newColony.getBuildingManager().getBuilding(buildingPos);
             if (building != null && building.getBuildingLevel() >= 1 && building.isInBuilding(pos))

--- a/src/main/java/com/minecolonies/coremod/event/EventHandler.java
+++ b/src/main/java/com/minecolonies/coremod/event/EventHandler.java
@@ -404,7 +404,7 @@ public class EventHandler
         for (final BlockPos buildingPos : newCloseColonies.getAllClaimingBuildings().getOrDefault(newCloseColonies.getOwningColony(), Collections.emptySet()))
         {
             final IBuilding building = newColony.getBuildingManager().getBuilding(buildingPos);
-            if (building != null && building.isInBuilding(pos))
+            if (building != null && building.getBuildingLevel() >= 1 && building.isInBuilding(pos))
             {
                 event.setCanceled(true);
             }

--- a/src/main/java/com/minecolonies/coremod/permissions/ColonyPermissionEventHandler.java
+++ b/src/main/java/com/minecolonies/coremod/permissions/ColonyPermissionEventHandler.java
@@ -12,7 +12,6 @@ import com.minecolonies.api.entity.citizen.AbstractEntityCitizen;
 import com.minecolonies.api.items.ModTags;
 import com.minecolonies.api.util.EntityUtils;
 import com.minecolonies.api.util.ItemStackUtils;
-import com.minecolonies.api.util.WorldUtil;
 import com.minecolonies.api.util.constant.Constants;
 import com.minecolonies.coremod.MineColonies;
 import com.minecolonies.coremod.blocks.huts.BlockHutTownHall;
@@ -40,7 +39,6 @@ import net.minecraft.world.World;
 import net.minecraftforge.common.util.FakePlayer;
 import net.minecraftforge.event.entity.item.ItemTossEvent;
 import net.minecraftforge.event.entity.living.LivingHurtEvent;
-import net.minecraftforge.event.entity.living.LivingSpawnEvent;
 import net.minecraftforge.event.entity.player.*;
 import net.minecraftforge.event.world.BlockEvent;
 import net.minecraftforge.event.world.ExplosionEvent;
@@ -566,27 +564,6 @@ public class ColonyPermissionEventHandler
             if (!(event.getTarget() instanceof MobEntity) && !perms.hasPermission(event.getPlayer(), Action.ATTACK_ENTITY))
             {
                 cancelEvent(event, event.getPlayer(), colony, Action.ATTACK_ENTITY, new BlockPos(event.getTarget().getPositionVec()));
-            }
-        }
-    }
-
-    /**
-     * Join world event.
-     * @param event the join world event.
-     */
-    @SubscribeEvent
-    public void on(final LivingSpawnEvent.CheckSpawn event)
-    {
-        final BlockPos pos = new BlockPos(event.getX(), event.getY(), event.getZ());
-        if (event.isSpawner() || event.getWorld().isRemote() || !WorldUtil.isEntityBlockLoaded(event.getWorld(), pos))
-        {
-            return;
-        }
-        if (colony.isCoordInColony((World) event.getWorld(), pos))
-        {
-            if (event.getEntity() instanceof MonsterEntity && colony.getBuildingManager().isInsideBuilding(pos))
-            {
-                event.setCanceled(true);
             }
         }
     }

--- a/src/main/java/com/minecolonies/coremod/permissions/ColonyPermissionEventHandler.java
+++ b/src/main/java/com/minecolonies/coremod/permissions/ColonyPermissionEventHandler.java
@@ -12,6 +12,7 @@ import com.minecolonies.api.entity.citizen.AbstractEntityCitizen;
 import com.minecolonies.api.items.ModTags;
 import com.minecolonies.api.util.EntityUtils;
 import com.minecolonies.api.util.ItemStackUtils;
+import com.minecolonies.api.util.WorldUtil;
 import com.minecolonies.api.util.constant.Constants;
 import com.minecolonies.coremod.MineColonies;
 import com.minecolonies.coremod.blocks.huts.BlockHutTownHall;
@@ -25,6 +26,7 @@ import net.minecraft.block.BlockState;
 import net.minecraft.block.ContainerBlock;
 import net.minecraft.entity.Entity;
 import net.minecraft.entity.MobEntity;
+import net.minecraft.entity.monster.MonsterEntity;
 import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.entity.player.ServerPlayerEntity;
 import net.minecraft.item.ItemStack;
@@ -38,6 +40,7 @@ import net.minecraft.world.World;
 import net.minecraftforge.common.util.FakePlayer;
 import net.minecraftforge.event.entity.item.ItemTossEvent;
 import net.minecraftforge.event.entity.living.LivingHurtEvent;
+import net.minecraftforge.event.entity.living.LivingSpawnEvent;
 import net.minecraftforge.event.entity.player.*;
 import net.minecraftforge.event.world.BlockEvent;
 import net.minecraftforge.event.world.ExplosionEvent;
@@ -532,7 +535,7 @@ public class ColonyPermissionEventHandler
     @SubscribeEvent
     public void on(final AttackEntityEvent event)
     {
-        if (event.getTarget() instanceof MobEntity)
+        if (event.getTarget() instanceof MonsterEntity)
         {
             return;
         }
@@ -563,6 +566,27 @@ public class ColonyPermissionEventHandler
             if (!(event.getTarget() instanceof MobEntity) && !perms.hasPermission(event.getPlayer(), Action.ATTACK_ENTITY))
             {
                 cancelEvent(event, event.getPlayer(), colony, Action.ATTACK_ENTITY, new BlockPos(event.getTarget().getPositionVec()));
+            }
+        }
+    }
+
+    /**
+     * Join world event.
+     * @param event the join world event.
+     */
+    @SubscribeEvent
+    public void on(final LivingSpawnEvent.CheckSpawn event)
+    {
+        final BlockPos pos = new BlockPos(event.getX(), event.getY(), event.getZ());
+        if (event.isSpawner() || event.getWorld().isRemote() || !WorldUtil.isEntityBlockLoaded(event.getWorld(), pos))
+        {
+            return;
+        }
+        if (colony.isCoordInColony((World) event.getWorld(), pos))
+        {
+            if (event.getEntity() instanceof MonsterEntity && colony.getBuildingManager().isInsideBuilding(pos))
+            {
+                event.setCanceled(true);
             }
         }
     }


### PR DESCRIPTION


# Changes proposed in this pull request:
- Mark dirt only on actual changes to avoid overhead
- Cleanup building manager a little bit
- Stop entity spawning within building zones

Review please
