### PR TITLE
Fix name generation for Eastern type names (fixes #7057)

### DIFF
--- a/src/main/java/com/minecolonies/coremod/colony/CitizenData.java
+++ b/src/main/java/com/minecolonies/coremod/colony/CitizenData.java
@@ -449,7 +449,7 @@ public class CitizenData implements ICitizenData
         if(MineColonies.getConfig().getServer().useEasternNameOrder.get())
         {
             //For now, don't include middle names, as their rules (and presence) vary heavily by region.
-            citizenName = String.format("%s%s", lastName, firstName);
+            citizenName = String.format("%s %s", lastName, firstName);
         }
         else
         {


### PR DESCRIPTION
Closes #
Closes #
Closes #

# Changes proposed in this pull request:
- Name generation does not put space between last name and first name if there is eastern name generation.
-
-

Review please
