### PR TITLE
Lang fixes

### DIFF
--- a/src/main/java/com/minecolonies/coremod/client/gui/huts/WindowHutBeekeeperModule.java
+++ b/src/main/java/com/minecolonies/coremod/client/gui/huts/WindowHutBeekeeperModule.java
@@ -80,6 +80,6 @@ public class WindowHutBeekeeperModule extends AbstractWindowWorkerModuleBuilding
     @Override
     public String getBuildingName()
     {
-        return "com.minecolonies.coremod.gui.workerhuts.beekeeperHut";
+        return "com.minecolonies.coremod.gui.workerhuts.beekeeperhut";
     }
 }

--- a/src/main/java/com/minecolonies/coremod/colony/buildings/AbstractBuilding.java
+++ b/src/main/java/com/minecolonies/coremod/colony/buildings/AbstractBuilding.java
@@ -498,7 +498,7 @@ public abstract class AbstractBuilding extends AbstractBuildingContainer
 
         if (workOrder.getID() != 0)
         {
-            LanguageHandler.sendPlayersMessage(colony.getImportantMessageEntityPlayers(), "com.minecolonies.coremod.workorderadded");
+            LanguageHandler.sendPlayersMessage(colony.getImportantMessageEntityPlayers(), "com.minecolonies.coremod.workorderadded", colony.getName());
         }
         markDirty();
     }

--- a/src/main/java/com/minecolonies/coremod/colony/buildings/workerbuildings/BuildingShepherd.java
+++ b/src/main/java/com/minecolonies/coremod/colony/buildings/workerbuildings/BuildingShepherd.java
@@ -36,6 +36,11 @@ public class BuildingShepherd extends AbstractBuildingWorker
     private static final String SHEPHERD = "shepherd";
 
     /**
+     * The hut name, used for the lang string in the GUI
+     */
+    private static final String HUT_NAME = "shepherdhut";
+
+    /**
      * Max building level of the hut.
      */
     private static final int MAX_BUILDING_LEVEL = 5;
@@ -128,7 +133,7 @@ public class BuildingShepherd extends AbstractBuildingWorker
         @Override
         public Window getWindow()
         {
-            return new WindowHutWorkerModulePlaceholder<>(this, SHEPHERD);
+            return new WindowHutWorkerModulePlaceholder<>(this, HUT_NAME);
         }
     }
 }

--- a/src/main/java/com/minecolonies/coremod/colony/workorders/WorkOrderBuildDecoration.java
+++ b/src/main/java/com/minecolonies/coremod/colony/workorders/WorkOrderBuildDecoration.java
@@ -177,7 +177,7 @@ public class WorkOrderBuildDecoration extends AbstractWorkOrder
             ConstructionTapeHelper.placeConstructionTape(this, colony.getWorld());
             LanguageHandler.sendPlayersMessage(
                     colony.getImportantMessageEntityPlayers(),
-                    "com.minecolonies.coremod.decoorderadded");
+                    "com.minecolonies.coremod.decoorderadded", colony.getName());
         }
     }
 

--- a/src/main/resources/assets/minecolonies/lang/en_us.json
+++ b/src/main/resources/assets/minecolonies/lang/en_us.json
@@ -353,7 +353,7 @@
 
   "entity.worker.inventoryfullchestfull": "Please make space in my chests/racks. I am not able to dump my inventory.",
 
-  "entity.builder.messagebuildstart": ": I've started work on %s!",
+  "entity.builder.messagebuildstart": "I've started work on %s!",
   "entity.builder.messagebuildcomplete": ": I've finished building the %s at %s %s %s!",
   "entity.builder.messagebuildcomplete_manual": ": I've finished building the %s at %s %s %s. You can assign me another task now!",
   "entity.builder.messageremovalcomplete": ": I've finished deconstructing building %s! §6 To move the building while retaining its current level, use the 'Pick Up' button on the building's 'Build Options' GUI.",
@@ -587,8 +587,8 @@
   "com.minecolonies.coremod.gui.townhall.feuds": "Feuds:",
   "com.minecolonies.coremod.gui.townhall.tp": "Do you really want to teleport to %s? [YES]",
 
-  "com.minecolonies.coremod.workorderadded": "Build request created!",
-  "com.minecolonies.coremod.decoorderadded": "Decoration request created!",
+  "com.minecolonies.coremod.workorderadded": "Build request created for colony %s!",
+  "com.minecolonies.coremod.decoorderadded": "Decoration request created for colony %s!",
 
   "com.minecolonies.coremod.gui.hiring.on": "Manual",
   "com.minecolonies.coremod.gui.requestfert.on": "Enabled",
@@ -1589,7 +1589,7 @@
   "com.minecolonies.coremod.entity.citizen.no.slepttonight": "I didn't have enough time to go to sleep in the last three days!",
   "com.minecolonies.coremod.entity.citizen.sleep": "All colonists are tucked into bed.",
 
-  "com.minecolonies.coremod.gui.townhall.happiness.homelessness": "Homelessness",
+  "com.minecolonies.coremod.gui.townhall.happiness.homelessness": "Housing",
   "com.minecolonies.coremod.gui.townhall.happiness.unemployment": "Unemployment",
   "com.minecolonies.coremod.gui.townhall.happiness.health": "Health",
   "com.minecolonies.coremod.gui.townhall.happiness.idleatjob": "Idling as a Worker",


### PR DESCRIPTION
Closes #
Closes #
Closes #

# Changes proposed in this pull request:
- Renames Homelessness to Housing in the town hall GUI, since it also depends on the homes' levels
- Fixes shepherd hut GUI not using the lang string for the hut's name (took fix from swineherder's hut)
- Adds colony name to the "Build request created!" messages
- Fixes double colon for one of the "started building" messages

Review please
