### PR TITLE
Fix server-side module views

### DIFF
--- a/src/main/java/com/minecolonies/apiimp/initializer/ModBuildingsInitializer.java
+++ b/src/main/java/com/minecolonies/apiimp/initializer/ModBuildingsInitializer.java
@@ -48,7 +48,7 @@ public final class ModBuildingsInitializer
                                  .setBuildingProducer(BuildingArchery::new)
                                  .setBuildingViewProducer(() -> BuildingArchery.View::new)
                                  .setRegistryName(new ResourceLocation(Constants.MOD_ID, ModBuildings.ARCHERY_ID))
-                                 .addBuildingModuleProducer(MinimumStockModule::new, MinimumStockModuleView::new)
+                                 .addBuildingModuleProducer(MinimumStockModule::new, () -> MinimumStockModuleView::new)
                                  .addBuildingModuleProducer(BedHandlingModule::new)
                                  .createBuildingEntry();
 
@@ -57,11 +57,11 @@ public final class ModBuildingsInitializer
                                 .setBuildingProducer(BuildingBaker::new)
                                 .setBuildingViewProducer(() -> BuildingBaker.View::new)
                                 .setRegistryName(new ResourceLocation(Constants.MOD_ID, ModBuildings.BAKERY_ID))
-                                .addBuildingModuleProducer(BuildingBaker.CraftingModule::new, CraftingModuleView::new)
-                                .addBuildingModuleProducer(MinimumStockModule::new, MinimumStockModuleView::new)
-                                .addBuildingModuleProducer(() -> new ItemListModule(FUEL_LIST), () -> new ItemListModuleView(FUEL_LIST, COM_MINECOLONIES_REQUESTS_BURNABLE, false,
+                                .addBuildingModuleProducer(BuildingBaker.CraftingModule::new, () -> CraftingModuleView::new)
+                                .addBuildingModuleProducer(MinimumStockModule::new, () -> MinimumStockModuleView::new)
+                                .addBuildingModuleProducer(() -> new ItemListModule(FUEL_LIST), () -> () -> new ItemListModuleView(FUEL_LIST, COM_MINECOLONIES_REQUESTS_BURNABLE, false,
                                   (buildingView) -> IColonyManager.getInstance().getCompatibilityManager().getFuel()))
-                                .addBuildingModuleViewProducer(CrafterTaskModuleView::new)
+                                .addBuildingModuleViewProducer(() -> CrafterTaskModuleView::new)
                                 .createBuildingEntry();
 
         ModBuildings.barracks = new BuildingEntry.Builder()
@@ -69,7 +69,7 @@ public final class ModBuildingsInitializer
                                   .setBuildingProducer(BuildingBarracks::new)
                                   .setBuildingViewProducer(() -> BuildingBarracks.View::new)
                                   .setRegistryName(new ResourceLocation(Constants.MOD_ID, ModBuildings.BARRACKS_ID))
-                                  .addBuildingModuleProducer(MinimumStockModule::new, MinimumStockModuleView::new)
+                                  .addBuildingModuleProducer(MinimumStockModule::new, () -> MinimumStockModuleView::new)
                                   .createBuildingEntry();
 
         ModBuildings.barracksTower = new BuildingEntry.Builder()
@@ -77,17 +77,17 @@ public final class ModBuildingsInitializer
                                        .setBuildingProducer(BuildingBarracksTower::new)
                                        .setBuildingViewProducer(() -> BuildingBarracksTower.View::new)
                                        .setRegistryName(new ResourceLocation(Constants.MOD_ID, ModBuildings.BARRACKS_TOWER_ID))
-                                       .addBuildingModuleProducer(MinimumStockModule::new, MinimumStockModuleView::new)
+                                       .addBuildingModuleProducer(MinimumStockModule::new, () -> MinimumStockModuleView::new)
                                        .addBuildingModuleProducer(BedHandlingModule::new)
-                                       .addBuildingModuleViewProducer(() -> new ToolModuleView(ModItems.scepterGuard))
-                                       .addBuildingModuleProducer(() -> new EntityListModule(HOSTILE_LIST), () -> new EntityListModuleView(HOSTILE_LIST, COM_MINECOLONIES_HOSTILES, true))
+                                       .addBuildingModuleViewProducer(() -> () -> new ToolModuleView(ModItems.scepterGuard))
+                                       .addBuildingModuleProducer(() -> new EntityListModule(HOSTILE_LIST), () -> () -> new EntityListModuleView(HOSTILE_LIST, COM_MINECOLONIES_HOSTILES, true))
                                        .addBuildingModuleProducer(() -> new SettingsModule()
                                                                           .with(AbstractBuildingGuards.JOB, new GuardJobSetting())
                                                                           .with(AbstractBuildingGuards.GUARD_TASK, new GuardTaskSetting(GuardTaskSetting.PATROL, GuardTaskSetting.GUARD, GuardTaskSetting.FOLLOW))
                                                                           .with(AbstractBuildingGuards.RETREAT, new BoolSetting(true))
                                                                           .with(AbstractBuildingGuards.HIRE_TRAINEE, new BoolSetting(true))
                                                                           .with(AbstractBuildingGuards.PATROL_MODE, new PatrolModeSetting())
-                                                                          .with(AbstractBuildingGuards.FOLLOW_MODE, new FollowModeSetting()), SettingsModuleView::new)
+                                                                          .with(AbstractBuildingGuards.FOLLOW_MODE, new FollowModeSetting()), () -> SettingsModuleView::new)
                                        .createBuildingEntry();
 
         ModBuildings.blacksmith = new BuildingEntry.Builder()
@@ -95,8 +95,8 @@ public final class ModBuildingsInitializer
                                     .setBuildingProducer(BuildingBlacksmith::new)
                                     .setBuildingViewProducer(() -> BuildingBlacksmith.View::new)
                                     .setRegistryName(new ResourceLocation(Constants.MOD_ID, ModBuildings.BLACKSMITH_ID))
-                                    .addBuildingModuleProducer(BuildingBlacksmith.CraftingModule::new, CraftingModuleView::new)
-                                    .addBuildingModuleViewProducer(CrafterTaskModuleView::new)
+                                    .addBuildingModuleProducer(BuildingBlacksmith.CraftingModule::new, () -> CraftingModuleView::new)
+                                    .addBuildingModuleViewProducer(() -> CrafterTaskModuleView::new)
                                     .createBuildingEntry();
 
         ModBuildings.builder = new BuildingEntry.Builder()
@@ -104,11 +104,11 @@ public final class ModBuildingsInitializer
                                  .setBuildingProducer(BuildingBuilder::new)
                                  .setBuildingViewProducer(() -> BuildingBuilder.View::new)
                                  .setRegistryName(new ResourceLocation(Constants.MOD_ID, ModBuildings.BUILDER_ID))
-                                 .addBuildingModuleProducer(MinimumStockModule::new, MinimumStockModuleView::new)
-                                 .addBuildingModuleProducer(() -> new SettingsModule().with(BuildingBuilder.MODE, new StringSetting(BuildingBuilder.AUTO_SETTING, BuildingBuilder.MANUAL_SETTING)), SettingsModuleView::new)
-                                 .addBuildingModuleProducer(SimpleCraftingModule::new, CraftingModuleView::new)
-                                 .addBuildingModuleViewProducer(WorkOrderListModuleView::new)
-                                 .addBuildingModuleProducer(BuildingResourcesModule::new, BuildingResourcesModuleView::new)
+                                 .addBuildingModuleProducer(MinimumStockModule::new, () -> MinimumStockModuleView::new)
+                                 .addBuildingModuleProducer(() -> new SettingsModule().with(BuildingBuilder.MODE, new StringSetting(BuildingBuilder.AUTO_SETTING, BuildingBuilder.MANUAL_SETTING)), () -> SettingsModuleView::new)
+                                 .addBuildingModuleProducer(SimpleCraftingModule::new, () -> CraftingModuleView::new)
+                                 .addBuildingModuleViewProducer(() -> WorkOrderListModuleView::new)
+                                 .addBuildingModuleProducer(BuildingResourcesModule::new, () -> BuildingResourcesModuleView::new)
                                  .createBuildingEntry();
 
         ModBuildings.chickenHerder = new BuildingEntry.Builder()
@@ -116,8 +116,8 @@ public final class ModBuildingsInitializer
                                        .setBuildingProducer(BuildingChickenHerder::new)
                                        .setBuildingViewProducer(() -> BuildingChickenHerder.View::new)
                                        .setRegistryName(new ResourceLocation(Constants.MOD_ID, ModBuildings.CHICKENHERDER_ID))
-                                       .addBuildingModuleProducer(MinimumStockModule::new, MinimumStockModuleView::new)
-                                       .addBuildingModuleProducer(() -> new SettingsModule().with(AbstractBuildingWorker.BREEDING, new BoolSetting(true)), SettingsModuleView::new)
+                                       .addBuildingModuleProducer(MinimumStockModule::new, () -> MinimumStockModuleView::new)
+                                       .addBuildingModuleProducer(() -> new SettingsModule().with(AbstractBuildingWorker.BREEDING, new BoolSetting(true)), () -> SettingsModuleView::new)
                                        .createBuildingEntry();
 
         ModBuildings.combatAcademy = new BuildingEntry.Builder()
@@ -125,7 +125,7 @@ public final class ModBuildingsInitializer
                                        .setBuildingProducer(BuildingCombatAcademy::new)
                                        .setBuildingViewProducer(() -> BuildingCombatAcademy.View::new)
                                        .setRegistryName(new ResourceLocation(Constants.MOD_ID, ModBuildings.COMBAT_ACADEMY_ID))
-                                       .addBuildingModuleProducer(MinimumStockModule::new, MinimumStockModuleView::new)
+                                       .addBuildingModuleProducer(MinimumStockModule::new, () -> MinimumStockModuleView::new)
                                        .addBuildingModuleProducer(BedHandlingModule::new)
                                        .createBuildingEntry();
 
@@ -134,9 +134,9 @@ public final class ModBuildingsInitializer
                                    .setBuildingProducer(BuildingComposter::new)
                                    .setBuildingViewProducer(() -> BuildingComposter.View::new)
                                    .setRegistryName(new ResourceLocation(Constants.MOD_ID, ModBuildings.COMPOSTER_ID))
-                                   .addBuildingModuleProducer(() -> new ItemListModule(COMPOSTABLE_LIST), () -> new ItemListModuleView(COMPOSTABLE_LIST, COM_MINECOLONIES_REQUESTS_COMPOSTABLE_UI, false,
+                                   .addBuildingModuleProducer(() -> new ItemListModule(COMPOSTABLE_LIST), () -> () -> new ItemListModuleView(COMPOSTABLE_LIST, COM_MINECOLONIES_REQUESTS_COMPOSTABLE_UI, false,
                                      (buildingView) -> IColonyManager.getInstance().getCompatibilityManager().getCompostInputs()))
-                                   .addBuildingModuleProducer(() -> new SettingsModule().with(BuildingComposter.PRODUCE_DIRT, new BoolSetting(false)).with(BuildingComposter.MIN, new IntSetting(16)), SettingsModuleView::new)
+                                   .addBuildingModuleProducer(() -> new SettingsModule().with(BuildingComposter.PRODUCE_DIRT, new BoolSetting(false)).with(BuildingComposter.MIN, new IntSetting(16)), () -> SettingsModuleView::new)
                                    .createBuildingEntry();
 
         ModBuildings.cook = new BuildingEntry.Builder()
@@ -144,14 +144,14 @@ public final class ModBuildingsInitializer
                               .setBuildingProducer(BuildingCook::new)
                               .setBuildingViewProducer(() -> BuildingCook.View::new)
                               .setRegistryName(new ResourceLocation(Constants.MOD_ID, ModBuildings.COOK_ID))
-                              .addBuildingModuleProducer(BuildingCook.CraftingModule::new, CraftingModuleView::new)
-                              .addBuildingModuleProducer(BuildingCook.SmeltingModule::new, CraftingModuleView::new)
-                              .addBuildingModuleProducer(MinimumStockModule::new, MinimumStockModuleView::new)
-                              .addBuildingModuleProducer(() -> new ItemListModule(FUEL_LIST), () -> new ItemListModuleView(FUEL_LIST, COM_MINECOLONIES_REQUESTS_BURNABLE, false,
+                              .addBuildingModuleProducer(BuildingCook.CraftingModule::new, () -> CraftingModuleView::new)
+                              .addBuildingModuleProducer(BuildingCook.SmeltingModule::new, () -> CraftingModuleView::new)
+                              .addBuildingModuleProducer(MinimumStockModule::new, () -> MinimumStockModuleView::new)
+                              .addBuildingModuleProducer(() -> new ItemListModule(FUEL_LIST), () -> () -> new ItemListModuleView(FUEL_LIST, COM_MINECOLONIES_REQUESTS_BURNABLE, false,
                                 (buildingView) -> IColonyManager.getInstance().getCompatibilityManager().getFuel()))
-                              .addBuildingModuleProducer(() -> new ItemListModule(FOOD_EXCLUSION_LIST), () -> new ItemListModuleView(FOOD_EXCLUSION_LIST, COM_MINECOLONIES_REQUESTS_FOOD, true,
+                              .addBuildingModuleProducer(() -> new ItemListModule(FOOD_EXCLUSION_LIST), () -> () -> new ItemListModuleView(FOOD_EXCLUSION_LIST, COM_MINECOLONIES_REQUESTS_FOOD, true,
                                 (buildingView) -> IColonyManager.getInstance().getCompatibilityManager().getEdibles()))
-                              .addBuildingModuleViewProducer(CrafterTaskModuleView::new)
+                              .addBuildingModuleViewProducer(() -> CrafterTaskModuleView::new)
                               .createBuildingEntry();
 
         ModBuildings.cowboy = new BuildingEntry.Builder()
@@ -159,9 +159,9 @@ public final class ModBuildingsInitializer
                                 .setBuildingProducer(BuildingCowboy::new)
                                 .setBuildingViewProducer(() -> BuildingCowboy.View::new)
                                 .setRegistryName(new ResourceLocation(Constants.MOD_ID, ModBuildings.COWBOY_ID))
-                                .addBuildingModuleProducer(MinimumStockModule::new, MinimumStockModuleView::new)
+                                .addBuildingModuleProducer(MinimumStockModule::new, () -> MinimumStockModuleView::new)
                                 .addBuildingModuleProducer(() -> new SettingsModule().with(AbstractBuildingWorker.BREEDING, new BoolSetting(true))
-                                                                                     .with(BuildingCowboy.MILKING, new BoolSetting(false)), SettingsModuleView::new)
+                                                                                     .with(BuildingCowboy.MILKING, new BoolSetting(false)), () -> SettingsModuleView::new)
                                 .createBuildingEntry();
 
         ModBuildings.crusher = new BuildingEntry.Builder()
@@ -169,8 +169,8 @@ public final class ModBuildingsInitializer
                                  .setBuildingProducer(BuildingCrusher::new)
                                  .setBuildingViewProducer(() -> BuildingCrusher.View::new)
                                  .setRegistryName(new ResourceLocation(Constants.MOD_ID, ModBuildings.CRUSHER_ID))
-                                 .addBuildingModuleProducer(BuildingCrusher.CraftingModule::new, CraftingModuleView::new)
-                                 .addBuildingModuleViewProducer(CrafterTaskModuleView::new)
+                                 .addBuildingModuleProducer(BuildingCrusher.CraftingModule::new, () -> CraftingModuleView::new)
+                                 .addBuildingModuleViewProducer(() -> CrafterTaskModuleView::new)
                                  .createBuildingEntry();
 
         ModBuildings.deliveryman = new BuildingEntry.Builder()
@@ -178,7 +178,7 @@ public final class ModBuildingsInitializer
                                      .setBuildingProducer(BuildingDeliveryman::new)
                                      .setBuildingViewProducer(() -> BuildingDeliveryman.View::new)
                                      .setRegistryName(new ResourceLocation(Constants.MOD_ID, ModBuildings.DELIVERYMAN_ID))
-                                     .addBuildingModuleViewProducer(CrafterTaskModuleView::new)
+                                     .addBuildingModuleViewProducer(() -> CrafterTaskModuleView::new)
                                      .createBuildingEntry();
 
         ModBuildings.farmer = new BuildingEntry.Builder()
@@ -186,9 +186,9 @@ public final class ModBuildingsInitializer
                                 .setBuildingProducer(BuildingFarmer::new)
                                 .setBuildingViewProducer(() -> BuildingFarmer.View::new)
                                 .setRegistryName(new ResourceLocation(Constants.MOD_ID, ModBuildings.FARMER_ID))
-                                .addBuildingModuleProducer(BuildingFarmer.CraftingModule::new, CraftingModuleView::new)
-                                .addBuildingModuleViewProducer(CrafterTaskModuleView::new)
-                                .addBuildingModuleProducer(() -> new SettingsModule().with(BuildingFarmer.FERTILIZE, new BoolSetting(true)), SettingsModuleView::new)
+                                .addBuildingModuleProducer(BuildingFarmer.CraftingModule::new, () -> CraftingModuleView::new)
+                                .addBuildingModuleViewProducer(() -> CrafterTaskModuleView::new)
+                                .addBuildingModuleProducer(() -> new SettingsModule().with(BuildingFarmer.FERTILIZE, new BoolSetting(true)), () -> SettingsModuleView::new)
                                 .createBuildingEntry();
 
         ModBuildings.fisherman = new BuildingEntry.Builder()
@@ -196,7 +196,7 @@ public final class ModBuildingsInitializer
                                    .setBuildingProducer(BuildingFisherman::new)
                                    .setBuildingViewProducer(() -> BuildingFisherman.View::new)
                                    .setRegistryName(new ResourceLocation(Constants.MOD_ID, ModBuildings.FISHERMAN_ID))
-                                   .addBuildingModuleProducer(MinimumStockModule::new, MinimumStockModuleView::new)
+                                   .addBuildingModuleProducer(MinimumStockModule::new, () -> MinimumStockModuleView::new)
                                    .createBuildingEntry();
 
         ModBuildings.guardTower = new BuildingEntry.Builder()
@@ -204,17 +204,17 @@ public final class ModBuildingsInitializer
                                     .setBuildingProducer(BuildingGuardTower::new)
                                     .setBuildingViewProducer(() -> BuildingGuardTower.View::new)
                                     .setRegistryName(new ResourceLocation(Constants.MOD_ID, ModBuildings.GUARD_TOWER_ID))
-                                    .addBuildingModuleProducer(MinimumStockModule::new, MinimumStockModuleView::new)
+                                    .addBuildingModuleProducer(MinimumStockModule::new, () -> MinimumStockModuleView::new)
                                     .addBuildingModuleProducer(BedHandlingModule::new)
-                                    .addBuildingModuleViewProducer(() -> new ToolModuleView(ModItems.scepterGuard))
-                                    .addBuildingModuleProducer(() -> new EntityListModule(HOSTILE_LIST), () -> new EntityListModuleView(HOSTILE_LIST, COM_MINECOLONIES_HOSTILES, true))
+                                    .addBuildingModuleViewProducer(() -> () -> new ToolModuleView(ModItems.scepterGuard))
+                                    .addBuildingModuleProducer(() -> new EntityListModule(HOSTILE_LIST), () -> () -> new EntityListModuleView(HOSTILE_LIST, COM_MINECOLONIES_HOSTILES, true))
                                     .addBuildingModuleProducer(() -> new SettingsModule()
                                                                        .with(AbstractBuildingGuards.JOB, new GuardJobSetting())
                                                                        .with(AbstractBuildingGuards.GUARD_TASK, new GuardTaskSetting())
                                                                        .with(AbstractBuildingGuards.RETREAT, new BoolSetting(true))
                                                                        .with(AbstractBuildingGuards.HIRE_TRAINEE, new BoolSetting(true))
                                                                        .with(AbstractBuildingGuards.PATROL_MODE, new PatrolModeSetting())
-                                                                       .with(AbstractBuildingGuards.FOLLOW_MODE, new FollowModeSetting()), SettingsModuleView::new)
+                                                                       .with(AbstractBuildingGuards.FOLLOW_MODE, new FollowModeSetting()), () -> SettingsModuleView::new)
                                     .createBuildingEntry();
 
         ModBuildings.home = new BuildingEntry.Builder()
@@ -232,7 +232,7 @@ public final class ModBuildingsInitializer
                                  .setBuildingProducer(BuildingLibrary::new)
                                  .setBuildingViewProducer(() -> BuildingLibrary.View::new)
                                  .setRegistryName(new ResourceLocation(Constants.MOD_ID, ModBuildings.LIBRARY_ID))
-                                 .addBuildingModuleProducer(MinimumStockModule::new, MinimumStockModuleView::new)
+                                 .addBuildingModuleProducer(MinimumStockModule::new, () -> MinimumStockModuleView::new)
                                  .createBuildingEntry();
 
         ModBuildings.lumberjack = new BuildingEntry.Builder()
@@ -240,12 +240,12 @@ public final class ModBuildingsInitializer
                                     .setBuildingProducer(BuildingLumberjack::new)
                                     .setBuildingViewProducer(() -> BuildingLumberjack.View::new)
                                     .setRegistryName(new ResourceLocation(Constants.MOD_ID, ModBuildings.LUMBERJACK_ID))
-                                    .addBuildingModuleProducer(BuildingLumberjack.CraftingModule::new, CraftingModuleView::new)
-                                    .addBuildingModuleProducer(() -> new ItemListModule(SAPLINGS_LIST), () -> new ItemListModuleView(SAPLINGS_LIST, COM_MINECOLONIES_REQUESTS_SAPLINGS, true,
+                                    .addBuildingModuleProducer(BuildingLumberjack.CraftingModule::new, () -> CraftingModuleView::new)
+                                    .addBuildingModuleProducer(() -> new ItemListModule(SAPLINGS_LIST), () -> () -> new ItemListModuleView(SAPLINGS_LIST, COM_MINECOLONIES_REQUESTS_SAPLINGS, true,
                                       (buildingView) -> IColonyManager.getInstance().getCompatibilityManager().getCopyOfSaplings()))
-                                    .addBuildingModuleViewProducer(CrafterTaskModuleView::new)
-                                    .addBuildingModuleProducer(() -> new SettingsModule().with(BuildingLumberjack.REPLANT, new BoolSetting(true)).with(BuildingLumberjack.RESTRICT, new BoolSetting(false)), SettingsModuleView::new)
-                                    .addBuildingModuleViewProducer(() -> new ToolModuleView(ModItems.scepterLumberjack))
+                                    .addBuildingModuleViewProducer(() -> CrafterTaskModuleView::new)
+                                    .addBuildingModuleProducer(() -> new SettingsModule().with(BuildingLumberjack.REPLANT, new BoolSetting(true)).with(BuildingLumberjack.RESTRICT, new BoolSetting(false)), () -> SettingsModuleView::new)
+                                    .addBuildingModuleViewProducer(() -> () -> new ToolModuleView(ModItems.scepterLumberjack))
                                     .createBuildingEntry();
 
         ModBuildings.miner = new BuildingEntry.Builder()
@@ -253,9 +253,9 @@ public final class ModBuildingsInitializer
                                .setBuildingProducer(BuildingMiner::new)
                                .setBuildingViewProducer(() -> BuildingMiner.View::new)
                                .setRegistryName(new ResourceLocation(Constants.MOD_ID, ModBuildings.MINER_ID))
-                               .addBuildingModuleProducer(SimpleCraftingModule::new, CraftingModuleView::new)
-                               .addBuildingModuleProducer(MinimumStockModule::new, MinimumStockModuleView::new)
-                               .addBuildingModuleProducer(BuildingResourcesModule::new, BuildingResourcesModuleView::new)
+                               .addBuildingModuleProducer(SimpleCraftingModule::new, () -> CraftingModuleView::new)
+                               .addBuildingModuleProducer(MinimumStockModule::new, () -> MinimumStockModuleView::new)
+                               .addBuildingModuleProducer(BuildingResourcesModule::new, () -> BuildingResourcesModuleView::new)
                                .createBuildingEntry();
 
         ModBuildings.sawmill = new BuildingEntry.Builder()
@@ -263,8 +263,8 @@ public final class ModBuildingsInitializer
                                  .setBuildingProducer(BuildingSawmill::new)
                                  .setBuildingViewProducer(() -> BuildingSawmill.View::new)
                                  .setRegistryName(new ResourceLocation(Constants.MOD_ID, ModBuildings.SAWMILL_ID))
-                                 .addBuildingModuleProducer(BuildingSawmill.CraftingModule::new, CraftingModuleView::new)
-                                 .addBuildingModuleViewProducer(CrafterTaskModuleView::new)
+                                 .addBuildingModuleProducer(BuildingSawmill.CraftingModule::new, () -> CraftingModuleView::new)
+                                 .addBuildingModuleViewProducer(() -> CrafterTaskModuleView::new)
                                  .createBuildingEntry();
 
         ModBuildings.shepherd = new BuildingEntry.Builder()
@@ -272,18 +272,18 @@ public final class ModBuildingsInitializer
                                   .setBuildingProducer(BuildingShepherd::new)
                                   .setBuildingViewProducer(() -> BuildingShepherd.View::new)
                                   .setRegistryName(new ResourceLocation(Constants.MOD_ID, ModBuildings.SHEPHERD_ID))
-                                  .addBuildingModuleProducer(MinimumStockModule::new, MinimumStockModuleView::new)
+                                  .addBuildingModuleProducer(MinimumStockModule::new, () -> MinimumStockModuleView::new)
                                   .addBuildingModuleProducer(() -> new SettingsModule().with(AbstractBuildingWorker.BREEDING, new BoolSetting(true))
                                                                                        .with(BuildingShepherd.DYEING, new BoolSetting(true))
-                                                                                       .with(BuildingShepherd.SHEARING, new BoolSetting(true)), SettingsModuleView::new)
+                                                                                       .with(BuildingShepherd.SHEARING, new BoolSetting(true)), () -> SettingsModuleView::new)
                                   .createBuildingEntry();
 
         ModBuildings.sifter = new BuildingEntry.Builder()
                                 .setBuildingBlock(ModBlocks.blockHutSifter)
                                 .setBuildingProducer(BuildingSifter::new)
                                 .setBuildingViewProducer(() -> BuildingSifter.View::new)
-                                .addBuildingModuleProducer(BuildingSifter.CraftingModule::new, CraftingModuleView::new)
-                                .addBuildingModuleProducer(MinimumStockModule::new, MinimumStockModuleView::new)
+                                .addBuildingModuleProducer(BuildingSifter.CraftingModule::new, () -> CraftingModuleView::new)
+                                .addBuildingModuleProducer(MinimumStockModule::new, () -> MinimumStockModuleView::new)
                                 .setRegistryName(new ResourceLocation(Constants.MOD_ID, ModBuildings.SIFTER_ID))
                                 .createBuildingEntry();
 
@@ -292,11 +292,11 @@ public final class ModBuildingsInitializer
                                   .setBuildingProducer(BuildingSmeltery::new)
                                   .setBuildingViewProducer(() -> BuildingSmeltery.View::new)
                                   .setRegistryName(new ResourceLocation(Constants.MOD_ID, ModBuildings.SMELTERY_ID))
-                                  .addBuildingModuleProducer(BuildingSmeltery.SmeltingModule::new, CraftingModuleView::new)
-                                  .addBuildingModuleProducer(() -> new ItemListModule(FUEL_LIST), () -> new ItemListModuleView(FUEL_LIST, COM_MINECOLONIES_REQUESTS_BURNABLE, false,
+                                  .addBuildingModuleProducer(BuildingSmeltery.SmeltingModule::new, () -> CraftingModuleView::new)
+                                  .addBuildingModuleProducer(() -> new ItemListModule(FUEL_LIST), () -> () -> new ItemListModuleView(FUEL_LIST, COM_MINECOLONIES_REQUESTS_BURNABLE, false,
                                     (buildingView) -> IColonyManager.getInstance().getCompatibilityManager().getFuel()))
-                                  .addBuildingModuleProducer(MinimumStockModule::new, MinimumStockModuleView::new)
-                                  .addBuildingModuleProducer(() -> new ItemListModule(ORE_LIST), () -> new ItemListModuleView(ORE_LIST, COM_MINECOLONIES_REQUESTS_SMELTABLE_ORE, true,
+                                  .addBuildingModuleProducer(MinimumStockModule::new, () -> MinimumStockModuleView::new)
+                                  .addBuildingModuleProducer(() -> new ItemListModule(ORE_LIST), () -> () -> new ItemListModuleView(ORE_LIST, COM_MINECOLONIES_REQUESTS_SMELTABLE_ORE, true,
                                     (buildingView) -> IColonyManager.getInstance().getCompatibilityManager().getSmeltableOres()))
                                   .createBuildingEntry();
 
@@ -305,8 +305,8 @@ public final class ModBuildingsInitializer
                                     .setBuildingProducer(BuildingStonemason::new)
                                     .setBuildingViewProducer(() -> BuildingStonemason.View::new)
                                     .setRegistryName(new ResourceLocation(Constants.MOD_ID, ModBuildings.STONE_MASON_ID))
-                                    .addBuildingModuleProducer(BuildingStonemason.CraftingModule::new, CraftingModuleView::new)
-                                    .addBuildingModuleViewProducer(CrafterTaskModuleView::new)
+                                    .addBuildingModuleProducer(BuildingStonemason.CraftingModule::new, () -> CraftingModuleView::new)
+                                    .addBuildingModuleViewProducer(() -> CrafterTaskModuleView::new)
                                     .createBuildingEntry();
 
         ModBuildings.stoneSmelter = new BuildingEntry.Builder()
@@ -314,10 +314,10 @@ public final class ModBuildingsInitializer
                                       .setBuildingProducer(BuildingStoneSmeltery::new)
                                       .setBuildingViewProducer(() -> BuildingStoneSmeltery.View::new)
                                       .setRegistryName(new ResourceLocation(Constants.MOD_ID, ModBuildings.STONE_SMELTERY_ID))
-                                      .addBuildingModuleProducer(BuildingStoneSmeltery.SmeltingModule::new, CraftingModuleView::new)
-                                      .addBuildingModuleProducer(() -> new ItemListModule(FUEL_LIST), () -> new ItemListModuleView(FUEL_LIST, COM_MINECOLONIES_REQUESTS_BURNABLE, false,
+                                      .addBuildingModuleProducer(BuildingStoneSmeltery.SmeltingModule::new, () -> CraftingModuleView::new)
+                                      .addBuildingModuleProducer(() -> new ItemListModule(FUEL_LIST), () -> () -> new ItemListModuleView(FUEL_LIST, COM_MINECOLONIES_REQUESTS_BURNABLE, false,
                                         (buildingView) -> IColonyManager.getInstance().getCompatibilityManager().getFuel()))
-                                      .addBuildingModuleViewProducer(CrafterTaskModuleView::new)
+                                      .addBuildingModuleViewProducer(() -> CrafterTaskModuleView::new)
                                       .createBuildingEntry();
 
         ModBuildings.swineHerder = new BuildingEntry.Builder()
@@ -325,8 +325,8 @@ public final class ModBuildingsInitializer
                                      .setBuildingProducer(BuildingSwineHerder::new)
                                      .setBuildingViewProducer(() -> BuildingSwineHerder.View::new)
                                      .setRegistryName(new ResourceLocation(Constants.MOD_ID, ModBuildings.SWINE_HERDER_ID))
-                                     .addBuildingModuleProducer(MinimumStockModule::new, MinimumStockModuleView::new)
-                                     .addBuildingModuleProducer(() -> new SettingsModule().with(AbstractBuildingWorker.BREEDING, new BoolSetting(true)), SettingsModuleView::new)
+                                     .addBuildingModuleProducer(MinimumStockModule::new, () -> MinimumStockModuleView::new)
+                                     .addBuildingModuleProducer(() -> new SettingsModule().with(AbstractBuildingWorker.BREEDING, new BoolSetting(true)), () -> SettingsModuleView::new)
                                      .createBuildingEntry();
 
         ModBuildings.townHall = new BuildingEntry.Builder()
@@ -341,7 +341,7 @@ public final class ModBuildingsInitializer
                                    .setBuildingProducer(BuildingWareHouse::new)
                                    .setBuildingViewProducer(() -> BuildingWareHouse.View::new)
                                    .setRegistryName(new ResourceLocation(Constants.MOD_ID, ModBuildings.WAREHOUSE_ID))
-                                   .addBuildingModuleProducer(MinimumStockModule::new, MinimumStockModuleView::new)
+                                   .addBuildingModuleProducer(MinimumStockModule::new, () -> MinimumStockModuleView::new)
                                    .createBuildingEntry();
 
         ModBuildings.postBox = new BuildingEntry.Builder()
@@ -356,8 +356,8 @@ public final class ModBuildingsInitializer
                                  .setBuildingProducer(BuildingFlorist::new)
                                  .setBuildingViewProducer(() -> BuildingFlorist.View::new)
                                  .setRegistryName(new ResourceLocation(Constants.MOD_ID, ModBuildings.FLORIST_ID))
-                                 .addBuildingModuleProducer(() -> new ItemListModule(BUILDING_FLOWER_LIST), () -> new FloristFlowerListModuleView())
-                                 .addBuildingModuleProducer(MinimumStockModule::new, MinimumStockModuleView::new)
+                                 .addBuildingModuleProducer(() -> new ItemListModule(BUILDING_FLOWER_LIST), () -> FloristFlowerListModuleView::new)
+                                 .addBuildingModuleProducer(MinimumStockModule::new, () -> MinimumStockModuleView::new)
                                  .createBuildingEntry();
 
         ModBuildings.enchanter = new BuildingEntry.Builder()
@@ -365,8 +365,8 @@ public final class ModBuildingsInitializer
                                    .setBuildingProducer(BuildingEnchanter::new)
                                    .setBuildingViewProducer(() -> BuildingEnchanter.View::new)
                                    .setRegistryName(new ResourceLocation(Constants.MOD_ID, ModBuildings.ENCHANTER_ID))
-                                   .addBuildingModuleProducer(BuildingEnchanter.CraftingModule::new, CraftingModuleView::new)
-                                   .addBuildingModuleProducer(MinimumStockModule::new, MinimumStockModuleView::new)
+                                   .addBuildingModuleProducer(BuildingEnchanter.CraftingModule::new, () -> CraftingModuleView::new)
+                                   .addBuildingModuleProducer(MinimumStockModule::new, () -> MinimumStockModuleView::new)
                                    .createBuildingEntry();
 
         ModBuildings.university = new BuildingEntry.Builder()
@@ -381,7 +381,7 @@ public final class ModBuildingsInitializer
                                   .setBuildingProducer(BuildingHospital::new)
                                   .setBuildingViewProducer(() -> BuildingHospital.View::new)
                                   .setRegistryName(new ResourceLocation(Constants.MOD_ID, ModBuildings.HOSPITAL_ID))
-                                  .addBuildingModuleProducer(MinimumStockModule::new, MinimumStockModuleView::new)
+                                  .addBuildingModuleProducer(MinimumStockModule::new, () -> MinimumStockModuleView::new)
                                   .createBuildingEntry();
 
         ModBuildings.stash = new BuildingEntry.Builder()
@@ -396,7 +396,7 @@ public final class ModBuildingsInitializer
                                 .setBuildingProducer(BuildingSchool::new)
                                 .setBuildingViewProducer(() -> BuildingSchool.View::new)
                                 .setRegistryName(new ResourceLocation(Constants.MOD_ID, ModBuildings.SCHOOL_ID))
-                                .addBuildingModuleProducer(MinimumStockModule::new, MinimumStockModuleView::new)
+                                .addBuildingModuleProducer(MinimumStockModule::new, () -> MinimumStockModuleView::new)
                                 .createBuildingEntry();
 
         ModBuildings.glassblower = new BuildingEntry.Builder()
@@ -404,11 +404,11 @@ public final class ModBuildingsInitializer
                                      .setBuildingProducer(BuildingGlassblower::new)
                                      .setBuildingViewProducer(() -> BuildingGlassblower.View::new)
                                      .setRegistryName(new ResourceLocation(Constants.MOD_ID, ModBuildings.GLASSBLOWER_ID))
-                                     .addBuildingModuleProducer(BuildingGlassblower.CraftingModule::new, CraftingModuleView::new)
-                                     .addBuildingModuleProducer(BuildingGlassblower.SmeltingModule::new, CraftingModuleView::new)
-                                     .addBuildingModuleProducer(() -> new ItemListModule(FUEL_LIST), () -> new ItemListModuleView(FUEL_LIST, COM_MINECOLONIES_REQUESTS_BURNABLE, false,
+                                     .addBuildingModuleProducer(BuildingGlassblower.CraftingModule::new, () -> CraftingModuleView::new)
+                                     .addBuildingModuleProducer(BuildingGlassblower.SmeltingModule::new, () -> CraftingModuleView::new)
+                                     .addBuildingModuleProducer(() -> new ItemListModule(FUEL_LIST), () -> () -> new ItemListModuleView(FUEL_LIST, COM_MINECOLONIES_REQUESTS_BURNABLE, false,
                                        (buildingView) -> IColonyManager.getInstance().getCompatibilityManager().getFuel()))
-                                     .addBuildingModuleViewProducer(CrafterTaskModuleView::new)
+                                     .addBuildingModuleViewProducer(() -> CrafterTaskModuleView::new)
                                      .createBuildingEntry();
 
         ModBuildings.dyer = new BuildingEntry.Builder()
@@ -416,11 +416,11 @@ public final class ModBuildingsInitializer
                               .setBuildingProducer(BuildingDyer::new)
                               .setBuildingViewProducer(() -> BuildingDyer.View::new)
                               .setRegistryName(new ResourceLocation(Constants.MOD_ID, ModBuildings.DYER_ID))
-                              .addBuildingModuleProducer(BuildingDyer.CraftingModule::new, CraftingModuleView::new)
-                              .addBuildingModuleProducer(BuildingDyer.SmeltingModule::new, CraftingModuleView::new)
-                              .addBuildingModuleProducer(() -> new ItemListModule(FUEL_LIST), () -> new ItemListModuleView(FUEL_LIST, COM_MINECOLONIES_REQUESTS_BURNABLE, false,
+                              .addBuildingModuleProducer(BuildingDyer.CraftingModule::new, () -> CraftingModuleView::new)
+                              .addBuildingModuleProducer(BuildingDyer.SmeltingModule::new, () -> CraftingModuleView::new)
+                              .addBuildingModuleProducer(() -> new ItemListModule(FUEL_LIST), () -> () -> new ItemListModuleView(FUEL_LIST, COM_MINECOLONIES_REQUESTS_BURNABLE, false,
                                 (buildingView) -> IColonyManager.getInstance().getCompatibilityManager().getFuel()))
-                              .addBuildingModuleViewProducer(CrafterTaskModuleView::new)
+                              .addBuildingModuleViewProducer(() -> CrafterTaskModuleView::new)
                               .createBuildingEntry();
 
         ModBuildings.fletcher = new BuildingEntry.Builder()
@@ -428,8 +428,8 @@ public final class ModBuildingsInitializer
                                   .setBuildingProducer(BuildingFletcher::new)
                                   .setBuildingViewProducer(() -> BuildingFletcher.View::new)
                                   .setRegistryName(new ResourceLocation(Constants.MOD_ID, ModBuildings.FLETCHER_ID))
-                                  .addBuildingModuleProducer(BuildingFletcher.CraftingModule::new, CraftingModuleView::new)
-                                  .addBuildingModuleViewProducer(CrafterTaskModuleView::new)
+                                  .addBuildingModuleProducer(BuildingFletcher.CraftingModule::new, () -> CraftingModuleView::new)
+                                  .addBuildingModuleViewProducer(() -> CrafterTaskModuleView::new)
                                   .createBuildingEntry();
 
         ModBuildings.tavern = new BuildingEntry.Builder()
@@ -447,8 +447,8 @@ public final class ModBuildingsInitializer
                                   .setBuildingProducer(BuildingMechanic::new)
                                   .setBuildingViewProducer(() -> BuildingMechanic.View::new)
                                   .setRegistryName(new ResourceLocation(Constants.MOD_ID, ModBuildings.MECHANIC_ID))
-                                  .addBuildingModuleProducer(BuildingMechanic.CraftingModule::new, CraftingModuleView::new)
-                                  .addBuildingModuleViewProducer(CrafterTaskModuleView::new)
+                                  .addBuildingModuleProducer(BuildingMechanic.CraftingModule::new, () -> CraftingModuleView::new)
+                                  .addBuildingModuleViewProducer(() -> CrafterTaskModuleView::new)
                                   .createBuildingEntry();
 
         ModBuildings.plantation = new BuildingEntry.Builder()
@@ -456,9 +456,9 @@ public final class ModBuildingsInitializer
                                     .setBuildingProducer(BuildingPlantation::new)
                                     .setBuildingViewProducer(() -> BuildingPlantation.View::new)
                                     .setRegistryName(new ResourceLocation(Constants.MOD_ID, ModBuildings.PLANTATION_ID))
-                                    .addBuildingModuleProducer(BuildingPlantation.CraftingModule::new, CraftingModuleView::new)
-                                    .addBuildingModuleViewProducer(CrafterTaskModuleView::new)
-                                    .addBuildingModuleProducer(() -> new SettingsModule().with(BuildingPlantation.MODE, new PlantationSetting(Items.SUGAR_CANE.getTranslationKey(), Items.CACTUS.getTranslationKey(), Items.BAMBOO.getTranslationKey())), SettingsModuleView::new)
+                                    .addBuildingModuleProducer(BuildingPlantation.CraftingModule::new, () -> CraftingModuleView::new)
+                                    .addBuildingModuleViewProducer(() -> CrafterTaskModuleView::new)
+                                    .addBuildingModuleProducer(() -> new SettingsModule().with(BuildingPlantation.MODE, new PlantationSetting(Items.SUGAR_CANE.getTranslationKey(), Items.CACTUS.getTranslationKey(), Items.BAMBOO.getTranslationKey())), () -> SettingsModuleView::new)
                                     .createBuildingEntry();
 
         ModBuildings.rabbitHutch = new BuildingEntry.Builder()
@@ -466,8 +466,8 @@ public final class ModBuildingsInitializer
                                      .setBuildingProducer(BuildingRabbitHutch::new)
                                      .setBuildingViewProducer(() -> BuildingRabbitHutch.View::new)
                                      .setRegistryName(new ResourceLocation(Constants.MOD_ID, ModBuildings.RABBIT_ID))
-                                     .addBuildingModuleProducer(MinimumStockModule::new, MinimumStockModuleView::new)
-                                     .addBuildingModuleProducer(() -> new SettingsModule().with(AbstractBuildingWorker.BREEDING, new BoolSetting(true)), SettingsModuleView::new)
+                                     .addBuildingModuleProducer(MinimumStockModule::new, () -> MinimumStockModuleView::new)
+                                     .addBuildingModuleProducer(() -> new SettingsModule().with(AbstractBuildingWorker.BREEDING, new BoolSetting(true)), () -> SettingsModuleView::new)
                                      .createBuildingEntry();
 
         //todo we want two here, one custom for the concrete placement, and one crafting for the normal crafting of the powder.
@@ -476,8 +476,8 @@ public final class ModBuildingsInitializer
                                        .setBuildingProducer(BuildingConcreteMixer::new)
                                        .setBuildingViewProducer(() -> BuildingConcreteMixer.View::new)
                                        .setRegistryName(new ResourceLocation(Constants.MOD_ID, ModBuildings.CONCRETE_ID))
-                                       .addBuildingModuleProducer(BuildingConcreteMixer.CraftingModule::new, CraftingModuleView::new)
-                                       .addBuildingModuleViewProducer(CrafterTaskModuleView::new)
+                                       .addBuildingModuleProducer(BuildingConcreteMixer.CraftingModule::new, () -> CraftingModuleView::new)
+                                       .addBuildingModuleViewProducer(() -> CrafterTaskModuleView::new)
                                        .createBuildingEntry();
 
         ModBuildings.beekeeper = new BuildingEntry.Builder()
@@ -485,13 +485,13 @@ public final class ModBuildingsInitializer
                                    .setBuildingProducer(BuildingBeekeeper::new)
                                    .setBuildingViewProducer(() -> BuildingBeekeeper.View::new)
                                    .setRegistryName(new ResourceLocation(Constants.MOD_ID, ModBuildings.BEEKEEPER_ID))
-                                   .addBuildingModuleProducer(MinimumStockModule::new, MinimumStockModuleView::new)
+                                   .addBuildingModuleProducer(MinimumStockModule::new, () -> MinimumStockModuleView::new)
                                    .addBuildingModuleProducer(() -> new SettingsModule()
                                                                       .with(AbstractBuildingWorker.BREEDING, new BoolSetting(true))
-                                                                      .with(BuildingBeekeeper.MODE, new StringSetting(BuildingBeekeeper.HONEYCOMB, BuildingBeekeeper.HONEY, BuildingBeekeeper.BOTH)), SettingsModuleView::new)
-                                   .addBuildingModuleProducer(() -> new ItemListModule(BUILDING_FLOWER_LIST),  () -> new ItemListModuleView(BUILDING_FLOWER_LIST, COM_MINECOLONIES_COREMOD_REQUEST_FLOWERS, false,
+                                                                      .with(BuildingBeekeeper.MODE, new StringSetting(BuildingBeekeeper.HONEYCOMB, BuildingBeekeeper.HONEY, BuildingBeekeeper.BOTH)), () -> SettingsModuleView::new)
+                                   .addBuildingModuleProducer(() -> new ItemListModule(BUILDING_FLOWER_LIST),  () -> () -> new ItemListModuleView(BUILDING_FLOWER_LIST, COM_MINECOLONIES_COREMOD_REQUEST_FLOWERS, false,
                                      (buildingView) -> CompatibilityManager.getAllBeekeeperFlowers()))
-                                   .addBuildingModuleViewProducer(() -> new ToolModuleView(ModItems.scepterBeekeeper))
+                                   .addBuildingModuleViewProducer(() -> () -> new ToolModuleView(ModItems.scepterBeekeeper))
                                    .createBuildingEntry();
 
         ModBuildings.mysticalSite = new BuildingEntry.Builder()

--- a/src/main/java/com/minecolonies/apiimp/initializer/ModBuildingsInitializer.java
+++ b/src/main/java/com/minecolonies/apiimp/initializer/ModBuildingsInitializer.java
@@ -356,7 +356,7 @@ public final class ModBuildingsInitializer
                                  .setBuildingProducer(BuildingFlorist::new)
                                  .setBuildingViewProducer(() -> BuildingFlorist.View::new)
                                  .setRegistryName(new ResourceLocation(Constants.MOD_ID, ModBuildings.FLORIST_ID))
-                                 .addBuildingModuleProducer(() -> new ItemListModule(BUILDING_FLOWER_LIST), FloristFlowerListModuleView::new)
+                                 .addBuildingModuleProducer(() -> new ItemListModule(BUILDING_FLOWER_LIST), () -> new FloristFlowerListModuleView())
                                  .addBuildingModuleProducer(MinimumStockModule::new, MinimumStockModuleView::new)
                                  .createBuildingEntry();
 


### PR DESCRIPTION
# Changes proposed in this pull request:
- Get server builds working again after 200aa5f5716c (couldn't classload `ClientPlayerEntity`)

Review please

This is the minimum fix required to get `runServer` to work.  Probably something more comprehensive is needed to properly isolate the view classloading and prevent this reoccurring in the future, for example to add an extra layer of indirection (e.g. `() -> FloristFlowerListModuleView::new`, similar to how the building views are declared), or something else.  Or finding what it was about that module in particular that couldn't classload on server and making it avoid it.