### PR TITLE
Allow hiring from existing huts

### DIFF
--- a/src/main/java/com/minecolonies/coremod/client/gui/WindowHireWorker.java
+++ b/src/main/java/com/minecolonies/coremod/client/gui/WindowHireWorker.java
@@ -210,6 +210,14 @@ public class WindowHireWorker extends AbstractWindowSkeleton
                      .filter(citizen -> !citizen.isChild())
                      .filter(citizen ->  citizen.getWorkBuilding() == null || building.getPosition().equals(citizen.getWorkBuilding()) || colony.getBuilding(citizen.getWorkBuilding()) instanceof IBuildingCanBeHiredFrom).sorted(Comparator.comparing(ICitizenDataView::getName))
                      .collect(Collectors.toList());
+
+        citizens.sort(
+                (c1, c2) -> {
+                    int i1 = building.getPosition().equals(c1.getWorkBuilding()) ? -1 : 0;
+                    int i2 = building.getPosition().equals(c2.getWorkBuilding()) ? -1 : 0;
+                    return Integer.compare(i1, i2);
+            }
+        );
     }
 
     /**


### PR DESCRIPTION
related to https://github.com/ldtteam/minecolonies-features/issues/281 but doesn't entirely close it

# Changes proposed in this pull request:
- makes it so you can hire people employed in other huts
- orders citizens by employment in hire/fire GUI (citizens with jobs are at the bottom)
- Fixes some iffy logic around hiring people with jobs that already existed and anecdotally caused bugs (this PR makes sure to fire people from their existing job before hiring them to the new job)

Review please
