### PR TITLE
Fix cook request food with 0 saturation

### DIFF
--- a/src/api/java/com/minecolonies/api/colony/requestsystem/requestable/Food.java
+++ b/src/api/java/com/minecolonies/api/colony/requestsystem/requestable/Food.java
@@ -171,7 +171,7 @@ public class Food implements IDeliverable
     @Override
     public boolean matches(@NotNull final ItemStack stack)
     {
-        return stack.getItem().isFood() && !exclusionList.contains(new ItemStorage(stack)) && !(ItemStackUtils.ISCOOKABLE.test(stack) && exclusionList.contains(new ItemStorage(MinecoloniesAPIProxy.getInstance().getFurnaceRecipes().getSmeltingResult(stack))));
+        return stack.getItem().isFood() && ItemStackUtils.ISFOOD.test(stack) && !exclusionList.contains(new ItemStorage(stack)) && !(ItemStackUtils.ISCOOKABLE.test(stack) && exclusionList.contains(new ItemStorage(MinecoloniesAPIProxy.getInstance().getFurnaceRecipes().getSmeltingResult(stack))));
     }
 
     @Override


### PR DESCRIPTION
Closes #
Closes #
Closes #

# Changes proposed in this pull request:
- Adds another check to the Food request to avoid requesting food with zero saturation to make this equal to the food list
-
-

Review please
