### PR TITLE
Recover the colony relationship for colony flags placed by the builder that are stuck "white" 

### DIFF
--- a/src/api/java/com/minecolonies/api/blocks/decorative/AbstractColonyFlagBanner.java
+++ b/src/api/java/com/minecolonies/api/blocks/decorative/AbstractColonyFlagBanner.java
@@ -55,7 +55,7 @@ public class AbstractColonyFlagBanner<B extends AbstractColonyFlagBanner<B>> ext
 
             // Allow the player to place their own beyond the colony
             if (colony == null && placer instanceof PlayerEntity)
-                IColonyManager.getInstance().getIColonyByOwner(worldIn, (PlayerEntity) placer);
+                colony = IColonyManager.getInstance().getIColonyByOwner(worldIn, (PlayerEntity) placer);
 
             if (colony != null)
                 ((TileEntityColonyFlag) te).colonyId = colony.getID();

--- a/src/api/java/com/minecolonies/api/blocks/decorative/AbstractColonyFlagBanner.java
+++ b/src/api/java/com/minecolonies/api/blocks/decorative/AbstractColonyFlagBanner.java
@@ -49,7 +49,7 @@ public class AbstractColonyFlagBanner<B extends AbstractColonyFlagBanner<B>> ext
         if (worldIn.isRemote) return;
 
         TileEntity te = worldIn.getTileEntity(pos);
-        if (te instanceof TileEntityColonyFlag)
+        if (te instanceof TileEntityColonyFlag && ((TileEntityColonyFlag) te).colonyId == -1 )
         {
             IColony colony = IColonyManager.getInstance().getIColony(worldIn, pos);
 

--- a/src/api/java/com/minecolonies/api/tileentities/TileEntityColonyFlag.java
+++ b/src/api/java/com/minecolonies/api/tileentities/TileEntityColonyFlag.java
@@ -43,6 +43,13 @@ public class TileEntityColonyFlag extends TileEntity
     {
         super.write(compound);
 
+        if(this.colonyId == -1 && this.hasWorld())
+        {
+            IColony colony = IColonyManager.getInstance().getIColony(this.getWorld(), pos);
+            if (colony != null)
+                this.colonyId = colony.getID();
+        }
+
         compound.put(TAG_FLAG_PATTERNS, this.flag);
         compound.put(TAG_BANNER_PATTERNS, this.patterns);
 
@@ -64,9 +71,11 @@ public class TileEntityColonyFlag extends TileEntity
         {
             IColony colony = IColonyManager.getInstance().getIColony(this.getWorld(), pos);
             if (colony != null)
+            {
                 this.colonyId = colony.getID();
+                this.markDirty();
+            }
         }
-
     }
 
     @Override

--- a/src/api/java/com/minecolonies/api/tileentities/TileEntityColonyFlag.java
+++ b/src/api/java/com/minecolonies/api/tileentities/TileEntityColonyFlag.java
@@ -1,6 +1,7 @@
 package com.minecolonies.api.tileentities;
 
 import com.minecolonies.api.blocks.ModBlocks;
+import com.minecolonies.api.colony.IColony;
 import com.minecolonies.api.colony.IColonyManager;
 import com.minecolonies.api.colony.IColonyView;
 import com.minecolonies.api.items.ModItems;
@@ -58,6 +59,14 @@ public class TileEntityColonyFlag extends TileEntity
         this.flag = compound.getList(TAG_FLAG_PATTERNS, 10);
         this.patterns = compound.getList(TAG_BANNER_PATTERNS, 10);
         this.colonyId = compound.getInt(TAG_COLONY_ID);
+
+        if(this.colonyId == -1 && this.hasWorld())
+        {
+            IColony colony = IColonyManager.getInstance().getIColony(this.getWorld(), pos);
+            if (colony != null)
+                this.colonyId = colony.getID();
+        }
+
     }
 
     @Override


### PR DESCRIPTION
# Changes proposed in this pull request:
- fix the placement of colonyflags outside a colony to properly bind to the players colony
- add recovery code to colonyflag load to bind to the colony they are within if colony is not set. 

Review please
