### PR TITLE
Add JEI recipe transfer for furnace (mostly for Stone Smeltery).

### DIFF
--- a/src/api/java/com/minecolonies/api/inventory/container/ContainerCraftingFurnace.java
+++ b/src/api/java/com/minecolonies/api/inventory/container/ContainerCraftingFurnace.java
@@ -297,11 +297,8 @@ public class ContainerCraftingFurnace extends Container
             final ServerPlayerEntity player = (ServerPlayerEntity) playerInventory.player;
             final ItemStack result = IMinecoloniesAPI.getInstance().getFurnaceRecipes().getSmeltingResult(furnaceInventory.getStackInSlot(0));
 
-            if (result != ItemStack.EMPTY)
-            {
-                this.furnaceInventory.insertItem(1, result, false);
-                player.connection.sendPacket(new SSetSlotPacket(this.windowId, 1, result));
-            }
+            this.furnaceInventory.insertItem(1, result, false);
+            player.connection.sendPacket(new SSetSlotPacket(this.windowId, 1, result));
         }
     }
 

--- a/src/api/java/com/minecolonies/api/util/constant/TranslationConstants.java
+++ b/src/api/java/com/minecolonies/api/util/constant/TranslationConstants.java
@@ -218,8 +218,6 @@ public final class TranslationConstants
     @NonNls
     public static final String TOGGLE_REPLANT_SAPLINGS_OFF                                          = "com.minecolonies.coremod.gui.workerhuts.togglereplantsaplingsoff";
     @NonNls
-    public static final String COM_MINECOLONIES_COREMOD_COMPAT_JEI_CRAFTIN_TEACHING_UNKNOWN_RECIPE  = "com.minecolonies.coremod.compat.jei.crafting.teaching.unknown.recipe";
-    @NonNls
     public static final String DO_REALLY_WANNA_TP                                                   = "com.minecolonies.coremod.gui.townhall.tp";
     @NonNls
     public static final String TH_TOO_LOW                                                           = "com.minecolonies.coremod.gui.townhall.tooLow";

--- a/src/main/java/com/minecolonies/coremod/compatibility/jei/JEIPlugin.java
+++ b/src/main/java/com/minecolonies/coremod/compatibility/jei/JEIPlugin.java
@@ -6,7 +6,8 @@ import com.minecolonies.api.colony.jobs.ModJobs;
 import com.minecolonies.api.crafting.CompostRecipe;
 import com.minecolonies.api.util.constant.Constants;
 import com.minecolonies.api.util.constant.TranslationConstants;
-import com.minecolonies.coremod.compatibility.jei.transer.PrivateCraftingTeachingTransferHandler;
+import com.minecolonies.coremod.compatibility.jei.transfer.PrivateCraftingTeachingTransferHandler;
+import com.minecolonies.coremod.compatibility.jei.transfer.PrivateSmeltingTeachingTransferHandler;
 import mezz.jei.api.IModPlugin;
 import mezz.jei.api.constants.VanillaRecipeCategoryUid;
 import mezz.jei.api.constants.VanillaTypes;
@@ -62,5 +63,6 @@ public class JEIPlugin implements IModPlugin
     public void registerRecipeTransferHandlers(@NotNull final IRecipeTransferRegistration registration)
     {
         registration.addRecipeTransferHandler(new PrivateCraftingTeachingTransferHandler(registration.getTransferHelper()), VanillaRecipeCategoryUid.CRAFTING);
+        registration.addRecipeTransferHandler(new PrivateSmeltingTeachingTransferHandler(registration.getTransferHelper()), VanillaRecipeCategoryUid.FURNACE);
     }
 }

--- a/src/main/java/com/minecolonies/coremod/compatibility/jei/transfer/PrivateCraftingTeachingTransferHandler.java
+++ b/src/main/java/com/minecolonies/coremod/compatibility/jei/transfer/PrivateCraftingTeachingTransferHandler.java
@@ -1,4 +1,4 @@
-package com.minecolonies.coremod.compatibility.jei.transer;
+package com.minecolonies.coremod.compatibility.jei.transfer;
 
 import com.google.common.collect.ImmutableSet;
 import com.ldtteam.structurize.util.LanguageHandler;
@@ -6,8 +6,7 @@ import com.minecolonies.api.inventory.container.ContainerCrafting;
 import com.minecolonies.api.util.ItemStackUtils;
 import com.minecolonies.api.util.constant.TranslationConstants;
 import com.minecolonies.coremod.Network;
-import com.minecolonies.coremod.network.messages.server.TransferRecipeCrafingTeachingMessage;
-import io.netty.buffer.Unpooled;
+import com.minecolonies.coremod.network.messages.server.TransferRecipeCraftingTeachingMessage;
 import mezz.jei.api.gui.IRecipeLayout;
 import mezz.jei.api.gui.ingredient.IGuiIngredient;
 import mezz.jei.api.gui.ingredient.IGuiItemStackGroup;
@@ -17,8 +16,8 @@ import mezz.jei.api.recipe.transfer.IRecipeTransferHandlerHelper;
 import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.inventory.CraftingInventory;
 import net.minecraft.item.ItemStack;
-import net.minecraft.network.PacketBuffer;
 import net.minecraft.world.GameRules;
+import org.jetbrains.annotations.NotNull;
 
 import javax.annotation.Nullable;
 import java.util.HashMap;
@@ -29,11 +28,12 @@ public class PrivateCraftingTeachingTransferHandler implements IRecipeTransferHa
 {
    private final IRecipeTransferHandlerHelper handlerHelper;
 
-    public PrivateCraftingTeachingTransferHandler(final IRecipeTransferHandlerHelper handlerHelper)
+    public PrivateCraftingTeachingTransferHandler(@NotNull final IRecipeTransferHandlerHelper handlerHelper)
     {
         this.handlerHelper = handlerHelper;
     }
 
+    @NotNull
     @Override
     public Class<ContainerCrafting> getContainerClass()
     {
@@ -43,14 +43,14 @@ public class PrivateCraftingTeachingTransferHandler implements IRecipeTransferHa
     @Nullable
     @Override
     public IRecipeTransferError transferRecipe(
-      final ContainerCrafting craftingGUIBuilding,
-      final IRecipeLayout recipeLayout,
-      final PlayerEntity player,
-      final boolean b,
-      final boolean b1)
+            @NotNull final ContainerCrafting craftingGUIBuilding,
+            @NotNull final Object recipe,
+            @NotNull final IRecipeLayout recipeLayout,
+            @NotNull final PlayerEntity player,
+            final boolean maxTransfer,
+            final boolean doTransfer)
     {
         final IGuiItemStackGroup itemStackGroup = recipeLayout.getItemStacks();
-
 
         // compact the crafting grid into a 2x2 area
         final Map<Integer, ItemStack> guiIngredients = new HashMap<>();
@@ -92,10 +92,8 @@ public class PrivateCraftingTeachingTransferHandler implements IRecipeTransferHa
                 inputIndex++;
             }
         }
-        final PacketBuffer buffer = new PacketBuffer(Unpooled.buffer());
-        buffer.writeBoolean(craftingGUIBuilding.isComplete());
-        final CraftingInventory craftMatrix = craftingGUIBuilding.getInv();
 
+        final CraftingInventory craftMatrix = craftingGUIBuilding.getInv();
         if (craftingGUIBuilding.isComplete())
         {
             craftMatrix.setInventorySlotContents(0, guiIngredients.get(0));
@@ -122,9 +120,9 @@ public class PrivateCraftingTeachingTransferHandler implements IRecipeTransferHa
             return handlerHelper.createUserErrorWithTooltip(tooltipMessage);
         }
 
-        if (b1)
+        if (doTransfer)
         {
-            final TransferRecipeCrafingTeachingMessage message = new TransferRecipeCrafingTeachingMessage(guiIngredients, craftingGUIBuilding.isComplete());
+            final TransferRecipeCraftingTeachingMessage message = new TransferRecipeCraftingTeachingMessage(guiIngredients, craftingGUIBuilding.isComplete());
             Network.getNetwork().sendToServer(message);
         }
 

--- a/src/main/java/com/minecolonies/coremod/compatibility/jei/transfer/PrivateCraftingTeachingTransferHandler.java
+++ b/src/main/java/com/minecolonies/coremod/compatibility/jei/transfer/PrivateCraftingTeachingTransferHandler.java
@@ -93,35 +93,29 @@ public class PrivateCraftingTeachingTransferHandler implements IRecipeTransferHa
             }
         }
 
-        final CraftingInventory craftMatrix = craftingGUIBuilding.getInv();
-        if (craftingGUIBuilding.isComplete())
-        {
-            craftMatrix.setInventorySlotContents(0, guiIngredients.get(0));
-            craftMatrix.setInventorySlotContents(1, guiIngredients.get(1));
-            craftMatrix.setInventorySlotContents(2, guiIngredients.get(2));
-            craftMatrix.setInventorySlotContents(3, guiIngredients.get(3));
-            craftMatrix.setInventorySlotContents(4, guiIngredients.get(4));
-            craftMatrix.setInventorySlotContents(5, guiIngredients.get(5));
-            craftMatrix.setInventorySlotContents(6, guiIngredients.get(6));
-            craftMatrix.setInventorySlotContents(7, guiIngredients.get(7));
-            craftMatrix.setInventorySlotContents(8, guiIngredients.get(8));
-        }
-        else
-        {
-            craftMatrix.setInventorySlotContents(0, guiIngredients.get(0));
-            craftMatrix.setInventorySlotContents(1, guiIngredients.get(1));
-            craftMatrix.setInventorySlotContents(2, guiIngredients.get(3));
-            craftMatrix.setInventorySlotContents(3, guiIngredients.get(4));
-        }
-
-        if (craftingGUIBuilding.getWorldObj().getGameRules().getBoolean(GameRules.DO_LIMITED_CRAFTING) && !craftingGUIBuilding.getPlayer().isCreative())
-        {
-            final String tooltipMessage = LanguageHandler.format(TranslationConstants.COM_MINECOLONIES_COREMOD_COMPAT_JEI_CRAFTIN_TEACHING_UNKNOWN_RECIPE);
-            return handlerHelper.createUserErrorWithTooltip(tooltipMessage);
-        }
-
         if (doTransfer)
         {
+            final CraftingInventory craftMatrix = craftingGUIBuilding.getInv();
+            if (craftingGUIBuilding.isComplete())
+            {
+                craftMatrix.setInventorySlotContents(0, guiIngredients.get(0));
+                craftMatrix.setInventorySlotContents(1, guiIngredients.get(1));
+                craftMatrix.setInventorySlotContents(2, guiIngredients.get(2));
+                craftMatrix.setInventorySlotContents(3, guiIngredients.get(3));
+                craftMatrix.setInventorySlotContents(4, guiIngredients.get(4));
+                craftMatrix.setInventorySlotContents(5, guiIngredients.get(5));
+                craftMatrix.setInventorySlotContents(6, guiIngredients.get(6));
+                craftMatrix.setInventorySlotContents(7, guiIngredients.get(7));
+                craftMatrix.setInventorySlotContents(8, guiIngredients.get(8));
+            }
+            else
+            {
+                craftMatrix.setInventorySlotContents(0, guiIngredients.get(0));
+                craftMatrix.setInventorySlotContents(1, guiIngredients.get(1));
+                craftMatrix.setInventorySlotContents(2, guiIngredients.get(3));
+                craftMatrix.setInventorySlotContents(3, guiIngredients.get(4));
+            }
+
             final TransferRecipeCraftingTeachingMessage message = new TransferRecipeCraftingTeachingMessage(guiIngredients, craftingGUIBuilding.isComplete());
             Network.getNetwork().sendToServer(message);
         }

--- a/src/main/java/com/minecolonies/coremod/compatibility/jei/transfer/PrivateCraftingTeachingTransferHandler.java
+++ b/src/main/java/com/minecolonies/coremod/compatibility/jei/transfer/PrivateCraftingTeachingTransferHandler.java
@@ -4,7 +4,6 @@ import com.google.common.collect.ImmutableSet;
 import com.ldtteam.structurize.util.LanguageHandler;
 import com.minecolonies.api.inventory.container.ContainerCrafting;
 import com.minecolonies.api.util.ItemStackUtils;
-import com.minecolonies.api.util.constant.TranslationConstants;
 import com.minecolonies.coremod.Network;
 import com.minecolonies.coremod.network.messages.server.TransferRecipeCraftingTeachingMessage;
 import mezz.jei.api.gui.IRecipeLayout;
@@ -16,7 +15,6 @@ import mezz.jei.api.recipe.transfer.IRecipeTransferHandlerHelper;
 import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.inventory.CraftingInventory;
 import net.minecraft.item.ItemStack;
-import net.minecraft.world.GameRules;
 import org.jetbrains.annotations.NotNull;
 
 import javax.annotation.Nullable;
@@ -24,6 +22,9 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
 
+/**
+ * JEI recipe transfer handler for teaching crafting recipes
+ */
 public class PrivateCraftingTeachingTransferHandler implements IRecipeTransferHandler<ContainerCrafting>
 {
    private final IRecipeTransferHandlerHelper handlerHelper;

--- a/src/main/java/com/minecolonies/coremod/compatibility/jei/transfer/PrivateSmeltingTeachingTransferHandler.java
+++ b/src/main/java/com/minecolonies/coremod/compatibility/jei/transfer/PrivateSmeltingTeachingTransferHandler.java
@@ -1,27 +1,24 @@
 package com.minecolonies.coremod.compatibility.jei.transfer;
 
-import com.ldtteam.structurize.util.LanguageHandler;
 import com.minecolonies.api.inventory.container.ContainerCraftingFurnace;
-import com.minecolonies.api.util.constant.TranslationConstants;
 import com.minecolonies.coremod.Network;
 import com.minecolonies.coremod.network.messages.server.TransferRecipeCraftingTeachingMessage;
-import io.netty.buffer.Unpooled;
 import mezz.jei.api.gui.IRecipeLayout;
 import mezz.jei.api.gui.ingredient.IGuiIngredient;
-import mezz.jei.api.gui.ingredient.IGuiItemStackGroup;
 import mezz.jei.api.recipe.transfer.IRecipeTransferError;
 import mezz.jei.api.recipe.transfer.IRecipeTransferHandler;
 import mezz.jei.api.recipe.transfer.IRecipeTransferHandlerHelper;
 import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.item.ItemStack;
-import net.minecraft.network.PacketBuffer;
-import net.minecraft.world.GameRules;
 import org.jetbrains.annotations.NotNull;
 
 import javax.annotation.Nullable;
 import java.util.HashMap;
 import java.util.Map;
 
+/**
+ * JEI recipe transfer handler for teaching furnace recipes
+ */
 public class PrivateSmeltingTeachingTransferHandler implements IRecipeTransferHandler<ContainerCraftingFurnace>
 {
     private final IRecipeTransferHandlerHelper handlerHelper;

--- a/src/main/java/com/minecolonies/coremod/compatibility/jei/transfer/PrivateSmeltingTeachingTransferHandler.java
+++ b/src/main/java/com/minecolonies/coremod/compatibility/jei/transfer/PrivateSmeltingTeachingTransferHandler.java
@@ -1,0 +1,70 @@
+package com.minecolonies.coremod.compatibility.jei.transfer;
+
+import com.ldtteam.structurize.util.LanguageHandler;
+import com.minecolonies.api.inventory.container.ContainerCraftingFurnace;
+import com.minecolonies.api.util.constant.TranslationConstants;
+import com.minecolonies.coremod.Network;
+import com.minecolonies.coremod.network.messages.server.TransferRecipeCraftingTeachingMessage;
+import io.netty.buffer.Unpooled;
+import mezz.jei.api.gui.IRecipeLayout;
+import mezz.jei.api.gui.ingredient.IGuiIngredient;
+import mezz.jei.api.gui.ingredient.IGuiItemStackGroup;
+import mezz.jei.api.recipe.transfer.IRecipeTransferError;
+import mezz.jei.api.recipe.transfer.IRecipeTransferHandler;
+import mezz.jei.api.recipe.transfer.IRecipeTransferHandlerHelper;
+import net.minecraft.entity.player.PlayerEntity;
+import net.minecraft.item.ItemStack;
+import net.minecraft.network.PacketBuffer;
+import net.minecraft.world.GameRules;
+import org.jetbrains.annotations.NotNull;
+
+import javax.annotation.Nullable;
+import java.util.HashMap;
+import java.util.Map;
+
+public class PrivateSmeltingTeachingTransferHandler implements IRecipeTransferHandler<ContainerCraftingFurnace>
+{
+    private final IRecipeTransferHandlerHelper handlerHelper;
+
+    public PrivateSmeltingTeachingTransferHandler(@NotNull final IRecipeTransferHandlerHelper handlerHelper)
+    {
+        this.handlerHelper = handlerHelper;
+    }
+
+    @NotNull
+    @Override
+    public Class<ContainerCraftingFurnace> getContainerClass()
+    {
+        return ContainerCraftingFurnace.class;
+    }
+
+    @Nullable
+    @Override
+    public IRecipeTransferError transferRecipe(
+            @NotNull final ContainerCraftingFurnace craftingGUIBuilding,
+            @NotNull final Object recipe,
+            @NotNull final IRecipeLayout recipeLayout,
+            @NotNull final PlayerEntity player,
+            final boolean maxTransfer,
+            final boolean doTransfer)
+    {
+        // we only care about the first input ingredient for furnace recipes
+        final ItemStack input = recipeLayout.getItemStacks().getGuiIngredients().values().stream()
+                .filter(ingredient -> ingredient.isInput() && !ingredient.getAllIngredients().isEmpty())
+                .map(IGuiIngredient::getDisplayedIngredient)
+                .findFirst()
+                .orElse(ItemStack.EMPTY);
+
+        if (!input.isEmpty() && doTransfer)
+        {
+            craftingGUIBuilding.setFurnaceInput(input);
+
+            final Map<Integer, ItemStack> guiIngredients = new HashMap<>();
+            guiIngredients.put(0, input);
+            final TransferRecipeCraftingTeachingMessage message = new TransferRecipeCraftingTeachingMessage(guiIngredients, false);
+            Network.getNetwork().sendToServer(message);
+        }
+
+        return null;
+    }
+}

--- a/src/main/java/com/minecolonies/coremod/network/NetworkChannel.java
+++ b/src/main/java/com/minecolonies/coremod/network/NetworkChannel.java
@@ -244,7 +244,7 @@ public class NetworkChannel
         registerMessage(++idx, ColonyVisitorViewDataMessage.class, ColonyVisitorViewDataMessage::new);
 
         //JEI Messages
-        registerMessage(++idx, TransferRecipeCrafingTeachingMessage.class, TransferRecipeCrafingTeachingMessage::new);
+        registerMessage(++idx, TransferRecipeCraftingTeachingMessage.class, TransferRecipeCraftingTeachingMessage::new);
 
         //Advancement Messages
         registerMessage(++idx, OpenGuiWindowTriggerMessage.class, OpenGuiWindowTriggerMessage::new);

--- a/src/main/java/com/minecolonies/coremod/network/messages/server/TransferRecipeCraftingTeachingMessage.java
+++ b/src/main/java/com/minecolonies/coremod/network/messages/server/TransferRecipeCraftingTeachingMessage.java
@@ -1,6 +1,7 @@
 package com.minecolonies.coremod.network.messages.server;
 
 import com.minecolonies.api.inventory.container.ContainerCrafting;
+import com.minecolonies.api.inventory.container.ContainerCraftingFurnace;
 import com.minecolonies.api.network.IMessage;
 import com.minecolonies.api.util.ItemStackUtils;
 import net.minecraft.entity.player.PlayerEntity;
@@ -16,7 +17,7 @@ import java.util.Map;
 /**
  * Creates a message to get jei recipes.
  */
-public class TransferRecipeCrafingTeachingMessage implements IMessage
+public class TransferRecipeCraftingTeachingMessage implements IMessage
 {
     /**
      * if the recipe is complete.
@@ -31,7 +32,7 @@ public class TransferRecipeCrafingTeachingMessage implements IMessage
     /**
      * Empty constructor used when registering the
      */
-    public TransferRecipeCrafingTeachingMessage()
+    public TransferRecipeCraftingTeachingMessage()
     {
         super();
     }
@@ -42,7 +43,7 @@ public class TransferRecipeCrafingTeachingMessage implements IMessage
      * @param itemStacks the stack recipes to register.
      * @param complete   whether we're complete
      */
-    public TransferRecipeCrafingTeachingMessage(final Map<Integer, ItemStack> itemStacks, final boolean complete)
+    public TransferRecipeCraftingTeachingMessage(final Map<Integer, ItemStack> itemStacks, final boolean complete)
     {
         super();
         this.itemStacks = itemStacks;
@@ -90,25 +91,31 @@ public class TransferRecipeCrafingTeachingMessage implements IMessage
 
             if (complete)
             {
-                container.handleSlotClick(container.getSlot(1), itemStacks.containsKey(0) ? itemStacks.get(0) : ItemStackUtils.EMPTY);
-                container.handleSlotClick(container.getSlot(2), itemStacks.containsKey(1) ? itemStacks.get(1) : ItemStackUtils.EMPTY);
-                container.handleSlotClick(container.getSlot(3), itemStacks.containsKey(2) ? itemStacks.get(2) : ItemStackUtils.EMPTY);
-                container.handleSlotClick(container.getSlot(4), itemStacks.containsKey(3) ? itemStacks.get(3) : ItemStackUtils.EMPTY);
-                container.handleSlotClick(container.getSlot(5), itemStacks.containsKey(4) ? itemStacks.get(4) : ItemStackUtils.EMPTY);
-                container.handleSlotClick(container.getSlot(6), itemStacks.containsKey(5) ? itemStacks.get(5) : ItemStackUtils.EMPTY);
-                container.handleSlotClick(container.getSlot(7), itemStacks.containsKey(6) ? itemStacks.get(6) : ItemStackUtils.EMPTY);
-                container.handleSlotClick(container.getSlot(8), itemStacks.containsKey(7) ? itemStacks.get(7) : ItemStackUtils.EMPTY);
-                container.handleSlotClick(container.getSlot(9), itemStacks.containsKey(8) ? itemStacks.get(8) : ItemStackUtils.EMPTY);
+                container.handleSlotClick(container.getSlot(1), itemStacks.getOrDefault(0, ItemStackUtils.EMPTY));
+                container.handleSlotClick(container.getSlot(2), itemStacks.getOrDefault(1, ItemStackUtils.EMPTY));
+                container.handleSlotClick(container.getSlot(3), itemStacks.getOrDefault(2, ItemStackUtils.EMPTY));
+                container.handleSlotClick(container.getSlot(4), itemStacks.getOrDefault(3, ItemStackUtils.EMPTY));
+                container.handleSlotClick(container.getSlot(5), itemStacks.getOrDefault(4, ItemStackUtils.EMPTY));
+                container.handleSlotClick(container.getSlot(6), itemStacks.getOrDefault(5, ItemStackUtils.EMPTY));
+                container.handleSlotClick(container.getSlot(7), itemStacks.getOrDefault(6, ItemStackUtils.EMPTY));
+                container.handleSlotClick(container.getSlot(8), itemStacks.getOrDefault(7, ItemStackUtils.EMPTY));
+                container.handleSlotClick(container.getSlot(9), itemStacks.getOrDefault(8, ItemStackUtils.EMPTY));
             }
             else
             {
-                container.handleSlotClick(container.getSlot(1), itemStacks.containsKey(0) ? itemStacks.get(0) : ItemStackUtils.EMPTY);
-                container.handleSlotClick(container.getSlot(2), itemStacks.containsKey(1) ? itemStacks.get(1) : ItemStackUtils.EMPTY);
-                container.handleSlotClick(container.getSlot(3), itemStacks.containsKey(3) ? itemStacks.get(3) : ItemStackUtils.EMPTY);
-                container.handleSlotClick(container.getSlot(4), itemStacks.containsKey(4) ? itemStacks.get(4) : ItemStackUtils.EMPTY);
+                container.handleSlotClick(container.getSlot(1), itemStacks.getOrDefault(0, ItemStackUtils.EMPTY));
+                container.handleSlotClick(container.getSlot(2), itemStacks.getOrDefault(1, ItemStackUtils.EMPTY));
+                container.handleSlotClick(container.getSlot(3), itemStacks.getOrDefault(3, ItemStackUtils.EMPTY));
+                container.handleSlotClick(container.getSlot(4), itemStacks.getOrDefault(4, ItemStackUtils.EMPTY));
             }
 
             container.detectAndSendChanges();
+        }
+        else if (player.openContainer instanceof ContainerCraftingFurnace)
+        {
+            final ContainerCraftingFurnace container = (ContainerCraftingFurnace) player.openContainer;
+
+            container.setFurnaceInput(itemStacks.getOrDefault(0, ItemStack.EMPTY));
         }
     }
 }

--- a/src/main/resources/assets/minecolonies/lang/en_us.json
+++ b/src/main/resources/assets/minecolonies/lang/en_us.json
@@ -917,9 +917,6 @@
   "com.minecolonies.coremod.resolvers.crafter.private": "Crafting",
   "com.minecolonies.coremod.gui.workerhuts.togglereplantsaplingson": "Replant On",
   "com.minecolonies.coremod.gui.workerhuts.togglereplantsaplingsoff": "Replant Off",
-
-  "com.minecolonies.coremod.compat.jei.crafting.teaching.unknown.recipe": "You have not learned this recipe yet!",
-
   "com.minecolonies.coremod.gui.workerhuts.switchstyle": "Switch Style",
   "com.minecolonies.coremod.gui.townhall.toolow": "Town Hall level too low!",
   "com.minecolonies.coremod.gui.recipe.full": "Max number of recipes reached for hut level",


### PR DESCRIPTION
# Changes proposed in this pull request:
- Adds a JEI recipe transfer handler for furnace recipes, allowing the Stone Smeltery to easily learn recipes from JEI too.
- Fixes some class/package name typos.
- Removes an unused leaked buffer allocation.
- Clear furnace teaching output when an invalid recipe is used.
- Fixed being unable to transfer recipes from JEI if doLimitedCrafting is enabled and not in creative mode.

Review please
