### PR TITLE
Bring back the Build Building button

### DIFF
--- a/src/main/java/com/minecolonies/coremod/client/gui/WindowBuildBuilding.java
+++ b/src/main/java/com/minecolonies/coremod/client/gui/WindowBuildBuilding.java
@@ -134,19 +134,18 @@ public class WindowBuildBuilding extends AbstractWindowSkeleton
         final Button buttonBuild = findPaneOfTypeByID(BUTTON_BUILD, Button.class);
         final IBuildingView parentBuilding = c.getBuilding(building.getParent());
 
-        if (building.getBuildingLevel() == 0 || parentBuilding != null)
+        if (building.getBuildingLevel() == 0)
         {
-            buttonBuild.setText(LanguageHandler.format("com.minecolonies.coremod.gui.workerhuts.build"));
+            buttonBuild.setText(new TranslationTextComponent("com.minecolonies.coremod.gui.workerhuts.build"));
             findPaneOfTypeByID(BUTTON_DECONSTRUCT_BUILDING, Button.class).hide();
         }
-
-        if (building.getBuildingLevel() == building.getBuildingMaxLevel() || (parentBuilding != null && building.getBuildingLevel() >= parentBuilding.getBuildingLevel()))
+        else if (building.getBuildingLevel() == building.getBuildingMaxLevel() || (parentBuilding != null && building.getBuildingLevel() >= parentBuilding.getBuildingLevel()))
         {
             buttonBuild.hide();
         }
         else
         {
-            buttonBuild.setText(LanguageHandler.format("com.minecolonies.coremod.gui.workerhuts.upgrade"));
+            buttonBuild.setText(new TranslationTextComponent("com.minecolonies.coremod.gui.workerhuts.upgrade"));
         }
 
         if (building.isDeconstructed())

--- a/src/main/java/com/minecolonies/coremod/client/gui/WindowBuildBuilding.java
+++ b/src/main/java/com/minecolonies/coremod/client/gui/WindowBuildBuilding.java
@@ -137,6 +137,7 @@ public class WindowBuildBuilding extends AbstractWindowSkeleton
         if (building.getBuildingLevel() == 0)
         {
             buttonBuild.setText(new TranslationTextComponent("com.minecolonies.coremod.gui.workerhuts.build"));
+            findPaneOfTypeByID(BUTTON_REPAIR, Button.class).hide();
             findPaneOfTypeByID(BUTTON_DECONSTRUCT_BUILDING, Button.class).hide();
         }
         else if (building.getBuildingLevel() == building.getBuildingMaxLevel() || (parentBuilding != null && building.getBuildingLevel() >= parentBuilding.getBuildingLevel()))
@@ -150,6 +151,7 @@ public class WindowBuildBuilding extends AbstractWindowSkeleton
 
         if (building.isDeconstructed())
         {
+            findPaneOfTypeByID(BUTTON_REPAIR, Button.class).setText(new TranslationTextComponent("com.minecolonies.coremod.gui.workerhuts.build"));
             findPaneOfTypeByID(BUTTON_DECONSTRUCT_BUILDING, Button.class).setText(new TranslationTextComponent("com.minecolonies.coremod.gui.workerhuts.pickup"));
         }
     }


### PR DESCRIPTION
# Changes proposed in this pull request:
- Restores the "Build Building" button appearing for level 0 buildings instead of the "Upgrade" button
- When moving a deconstructed building, shows "Build Building" instead of "Repair", to reduce confusion

Review please
