### PR TITLE
Have custom Recipes delegate reading of ItemStorage inputs to ItemStorage

### DIFF
--- a/src/api/java/com/minecolonies/api/crafting/IImmutableItemStorageFactory.java
+++ b/src/api/java/com/minecolonies/api/crafting/IImmutableItemStorageFactory.java
@@ -1,0 +1,50 @@
+package com.minecolonies.api.crafting;
+
+import com.minecolonies.api.colony.requestsystem.factory.FactoryVoidInput;
+import com.minecolonies.api.colony.requestsystem.factory.IFactory;
+import com.minecolonies.api.colony.requestsystem.factory.IFactoryController;
+import net.minecraft.item.ItemStack;
+import org.jetbrains.annotations.NotNull;
+
+import static com.minecolonies.api.util.constant.Constants.PARAMS_ITEMSTORAGE;
+
+/**
+ * Interface for the IItemStorageFactory which is responsible for creating and maintaining ItemStorage objects.
+ */
+public interface IImmutableItemStorageFactory extends IFactory<FactoryVoidInput, ImmutableItemStorage>
+{
+    @NotNull
+    @Override
+    default ImmutableItemStorage getNewInstance(@NotNull final IFactoryController factoryController, @NotNull final FactoryVoidInput token, @NotNull final Object... context)
+    {
+        if (context.length < PARAMS_ITEMSTORAGE)
+        {
+            throw new IllegalArgumentException("Unsupported context - Not correct number of parameters. Only 2 are allowed!");
+        }
+
+        if (!(context[0] instanceof ItemStack))
+        {
+            throw new IllegalArgumentException("First parameter is supposed to be an ItemStack!");
+        }
+
+        if (!(context[1] instanceof Integer))
+        {
+            throw new IllegalArgumentException("Second parameter is supposed to be an Integer!");
+        }
+
+        final ItemStack stack = (ItemStack) context[0];
+        final int size = (int) context[1];
+        return getNewInstance(stack, size);
+    }
+
+    /**
+     * Method to get a new Instance of an itemStorage.
+     *
+     * @param stack the input.
+     * @param size  the grid size.
+     * @return a new Instance of ItemStorage.
+     */
+    @NotNull
+    ImmutableItemStorage getNewInstance(@NotNull final ItemStack stack, final int size);
+}
+

--- a/src/api/java/com/minecolonies/api/crafting/ItemStorage.java
+++ b/src/api/java/com/minecolonies/api/crafting/ItemStorage.java
@@ -15,6 +15,8 @@ import java.util.Objects;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
+import static com.minecolonies.api.util.constant.NbtTagConstants.*;
+
 /**
  * Used to store an stack with various informations to compare items later on.
  */
@@ -44,17 +46,6 @@ public class ItemStorage
      * Amount of the storage.
      */
     private int amount;
-
-    /**
-     * The property name for Count, used both in inputs array and for result
-     */
-    public static final String COUNT_PROP = "count";
-
-    /**
-     * The property name for the item id in the inputs array
-     */
-    public static final String ITEM_PROP = "item";
-
 
     /**
      * Creates an instance of the storage.
@@ -138,10 +129,10 @@ public class ItemStorage
                 this.amount = parsedStack.getCount();
             }
             this.stack = parsedStack;
-            if(jObject.has("matchType"))
+            if(jObject.has(MATCHTYPE_PROP))
             {
-                String matchType = jObject.get("matchType").getAsString();
-                if(matchType.equals("ignore"))
+                String matchType = jObject.get(MATCHTYPE_PROP).getAsString();
+                if(matchType.equals(MATCH_NBTIGNORE))
                 {
                     this.shouldIgnoreNBTValue = true;
                 }

--- a/src/api/java/com/minecolonies/api/crafting/ItemStorage.java
+++ b/src/api/java/com/minecolonies/api/crafting/ItemStorage.java
@@ -5,7 +5,6 @@ import com.minecolonies.api.util.ItemStackUtils;
 
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
-import net.minecraft.item.Items;
 
 import org.jetbrains.annotations.NotNull;
 
@@ -149,7 +148,7 @@ public class ItemStorage
         }
         else
         {
-            this.stack = new ItemStack(Items.AIR);
+            this.stack = ItemStack.EMPTY;
             this.amount = 0;
             this.shouldIgnoreDamageValue = true;
             this.shouldIgnoreNBTValue = true;

--- a/src/api/java/com/minecolonies/api/crafting/ItemStorage.java
+++ b/src/api/java/com/minecolonies/api/crafting/ItemStorage.java
@@ -145,9 +145,10 @@ public class ItemStorage
             {
                 this.shouldIgnoreNBTValue = false;
             }
-
             this.shouldIgnoreDamageValue= true;
-        } else {
+        }
+        else
+        {
             this.stack = new ItemStack(Items.AIR);
             this.amount = 0;
             this.shouldIgnoreDamageValue = true;

--- a/src/api/java/com/minecolonies/api/util/constant/NbtTagConstants.java
+++ b/src/api/java/com/minecolonies/api/util/constant/NbtTagConstants.java
@@ -580,6 +580,14 @@ public final class NbtTagConstants
     public static final String TAG_SAVED_CITIZEN_DATA = "savedcitizendata";
 
     /**
+     * Tags/JSON names for storing item informations
+     */
+    public static final String COUNT_PROP = "count";
+    public static final String ITEM_PROP = "item";
+    public static final String MATCHTYPE_PROP = "matchType";
+    public static final String MATCH_NBTIGNORE = "ignore";
+
+    /**
      * Private constructor to hide the implicit one.
      */
     private NbtTagConstants()

--- a/src/api/java/com/minecolonies/api/util/constant/TypeConstants.java
+++ b/src/api/java/com/minecolonies/api/util/constant/TypeConstants.java
@@ -11,6 +11,7 @@ import com.minecolonies.api.colony.requestsystem.resolver.player.IPlayerRequestR
 import com.minecolonies.api.colony.requestsystem.resolver.retrying.IRetryingRequestResolver;
 import com.minecolonies.api.colony.requestsystem.token.IToken;
 import com.minecolonies.api.colony.requestsystem.token.StandardToken;
+import com.minecolonies.api.crafting.ImmutableItemStorage;
 import com.minecolonies.api.crafting.ItemStorage;
 import com.minecolonies.api.crafting.RecipeStorage;
 
@@ -38,6 +39,8 @@ public class TypeConstants
     public static final TypeToken<IDeliverable>     DELIVERABLE      = TypeToken.of(IDeliverable.class);
     public static final TypeToken<Tag>              TAG_REQUEST      = TypeToken.of(Tag.class);
     public static final TypeToken<ItemStorage>      ITEMSTORAGE      = TypeToken.of(ItemStorage.class);
+
+    public static final TypeToken<ImmutableItemStorage> IMMUTABLEITEMSTORAGE = TypeToken.of(ImmutableItemStorage.class);
 
     /////Request system specific
     public static final TypeToken<IPlayerRequestResolver>                             PLAYER_REQUEST_RESOLVER                         = TypeToken.of(IPlayerRequestResolver.class);

--- a/src/main/java/com/minecolonies/coremod/colony/buildings/AbstractBuildingWorker.java
+++ b/src/main/java/com/minecolonies/coremod/colony/buildings/AbstractBuildingWorker.java
@@ -402,12 +402,12 @@ public abstract class AbstractBuildingWorker extends AbstractBuilding implements
                 {
                     reducedItem = input.copy();
                     reducedItem.setAmount(input.getAmount() - 1);
-                    newRecipe.add(reducedItem);
+                    newRecipe.add(reducedItem.toImmutable());
                     didReduction = true;
                 }
                 else
                 {
-                    newRecipe.add(input.copy());
+                    newRecipe.add(input.copy().toImmutable());
                 }
             }
 

--- a/src/main/java/com/minecolonies/coremod/colony/crafting/CustomRecipe.java
+++ b/src/main/java/com/minecolonies/coremod/colony/crafting/CustomRecipe.java
@@ -31,6 +31,8 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 
+import static com.minecolonies.api.util.constant.NbtTagConstants.*;
+
 /**
  * This class represents a recipe loaded from custom data that is available to a crafter
  * but not to a player
@@ -97,16 +99,6 @@ public class CustomRecipe
      * The property namefor the result loottable
      */
     public static final String RECIPE_LOOTTABLE_PROP = "loot-table";
-
-    /**
-     * The property name for Count, used both in inputs array and for result
-     */
-    public static final String COUNT_PROP = "count";
-
-    /**
-     * The property name for the item id in the inputs array
-     */
-    public static final String ITEM_PROP = "item";
 
     /**
      * The property name for the intermediate block ID

--- a/src/main/java/com/minecolonies/coremod/colony/crafting/CustomRecipe.java
+++ b/src/main/java/com/minecolonies/coremod/colony/crafting/CustomRecipe.java
@@ -226,51 +226,6 @@ public class CustomRecipe
     }
 
     /**
-     * Convert an Item string with NBT to an ItemStack
-     * @param itemData ie: minecraft:potion{Potion=minecraft:water}
-     * @return stack with any defined NBT
-     */
-    private static ItemStack idToItemStack(final String itemData)
-    {
-        String itemId = itemData;
-        final int tagIndex = itemId.indexOf("{");
-        final String tag = tagIndex > 0 ? itemId.substring(tagIndex) : null;
-        itemId = tagIndex > 0 ? itemId.substring(0, tagIndex) : itemId;
-        String[] split = itemId.split(":");
-        if(split.length != 2)
-        {
-            if(split.length == 1)
-            {
-                final String[] tempArray ={"minecraft", split[0]};
-                split = tempArray;
-            }
-            else
-            {
-                Log.getLogger().error("Unable to parse item definition: " + itemData);
-            }
-        }
-        final Item item = ForgeRegistries.ITEMS.getValue(new ResourceLocation(split[0], split[1]));
-        final ItemStack stack = new ItemStack(item);
-        if (tag != null)
-        {
-            try
-            {
-                stack.setTag(JsonToNBT.getTagFromJson(tag));
-            }
-            catch (CommandSyntaxException e1)
-            {
-                //Unable to parse tags, drop them.
-                Log.getLogger().error("Unable to parse item definition: " + itemData);
-            }
-        }
-        if (stack.isEmpty())
-        {
-            Log.getLogger().warn("Parsed item definition returned empty: " + itemData);
-        }
-        return stack;
-    }
-
-    /**
      * Parse a Json object into a Custom recipe
      *
      * @param recipeId the recipe id
@@ -293,23 +248,14 @@ public class CustomRecipe
                 if (e.isJsonObject())
                 {
                     JsonObject ingredient = e.getAsJsonObject();
-                    if (ingredient.has(ITEM_PROP))
-                    {
-                        final ItemStack stack = idToItemStack(ingredient.get(ITEM_PROP).getAsString());
-                        if(ingredient.has(COUNT_PROP))
-                        {
-                            stack.setCount(ingredient.get(COUNT_PROP).getAsInt());
-                        }
-                        recipe.inputs.add(new ItemStorage(stack));
-                    }
-
+                    recipe.inputs.add(new ItemStorage(ingredient));
                 }
             }
         }
 
         if (recipeJson.has(RECIPE_RESULT_PROP))
         {
-            recipe.result = idToItemStack(recipeJson.get(RECIPE_RESULT_PROP).getAsString());
+            recipe.result = ItemStackUtils.idToItemStack(recipeJson.get(RECIPE_RESULT_PROP).getAsString());
         }
         else
         {
@@ -330,7 +276,7 @@ public class CustomRecipe
                     JsonObject ingredient = e.getAsJsonObject();
                     if (ingredient.has(ITEM_PROP))
                     {
-                        final ItemStack stack = idToItemStack(ingredient.get(ITEM_PROP).getAsString());
+                        final ItemStack stack = ItemStackUtils.idToItemStack(ingredient.get(ITEM_PROP).getAsString());
                         if(ingredient.has(COUNT_PROP))
                         {
                             stack.setCount(ingredient.get(COUNT_PROP).getAsInt());
@@ -352,7 +298,7 @@ public class CustomRecipe
                     JsonObject ingredient = e.getAsJsonObject();
                     if (ingredient.has(ITEM_PROP))
                     {
-                        final ItemStack stack = idToItemStack(ingredient.get(ITEM_PROP).getAsString());
+                        final ItemStack stack = ItemStackUtils.idToItemStack(ingredient.get(ITEM_PROP).getAsString());
                         if(ingredient.has(COUNT_PROP))
                         {
                             stack.setCount(ingredient.get(COUNT_PROP).getAsInt());

--- a/src/main/java/com/minecolonies/coremod/colony/crafting/CustomRecipe.java
+++ b/src/main/java/com/minecolonies/coremod/colony/crafting/CustomRecipe.java
@@ -240,7 +240,10 @@ public class CustomRecipe
                 if (e.isJsonObject())
                 {
                     JsonObject ingredient = e.getAsJsonObject();
-                    recipe.inputs.add(new ItemStorage(ingredient));
+                    ItemStorage parsed = new ItemStorage(ingredient);
+                    if(!parsed.isEmpty()) {
+                        recipe.inputs.add(parsed);
+                    }
                 }
             }
         }

--- a/src/main/java/com/minecolonies/coremod/colony/crafting/ImmutableItemStorageFactory.java
+++ b/src/main/java/com/minecolonies/coremod/colony/crafting/ImmutableItemStorageFactory.java
@@ -1,0 +1,77 @@
+package com.minecolonies.coremod.colony.crafting;
+
+import com.google.common.reflect.TypeToken;
+import com.minecolonies.api.colony.requestsystem.StandardFactoryController;
+import com.minecolonies.api.colony.requestsystem.factory.FactoryVoidInput;
+import com.minecolonies.api.colony.requestsystem.factory.IFactoryController;
+import com.minecolonies.api.crafting.IImmutableItemStorageFactory;
+import com.minecolonies.api.crafting.ImmutableItemStorage;
+import com.minecolonies.api.crafting.ItemStorage;
+import com.minecolonies.api.util.constant.TypeConstants;
+
+import org.jetbrains.annotations.NotNull;
+
+import net.minecraft.item.ItemStack;
+import net.minecraft.nbt.CompoundNBT;
+import net.minecraft.network.PacketBuffer;
+
+public class ImmutableItemStorageFactory implements IImmutableItemStorageFactory
+{
+
+    @NotNull
+    @Override
+    public TypeToken<? extends ImmutableItemStorage> getFactoryOutputType()
+    {
+        return TypeConstants.IMMUTABLEITEMSTORAGE;
+    }
+
+    @NotNull
+    @Override
+    public TypeToken<? extends FactoryVoidInput> getFactoryInputType()
+    {
+        return TypeConstants.FACTORYVOIDINPUT;
+    }
+
+    @Override
+    public short getSerializationId()
+    {
+        return 45;
+    }
+
+    @Override
+    public CompoundNBT serialize(IFactoryController controller, ImmutableItemStorage output)
+    {
+        @NotNull final CompoundNBT compound = StandardFactoryController.getInstance().serialize(output.copy());
+
+        return compound;
+    }
+
+    @Override
+    public ImmutableItemStorage deserialize(IFactoryController controller, CompoundNBT nbt) throws Throwable
+    {
+        final ItemStorage readStorage = StandardFactoryController.getInstance().deserialize(nbt);
+        return readStorage.toImmutable();
+    }
+
+    @Override
+    public void serialize(IFactoryController controller, ImmutableItemStorage output, PacketBuffer packetBuffer)
+    {
+        StandardFactoryController.getInstance().serialize(packetBuffer, output.copy());
+    }
+
+    @Override
+    public ImmutableItemStorage deserialize(IFactoryController controller, PacketBuffer buffer) throws Throwable
+    {
+        @NotNull final ItemStorage newItem = StandardFactoryController.getInstance().deserialize(buffer);
+        return newItem.toImmutable();
+    }
+
+    @Override
+    public ImmutableItemStorage getNewInstance(ItemStack stack, int size)
+    {
+        @NotNull final ItemStorage newItem = new ItemStorage(stack);
+        newItem.setAmount(size);
+        return newItem.toImmutable();
+    }
+    
+}

--- a/src/main/java/com/minecolonies/coremod/colony/crafting/ImmutableItemStorageFactory.java
+++ b/src/main/java/com/minecolonies/coremod/colony/crafting/ImmutableItemStorageFactory.java
@@ -15,6 +15,9 @@ import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.CompoundNBT;
 import net.minecraft.network.PacketBuffer;
 
+/**
+ * Factory implementation taking care of creating new instances, serializing and deserializing ImmutableItemStorage.
+ */
 public class ImmutableItemStorageFactory implements IImmutableItemStorageFactory
 {
 

--- a/src/main/java/com/minecolonies/coremod/colony/requestsystem/management/manager/StandardRecipeManager.java
+++ b/src/main/java/com/minecolonies/coremod/colony/requestsystem/management/manager/StandardRecipeManager.java
@@ -94,7 +94,7 @@ public class StandardRecipeManager implements IRecipeManager
         for (int i = 0; i < list.size(); i++)
         {
             IRecipeStorage recipe = StandardFactoryController.getInstance().deserialize(list.getCompound(i));
-            if (recipe != null && !recipes.containsValue(recipe))
+            if (recipe != null && !recipes.containsValue(recipe) && !recipe.getCleanedInput().isEmpty())
             {
                 try
                 {

--- a/src/main/java/com/minecolonies/coremod/generation/CustomRecipeProvider.java
+++ b/src/main/java/com/minecolonies/coremod/generation/CustomRecipeProvider.java
@@ -30,6 +30,8 @@ import java.util.Objects;
 import java.util.Set;
 import java.util.function.Consumer;
 
+import static com.minecolonies.api.util.constant.NbtTagConstants.*;
+
 public abstract class CustomRecipeProvider implements IDataProvider
 {
     private static final Logger LOGGER = LogManager.getLogger();
@@ -117,7 +119,7 @@ public abstract class CustomRecipeProvider implements IDataProvider
             this.json.addProperty(CustomRecipe.RECIPE_RESULT_PROP, result.getItem().getRegistryName().toString());
             if (result.getCount() != 1)
             {
-                this.json.addProperty(CustomRecipe.COUNT_PROP, result.getCount());
+                this.json.addProperty(COUNT_PROP, result.getCount());
             }
             return this;
         }
@@ -205,10 +207,10 @@ public abstract class CustomRecipeProvider implements IDataProvider
             for (final ItemStack itemStack : itemStacks)
             {
                 final JsonObject jsonItemStack = new JsonObject();
-                jsonItemStack.addProperty(CustomRecipe.ITEM_PROP, itemStack.getItem().getRegistryName().toString());
+                jsonItemStack.addProperty(ITEM_PROP, itemStack.getItem().getRegistryName().toString());
                 if (itemStack.getCount() != 1)
                 {
-                    jsonItemStack.addProperty(CustomRecipe.COUNT_PROP, itemStack.getCount());
+                    jsonItemStack.addProperty(COUNT_PROP, itemStack.getCount());
                 }
                 jsonItemStacks.add(jsonItemStack);
             }


### PR DESCRIPTION
# Changes proposed in this pull request:
- Now, ItemStorage owns the interpretation of the JSON object that encodes an item in customrecipe JSONs
- This allowed me to add a matchType to the object, which informs the ItemStorage what state to set the shouldIgnoreNBT to
- This enables future extension for more complex NBT matches. 

Review please
