### PR TITLE
Add minimum stock to more buildings

### DIFF
--- a/src/main/java/com/minecolonies/apiimp/initializer/ModBuildingsInitializer.java
+++ b/src/main/java/com/minecolonies/apiimp/initializer/ModBuildingsInitializer.java
@@ -53,6 +53,7 @@ public final class ModBuildingsInitializer
                                  .setBuildingProducer(BuildingArchery::new)
                                  .setBuildingViewProducer(() -> BuildingArchery.View::new)
                                  .setRegistryName(new ResourceLocation(Constants.MOD_ID, ModBuildings.ARCHERY_ID))
+                                 .addBuildingModuleProducer(MinimumStockModule::new, MinimumStockModuleView::new)
                                  .addBuildingModuleProducer(BedHandlingModule::new)
                                  .createBuildingEntry();
 
@@ -79,6 +80,7 @@ public final class ModBuildingsInitializer
                                        .setBuildingProducer(BuildingBarracksTower::new)
                                        .setBuildingViewProducer(() -> BuildingBarracksTower.View::new)
                                        .setRegistryName(new ResourceLocation(Constants.MOD_ID, ModBuildings.BARRACKS_TOWER_ID))
+                                       .addBuildingModuleProducer(MinimumStockModule::new, MinimumStockModuleView::new)
                                        .addBuildingModuleProducer(BedHandlingModule::new)
                                        .createBuildingEntry();
 
@@ -95,6 +97,7 @@ public final class ModBuildingsInitializer
                                  .setBuildingProducer(BuildingBuilder::new)
                                  .setBuildingViewProducer(() -> BuildingBuilder.View::new)
                                  .setRegistryName(new ResourceLocation(Constants.MOD_ID, ModBuildings.BUILDER_ID))
+                                 .addBuildingModuleProducer(MinimumStockModule::new, MinimumStockModuleView::new)
                                  .addBuildingModuleProducer(() -> new SettingsModule().with(BuildingBuilder.MODE, new StringSetting(BuildingBuilder.AUTO_SETTING, BuildingBuilder.MANUAL_SETTING)), SettingsModuleView::new)
                                  .addBuildingModuleViewProducer(WorkOrderListModuleView::new)
                                  .addBuildingModuleProducer(BuildingResourcesModule::new, BuildingResourcesModuleView::new)
@@ -105,6 +108,7 @@ public final class ModBuildingsInitializer
                                        .setBuildingProducer(BuildingChickenHerder::new)
                                        .setBuildingViewProducer(() -> BuildingChickenHerder.View::new)
                                        .setRegistryName(new ResourceLocation(Constants.MOD_ID, ModBuildings.CHICKENHERDER_ID))
+                                       .addBuildingModuleProducer(MinimumStockModule::new, MinimumStockModuleView::new)
                                        .addBuildingModuleProducer(() -> new SettingsModule().with(AbstractBuildingWorker.BREEDING, new BoolSetting(true)), SettingsModuleView::new)
                                        .createBuildingEntry();
 
@@ -113,6 +117,7 @@ public final class ModBuildingsInitializer
                                        .setBuildingProducer(BuildingCombatAcademy::new)
                                        .setBuildingViewProducer(() -> BuildingCombatAcademy.View::new)
                                        .setRegistryName(new ResourceLocation(Constants.MOD_ID, ModBuildings.COMBAT_ACADEMY_ID))
+                                       .addBuildingModuleProducer(MinimumStockModule::new, MinimumStockModuleView::new)
                                        .addBuildingModuleProducer(BedHandlingModule::new)
                                        .createBuildingEntry();
 
@@ -149,6 +154,7 @@ public final class ModBuildingsInitializer
                                 .setBuildingProducer(BuildingCowboy::new)
                                 .setBuildingViewProducer(() -> BuildingCowboy.View::new)
                                 .setRegistryName(new ResourceLocation(Constants.MOD_ID, ModBuildings.COWBOY_ID))
+                                .addBuildingModuleProducer(MinimumStockModule::new, MinimumStockModuleView::new)
                                 .addBuildingModuleProducer(() -> new SettingsModule().with(AbstractBuildingWorker.BREEDING, new BoolSetting(true))
                                                                                      .with(BuildingCowboy.MILKING, new BoolSetting(false)), SettingsModuleView::new)
                                 .createBuildingEntry();
@@ -183,6 +189,7 @@ public final class ModBuildingsInitializer
                                    .setBuildingProducer(BuildingFisherman::new)
                                    .setBuildingViewProducer(() -> BuildingFisherman.View::new)
                                    .setRegistryName(new ResourceLocation(Constants.MOD_ID, ModBuildings.FISHERMAN_ID))
+                                   .addBuildingModuleProducer(MinimumStockModule::new, MinimumStockModuleView::new)
                                    .createBuildingEntry();
 
         ModBuildings.guardTower = new BuildingEntry.Builder()
@@ -190,6 +197,7 @@ public final class ModBuildingsInitializer
                                     .setBuildingProducer(BuildingGuardTower::new)
                                     .setBuildingViewProducer(() -> BuildingGuardTower.View::new)
                                     .setRegistryName(new ResourceLocation(Constants.MOD_ID, ModBuildings.GUARD_TOWER_ID))
+                                    .addBuildingModuleProducer(MinimumStockModule::new, MinimumStockModuleView::new)
                                     .addBuildingModuleProducer(BedHandlingModule::new)
                                     .createBuildingEntry();
 
@@ -208,6 +216,7 @@ public final class ModBuildingsInitializer
                                  .setBuildingProducer(BuildingLibrary::new)
                                  .setBuildingViewProducer(() -> BuildingLibrary.View::new)
                                  .setRegistryName(new ResourceLocation(Constants.MOD_ID, ModBuildings.LIBRARY_ID))
+                                 .addBuildingModuleProducer(MinimumStockModule::new, MinimumStockModuleView::new)
                                  .createBuildingEntry();
 
         ModBuildings.lumberjack = new BuildingEntry.Builder()
@@ -227,6 +236,7 @@ public final class ModBuildingsInitializer
                                .setBuildingProducer(BuildingMiner::new)
                                .setBuildingViewProducer(() -> BuildingMiner.View::new)
                                .setRegistryName(new ResourceLocation(Constants.MOD_ID, ModBuildings.MINER_ID))
+                               .addBuildingModuleProducer(MinimumStockModule::new, MinimumStockModuleView::new)
                                .addBuildingModuleProducer(BuildingResourcesModule::new, BuildingResourcesModuleView::new)
                                .createBuildingEntry();
 
@@ -243,6 +253,7 @@ public final class ModBuildingsInitializer
                                   .setBuildingProducer(BuildingShepherd::new)
                                   .setBuildingViewProducer(() -> BuildingShepherd.View::new)
                                   .setRegistryName(new ResourceLocation(Constants.MOD_ID, ModBuildings.SHEPHERD_ID))
+                                  .addBuildingModuleProducer(MinimumStockModule::new, MinimumStockModuleView::new)
                                   .addBuildingModuleProducer(() -> new SettingsModule().with(AbstractBuildingWorker.BREEDING, new BoolSetting(true))
                                                                                        .with(BuildingShepherd.DYEING, new BoolSetting(true))
                                                                                        .with(BuildingShepherd.SHEARING, new BoolSetting(true)), SettingsModuleView::new)
@@ -263,6 +274,7 @@ public final class ModBuildingsInitializer
                                   .setRegistryName(new ResourceLocation(Constants.MOD_ID, ModBuildings.SMELTERY_ID))
                                   .addBuildingModuleProducer(() -> new ItemListModule(FUEL_LIST), () -> new ItemListModuleView(FUEL_LIST, COM_MINECOLONIES_REQUESTS_BURNABLE, false,
                                     (buildingView) -> IColonyManager.getInstance().getCompatibilityManager().getFuel()))
+                                  .addBuildingModuleProducer(MinimumStockModule::new, MinimumStockModuleView::new)
                                   .addBuildingModuleProducer(() -> new ItemListModule(ORE_LIST), () -> new ItemListModuleView(ORE_LIST, COM_MINECOLONIES_REQUESTS_SMELTABLE_ORE, true,
                                     (buildingView) -> IColonyManager.getInstance().getCompatibilityManager().getSmeltableOres()))
                                   .createBuildingEntry();
@@ -290,6 +302,7 @@ public final class ModBuildingsInitializer
                                      .setBuildingProducer(BuildingSwineHerder::new)
                                      .setBuildingViewProducer(() -> BuildingSwineHerder.View::new)
                                      .setRegistryName(new ResourceLocation(Constants.MOD_ID, ModBuildings.SWINE_HERDER_ID))
+                                     .addBuildingModuleProducer(MinimumStockModule::new, MinimumStockModuleView::new)
                                      .addBuildingModuleProducer(() -> new SettingsModule().with(AbstractBuildingWorker.BREEDING, new BoolSetting(true)), SettingsModuleView::new)
                                      .createBuildingEntry();
 
@@ -320,6 +333,7 @@ public final class ModBuildingsInitializer
                                  .setBuildingProducer(BuildingFlorist::new)
                                  .setBuildingViewProducer(() -> BuildingFlorist.View::new)
                                  .setRegistryName(new ResourceLocation(Constants.MOD_ID, ModBuildings.FLORIST_ID))
+                                 .addBuildingModuleProducer(MinimumStockModule::new, MinimumStockModuleView::new)
                                  .addBuildingModuleProducer(() -> new ItemListModule(FLORIST_FLOWER_LIST), () -> new FloristFlowerListModuleView())
                                  .createBuildingEntry();
 
@@ -328,6 +342,7 @@ public final class ModBuildingsInitializer
                                    .setBuildingProducer(BuildingEnchanter::new)
                                    .setBuildingViewProducer(() -> BuildingEnchanter.View::new)
                                    .setRegistryName(new ResourceLocation(Constants.MOD_ID, ModBuildings.ENCHANTER_ID))
+                                   .addBuildingModuleProducer(MinimumStockModule::new, MinimumStockModuleView::new)
                                    .createBuildingEntry();
 
         ModBuildings.university = new BuildingEntry.Builder()
@@ -342,6 +357,7 @@ public final class ModBuildingsInitializer
                                   .setBuildingProducer(BuildingHospital::new)
                                   .setBuildingViewProducer(() -> BuildingHospital.View::new)
                                   .setRegistryName(new ResourceLocation(Constants.MOD_ID, ModBuildings.HOSPITAL_ID))
+                                  .addBuildingModuleProducer(MinimumStockModule::new, MinimumStockModuleView::new)
                                   .createBuildingEntry();
 
         ModBuildings.stash = new BuildingEntry.Builder()
@@ -356,6 +372,7 @@ public final class ModBuildingsInitializer
                                 .setBuildingProducer(BuildingSchool::new)
                                 .setBuildingViewProducer(() -> BuildingSchool.View::new)
                                 .setRegistryName(new ResourceLocation(Constants.MOD_ID, ModBuildings.SCHOOL_ID))
+                                .addBuildingModuleProducer(MinimumStockModule::new, MinimumStockModuleView::new)
                                 .createBuildingEntry();
 
         ModBuildings.glassblower = new BuildingEntry.Builder()
@@ -418,6 +435,7 @@ public final class ModBuildingsInitializer
                                      .setBuildingProducer(BuildingRabbitHutch::new)
                                      .setBuildingViewProducer(() -> BuildingRabbitHutch.View::new)
                                      .setRegistryName(new ResourceLocation(Constants.MOD_ID, ModBuildings.RABBIT_ID))
+                                     .addBuildingModuleProducer(MinimumStockModule::new, MinimumStockModuleView::new)
                                      .addBuildingModuleProducer(() -> new SettingsModule().with(AbstractBuildingWorker.BREEDING, new BoolSetting(true)), SettingsModuleView::new)
                                      .createBuildingEntry();
 
@@ -434,6 +452,7 @@ public final class ModBuildingsInitializer
                                    .setBuildingProducer(BuildingBeekeeper::new)
                                    .setBuildingViewProducer(() -> BuildingBeekeeper.View::new)
                                    .setRegistryName(new ResourceLocation(Constants.MOD_ID, ModBuildings.BEEKEEPER_ID))
+                                   .addBuildingModuleProducer(MinimumStockModule::new, MinimumStockModuleView::new)
                                    .addBuildingModuleProducer(() -> new SettingsModule()
                                                                       .with(AbstractBuildingWorker.BREEDING, new BoolSetting(true))
                                                                       .with(BuildingBeekeeper.MODE, new StringSetting(BuildingBeekeeper.HONEYCOMB, BuildingBeekeeper.HONEY, BuildingBeekeeper.BOTH)), SettingsModuleView::new)


### PR DESCRIPTION
This adds minimum stock to every building except for:
 * those where no one uses the inventory (Barracks, Courier, etc.)
 * crafters which doesn't use fuel (Blacksmith, Fletcher, etc.)
 * university and Plantation, because it seemed useless there
 * Postbox, because the UI is different so it wasn't as simple as the
   other buildings

# Notes
Does not close any issues, but touches on ldtteam/minecolonies-features#186 and ldtteam/minecolonies-features#440.

I haven't tested this as much as I want yet.  The "Minimum Stock" tab shows up on all these buildings, seems to work correctly for some of them, and doesn't *visibly* fail for any of them but I haven't fully tested that it works.

I'm getting a display issue where I need to go away from the tab and back for minimum stock to show up, on both the buildings I added it for and the buildings that already have it.  I don't remember seeing this issue before but I bet when I get a chance to test in released minecolonies it'll be there too.

Review please
