### PR TITLE
Add honey and honeycomb blocks to mechanic repertoire

### DIFF
--- a/src/main/resources/data/minecolonies/tags/items/mechanic_product.json
+++ b/src/main/resources/data/minecolonies/tags/items/mechanic_product.json
@@ -24,6 +24,8 @@
     "minecraft:ender_chest",
     "minecraft:lever",
     "minecraft:daylight_detector",
-    "minecraft:dried_kelp_block"
+    "minecraft:dried_kelp_block",
+    "minecraft:honey_block",
+    "minecraft:honeycomb_block"
   ]
 }


### PR DESCRIPTION
# Changes proposed in this pull request:
- Allow the mechanic to make honey-based blocks

**Note**: I haven't tested this yet due to technical issues.  I should within a couple hours, but if you don't trust me to write two untested lines without typos, wait to merge.

Review please
