### PR TITLE
Show interaction icon when requests need player interaction

### DIFF
--- a/src/api/java/com/minecolonies/api/colony/requestsystem/request/RequestUtils.java
+++ b/src/api/java/com/minecolonies/api/colony/requestsystem/request/RequestUtils.java
@@ -1,0 +1,56 @@
+package com.minecolonies.api.colony.requestsystem.request;
+
+import com.minecolonies.api.colony.requestsystem.manager.IRequestManager;
+import com.minecolonies.api.colony.requestsystem.resolver.IRequestResolver;
+import com.minecolonies.api.colony.requestsystem.resolver.player.IPlayerRequestResolver;
+import com.minecolonies.api.colony.requestsystem.resolver.retrying.IRetryingRequestResolver;
+import com.minecolonies.api.colony.requestsystem.token.IToken;
+
+/**
+ * Util class for requests
+ */
+public class RequestUtils
+{
+    /**
+     * Private constructor to hide the implicit one.
+     */
+    private RequestUtils()
+    {
+        /*
+         * Intentionally left empty.
+         */
+    }
+
+    /**
+     * Checks if the request for this token requires player interaction
+     *
+     * @param token   Request token to check
+     * @param manager Request manager
+     */
+    public static boolean requestChainNeedsPlayer(final IToken<?> token, final IRequestManager manager)
+    {
+        final IRequest<?> request = manager.getRequestForToken(token);
+        if (request == null)
+        {
+            return false;
+        }
+
+        if (request.hasChildren())
+        {
+            for (final IToken<?> childToken : request.getChildren())
+            {
+                if (requestChainNeedsPlayer(childToken, manager))
+                {
+                    return true;
+                }
+            }
+        }
+        else
+        {
+            final IRequestResolver<?> resolver = manager.getResolverForRequest(token);
+            return request.getState() == RequestState.IN_PROGRESS && (resolver instanceof IPlayerRequestResolver || resolver instanceof IRetryingRequestResolver);
+        }
+
+        return false;
+    }
+}

--- a/src/main/java/com/minecolonies/apiimp/initializer/InteractionValidatorInitializer.java
+++ b/src/main/java/com/minecolonies/apiimp/initializer/InteractionValidatorInitializer.java
@@ -8,11 +8,7 @@ import com.minecolonies.api.colony.buildings.IBuildingWorker;
 import com.minecolonies.api.colony.buildings.workerbuildings.IBuildingDeliveryman;
 import com.minecolonies.api.colony.buildings.workerbuildings.IWareHouse;
 import com.minecolonies.api.colony.interactionhandling.InteractionValidatorRegistry;
-import com.minecolonies.api.colony.requestsystem.request.IRequest;
-import com.minecolonies.api.colony.requestsystem.request.RequestState;
-import com.minecolonies.api.colony.requestsystem.resolver.IRequestResolver;
-import com.minecolonies.api.colony.requestsystem.resolver.player.IPlayerRequestResolver;
-import com.minecolonies.api.colony.requestsystem.resolver.retrying.IRetryingRequestResolver;
+import com.minecolonies.api.colony.requestsystem.request.RequestUtils;
 import com.minecolonies.api.crafting.ItemStorage;
 import com.minecolonies.api.items.ModTags;
 import com.minecolonies.api.util.InventoryUtils;
@@ -163,11 +159,7 @@ public class InteractionValidatorInitializer
               final IColony colony = citizen.getColony();
               if (colony != null)
               {
-                  final IRequest<?> request = citizen.getColony().getRequestManager().getRequestForToken(token);
-                  final IRequestResolver<?> resolver =
-                    request == null ? null : citizen.getColony().getRequestManager().getResolverForRequest(token);
-                  return request != null && request.getState() == RequestState.IN_PROGRESS && (resolver instanceof IPlayerRequestResolver
-                                                                                                 || resolver instanceof IRetryingRequestResolver);
+                  return RequestUtils.requestChainNeedsPlayer(token, citizen.getColony().getRequestManager());
               }
               return false;
           });
@@ -220,7 +212,7 @@ public class InteractionValidatorInitializer
 
             return true;
           });
-        InteractionValidatorRegistry.registerStandardPredicate(new TranslationTextComponent(SIFTER_NO_MESH), 
+        InteractionValidatorRegistry.registerStandardPredicate(new TranslationTextComponent(SIFTER_NO_MESH),
           citizen -> {
             if (!(citizen.getWorkBuilding() instanceof BuildingSifter))
             {

--- a/src/main/resources/data/minecolonies/loot_tables/chests/supplycamp.json
+++ b/src/main/resources/data/minecolonies/loot_tables/chests/supplycamp.json
@@ -9,7 +9,7 @@
           "conditions": [
             {
               "condition": "minecraft:random_chance",
-              "chance": 0.2
+              "chance": 0.1
             }
           ],
           "name": "minecolonies:supplycampdeployer",

--- a/src/main/resources/data/minecolonies/loot_tables/chests/supplyship.json
+++ b/src/main/resources/data/minecolonies/loot_tables/chests/supplyship.json
@@ -9,7 +9,7 @@
           "conditions": [
             {
               "condition": "minecraft:random_chance",
-              "chance": 0.2
+              "chance": 0.1
             }
           ],
           "name": "minecolonies:supplychestdeployer",


### PR DESCRIPTION
# Changes proposed in this pull request:
Show interaction icon when any part of the request chain needs a player interaction
Reduce the loot chance of free supply things, they appear too often.

Review please
