### PR TITLE
Fix stuckhandler not detecting unsuccessfull loops through timeouts

### DIFF
--- a/src/api/java/com/minecolonies/api/entity/pathfinding/PathingStuckHandler.java
+++ b/src/api/java/com/minecolonies/api/entity/pathfinding/PathingStuckHandler.java
@@ -40,9 +40,9 @@ public class PathingStuckHandler implements IStuckHandler
     private int teleportRange = 0;
 
     /**
-     * Max timeout per block to go, default = 5sec per block
+     * Max timeout per block to go, default = 10sec per block
      */
-    private int timePerBlockDistance = 100;
+    private int timePerBlockDistance = 200;
 
     /**
      * The current stucklevel, determines actions taken
@@ -154,7 +154,7 @@ public class PathingStuckHandler implements IStuckHandler
             globalTimeout++;
 
             // Try path first, if path fits target pos
-            if (stuckLevel > 4 && globalTimeout > timePerBlockDistance * distanceToGoal)
+            if (globalTimeout > timePerBlockDistance * distanceToGoal)
             {
                 completeStuckAction(navigator);
             }

--- a/src/main/java/com/minecolonies/coremod/entity/pathfinding/pathjobs/AbstractPathJob.java
+++ b/src/main/java/com/minecolonies/coremod/entity/pathfinding/pathjobs/AbstractPathJob.java
@@ -10,7 +10,6 @@ import com.minecolonies.api.entity.pathfinding.PathingOptions;
 import com.minecolonies.api.util.BlockPosUtil;
 import com.minecolonies.api.util.CompatibilityUtils;
 import com.minecolonies.api.util.Log;
-import com.minecolonies.api.util.WorldUtil;
 import com.minecolonies.coremod.MineColonies;
 import com.minecolonies.coremod.blocks.BlockDecorationController;
 import com.minecolonies.coremod.entity.pathfinding.ChunkCache;
@@ -1278,6 +1277,7 @@ public abstract class AbstractPathJob implements Callable<Path>
               || block instanceof AbstractBlockMinecoloniesDefault
               || block instanceof AbstractBlockBarrel
               || block instanceof BambooBlock
+              || block instanceof DoorBlock
               || (blockState.getShape(world, pos).getEnd(Direction.Axis.Y) > 1.0))
         {
             return SurfaceType.NOT_PASSABLE;


### PR DESCRIPTION
# Changes proposed in this pull request:
Fix stuckhandler not detecting unsuccessfull loops through timeouts, because it was gated by other stuck logic

Review please
