### PR TITLE
Add some recipe bullet-proofing

### DIFF
--- a/src/main/java/com/minecolonies/coremod/colony/crafting/CustomRecipe.java
+++ b/src/main/java/com/minecolonies/coremod/colony/crafting/CustomRecipe.java
@@ -574,6 +574,7 @@ public class CustomRecipe
             {
                 cachedRecipeStorage = (RecipeStorage) recipeManager.getRecipes().get(cachedRecipeToken);
             }
+            recipeManager.registerUse(cachedRecipeStorage.getToken());
         }
         return cachedRecipeStorage;
     }

--- a/src/main/java/com/minecolonies/coremod/colony/requestsystem/management/manager/StandardRecipeManager.java
+++ b/src/main/java/com/minecolonies/coremod/colony/requestsystem/management/manager/StandardRecipeManager.java
@@ -96,7 +96,14 @@ public class StandardRecipeManager implements IRecipeManager
             IRecipeStorage recipe = StandardFactoryController.getInstance().deserialize(list.getCompound(i));
             if (recipe != null && !recipes.containsValue(recipe))
             {
-                recipes.put(recipe.getToken(), recipe);
+                try
+                {
+                    recipes.put(recipe.getToken(), recipe);
+                }
+                catch (Exception e)
+                {
+                    // Eat the exception
+                }
             }
         }
         cache = null;


### PR DESCRIPTION
# Changes proposed in this pull request:
- ensure that when loading recipes if one causes the bimap to exception, it doesn't stop other recipes from loading after it.
- Add a registerUse for cached custom recipes, as a safety measure

Review please
