### PR TITLE
Remind gradle to rebuild mods.toml if build.properties changes

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -315,6 +315,7 @@ task setupCIWorkspace {
 }
 
 processResources {
+    inputs.file 'build.properties'
     from(sourceSets.main.resources.srcDirs) {
         include 'META-INF/mods.toml'
         expand 'config': config


### PR DESCRIPTION
# Changes proposed in this pull request:
- Fixes mods.toml being outdated sometimes (and getting mod version errors on startup) when bumping build.properties

Review please
