### PR TITLE
Bump minimum MC/Forge versions to match build.properties

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -104,12 +104,12 @@ dependencies {
     additionalMods "com.ldtteam:structurize:${config.structurize_version}"
     compile "com.ldtteam:datagenerators:${config.datagen_version}"
     
-    implementation fg.deobf("mezz.jei:jei-${config.jei_version}")
+    implementation fg.deobf("mezz.jei:jei-${config.jei_mcversion}:${config.jei_version}")
     compileOnly fg.deobf("com.resourcefulbees:ResourcefulBees:${config.rb_version}")
     apiCompileOnly fg.deobf("com.resourcefulbees:ResourcefulBees:${config.rb_version}")
-    apiCompileOnly fg.deobf("slimeknights.mantle:Mantle:1.16.5-${config.mantle_version}")
-    apiCompileOnly fg.deobf("slimeknights.tconstruct:TConstruct:1.16.5-${config.tc_version}")
-    apiCompileOnly fg.deobf("com.ferreusveritas.dynamictrees:DynamicTrees-${config.minecraft_version}:${config.dt_version}")
+    apiCompileOnly fg.deobf("slimeknights.mantle:Mantle:${config.mantle_mcversion}-${config.mantle_version}")
+    apiCompileOnly fg.deobf("slimeknights.tconstruct:TConstruct:${config.tc_mcversion}-${config.tc_version}")
+    apiCompileOnly fg.deobf("com.ferreusveritas.dynamictrees:DynamicTrees-${config.dt_mcversion}:${config.dt_version}")
 
     testImplementation  'junit:junit:4.12'
     testImplementation  "org.mockito:mockito-core:1.+"

--- a/build.gradle
+++ b/build.gradle
@@ -315,6 +315,13 @@ task setupCIWorkspace {
 }
 
 processResources {
+    from(sourceSets.main.resources.srcDirs) {
+        include 'META-INF/mods.toml'
+        expand 'config': config
+    }
+    from(sourceSets.main.resources.srcDirs) {
+        exclude 'META-INF/mods.toml'
+    }
     doLast {
         if(file('src/main/generated/resources/assets/minecolonies/lang/default.json').exists()) {
             def slurper = new JsonSlurper()

--- a/build.properties
+++ b/build.properties
@@ -3,7 +3,10 @@
 #
 # Minecraft / Forge.
 minecraft_version=1.16.5
+minecraft_range=[1.16.5, 1.17)
 forge_version=36.1.24
+forge_range=[36.1.0,)
+fml_range=[36,)
 mappings=20201028-1.16.3
 # Dependencies
 jei_version=1.16.4:7.6.1.71

--- a/build.properties
+++ b/build.properties
@@ -9,10 +9,14 @@ forge_range=[36.1.0,)
 fml_range=[36,)
 mappings=20201028-1.16.3
 # Dependencies
-jei_version=1.16.4:7.6.1.71
 structurize_version=0.13.197-ALPHA
-rb_version=1.16.5-0.6.1b
 datagen_version=0.1.48-ALPHA
+jei_mcversion=1.16.4
+jei_version=7.6.1.71
+rb_version=1.16.5-0.6.1b
+tc_mcversion=1.16.5
 tc_version=3.0.4.197
+mantle_mcversion=1.16.5
 mantle_version=1.6.108
+dt_mcversion=1.16.5
 dt_version=0.10.0-Beta15

--- a/src/main/resources/META-INF/mods.toml
+++ b/src/main/resources/META-INF/mods.toml
@@ -60,4 +60,22 @@ MineColonies is a colony simulator within Minecraft! There are numerous types of
     versionRange="[${config.structurize_version}]"
     ordering="AFTER"
     side="BOTH"
-
+# The rest of these are not required, but if you have them then they must be at least this version
+[[dependencies.minecolonies]]
+    modId="tconstruct"
+    mandatory=false
+    versionRange="[${config.tc_version},)"
+    ordering="NONE"
+    side="BOTH"
+[[dependencies.minecolonies]]
+    modId="resourcefulbees"
+    mandatory=false
+    versionRange="[${config.rb_version},)"
+    ordering="NONE"
+    side="BOTH"
+[[dependencies.minecolonies]]
+    modId="dynamictrees"
+    mandatory=false
+    versionRange="[${config.dt_version},)"
+    ordering="NONE"
+    side="BOTH"

--- a/src/main/resources/META-INF/mods.toml
+++ b/src/main/resources/META-INF/mods.toml
@@ -62,6 +62,12 @@ MineColonies is a colony simulator within Minecraft! There are numerous types of
     side="BOTH"
 # The rest of these are not required, but if you have them then they must be at least this version
 [[dependencies.minecolonies]]
+    modId="jei"
+    mandatory=false
+    versionRange="[${config.jei_version},)"
+    ordering="NONE"
+    side="BOTH"
+[[dependencies.minecolonies]]
     modId="tconstruct"
     mandatory=false
     versionRange="[${config.tc_version},)"
@@ -76,6 +82,6 @@ MineColonies is a colony simulator within Minecraft! There are numerous types of
 [[dependencies.minecolonies]]
     modId="dynamictrees"
     mandatory=false
-    versionRange="[${config.dt_version},)"
+    versionRange="[${config.dt_mcversion}-${config.dt_version},)"
     ordering="NONE"
     side="BOTH"

--- a/src/main/resources/META-INF/mods.toml
+++ b/src/main/resources/META-INF/mods.toml
@@ -6,7 +6,7 @@
 # The name of the mod loader type to load - for regular FML @Mod mods it should be javafml
 modLoader="javafml" #mandatory
 # A version range to match for said mod loader - for regular FML @Mod it will be the forge version
-loaderVersion="[36,)" #mandatory (27 is current forge version)
+loaderVersion="${config.fml_range}" #mandatory (27 is current forge version)
 # The license for you mod. This is mandatory metadata and allows for easier comprehension of your redistributive properties.
 # Review your options at https://choosealicense.com/. All rights reserved is the default copyright stance, and is thus the default here.
 license="GPL 3.0"
@@ -17,7 +17,7 @@ issueTrackerURL="https://github.com/ldtteam/minecolonies/issues/new/choose" #opt
 # The modid of the mod
 modId="minecolonies" #mandatory
 # The version number of the mod - there's a few well known ${} variables useable here or just hardcode it
-version="${file.jarVersion}" #mandatory
+version="\${file.jarVersion}" #mandatory
  # A display name for the mod
 displayName="MineColonies" #mandatory
 # A URL to query for updates for this mod. See the JSON update specification <here>
@@ -41,7 +41,7 @@ MineColonies is a colony simulator within Minecraft! There are numerous types of
     # Does this dependency have to exist - if not, ordering below must be specified
     mandatory=true #mandatory
     # The version range of the dependency
-    versionRange="[36.1.0,)" #mandatory
+    versionRange="${config.forge_range}" #mandatory
     # An ordering relationship for the dependency - BEFORE or AFTER required if the relationship is not mandatory
     ordering="NONE"
     # Side this dependency is applied on - BOTH, CLIENT or SERVER
@@ -50,14 +50,14 @@ MineColonies is a colony simulator within Minecraft! There are numerous types of
 [[dependencies.minecolonies]]
     modId="minecraft"
     mandatory=true
-    versionRange="[1.16.5, 1.17)"
+    versionRange="${config.minecraft_range}"
     ordering="NONE"
     side="BOTH"
 # Here's another dependency
 [[dependencies.minecolonies]]
     modId="structurize"
     mandatory=true
-    versionRange="[0.13.197-ALPHA]"
+    versionRange="[${config.structurize_version}]"
     ordering="AFTER"
     side="BOTH"
 

--- a/src/main/resources/META-INF/mods.toml
+++ b/src/main/resources/META-INF/mods.toml
@@ -6,7 +6,7 @@
 # The name of the mod loader type to load - for regular FML @Mod mods it should be javafml
 modLoader="javafml" #mandatory
 # A version range to match for said mod loader - for regular FML @Mod it will be the forge version
-loaderVersion="[34,)" #mandatory (27 is current forge version)
+loaderVersion="[36,)" #mandatory (27 is current forge version)
 # The license for you mod. This is mandatory metadata and allows for easier comprehension of your redistributive properties.
 # Review your options at https://choosealicense.com/. All rights reserved is the default copyright stance, and is thus the default here.
 license="GPL 3.0"
@@ -41,7 +41,7 @@ MineColonies is a colony simulator within Minecraft! There are numerous types of
     # Does this dependency have to exist - if not, ordering below must be specified
     mandatory=true #mandatory
     # The version range of the dependency
-    versionRange="[34.1.0,)" #mandatory
+    versionRange="[36.1.0,)" #mandatory
     # An ordering relationship for the dependency - BEFORE or AFTER required if the relationship is not mandatory
     ordering="NONE"
     # Side this dependency is applied on - BOTH, CLIENT or SERVER
@@ -50,7 +50,7 @@ MineColonies is a colony simulator within Minecraft! There are numerous types of
 [[dependencies.minecolonies]]
     modId="minecraft"
     mandatory=true
-    versionRange="[1.16.3, 1.17)"
+    versionRange="[1.16.5, 1.17)"
     ordering="NONE"
     side="BOTH"
 # Here's another dependency


### PR DESCRIPTION
# Changes proposed in this pull request:
- Bump minimum MC/Forge versions to match build.properties
- Make mods.toml update automatically when bumping versions in the future
- Add optional mod dependencies

Review please

Tested by trying to build mcol for 1.16.4, but that failed due to something related to the zombie villager feature.  So I believe this limit is accurate and the toml shouldn't be over-promising.  But I admit I didn't try taking a prebuilt jar and trying to run it against 1.16.4 outside a dev environment, so it might not be impossible that this was intended.  (Although it looks like the CF upload stopped claiming 1.16.4 compatibility at 0.14.162.)