### PR TITLE
Fix ItemStorage serialization, ensure that matching information persists in RecipeStorage

### DIFF
--- a/src/api/java/com/minecolonies/api/crafting/IItemStorageFactory.java
+++ b/src/api/java/com/minecolonies/api/crafting/IItemStorageFactory.java
@@ -44,8 +44,8 @@ public interface IItemStorageFactory extends IFactory<FactoryVoidInput, ItemStor
 
         final ItemStack stack = (ItemStack) context[0];
         final int size = (int) context[1];
-        final boolean ignoreDamage = context[2] != null ? (Boolean) context[2] : false;
-        final boolean ignoreNBT = context[3] != null ? (Boolean) context[3] : false;
+        final boolean ignoreDamage = context.length >= 3 ? (Boolean) context[2] : false;
+        final boolean ignoreNBT = context.length >= 4 ? (Boolean) context[3] : false;
 
         return getNewInstance(stack, size, ignoreDamage, ignoreNBT);
     }

--- a/src/api/java/com/minecolonies/api/crafting/IItemStorageFactory.java
+++ b/src/api/java/com/minecolonies/api/crafting/IItemStorageFactory.java
@@ -32,9 +32,22 @@ public interface IItemStorageFactory extends IFactory<FactoryVoidInput, ItemStor
             throw new IllegalArgumentException("Second parameter is supposed to be an Integer!");
         }
 
+        if (context.length >= PARAMS_ITEMSTORAGE + 1 && !(context[2] instanceof Boolean))
+        {
+            throw new IllegalArgumentException("Third parameter is supposed to be an Boolean!");
+        }
+
+        if (context.length >= PARAMS_ITEMSTORAGE + 2 && !(context[3] instanceof Boolean))
+        {
+            throw new IllegalArgumentException("Fourth parameter is supposed to be an Boolean!");
+        }
+
         final ItemStack stack = (ItemStack) context[0];
         final int size = (int) context[1];
-        return getNewInstance(stack, size);
+        final boolean ignoreDamage = context[2] != null ? (Boolean) context[2] : false;
+        final boolean ignoreNBT = context[3] != null ? (Boolean) context[3] : false;
+
+        return getNewInstance(stack, size, ignoreDamage, ignoreNBT);
     }
 
     /**
@@ -45,6 +58,6 @@ public interface IItemStorageFactory extends IFactory<FactoryVoidInput, ItemStor
      * @return a new Instance of ItemStorage.
      */
     @NotNull
-    ItemStorage getNewInstance(@NotNull final ItemStack stack, final int size);
+    ItemStorage getNewInstance(@NotNull final ItemStack stack, final int size, final boolean ignoreDamage, final boolean ignoreNBT);
 }
 

--- a/src/api/java/com/minecolonies/api/crafting/ItemStorage.java
+++ b/src/api/java/com/minecolonies/api/crafting/ItemStorage.java
@@ -269,10 +269,16 @@ public class ItemStorage
 
 
         return stack.isItemEqual(that.getItemStack())
-                 && (this.shouldIgnoreDamageValue || that.getDamageValue() == this.getDamageValue())
+                 && (this.shouldIgnoreDamageValue || that.shouldIgnoreDamageValue || that.getDamageValue() == this.getDamageValue())
                  && (this.shouldIgnoreNBTValue || that.shouldIgnoreNBTValue
                        || (that.getItemStack().getTag() == null && this.getItemStack().getTag() == null)
                        || (that.getItemStack().getTag() != null && that.getItemStack().getTag().equals(this.getItemStack().getTag())));
+    }
+
+    public boolean matchDefinitionEquals(ItemStorage that)
+    {
+        return this.shouldIgnoreDamageValue == that.shouldIgnoreDamageValue 
+        && this.shouldIgnoreNBTValue == that.shouldIgnoreNBTValue;
     }
 
     /**

--- a/src/api/java/com/minecolonies/api/crafting/ItemStorage.java
+++ b/src/api/java/com/minecolonies/api/crafting/ItemStorage.java
@@ -275,6 +275,11 @@ public class ItemStorage
                        || (that.getItemStack().getTag() != null && that.getItemStack().getTag().equals(this.getItemStack().getTag())));
     }
 
+    /**
+     * Ensure that two ItemStorage have the same comparison defintion
+     * @param that the item to compare to
+     * @return true if the comparisons match
+     */
     public boolean matchDefinitionEquals(ItemStorage that)
     {
         return this.shouldIgnoreDamageValue == that.shouldIgnoreDamageValue 

--- a/src/api/java/com/minecolonies/api/crafting/RecipeStorage.java
+++ b/src/api/java/com/minecolonies/api/crafting/RecipeStorage.java
@@ -190,13 +190,18 @@ public class RecipeStorage implements IRecipeStorage
                 continue;
             }
 
-            ItemStorage storage = new ItemStorage(inputItem.getItemStack());
-            storage.setAmount(inputItem.getAmount());
-            if (items.contains(storage))
+            ItemStorage storage = inputItem.copy();
+            if (items.contains(storage) )
             {
                 final int index = items.indexOf(storage);
-                final ItemStorage tempStorage = items.remove(index);
+                ItemStorage tempStorage = items.remove(index);
                 tempStorage.setAmount(tempStorage.getAmount() + storage.getAmount());
+                if(!tempStorage.matchDefinitionEquals(storage))
+                {
+                    int amount = tempStorage.getAmount();
+                    tempStorage = new ItemStorage(tempStorage.getItemStack(), tempStorage.ignoreDamageValue() || storage.ignoreDamageValue(), tempStorage.ignoreNBT() || storage.ignoreNBT());
+                    tempStorage.setAmount(amount);
+                }
                 storage = tempStorage;
             }
             items.add(storage);
@@ -348,7 +353,7 @@ public class RecipeStorage implements IRecipeStorage
 
         for (int i = 0; i < cleanedInput.size(); i++)
         {
-            if(!cleanedInput.get(i).equals(that.cleanedInput.get(i)) || cleanedInput.get(i).getAmount() != that.cleanedInput.get(i).getAmount())
+            if(!cleanedInput.get(i).equals(that.cleanedInput.get(i)) || !cleanedInput.get(i).matchDefinitionEquals(that.cleanedInput.get(i)) || cleanedInput.get(i).getAmount() != that.cleanedInput.get(i).getAmount())
             {
                 return false;
             }

--- a/src/main/java/com/minecolonies/coremod/colony/crafting/ItemStorageFactory.java
+++ b/src/main/java/com/minecolonies/coremod/colony/crafting/ItemStorageFactory.java
@@ -54,7 +54,7 @@ public class ItemStorageFactory implements IItemStorageFactory
     @Override
     public ItemStorage getNewInstance(@NotNull final ItemStack stack, final int size, final boolean ignoreDamage, final boolean ignoreNBT)
     {
-        ItemStorage newItem = new ItemStorage(stack,false, false);
+        ItemStorage newItem = new ItemStorage(stack, ignoreDamage, ignoreNBT);
         newItem.setAmount(size);
         return newItem;
 
@@ -80,8 +80,8 @@ public class ItemStorageFactory implements IItemStorageFactory
     {
         final ItemStack stack = ItemStack.read(nbt.getCompound(TAG_STACK));
         final int size = nbt.getInt(TAG_SIZE);
-        final boolean ignoreNBT = nbt.contains(TAG_SHOULDIGNORENBT) ? nbt.getBoolean(TAG_SHOULDIGNORENBT) : false;
-        final boolean ignoreDamage = nbt.contains(TAG_SHOULDIGNOREDAMAGE) ? nbt.getBoolean(TAG_SHOULDIGNOREDAMAGE) : false;
+        final boolean ignoreNBT = nbt.getBoolean(TAG_SHOULDIGNORENBT);
+        final boolean ignoreDamage = nbt.getBoolean(TAG_SHOULDIGNOREDAMAGE);
         return this.getNewInstance(stack, size, ignoreDamage, ignoreNBT);
     }
 

--- a/src/main/java/com/minecolonies/coremod/colony/crafting/ItemStorageFactory.java
+++ b/src/main/java/com/minecolonies/coremod/colony/crafting/ItemStorageFactory.java
@@ -26,6 +26,16 @@ public class ItemStorageFactory implements IItemStorageFactory
      */
     private static final String TAG_STACK = "stack";
 
+    /**
+     * Compound tag for the NBT info
+     */
+    private static final String TAG_SHOULDIGNORENBT = "ignoreNBT";
+
+    /**
+     * Compound tag for the Damage Match Info
+     */
+    private static final String TAG_SHOULDIGNOREDAMAGE = "ignoreDamage";
+
     @NotNull
     @Override
     public TypeToken<ItemStorage> getFactoryOutputType()
@@ -42,9 +52,12 @@ public class ItemStorageFactory implements IItemStorageFactory
 
     @NotNull
     @Override
-    public ItemStorage getNewInstance(@NotNull final ItemStack stack, final int size)
+    public ItemStorage getNewInstance(@NotNull final ItemStack stack, final int size, final boolean ignoreDamage, final boolean ignoreNBT)
     {
-        return new ItemStorage(stack, size, false);
+        ItemStorage newItem = new ItemStorage(stack,false, false);
+        newItem.setAmount(size);
+        return newItem;
+
     }
 
     @NotNull
@@ -56,6 +69,8 @@ public class ItemStorageFactory implements IItemStorageFactory
         storage.getItemStack().write(stackTag);
         compound.put(TAG_STACK, stackTag);
         compound.putInt(TAG_SIZE, storage.getAmount());
+        compound.putBoolean(TAG_SHOULDIGNOREDAMAGE, storage.ignoreDamageValue());
+        compound.putBoolean(TAG_SHOULDIGNORENBT , storage.ignoreNBT());
         return compound;
     }
 
@@ -65,7 +80,9 @@ public class ItemStorageFactory implements IItemStorageFactory
     {
         final ItemStack stack = ItemStack.read(nbt.getCompound(TAG_STACK));
         final int size = nbt.getInt(TAG_SIZE);
-        return this.getNewInstance(stack, size);
+        final boolean ignoreNBT = nbt.contains(TAG_SHOULDIGNORENBT) ? nbt.getBoolean(TAG_SHOULDIGNORENBT) : false;
+        final boolean ignoreDamage = nbt.contains(TAG_SHOULDIGNOREDAMAGE) ? nbt.getBoolean(TAG_SHOULDIGNOREDAMAGE) : false;
+        return this.getNewInstance(stack, size, ignoreDamage, ignoreNBT);
     }
 
     @Override
@@ -73,6 +90,8 @@ public class ItemStorageFactory implements IItemStorageFactory
     {
         packetBuffer.writeItemStack(input.getItemStack());
         packetBuffer.writeVarInt(input.getAmount());
+        packetBuffer.writeBoolean(input.ignoreDamageValue());
+        packetBuffer.writeBoolean(input.ignoreNBT());
     }
 
     @Override
@@ -80,7 +99,9 @@ public class ItemStorageFactory implements IItemStorageFactory
     {
         final ItemStack stack = buffer.readItemStack();
         final int size = buffer.readVarInt();
-        return this.getNewInstance(stack, size);
+        final boolean ignoreDamage = buffer.readBoolean();
+        final boolean ignoreNBT = buffer.readBoolean();
+        return this.getNewInstance(stack, size, ignoreDamage, ignoreNBT);
     }
 
     @Override


### PR DESCRIPTION
# Changes proposed in this pull request:
- Made sure ItemStorage serializes ignoreNBT and ignoreDamage
- Made sure that RecipeStorage properly combines ignoreNBT and ignoreDamage when calculating cleanedInput
- Made sure that RecipeStorage.equals takes ItemStorage comparison information into account

Review please
