### PR TITLE
Fix JEI datapack loot, kinda

### DIFF
--- a/src/main/java/com/minecolonies/coremod/colony/CitizenData.java
+++ b/src/main/java/com/minecolonies/coremod/colony/CitizenData.java
@@ -636,8 +636,10 @@ public class CitizenData implements ICitizenData
             colony.getCitizenManager().spawnOrCreateCivilian(this, colony.getWorld(), nextRespawnPos, true);
             nextRespawnPos = null;
         }
-
-        colony.getCitizenManager().spawnOrCreateCivilian(this, colony.getWorld(), lastPosition, true);
+        else
+        {
+            colony.getCitizenManager().spawnOrCreateCivilian(this, colony.getWorld(), lastPosition, true);
+        }
     }
 
     @Override

--- a/src/main/java/com/minecolonies/coremod/compatibility/jei/GenericRecipeCategory.java
+++ b/src/main/java/com/minecolonies/coremod/compatibility/jei/GenericRecipeCategory.java
@@ -210,6 +210,17 @@ public class GenericRecipeCategory extends JobBasedRecipeCategory<IGenericRecipe
             }
         }
 
+        boolean showLootTooltip = true;
+        if (drops.isEmpty())
+        {
+            // this is a temporary workaround for cases where we currently fail to load the loot table
+            // (mostly when it's in a datapack).  assume that someone has set the alternate-outputs
+            // appropriately, but we can't display the percentage chances.
+            showLootTooltip = false;
+            drops.addAll(recipe.getAdditionalOutputs().stream()
+                    .map(stack -> new LootTableAnalyzer.LootDrop(Collections.singletonList(stack), 0, false))
+                    .collect(Collectors.toList()));
+        }
         if (!drops.isEmpty())
         {
             final int initialColumns = LOOT_SLOTS_W / this.slot.getWidth();
@@ -220,7 +231,10 @@ public class GenericRecipeCategory extends JobBasedRecipeCategory<IGenericRecipe
             y = CITIZEN_Y + CITIZEN_H - rows * this.slot.getHeight() + 1;
             int c = 0;
 
-            guiItemStacks.addTooltipCallback(new LootTableTooltipCallback(slot, drops));
+            if (showLootTooltip)
+            {
+                guiItemStacks.addTooltipCallback(new LootTableTooltipCallback(slot, drops));
+            }
             for (final LootTableAnalyzer.LootDrop drop : drops)
             {
                 guiItemStacks.init(slot, true, x, y);


### PR DESCRIPTION
Mitigates (but doesn't fix) #7223

# Changes proposed in this pull request:
- If we can't load a crafterrecipe's loot table (probably because it was in a datapack instead of a mod, and the loader can't cope with that just yet), fall back to showing the alternate outputs (which are set manually for use in the recipe list).  This should show the correct items (if set properly in the recipe) but not the drop chances.
- Also fix that missing else that briefly spawns a duplicate citizen.

Review please

This is intended as a temporary mitigation for the linked issue, a proper fix will require more thought (and probably doing the custom packet thing suggested in the LootTableAnalyzer javadoc).