### PR TITLE
Fix builder job start message typo

### DIFF
--- a/src/main/resources/assets/minecolonies/lang/en_us.json
+++ b/src/main/resources/assets/minecolonies/lang/en_us.json
@@ -354,7 +354,7 @@
 
   "entity.worker.inventoryfullchestfull": "Please make space in my chests/racks. I am not able to dump my inventory.",
 
-  "entity.builder.messagebuildstart": " I've started work on %s!",
+  "entity.builder.messagebuildstart": ": I've started work on %s!",
   "entity.builder.messagebuildcomplete": ": I've finished building the %s at %s %s %s!",
   "entity.builder.messagebuildcomplete_manual": ": I've finished building the %s at %s %s %s. You can assign me another task now!",
   "entity.builder.messageremovalcomplete": ": I've finished deconstructing building %s! §6 To move the building while retaining its current level, use the 'Pick Up' button on the building's 'Build Options' GUI.",


### PR DESCRIPTION
Closes #7197
Closes #
Closes #

# Changes proposed in this pull request:
- Add missing ':' to en_us.json to fix the builder job start message.
- This PR is so huge it could have easily been done in the web editor.
- I have tested this somewhat, but I don't think there is much this could break.

Review please
