### PR TITLE
Added new kill command to remove Phantoms

### DIFF
--- a/src/main/java/com/minecolonies/coremod/commands/EntryPoint.java
+++ b/src/main/java/com/minecolonies/coremod/commands/EntryPoint.java
@@ -33,7 +33,8 @@ public class EntryPoint
                                            .addNode(new CommandKillMonster().build())
                                            .addNode(new CommandKillPig().build())
                                            .addNode(new CommandKillRaider().build())
-                                           .addNode(new CommandKillSheep().build());
+                                           .addNode(new CommandKillSheep().build())
+                                           .addNode(new CommandKillPhantom().build());
 
         /**
          * Colony commands subtree

--- a/src/main/java/com/minecolonies/coremod/commands/killcommands/CommandKillPhantom.java
+++ b/src/main/java/com/minecolonies/coremod/commands/killcommands/CommandKillPhantom.java
@@ -1,0 +1,43 @@
+package com.minecolonies.coremod.commands.killcommands;
+
+import com.minecolonies.coremod.commands.commandTypes.IMCOPCommand;
+import com.mojang.brigadier.context.CommandContext;
+import net.minecraft.command.CommandSource;
+import net.minecraft.entity.monster.PhantomEntity;
+import net.minecraft.util.text.StringTextComponent;
+
+public class CommandKillPhantom implements IMCOPCommand
+{
+    int entitiesKilled = 0;
+
+    /**
+     * What happens when the command is executed
+     *
+     * @param context the context of the command execution
+     */
+    @Override
+    public int onExecute(final CommandContext<CommandSource> context)
+    {
+        entitiesKilled = 0;
+
+        context.getSource().getWorld().getEntities().forEach(entity ->
+        {
+            if (entity instanceof PhantomEntity)
+            {
+                entity.remove();
+                entitiesKilled++;
+            }
+        });
+        context.getSource().sendFeedback(new StringTextComponent(entitiesKilled + " Phantoms killed"), true);
+        return 1;
+    }
+
+    /**
+     * Name string of the command.
+     */
+    @Override
+    public String getName()
+    {
+        return "phantom";
+    }
+}


### PR DESCRIPTION
Added new CommandKillPhantom subclass that allows OP's to use /mc kill phantom to remove them during the night.

I didn't include this in the CommandKillMonster class, as you may want to leave the mobs alive.

Closes #7156 


# Changes proposed in this pull request:
- Added new /mc kill phantom command to remove phantoms


Review please
