### PR TITLE
Prevent jumping at fence gates

### DIFF
--- a/src/main/java/com/minecolonies/coremod/entity/citizen/citizenhandlers/MovementHandler.java
+++ b/src/main/java/com/minecolonies/coremod/entity/citizen/citizenhandlers/MovementHandler.java
@@ -95,7 +95,7 @@ public class MovementHandler extends MovementController
             final VoxelShape voxelshape = blockstate.getCollisionShape(this.mob.world, blockpos);
             if ((yDif > (double) this.mob.stepHeight && xDif * xDif + zDif * zDif < (double) Math.max(1.0F, this.mob.getWidth()))
                   || (!voxelshape.isEmpty() && this.mob.getPosY() < voxelshape.getEnd(Direction.Axis.Y) + (double) blockpos.getY() && !block.isIn(BlockTags.DOORS) && !block.isIn(
-              BlockTags.FENCES))
+              BlockTags.FENCES) && !block.isIn(BlockTags.FENCE_GATES))
                        && !block.isLadder(blockstate, this.mob.world, blockpos, this.mob))
             {
                 this.mob.getJumpController().setJumping();


### PR DESCRIPTION
Closes #6304
Closes #
Closes #

# Changes proposed in this pull request:
- Stop citizens from jumping whenever they come to a fence gate, which also prevents crop trampling.
-
-

Review please
