### PR TITLE
Make the 75 pop advancement actually take 75 population.

### DIFF
--- a/src/main/resources/data/minecolonies/advancements/minecolonies/colony_population_75.json
+++ b/src/main/resources/data/minecolonies/advancements/minecolonies/colony_population_75.json
@@ -18,7 +18,7 @@
     "population_5": {
       "trigger": "minecolonies:colony_population",
       "conditions": {
-        "population_count": 50
+        "population_count": 75
       }
     }
   }


### PR DESCRIPTION
Closes #7279

# Changes proposed in this pull request:
- Make the 75 pop advancement actually take 75 population.

Review please
