### PR TITLE
Add threat tables to citizens/guards

### DIFF
--- a/src/api/java/com/minecolonies/api/entity/combat/combat/IThreatTableEntity.java
+++ b/src/api/java/com/minecolonies/api/entity/combat/combat/IThreatTableEntity.java
@@ -1,0 +1,14 @@
+package com.minecolonies.api.entity.combat.combat;
+
+/**
+ * Entities implement this for the necessary hooks
+ */
+public interface IThreatTableEntity
+{
+    /**
+     * Get the entities threat table
+     *
+     * @return
+     */
+    public ThreatTable getThreatTable();
+}

--- a/src/api/java/com/minecolonies/api/entity/combat/combat/ThreatTable.java
+++ b/src/api/java/com/minecolonies/api/entity/combat/combat/ThreatTable.java
@@ -1,0 +1,257 @@
+package com.minecolonies.api.entity.combat.combat;
+
+import net.minecraft.entity.LivingEntity;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static com.minecolonies.api.util.constant.Constants.TICKS_SECOND;
+
+/**
+ * Threat table class, basically a list of entities with an associated threat value
+ */
+public class ThreatTable
+{
+    /**
+     * Melee range
+     */
+    private static final int MELEE_RANGE = 8;
+
+    /**
+     * Max tracking time
+     */
+    private static final int MAX_TRACKING_TICKS = TICKS_SECOND * 120;
+
+    /**
+     * List holding the threat entries
+     */
+    private List<ThreatTableEntry> threatList = new ArrayList<>();
+
+    /**
+     * Currently targeted entity
+     */
+    private int currentTargetIndex = 0;
+
+    /**
+     * The owner entity of this table
+     */
+    private final LivingEntity owner;
+
+    public ThreatTable(final LivingEntity owner)
+    {
+        this.owner = owner;
+    }
+
+    /**
+     * Adds X threat to the given entity
+     *
+     * @param attacker entity to add the value to
+     * @param threat   threat value to add
+     */
+    public void addThreat(final LivingEntity attacker, final int threat)
+    {
+        ThreatTableEntry threatTableEntry = null;
+        int index = threatList.size();
+
+        for (int i = 0; i < index; i++)
+        {
+            final ThreatTableEntry entry = threatList.get(i);
+            if (entry.getEntity() == attacker)
+            {
+                threatTableEntry = entry;
+                index = i;
+                break;
+            }
+        }
+
+        if (threatTableEntry == null)
+        {
+            threatTableEntry = new ThreatTableEntry(attacker);
+            threatList.add(threatTableEntry);
+            threatTableEntry.addThreat(Math.max(0, 10 - (owner.blockPosition().distManhattan(attacker.blockPosition()) / 4)));
+        }
+
+        threatTableEntry.addThreat(threat);
+        adaptTableToThreat(index);
+    }
+
+    /**
+     * Get the threat value for the given entity
+     *
+     * @param attacker entity
+     * @return threat value
+     */
+    public int getThreatFor(final LivingEntity attacker)
+    {
+        ThreatTableEntry threatTableEntry = null;
+        int index = threatList.size();
+
+        for (int i = 0; i < index; i++)
+        {
+            final ThreatTableEntry entry = threatList.get(i);
+            if (entry.getEntity() == attacker)
+            {
+                return entry.getThreat();
+            }
+        }
+
+        return 0;
+    }
+
+    /**
+     * Resorts the given index after its threat value changed
+     *
+     * @param index
+     */
+    private void adaptTableToThreat(final int index)
+    {
+        for (int i = index; i > 0; i--)
+        {
+            final ThreatTableEntry current = threatList.get(i);
+            final ThreatTableEntry above = threatList.get(i - 1);
+
+            if (current.getThreat() > above.getThreat())
+            {
+                if (currentTargetIndex == (i - 1))
+                {
+                    currentTargetIndex = i;
+                }
+
+                threatList.set(i, above);
+                threatList.set(i - 1, current);
+            }
+            else
+            {
+                break;
+            }
+        }
+    }
+
+    /**
+     * Get the current target
+     *
+     * @return target or null
+     */
+    public ThreatTableEntry getTarget()
+    {
+        if (threatList.isEmpty())
+        {
+            return null;
+        }
+
+        /// Add ignore logic
+        final ThreatTableEntry current = threatList.get(currentTargetIndex);
+        final ThreatTableEntry top = threatList.get(0);
+        if (top.getThreat() > current.getThreat())
+        {
+            if (top.getEntity().distanceToSqr(owner) > MELEE_RANGE)
+            {
+                // Targets not in meleerange need 30% more threat than current to cause a target change
+                if (top.getThreat() > (current.getThreat() * 1.3))
+                {
+                    currentTargetIndex = 0;
+                    return top;
+                }
+            }
+            else
+            {
+                // Targets in meleerange need 10% more threat than current to cause a target change
+                if (top.getThreat() > (current.getThreat() * 1.1))
+                {
+                    currentTargetIndex = 0;
+                    return top;
+                }
+            }
+        }
+
+        if (current.getThreat() < 0)
+        {
+            return null;
+        }
+
+        if ((owner.level.getGameTime() - current.getLastSeen()) > MAX_TRACKING_TICKS || !current.getEntity().isAlive())
+        {
+            removeCurrentTarget();
+            if (threatList.isEmpty())
+            {
+                return null;
+            }
+            else
+            {
+                return threatList.get(currentTargetIndex);
+            }
+        }
+
+        return current;
+    }
+
+    /**
+     * Only gets the currently targeted mob
+     *
+     * @return
+     */
+    public LivingEntity getTargetMob()
+    {
+        final ThreatTableEntry entry = getTarget();
+        if (entry == null)
+        {
+            return null;
+        }
+        return entry.getEntity();
+    }
+
+    /**
+     * Reset current target threat to 0
+     */
+    public void resetCurrentTargetThreat()
+    {
+        final ThreatTableEntry entry = threatList.get(currentTargetIndex);
+        if (entry.getThreat() > 0)
+        {
+            entry.setThreat(0);
+            threatList.remove(currentTargetIndex);
+            currentTargetIndex = 0;
+            threatList.add(entry);
+        }
+    }
+
+    /**
+     * Sets the current target to be invalid until it does a threatening action again
+     */
+    public void markInvalidTarget()
+    {
+        if (threatList.isEmpty())
+        {
+            return;
+        }
+
+        final ThreatTableEntry entry = threatList.get(currentTargetIndex);
+        if (!entry.getEntity().isAlive())
+        {
+            removeCurrentTarget();
+            return;
+        }
+
+        if (entry.getThreat() != -1)
+        {
+            entry.setThreat(-1);
+            threatList.remove(currentTargetIndex);
+            currentTargetIndex = 0;
+            threatList.add(entry);
+        }
+    }
+
+    /**
+     * Reset current target threat to 0
+     */
+    public void removeCurrentTarget()
+    {
+        if (threatList.isEmpty())
+        {
+            return;
+        }
+
+        threatList.remove(currentTargetIndex);
+        currentTargetIndex = 0;
+    }
+}

--- a/src/api/java/com/minecolonies/api/entity/combat/combat/ThreatTable.java
+++ b/src/api/java/com/minecolonies/api/entity/combat/combat/ThreatTable.java
@@ -46,9 +46,9 @@ public class ThreatTable
      * Adds X threat to the given entity
      *
      * @param attacker entity to add the value to
-     * @param threat   threat value to add
+     * @param additionalThreat   threat value to add
      */
-    public void addThreat(final LivingEntity attacker, final int threat)
+    public void addThreat(final LivingEntity attacker, final int additionalThreat)
     {
         ThreatTableEntry threatTableEntry = null;
         int index = threatList.size();
@@ -71,7 +71,7 @@ public class ThreatTable
             threatTableEntry.addThreat(Math.max(0, 10 - (owner.blockPosition().distManhattan(attacker.blockPosition()) / 4)));
         }
 
-        threatTableEntry.addThreat(threat);
+        threatTableEntry.addThreat(additionalThreat);
         adaptTableToThreat(index);
     }
 

--- a/src/api/java/com/minecolonies/api/entity/combat/combat/ThreatTableEntry.java
+++ b/src/api/java/com/minecolonies/api/entity/combat/combat/ThreatTableEntry.java
@@ -1,0 +1,94 @@
+package com.minecolonies.api.entity.combat.combat;
+
+import net.minecraft.entity.LivingEntity;
+
+/**
+ * Data entry in the threat table
+ */
+public class ThreatTableEntry
+{
+    /**
+     * Threat value
+     */
+    private int threat = 10;
+
+    /**
+     * Entity which caused the threat
+     */
+    private final LivingEntity entity;
+
+    /**
+     * Time at which it was last seen
+     */
+    private long lastSeen;
+
+    public ThreatTableEntry(final LivingEntity entity)
+    {
+        this.entity = entity;
+        this.lastSeen = entity.level.getGameTime();
+    }
+
+    /**
+     * Adds threat
+     */
+    protected void addThreat(final int threat)
+    {
+        if (threat == 0)
+        {
+            return;
+        }
+
+        this.threat = Math.max(0, this.threat + threat);
+        lastSeen = entity.level.getGameTime();
+    }
+
+    /**
+     * Set the threat value directly
+     *
+     * @param threat
+     */
+    protected void setThreat(final int threat)
+    {
+        this.threat = threat;
+    }
+
+    /**
+     * Get the threat value
+     *
+     * @return
+     */
+    public int getThreat()
+    {
+        return threat;
+    }
+
+    /**
+     * Get the target entity
+     *
+     * @return target
+     */
+    public LivingEntity getEntity()
+    {
+        return entity;
+    }
+
+    /**
+     * Get the worldtime of where it was last seen
+     *
+     * @return
+     */
+    public long getLastSeen()
+    {
+        return lastSeen;
+    }
+
+    /**
+     * Set the world time of when it was last seen
+     *
+     * @param gameTime
+     */
+    public void setLastSeen(final long gameTime)
+    {
+        this.lastSeen = gameTime;
+    }
+}

--- a/src/api/java/com/minecolonies/api/entity/mobs/AbstractEntityMinecoloniesMob.java
+++ b/src/api/java/com/minecolonies/api/entity/mobs/AbstractEntityMinecoloniesMob.java
@@ -7,6 +7,8 @@ import com.minecolonies.api.colony.colonyEvents.IColonyCampFireRaidEvent;
 import com.minecolonies.api.colony.colonyEvents.IColonyEvent;
 import com.minecolonies.api.enchants.ModEnchants;
 import com.minecolonies.api.entity.CustomGoalSelector;
+import com.minecolonies.api.entity.combat.combat.IThreatTableEntity;
+import com.minecolonies.api.entity.combat.combat.ThreatTable;
 import com.minecolonies.api.entity.pathfinding.AbstractAdvancedPathNavigate;
 import com.minecolonies.api.entity.pathfinding.IStuckHandlerEntity;
 import com.minecolonies.api.entity.pathfinding.PathingStuckHandler;
@@ -41,7 +43,7 @@ import static com.minecolonies.api.util.constant.RaiderConstants.*;
 /**
  * Abstract for all Barbarian entities.
  */
-public abstract class AbstractEntityMinecoloniesMob extends MobEntity implements IStuckHandlerEntity
+public abstract class AbstractEntityMinecoloniesMob extends MobEntity implements IStuckHandlerEntity, IThreatTableEntity
 {
     /**
      * Difficulty at which raiders team up
@@ -143,6 +145,11 @@ public abstract class AbstractEntityMinecoloniesMob extends MobEntity implements
      * Mob difficulty
      */
     private double difficulty = 1.0d;
+
+    /**
+     * The threattable of the mob
+     */
+    private ThreatTable threatTable = new ThreatTable(this);
 
     /**
      * Constructor method for Abstract Barbarians.
@@ -472,6 +479,11 @@ public abstract class AbstractEntityMinecoloniesMob extends MobEntity implements
     @Override
     public boolean hurt(@NotNull final DamageSource damageSource, final float damage)
     {
+        if (damageSource.getEntity() instanceof LivingEntity)
+        {
+            threatTable.addThreat((LivingEntity) damageSource.getEntity(), (int) damage);
+        }
+
         if (damageSource.getDirectEntity() == null)
         {
             if (envDamageImmunity)
@@ -678,5 +690,11 @@ public abstract class AbstractEntityMinecoloniesMob extends MobEntity implements
     public void onInsideBubbleColumn(boolean down)
     {
 
+    }
+
+    @Override
+    public ThreatTable getThreatTable()
+    {
+        return threatTable;
     }
 }

--- a/src/api/java/com/minecolonies/api/util/constant/GuardConstants.java
+++ b/src/api/java/com/minecolonies/api/util/constant/GuardConstants.java
@@ -30,7 +30,7 @@ public final class GuardConstants
     /**
      * Y search range.
      */
-    public static final int Y_VISION = 10;
+    public static final int Y_VISION = 3;
 
     /**
      * Experience to add when a mob is killed

--- a/src/main/java/com/minecolonies/coremod/entity/ai/citizen/guard/AbstractEntityAIGuard.java
+++ b/src/main/java/com/minecolonies/coremod/entity/ai/citizen/guard/AbstractEntityAIGuard.java
@@ -16,7 +16,9 @@ import com.minecolonies.api.entity.ai.statemachine.states.AIBlockingEventType;
 import com.minecolonies.api.entity.ai.statemachine.states.IAIState;
 import com.minecolonies.api.entity.citizen.AbstractEntityCitizen;
 import com.minecolonies.api.entity.citizen.Skill;
+import com.minecolonies.api.entity.combat.combat.ThreatTableEntry;
 import com.minecolonies.api.entity.mobs.AbstractEntityMinecoloniesMob;
+import com.minecolonies.api.entity.pathfinding.PathResult;
 import com.minecolonies.api.util.BlockPosUtil;
 import com.minecolonies.api.util.InventoryUtils;
 import com.minecolonies.api.util.constant.ToolType;
@@ -86,7 +88,7 @@ public abstract class AbstractEntityAIGuard<J extends AbstractJobGuard<J>, B ext
     /**
      * After this amount of ticks not seeing an entity stop persecution.
      */
-    private static final int STOP_PERSECUTION_AFTER = TICKS_SECOND * 10;
+    private static final int STOP_PERSECUTION_AFTER = TICKS_SECOND * 60;
 
     /**
      * How far off patrols are alterated to match a raider attack point, sq dist
@@ -151,7 +153,7 @@ public abstract class AbstractEntityAIGuard<J extends AbstractJobGuard<J>, B ext
     /**
      * Search area for target interval
      */
-    private static final int SEARCH_TARGET_INTERVAL = 40;
+    private static final int SEARCH_TARGET_INTERVAL = 80;
 
     /**
      * Interval between guard task updates
@@ -204,6 +206,11 @@ public abstract class AbstractEntityAIGuard<J extends AbstractJobGuard<J>, B ext
     private int regularActionTimer = 0;
 
     /**
+     * The path result of moving towards the target
+     */
+    private PathResult targetPath = null;
+
+    /**
      * Creates the abstract part of the AI. Always use this constructor!
      *
      * @param job the job to fulfill
@@ -217,19 +224,19 @@ public abstract class AbstractEntityAIGuard<J extends AbstractJobGuard<J>, B ext
           new AITarget(GUARD_DECIDE, this::decide, GUARD_TASK_INTERVAL),
           new AITarget(GUARD_PATROL, this::shouldSleep, () -> GUARD_SLEEP, SHOULD_SLEEP_INTERVAL),
           new AIEventTarget(AIBlockingEventType.STATE_BLOCKING, this::checkAndAttackTarget, CHECK_TARGET_INTERVAL),
-          new AITarget(GUARD_PATROL, () -> searchNearbyTarget() != null, this::checkAndAttackTarget, SEARCH_TARGET_INTERVAL),
+          new AITarget(GUARD_PATROL, () -> searchNearbyTarget(), this::checkAndAttackTarget, SEARCH_TARGET_INTERVAL),
           new AITarget(GUARD_PATROL, this::decide, GUARD_TASK_INTERVAL),
           new AITarget(GUARD_SLEEP, this::sleep, 1),
           new AITarget(GUARD_SLEEP, this::sleepParticles, PARTICLE_INTERVAL),
           new AITarget(GUARD_WAKE, this::wakeUpGuard, TICKS_SECOND),
           new AITarget(GUARD_FOLLOW, this::decide, GUARD_TASK_INTERVAL),
-          new AITarget(GUARD_FOLLOW, () -> searchNearbyTarget() != null, this::checkAndAttackTarget, SEARCH_TARGET_INTERVAL),
+          new AITarget(GUARD_FOLLOW, () -> searchNearbyTarget(), this::checkAndAttackTarget, SEARCH_TARGET_INTERVAL),
           new AITarget(GUARD_RALLY, this::decide, GUARD_TASK_INTERVAL),
-          new AITarget(GUARD_RALLY, () -> searchNearbyTarget() != null, this::checkAndAttackTarget, SEARCH_TARGET_INTERVAL),
+          new AITarget(GUARD_RALLY, () -> searchNearbyTarget(), this::checkAndAttackTarget, SEARCH_TARGET_INTERVAL),
           new AITarget(GUARD_RALLY, this::decreaseSaturation, RALLY_SATURATION_LOSS_INTERVAL),
           new AITarget(GUARD_GUARD, this::shouldSleep, () -> GUARD_SLEEP, SHOULD_SLEEP_INTERVAL),
           new AITarget(GUARD_GUARD, this::decide, GUARD_TASK_INTERVAL),
-          new AITarget(GUARD_GUARD, () -> searchNearbyTarget() != null, this::checkAndAttackTarget, SEARCH_TARGET_INTERVAL),
+          new AITarget(GUARD_GUARD, () -> searchNearbyTarget(), this::checkAndAttackTarget, SEARCH_TARGET_INTERVAL),
           new AITarget(GUARD_REGEN, this::regen, GUARD_REGEN_INTERVAL),
           new AITarget(HELP_CITIZEN, this::helping, GUARD_TASK_INTERVAL)
         );
@@ -420,7 +427,7 @@ public abstract class AbstractEntityAIGuard<J extends AbstractJobGuard<J>, B ext
             worker.getNavigation().getPathingOptions().setCanUseRails(false);
             fighttimer = COMBAT_TIME;
             equipInventoryArmor();
-            moveInAttackPosition();
+
             return getAttackState();
         }
 
@@ -528,7 +535,8 @@ public abstract class AbstractEntityAIGuard<J extends AbstractJobGuard<J>, B ext
     protected IAIState startWorkingAtOwnBuilding()
     {
         final ILocation rallyLocation = buildingGuards.getRallyLocation();
-        if ((rallyLocation != null && rallyLocation.isReachableFromLocation(worker.getLocation()) || !canBeInterrupted()) || (buildingGuards.getTask().equals(GuardTaskSetting.PATROL_MINE) && buildingGuards.getMinePos() != null))
+        if ((rallyLocation != null && rallyLocation.isReachableFromLocation(worker.getLocation()) || !canBeInterrupted()) || (
+          buildingGuards.getTask().equals(GuardTaskSetting.PATROL_MINE) && buildingGuards.getMinePos() != null))
         {
             return PREPARING;
         }
@@ -573,7 +581,7 @@ public abstract class AbstractEntityAIGuard<J extends AbstractJobGuard<J>, B ext
                 {
                     currentPatrolPoint = findRandomPositionToWalkTo(20);
                 }
-                
+
                 if (currentPatrolPoint != null)
                 {
                     setNextPatrolTarget(currentPatrolPoint);
@@ -597,6 +605,7 @@ public abstract class AbstractEntityAIGuard<J extends AbstractJobGuard<J>, B ext
 
     /**
      * Patrol between all completed nodes in the assigned mine
+     *
      * @return the next point to patrol to
      */
     public IAIState patrolMine()
@@ -605,7 +614,7 @@ public abstract class AbstractEntityAIGuard<J extends AbstractJobGuard<J>, B ext
         {
             return PREPARING;
         }
-        if (currentPatrolPoint == null ||  worker.isWorkerAtSiteWithMove(currentPatrolPoint, 2))
+        if (currentPatrolPoint == null || worker.isWorkerAtSiteWithMove(currentPatrolPoint, 2))
         {
             final IBuilding building = buildingGuards.getColony().getBuildingManager().getBuilding(buildingGuards.getMinePos());
             if (building != null)
@@ -730,7 +739,7 @@ public abstract class AbstractEntityAIGuard<J extends AbstractJobGuard<J>, B ext
         }
 
         // Move towards the target
-        moveInAttackPosition();
+        targetPath = moveInAttackPosition();
 
         return HELP_CITIZEN;
     }
@@ -792,29 +801,30 @@ public abstract class AbstractEntityAIGuard<J extends AbstractJobGuard<J>, B ext
         {
             incrementActionsDoneAndDecSaturation();
             worker.getCitizenExperienceHandler().addExperience(EXP_PER_MOB_DEATH);
+            ((EntityCitizen) worker).getThreatTable().removeCurrentTarget();
+        }
+
+        final ThreatTableEntry nextTarget = ((EntityCitizen) worker).getThreatTable().getTarget();
+        if (nextTarget == null)
+        {
+            return false;
         }
 
         // Check Current target
-        if (isEntityValidTarget(target))
+        if (isEntityValidTarget(nextTarget.getEntity()))
         {
-            if (target != worker.getLastHurtByMob() && isEntityValidTargetAndCanbeSeen(worker.getLastHurtByMob())
-                  && worker.distanceToSqr(worker.getLastHurtByMob()) < worker.distanceToSqr(target) - 15)
+            if (target != nextTarget.getEntity())
             {
-                target = worker.getLastHurtByMob();
+                target = nextTarget.getEntity();
                 onTargetChange();
             }
 
             // Check sight
-            if (!worker.canSee(target))
+            if (worker.getSensing().canSee(target))
             {
-                lastSeen += 10;
+                nextTarget.setLastSeen(world.getGameTime());
             }
-            else
-            {
-                lastSeen = 0;
-            }
-
-            if (lastSeen > STOP_PERSECUTION_AFTER)
+            else if ((world.getGameTime() - nextTarget.getLastSeen()) > STOP_PERSECUTION_AFTER)
             {
                 resetTarget();
                 return false;
@@ -825,7 +835,20 @@ public abstract class AbstractEntityAIGuard<J extends AbstractJobGuard<J>, B ext
             {
                 if (worker.getNavigation().isDone())
                 {
-                    moveInAttackPosition();
+                    if (targetPath != null && targetPath.failedToReachDestination())
+                    {
+                        ((EntityCitizen) worker).getThreatTable().addThreat(target, -1);
+                        if (nextTarget.getThreat() < 5)
+                        {
+                            resetTarget();
+                            return false;
+                        }
+                    }
+
+                    if (targetPath == null || targetPath.isDone())
+                    {
+                        targetPath = moveInAttackPosition();
+                    }
                 }
             }
 
@@ -834,14 +857,6 @@ public abstract class AbstractEntityAIGuard<J extends AbstractJobGuard<J>, B ext
         else
         {
             resetTarget();
-        }
-
-        // Check the revenge target
-        if (isEntityValidTargetAndCanbeSeen(worker.getLastHurtByMob()))
-        {
-            target = worker.getLastHurtByMob();
-            onTargetChange();
-            return true;
         }
 
         return target != null;
@@ -856,7 +871,7 @@ public abstract class AbstractEntityAIGuard<J extends AbstractJobGuard<J>, B ext
         {
             if (citizen.getEntity().isPresent() && citizen.getEntity().get().getLastHurtByMob() == null)
             {
-                citizen.getEntity().get().setLastHurtByMob(target);
+                ((EntityCitizen) citizen.getEntity().get()).getThreatTable().addThreat(target, 0);
             }
         }
 
@@ -872,17 +887,6 @@ public abstract class AbstractEntityAIGuard<J extends AbstractJobGuard<J>, B ext
                 }
             }
         }
-    }
-
-    /**
-     * Returns whether the entity is a valid target and is visisble.
-     *
-     * @param entity entity to check
-     * @return boolean
-     */
-    public boolean isEntityValidTargetAndCanbeSeen(final LivingEntity entity)
-    {
-        return isEntityValidTarget(entity) && worker.canSee(entity);
     }
 
     /**
@@ -903,7 +907,9 @@ public abstract class AbstractEntityAIGuard<J extends AbstractJobGuard<J>, B ext
             return true;
         }
 
-        if (IColonyManager.getInstance().getCompatibilityManager().getAllMonsters().contains(entity.getType().getRegistryName()) && !buildingGuards.getModuleMatching(EntityListModule.class, m -> m.getId().equals(HOSTILE_LIST)).isEntityInList(entity.getType().getRegistryName()))
+        if (IColonyManager.getInstance().getCompatibilityManager().getAllMonsters().contains(entity.getType().getRegistryName()) && !buildingGuards.getModuleMatching(
+          EntityListModule.class,
+          m -> m.getId().equals(HOSTILE_LIST)).isEntityInList(entity.getType().getRegistryName()))
         {
             return true;
         }
@@ -950,13 +956,15 @@ public abstract class AbstractEntityAIGuard<J extends AbstractJobGuard<J>, B ext
             worker.setLastHurtByMob(null);
         }
 
+        targetPath = null;
+        ((EntityCitizen) worker).getThreatTable().markInvalidTarget();
         target = null;
     }
 
     /**
      * Move the guard into a good attacking position.
      */
-    public abstract void moveInAttackPosition();
+    public abstract PathResult moveInAttackPosition();
 
     /**
      * Execute pre attack checks to check if worker can attack enemy.
@@ -1002,19 +1010,26 @@ public abstract class AbstractEntityAIGuard<J extends AbstractJobGuard<J>, B ext
      *
      * @return The next IAIState to go to.
      */
-    protected LivingEntity searchNearbyTarget()
+    protected boolean searchNearbyTarget()
     {
         final IColony colony = worker.getCitizenColonyHandler().getColony();
         if (colony == null)
         {
             resetTarget();
-            return null;
+            return false;
+        }
+
+        if (checkForTarget())
+        {
+            return true;
         }
 
         final List<LivingEntity> entities = world.getLoadedEntitiesOfClass(LivingEntity.class, getSearchArea());
 
-        int closest = Integer.MAX_VALUE;
-        LivingEntity targetEntity = null;
+        if (entities.isEmpty())
+        {
+            return false;
+        }
 
         for (final LivingEntity entity : entities)
         {
@@ -1028,30 +1043,22 @@ public abstract class AbstractEntityAIGuard<J extends AbstractJobGuard<J>, B ext
             {
                 final EntityCitizen citizen = (EntityCitizen) entity;
                 if (citizen.getCitizenJobHandler().getColonyJob() instanceof AbstractJobGuard && ((AbstractJobGuard<?>) citizen.getCitizenJobHandler().getColonyJob()).isAsleep()
-                      && worker.canSee(entity))
+                      && worker.getSensing().canSee(entity))
                 {
                     sleepingGuard = new WeakReference<>(citizen);
                     wakeTimer = 0;
                     registerTarget(new AIOneTimeEventTarget(GUARD_WAKE));
-                    return null;
+                    return false;
                 }
             }
 
-            if (isEntityValidTarget(entity) && worker.canSee(entity))
+            if (isEntityValidTarget(entity))
             {
-                // Find closest
-                final int tempDistance = (int) BlockPosUtil.getDistanceSquared(worker.blockPosition(), new BlockPos(entity.position()));
-                if (tempDistance < closest)
-                {
-                    closest = tempDistance;
-                    targetEntity = entity;
-                }
+                ((EntityCitizen) worker).getThreatTable().addThreat(entity, 0);
             }
         }
 
-        target = targetEntity;
-        onTargetChange();
-        return targetEntity;
+        return true;
     }
 
     /**
@@ -1155,8 +1162,8 @@ public abstract class AbstractEntityAIGuard<J extends AbstractJobGuard<J>, B ext
 
         final double x1 = worker.blockPosition().getX() + (Math.max(buildingBonus * randomDirection.getStepX() + DEFAULT_VISION, DEFAULT_VISION));
         final double x2 = worker.blockPosition().getX() + (Math.min(buildingBonus * randomDirection.getStepX() - DEFAULT_VISION, -DEFAULT_VISION));
-        final double y1 = worker.blockPosition().getY() + (Y_VISION >> 1);
-        final double y2 = worker.blockPosition().getY() - (Y_VISION << 1);
+        final double y1 = worker.blockPosition().getY() + (Y_VISION);
+        final double y2 = worker.blockPosition().getY() - (Y_VISION);
         final double z1 = worker.blockPosition().getZ() + (Math.max(buildingBonus * randomDirection.getStepZ() + DEFAULT_VISION, DEFAULT_VISION));
         final double z2 = worker.blockPosition().getZ() + (Math.min(buildingBonus * randomDirection.getStepZ() - DEFAULT_VISION, -DEFAULT_VISION));
 

--- a/src/main/java/com/minecolonies/coremod/entity/ai/citizen/guard/EntityAIKnight.java
+++ b/src/main/java/com/minecolonies/coremod/entity/ai/citizen/guard/EntityAIKnight.java
@@ -6,6 +6,8 @@ import com.minecolonies.api.entity.ai.statemachine.AITarget;
 import com.minecolonies.api.entity.ai.statemachine.states.IAIState;
 import com.minecolonies.api.entity.citizen.Skill;
 import com.minecolonies.api.entity.citizen.VisibleCitizenStatus;
+import com.minecolonies.api.entity.combat.combat.IThreatTableEntity;
+import com.minecolonies.api.entity.pathfinding.PathResult;
 import com.minecolonies.api.util.InventoryUtils;
 import com.minecolonies.api.util.ItemStackUtils;
 import com.minecolonies.api.util.SoundUtils;
@@ -31,9 +33,9 @@ import net.minecraft.util.DamageSource;
 import net.minecraft.util.Hand;
 import net.minecraft.util.ResourceLocation;
 import net.minecraft.util.SoundEvents;
+import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.math.MathHelper;
 import net.minecraft.world.server.ServerWorld;
-import net.minecraft.util.math.BlockPos;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.List;
@@ -286,6 +288,10 @@ public class EntityAIKnight extends AbstractEntityAIGuard<JobKnight, AbstractBui
             if (worker.getCitizenColonyHandler().getColony().getResearchManager().getResearchEffects().getEffectStrength(KNIGHT_TAUNT) > 0)
             {
                 ((MobEntity) target).setTarget(worker);
+                if (target instanceof IThreatTableEntity)
+                {
+                    ((IThreatTableEntity) target).getThreatTable().addThreat(worker, 5);
+                }
             }
         }
 
@@ -331,9 +337,9 @@ public class EntityAIKnight extends AbstractEntityAIGuard<JobKnight, AbstractBui
     }
 
     @Override
-    public void moveInAttackPosition()
+    public PathResult moveInAttackPosition()
     {
-        worker.getNavigation().moveTo(target, getCombatMovementSpeed());
+        return worker.getNavigation().moveToLivingEntity(target, getCombatMovementSpeed());
     }
 
     @Override

--- a/src/main/java/com/minecolonies/coremod/entity/ai/citizen/guard/EntityAIRanger.java
+++ b/src/main/java/com/minecolonies/coremod/entity/ai/citizen/guard/EntityAIRanger.java
@@ -523,9 +523,9 @@ public class EntityAIRanger extends AbstractEntityAIGuard<JobRanger, AbstractBui
     }
 
     @Override
-    public void moveInAttackPosition()
+    public PathResult moveInAttackPosition()
     {
-        ((MinecoloniesAdvancedPathNavigate) worker.getNavigation()).setPathJob(new PathJobCanSee(worker,
+        return ((MinecoloniesAdvancedPathNavigate) worker.getNavigation()).setPathJob(new PathJobCanSee(worker,
             target,
             world,
             buildingGuards.getGuardPos(), shouldStayCloseToPos()

--- a/src/main/java/com/minecolonies/coremod/entity/ai/minimal/EntityAICitizenAvoidEntity.java
+++ b/src/main/java/com/minecolonies/coremod/entity/ai/minimal/EntityAICitizenAvoidEntity.java
@@ -10,6 +10,7 @@ import com.minecolonies.api.util.CompatibilityUtils;
 import com.minecolonies.api.util.Log;
 import com.minecolonies.coremod.colony.buildings.workerbuildings.BuildingHospital;
 import com.minecolonies.coremod.colony.jobs.AbstractJobGuard;
+import com.minecolonies.coremod.entity.citizen.EntityCitizen;
 import net.minecraft.entity.Entity;
 import net.minecraft.entity.ai.goal.Goal;
 import net.minecraft.entity.player.PlayerEntity;
@@ -26,8 +27,6 @@ import static com.minecolonies.api.entity.ai.statemachine.states.AIWorkerState.R
 import static com.minecolonies.api.entity.ai.statemachine.states.AIWorkerState.SAFE;
 import static com.minecolonies.api.util.constant.CitizenConstants.MAX_GUARD_CALL_RANGE;
 import static com.minecolonies.coremod.entity.citizen.citizenhandlers.CitizenDiseaseHandler.SEEK_DOCTOR_HEALTH;
-
-import net.minecraft.entity.ai.goal.Goal.Flag;
 
 /**
  * AI task to avoid an Entity class.
@@ -54,7 +53,7 @@ public class EntityAICitizenAvoidEntity extends Goal
     /**
      * The entity we are attached to.
      */
-    private final AbstractEntityCitizen   citizen;
+    private final EntityCitizen           citizen;
     private final double                  farSpeed;
     private final double                  nearSpeed;
     private final float                   distanceFromEntity;
@@ -97,7 +96,7 @@ public class EntityAICitizenAvoidEntity extends Goal
      * @param nearSpeed          how fast we should move when we are close.
      */
     public EntityAICitizenAvoidEntity(
-      @NotNull final AbstractEntityCitizen entity, @NotNull final Class<? extends Entity> targetEntityClass,
+      @NotNull final EntityCitizen entity, @NotNull final Class<? extends Entity> targetEntityClass,
       final float distanceFromEntity, final double farSpeed, final double nearSpeed)
     {
         super();
@@ -148,7 +147,7 @@ public class EntityAICitizenAvoidEntity extends Goal
             return false;
         }
 
-        closestLivingEntity = getClosestToAvoid();
+        closestLivingEntity = citizen.getThreatTable().getTargetMob();
 
         return closestLivingEntity != null && !(citizen.getCitizenJobHandler().getColonyJob() instanceof AbstractJobGuard);
     }

--- a/src/main/java/com/minecolonies/coremod/entity/citizen/EntityCitizen.java
+++ b/src/main/java/com/minecolonies/coremod/entity/citizen/EntityCitizen.java
@@ -149,43 +149,52 @@ public class EntityCitizen extends AbstractEntityCitizen implements IThreatTable
     /**
      * The citizen colony handler.
      */
-    private ICitizenColonyHandler  citizenColonyHandler;
+    private ICitizenColonyHandler citizenColonyHandler;
+
     /**
      * The citizen job handler.
      */
-    private ICitizenJobHandler     citizenJobHandler;
+    private ICitizenJobHandler citizenJobHandler;
+
     /**
      * The citizen sleep handler.
      */
-    private ICitizenSleepHandler   citizenSleepHandler;
+    private ICitizenSleepHandler citizenSleepHandler;
+
     /**
      * The citizen sleep handler.
      */
     private ICitizenDiseaseHandler citizenDiseaseHandler;
+
     /**
      * The path-result of trying to move away
      */
-    private PathResult             moveAwayPath;
+    private PathResult moveAwayPath;
+
     /**
      * IsChild flag
      */
-    private boolean                child               = false;
+    private boolean child = false;
+
     /**
      * Whether the citizen is currently running away
      */
-    private boolean                currentlyFleeing    = false;
+    private boolean currentlyFleeing = false;
+
     /**
      * Timer for the call for help cd.
      */
-    private int                    callForHelpCooldown = 0;
+    private int callForHelpCooldown = 0;
+
     /**
      * Distance walked for consuming food
      */
-    private float                  lastDistanceWalked  = 0;
+    private float lastDistanceWalked = 0;
+
     /**
      * Citizen data view.
      */
-    private ICitizenDataView       citizenDataView;
+    private ICitizenDataView citizenDataView;
 
     /**
      * The location used for requests

--- a/src/main/java/com/minecolonies/coremod/entity/citizen/EntityCitizen.java
+++ b/src/main/java/com/minecolonies/coremod/entity/citizen/EntityCitizen.java
@@ -606,7 +606,6 @@ public class EntityCitizen extends AbstractEntityCitizen implements IThreatTable
             else
             {
                 healAmount = 1 * (1.0 + getCitizenColonyHandler().getColony().getResearchManager().getResearchEffects().getEffectStrength(REGENERATION));
-                ;
             }
 
             heal((float) healAmount);

--- a/src/main/java/com/minecolonies/coremod/entity/pathfinding/pathjobs/AbstractPathJob.java
+++ b/src/main/java/com/minecolonies/coremod/entity/pathfinding/pathjobs/AbstractPathJob.java
@@ -958,6 +958,11 @@ public abstract class AbstractPathJob implements Callable<Path>
         boolean corner = false;
         if (pos.getY() != newY)
         {
+            if (parent.isCornerNode())
+            {
+                return false;
+            }
+
             // if the new position is above the current node, we're taking the node directly above
             if (!parent.isCornerNode() && newY - pos.getY() > 0 && (parent.parent == null || !parent.parent.pos.equals(parent.pos.offset(new BlockPos(0, newY - pos.getY(), 0)))))
             {


### PR DESCRIPTION
# Changes proposed in this pull request:
Add threat tables to citizens/guards:
- Threat tables are a list of potential targets/threat which are associated and sorted by their threat value.
- Threat is generated by two things atm: Initial threat based on distance and Threat from getting damage(1 damage = 1 threat)
- Threat tables allows us to scan for targets less frequently and at the same time have citizens react to target changes smartly and faster during combat:
- It is now possible to ignore unreachable targets, those get marked as invalid until they cause an action that generates threat
- Target priorization is now done smarter by attacking the most dangerous target

Review please
