### PR TITLE
Prevent portal travel

### DIFF
--- a/src/api/java/com/minecolonies/api/entity/citizen/AbstractCivilianEntity.java
+++ b/src/api/java/com/minecolonies/api/entity/citizen/AbstractCivilianEntity.java
@@ -3,9 +3,13 @@ package com.minecolonies.api.entity.citizen;
 import com.minecolonies.api.colony.ICivilianData;
 import com.minecolonies.api.entity.pathfinding.IStuckHandlerEntity;
 import net.minecraft.entity.AgeableEntity;
+import net.minecraft.entity.Entity;
 import net.minecraft.entity.EntityType;
 import net.minecraft.entity.INPC;
 import net.minecraft.world.World;
+import net.minecraft.world.server.ServerWorld;
+import net.minecraftforge.common.util.ITeleporter;
+import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 public abstract class AbstractCivilianEntity extends AgeableEntity implements INPC, IStuckHandlerEntity
@@ -61,5 +65,15 @@ public abstract class AbstractCivilianEntity extends AgeableEntity implements IN
     public void setCanBeStuck(final boolean canBeStuck)
     {
         this.canBeStuck = canBeStuck;
+    }
+
+    /**
+     * Prevent citizens and visitors from travelling to other dimensions through portals.
+     */
+    @Nullable
+    @Override
+    public Entity changeDimension(@NotNull final ServerWorld serverWorld, @NotNull final ITeleporter teleporter)
+    {
+        return null;
     }
 }

--- a/src/api/java/com/minecolonies/api/entity/citizen/AbstractEntityCitizen.java
+++ b/src/api/java/com/minecolonies/api/entity/citizen/AbstractEntityCitizen.java
@@ -143,13 +143,6 @@ public abstract class AbstractEntityCitizen extends AbstractCivilianEntity imple
         return ticksExisted;
     }
 
-    @Nullable
-    @Override
-    public Entity changeDimension(final ServerWorld p_241206_1_)
-    {
-        return null;
-    }
-
     @NotNull
     public BlockPos getPosition()
     {

--- a/src/api/java/com/minecolonies/api/entity/mobs/AbstractEntityMinecoloniesMob.java
+++ b/src/api/java/com/minecolonies/api/entity/mobs/AbstractEntityMinecoloniesMob.java
@@ -29,6 +29,7 @@ import net.minecraft.world.DifficultyInstance;
 import net.minecraft.world.IServerWorld;
 import net.minecraft.world.World;
 import net.minecraft.world.server.ServerWorld;
+import net.minecraftforge.common.util.ITeleporter;
 import org.jetbrains.annotations.NotNull;
 
 import javax.annotation.Nullable;
@@ -309,13 +310,13 @@ public abstract class AbstractEntityMinecoloniesMob extends MobEntity implements
         super.writeAdditional(compound);
     }
 
+
     /**
-     * We override this method and execute no code to avoid citizens travelling to the nether.
-     *
+     * Prevent raiders from travelling to other dimensions through portals.
      */
     @Nullable
     @Override
-    public Entity changeDimension(final ServerWorld p_241206_1_)
+    public Entity changeDimension(@NotNull final ServerWorld serverWorld, @NotNull final ITeleporter teleporter)
     {
         return null;
     }


### PR DESCRIPTION
Closes #7262

# Changes proposed in this pull request:
- Teaches colonists and raiders how to properly avoid portals.

Review please

I have not actually tested this with Twilight Forest, but I have confirmed that it uses this overload instead of the one that was previously overridden (as does vanilla, via forwarding).