### PR TITLE
Fixes the "requires crafter X" item tooltips

### DIFF
--- a/src/main/resources/assets/minecolonies/lang/en_us.json
+++ b/src/main/resources/assets/minecolonies/lang/en_us.json
@@ -1829,8 +1829,8 @@
   "com.minecolonies.coremod.item.milky.bread.gui": "Removes potion effects",
   "com.minecolonies.coremod.item.golden.bread.gui": "Instantly heals 2 hearts",
   "com.minecolonies.coremod.item.chorus.bread.gui": "Teleports you to the surface",
-  "com.minecolonies.coremod.item.available.gui": "Crafted by a MineColonies %s",
-  "com.minecolonies.coremod.item.buildlevel.gui": "Crafted by a MineColonies %s level %s or higher",
+  "com.minecolonies.coremod.item.available.gui": "Crafted by a %s",
+  "com.minecolonies.coremod.item.buildlevel.gui": "Crafted by a %s level %s or higher",
   "com.minecolonies.coremod.item.requiresresearch.gui": "Requires Research: %s",
 
   "com.minecolonies.coremod.gui.xofz": "%d of %d",


### PR DESCRIPTION
# Changes proposed in this pull request:
- Fixes the tooltips shown on custom-crafted items (e.g. scrolls, meshes, custom bread) to not show the module suffix and to support translated building names
- Future-proofs the mod identification in anticipation of addon mods with additional crafting buildings.

Review please

(Arguably one or both of the utility methods could go into a utilities class or something as they're potentially more generally applicable.  However that can possibly wait until something else actually wants to use the results.)