### PR TITLE
Made it so that citizens that work in a building are always at the to…

### DIFF
--- a/src/main/java/com/minecolonies/coremod/client/gui/WindowHireWorker.java
+++ b/src/main/java/com/minecolonies/coremod/client/gui/WindowHireWorker.java
@@ -210,6 +210,14 @@ public class WindowHireWorker extends AbstractWindowSkeleton
                      .filter(citizen -> !citizen.isChild())
                      .filter(citizen ->  citizen.getWorkBuilding() == null || building.getPosition().equals(citizen.getWorkBuilding()) || colony.getBuilding(citizen.getWorkBuilding()) instanceof IBuildingCanBeHiredFrom).sorted(Comparator.comparing(ICitizenDataView::getName))
                      .collect(Collectors.toList());
+
+        citizens.sort(
+                (c1, c2) -> {
+                    int i1 = building.getPosition().equals(c1.getWorkBuilding()) ? -1 : 0;
+                    int i2 = building.getPosition().equals(c2.getWorkBuilding()) ? -1 : 0;
+                    return Integer.compare(i1, i2);
+            }
+        );
     }
 
     /**


### PR DESCRIPTION
…p of the building's hire/fire list

Closes https://github.com/ldtteam/minecolonies-features/issues/451

# Changes proposed in this pull request:
# sorts citizens in WindowHireWorker

Review please
