### PR TITLE
Add error message when adding player

### DIFF
--- a/src/api/java/com/minecolonies/api/util/constant/WindowConstants.java
+++ b/src/api/java/com/minecolonies/api/util/constant/WindowConstants.java
@@ -1107,6 +1107,7 @@ public final class WindowConstants
     public static final String TOWNHALL_SWITCH_PLAYER_RANK = "playerEditRank";
     public static final String TOWNHALL_USER_VIEW = "pageAddPlayer";
     public static final String TOWNHALL_RANK_TYPE_PICKER = "rankTypePicker";
+    public static final String TOWNHALL_PERMISSION_ERROR = "permissionError";
 
     /**
      * Input filter id.

--- a/src/main/java/com/minecolonies/coremod/client/gui/townhall/WindowTownHall.java
+++ b/src/main/java/com/minecolonies/coremod/client/gui/townhall/WindowTownHall.java
@@ -44,6 +44,7 @@ import com.minecolonies.coremod.network.messages.server.colony.citizen.RecallSin
 import net.minecraft.block.Block;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.screen.Screen;
+import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.util.ResourceLocation;
 import net.minecraft.util.ResourceLocationException;
 import net.minecraft.util.math.BlockPos;
@@ -1556,6 +1557,22 @@ public class WindowTownHall extends AbstractWindowModuleBuilding<ITownHallView>
         if (switchView.getCurrentView().getID().equals(PERMISSION_VIEW))
         {
             findPaneOfTypeByID(TOWNHALL_ADD_RANK_ERROR, Text.class).hide();
+        }
+        if (switchView.getCurrentView().getID().equals(TOWNHALL_USER_VIEW))
+        {
+            PlayerEntity player = Minecraft.getInstance().player;
+            Text label = findPaneOfTypeByID(TOWNHALL_PERMISSION_ERROR, Text.class);
+            Button button = findPaneOfTypeByID(BUTTON_ADD_PLAYER, Button.class);
+            if (townHall.getColony().getPermissions().hasPermission(player, Action.EDIT_PERMISSIONS))
+            {
+                label.hide();
+                button.setEnabled(true);
+            }
+            else
+            {
+                label.show();
+                button.setEnabled(false);
+            }
         }
     }
 

--- a/src/main/resources/assets/minecolonies/gui/townhall/layoutpermissions.xml
+++ b/src/main/resources/assets/minecolonies/gui/townhall/layoutpermissions.xml
@@ -28,6 +28,7 @@
             <label size="148 11" pos="26 65" color="black" label="$(com.minecolonies.coremod.gui.townHall.addPlayer)"/>
             <input id="addPlayerName" size="100 18" pos="26 76" maxlength="32"/>
             <button id="addPlayer" size="19 19" pos="130 76" label="+"/>
+            <label id="permissionError" size="148 100" pos="26 100" color="red" label="$(com.minecolonies.coremod.gui.townhall.player_permission_error)" textalign="TOP_MIDDLE" />
         </view>
         <view id="managePermissions">
             <switch id="permissionsManagement" size="148 171" pos="201 36">

--- a/src/main/resources/assets/minecolonies/lang/en_us.json
+++ b/src/main/resources/assets/minecolonies/lang/en_us.json
@@ -714,6 +714,7 @@
   "com.minecolonies.coremod.permission.no": "You do not have permission to do this in this colony!",
   "com.minecolonies.coremod.gui.townhall.freeblocks": "Free for Interaction",
   "com.minecolonies.coremod.gui.townhall.add": "Add",
+  "com.minecolonies.coremod.gui.townhall.player_permission_error": "You are not permitted to add new players. Ask a colony manager to turn on \"Edit permissions\" for your rank.",
 
   "com.minecolonies.coremod.permission.access_huts": "Access GUIs",
   "com.minecolonies.coremod.permission.guards_attack": "Fight Guards",


### PR DESCRIPTION
Closes #
Closes #
Closes #

# Changes proposed in this pull request:
- Adds an error message in the townhall GUI that's displayed when the player's rank is not allowed to add players to avoid confusion
-
-

Review please
