### PR TITLE
Add sleeping and mourning interactions

### DIFF
--- a/src/api/java/com/minecolonies/api/colony/ICitizenDataView.java
+++ b/src/api/java/com/minecolonies/api/colony/ICitizenDataView.java
@@ -116,6 +116,13 @@ public interface ICitizenDataView extends ICitizen
     boolean hasBlockingInteractions();
 
     /**
+     * Check if the citizen has any visible interactions.
+     * 
+     * @return true if so.
+     */
+    boolean hasVisibleInteractions();
+
+    /**
      * Check if the citizen has any interactions.
      *
      * @return true if so.

--- a/src/api/java/com/minecolonies/api/colony/interactionhandling/ChatPriority.java
+++ b/src/api/java/com/minecolonies/api/colony/interactionhandling/ChatPriority.java
@@ -5,6 +5,7 @@ package com.minecolonies.api.colony.interactionhandling;
  */
 public enum ChatPriority implements IChatPriority
 {
+    HIDDEN,
     CHITCHAT,
     PENDING,
     IMPORTANT,

--- a/src/api/java/com/minecolonies/api/entity/citizen/citizenhandlers/ICitizenMournHandler.java
+++ b/src/api/java/com/minecolonies/api/entity/citizen/citizenhandlers/ICitizenMournHandler.java
@@ -1,5 +1,7 @@
 package com.minecolonies.api.entity.citizen.citizenhandlers;
 
+import java.util.Set;
+
 import net.minecraft.nbt.CompoundNBT;
 
 /**
@@ -26,6 +28,12 @@ public interface ICitizenMournHandler
      * @param name the name of the citizen.
      */
     void addDeceasedCitizen(final String name);
+
+    /**
+     * Gets a set with all the recently deceased citizens.
+     * @return a set with all the recently deceased citizens.
+     */
+    Set<String> getDeceasedCitizens();
 
     /**
      * Remove a deceased citizen from the handler.

--- a/src/api/java/com/minecolonies/api/util/constant/TranslationConstants.java
+++ b/src/api/java/com/minecolonies/api/util/constant/TranslationConstants.java
@@ -396,6 +396,10 @@ public final class TranslationConstants
     @NonNls
     public static final String COM_MINECOLONIES_COREMOD_ENTITY_CITIZEN_RAID                         = "com.minecolonies.coremod.entity.citizen.raid";
     @NonNls
+    public static final String COM_MINECOLONIES_COREMOD_ENTITY_CITIZEN_SLEEPING                     = "com.minecolonies.coremod.entity.citizen.sleeping";
+    @NonNls
+    public static final String COM_MINECOLONIES_COREMOD_ENTITY_CITIZEN_MOURNING                     = "com.minecolonies.coremod.entity.citizen.mourning";
+    @NonNls
     public static final String CITIZEN_NOT_GUARD_NEAR_WORK                                          = "com.minecolonies.coremod.gui.chat.noguardnearwork";
     @NonNls
     public static final String CITIZEN_NOT_GUARD_NEAR_HOME                                          = "com.minecolonies.coremod.gui.chat.noguardnearhome";

--- a/src/main/java/com/minecolonies/apiimp/initializer/InteractionValidatorInitializer.java
+++ b/src/main/java/com/minecolonies/apiimp/initializer/InteractionValidatorInitializer.java
@@ -296,10 +296,22 @@ public class InteractionValidatorInitializer
                        && ((BuildingBeekeeper) citizen.getWorkBuilding()).getModuleMatching(ItemListModule.class, m -> m.getId().equals(BUILDING_FLOWER_LIST)).getList().isEmpty());
 
         InteractionValidatorRegistry.registerStandardPredicate(new TranslationTextComponent(COM_MINECOLONIES_COREMOD_ENTITY_CITIZEN_RAINING),
-          citizen -> citizen.getEntity().isPresent() && citizen.getEntity().get().getCommandSenderWorld().isRaining() && !citizen.getColony().getRaiderManager().isRaided());
+          citizen -> citizen.getEntity().isPresent() && citizen.getEntity().get().getCommandSenderWorld().isRaining()
+                       && !citizen.getColony().getRaiderManager().isRaided()
+                       && !citizen.getCitizenMournHandler().isMourning());
 
         InteractionValidatorRegistry.registerStandardPredicate(new TranslationTextComponent(COM_MINECOLONIES_COREMOD_ENTITY_CITIZEN_RAID),
           citizen -> citizen.getEntity().isPresent() && citizen.getColony().getRaiderManager().isRaided());
+
+        InteractionValidatorRegistry.registerStandardPredicate(new TranslationTextComponent(COM_MINECOLONIES_COREMOD_ENTITY_CITIZEN_SLEEPING),
+          citizen -> citizen.getEntity().isPresent() && citizen.getEntity().get().getCitizenSleepHandler().isAsleep()
+                      && !citizen.getColony().getRaiderManager().isRaided()
+                      && !citizen.getCitizenMournHandler().isMourning()
+                      && !citizen.getEntity().get().getCommandSenderWorld().isRaining());
+
+        InteractionValidatorRegistry.registerStandardPredicate(new TranslationTextComponent(COM_MINECOLONIES_COREMOD_ENTITY_CITIZEN_MOURNING),
+          citizen -> citizen.getEntity().isPresent() && citizen.getCitizenMournHandler().isMourning()
+                     && !citizen.getColony().getRaiderManager().isRaided());
 
         InteractionValidatorRegistry.registerStandardPredicate(new TranslationTextComponent(CITIZEN_NOT_GUARD_NEAR_WORK),
           citizen -> citizen.getWorkBuilding() != null && !citizen.getWorkBuilding().isGuardBuildingNear());

--- a/src/main/java/com/minecolonies/apiimp/initializer/InteractionValidatorInitializer.java
+++ b/src/main/java/com/minecolonies/apiimp/initializer/InteractionValidatorInitializer.java
@@ -304,7 +304,7 @@ public class InteractionValidatorInitializer
           citizen -> citizen.getEntity().isPresent() && citizen.getColony().getRaiderManager().isRaided());
 
         InteractionValidatorRegistry.registerStandardPredicate(new TranslationTextComponent(COM_MINECOLONIES_COREMOD_ENTITY_CITIZEN_SLEEPING),
-          citizen -> citizen.getEntity().isPresent() && citizen.getEntity().get().getCitizenSleepHandler().isAsleep()
+          citizen -> citizen.getEntity().isPresent() && citizen.getEntity().get().getCitizenSleepHandler().shouldGoSleep()
                       && !citizen.getColony().getRaiderManager().isRaided()
                       && !citizen.getCitizenMournHandler().isMourning()
                       && !citizen.getEntity().get().getCommandSenderWorld().isRaining());

--- a/src/main/java/com/minecolonies/coremod/client/render/RenderBipedCitizen.java
+++ b/src/main/java/com/minecolonies/coremod/client/render/RenderBipedCitizen.java
@@ -105,7 +105,7 @@ public class RenderBipedCitizen extends MobRenderer<AbstractEntityCitizen, Citiz
     {
         super.renderNameTag(entityIn, str, matrixStack, buffer, maxDistance);
 
-        if (entityIn.getCitizenDataView() != null && entityIn.getCitizenDataView().hasPendingInteractions())
+        if (entityIn.getCitizenDataView() != null && entityIn.getCitizenDataView().hasVisibleInteractions())
         {
             double distance = this.entityRenderDispatcher.distanceToSqr(entityIn.getX(), entityIn.getY(), entityIn.getZ());
             if (distance <= 4096.0D)

--- a/src/main/java/com/minecolonies/coremod/colony/CitizenDataView.java
+++ b/src/main/java/com/minecolonies/coremod/colony/CitizenDataView.java
@@ -388,6 +388,23 @@ public class CitizenDataView implements ICitizenDataView
     }
 
     @Override
+    public boolean hasVisibleInteractions()
+    {
+        if (sortedInteractions.isEmpty())
+        {
+            return false;
+        }
+
+        final IInteractionResponseHandler interaction = sortedInteractions.get(0);
+        if (interaction != null)
+        {
+            return interaction.getPriority().getPriority() >= ChatPriority.CHITCHAT.getPriority();
+        }
+
+        return false;
+    }
+
+    @Override
     public boolean hasPendingInteractions()
     {
         if (sortedInteractions.isEmpty())
@@ -431,7 +448,7 @@ public class CitizenDataView implements ICitizenDataView
             {
                 icon = BLOCKING_RESOURCE;
             }
-            else
+            else if (hasVisibleInteractions())
             {
                 icon = PENDING_RESOURCE;
             }

--- a/src/main/java/com/minecolonies/coremod/entity/citizen/EntityCitizen.java
+++ b/src/main/java/com/minecolonies/coremod/entity/citizen/EntityCitizen.java
@@ -1015,7 +1015,7 @@ public class EntityCitizen extends AbstractEntityCitizen
 
         if (getCitizenColonyHandler().getColony().getRaiderManager().isRaided())
         {
-            citizenData.triggerInteraction(new StandardInteraction(new TranslationTextComponent(COM_MINECOLONIES_COREMOD_ENTITY_CITIZEN_RAID), ChatPriority.CHITCHAT));
+            citizenData.triggerInteraction(new StandardInteraction(new TranslationTextComponent(COM_MINECOLONIES_COREMOD_ENTITY_CITIZEN_RAID), ChatPriority.IMPORTANT));
             setVisibleStatusIfNone(RAIDED);
             desiredActivity = DesiredActivity.SLEEP;
             return false;
@@ -1026,6 +1026,12 @@ public class EntityCitizen extends AbstractEntityCitizen
         {
             if (desiredActivity == DesiredActivity.SLEEP)
             {
+                if (!getCitizenColonyHandler().getColony().getRaiderManager().isRaided()
+                      && !citizenData.getCitizenMournHandler().isMourning()
+                      && !CompatibilityUtils.getWorldFromCitizen(this).isRaining())
+                {
+            	    citizenData.triggerInteraction(new StandardInteraction(new TranslationTextComponent(COM_MINECOLONIES_COREMOD_ENTITY_CITIZEN_SLEEPING), ChatPriority.CHITCHAT));
+                }
                 setVisibleStatusIfNone(SLEEP);
                 return false;
             }
@@ -1041,8 +1047,13 @@ public class EntityCitizen extends AbstractEntityCitizen
             }
         }
 
+        // Mourning
         if (citizenData.getCitizenMournHandler().isMourning() && citizenData.getCitizenMournHandler().shouldMourn())
         {
+            if (!getCitizenColonyHandler().getColony().getRaiderManager().isRaided())
+            {
+                citizenData.triggerInteraction(new StandardInteraction(new TranslationTextComponent(COM_MINECOLONIES_COREMOD_ENTITY_CITIZEN_MOURNING, citizenData.getCitizenMournHandler().getDeceasedCitizens().iterator().next()), new TranslationTextComponent(COM_MINECOLONIES_COREMOD_ENTITY_CITIZEN_MOURNING), ChatPriority.IMPORTANT));
+            }
             setVisibleStatusIfNone(MOURNING);
             desiredActivity = DesiredActivity.MOURN;
             return false;
@@ -1059,7 +1070,8 @@ public class EntityCitizen extends AbstractEntityCitizen
             citizenStatusHandler.setLatestStatus(new TranslationTextComponent("com.minecolonies.coremod.status.waiting"),
               new TranslationTextComponent("com.minecolonies.coremod.status.rainStop"));
             setVisibleStatusIfNone(BAD_WEATHER);
-            if (!citizenData.getColony().getRaiderManager().isRaided())
+            if (!citizenData.getColony().getRaiderManager().isRaided()
+                  && !citizenData.getCitizenMournHandler().isMourning())
             {
                 citizenData.triggerInteraction(new StandardInteraction(new TranslationTextComponent(COM_MINECOLONIES_COREMOD_ENTITY_CITIZEN_RAINING), ChatPriority.CHITCHAT));
             }

--- a/src/main/java/com/minecolonies/coremod/entity/citizen/EntityCitizen.java
+++ b/src/main/java/com/minecolonies/coremod/entity/citizen/EntityCitizen.java
@@ -1030,7 +1030,7 @@ public class EntityCitizen extends AbstractEntityCitizen
                       && !citizenData.getCitizenMournHandler().isMourning()
                       && !CompatibilityUtils.getWorldFromCitizen(this).isRaining())
                 {
-            	    citizenData.triggerInteraction(new StandardInteraction(new TranslationTextComponent(COM_MINECOLONIES_COREMOD_ENTITY_CITIZEN_SLEEPING), ChatPriority.CHITCHAT));
+            	    citizenData.triggerInteraction(new StandardInteraction(new TranslationTextComponent(COM_MINECOLONIES_COREMOD_ENTITY_CITIZEN_SLEEPING), ChatPriority.HIDDEN));
                 }
                 setVisibleStatusIfNone(SLEEP);
                 return false;
@@ -1073,7 +1073,7 @@ public class EntityCitizen extends AbstractEntityCitizen
             if (!citizenData.getColony().getRaiderManager().isRaided()
                   && !citizenData.getCitizenMournHandler().isMourning())
             {
-                citizenData.triggerInteraction(new StandardInteraction(new TranslationTextComponent(COM_MINECOLONIES_COREMOD_ENTITY_CITIZEN_RAINING), ChatPriority.CHITCHAT));
+                citizenData.triggerInteraction(new StandardInteraction(new TranslationTextComponent(COM_MINECOLONIES_COREMOD_ENTITY_CITIZEN_RAINING), ChatPriority.HIDDEN));
             }
             desiredActivity = DesiredActivity.SLEEP;
             return false;

--- a/src/main/java/com/minecolonies/coremod/entity/citizen/citizenhandlers/CitizenMournHandler.java
+++ b/src/main/java/com/minecolonies/coremod/entity/citizen/citizenhandlers/CitizenMournHandler.java
@@ -67,6 +67,11 @@ public class CitizenMournHandler implements ICitizenMournHandler
     }
 
     @Override
+    public Set<String> getDeceasedCitizens() {
+    	return deceasedCitizens;
+    }
+
+    @Override
     public void removeDeceasedCitizen(final String name)
     {
         deceasedCitizens.remove(name);

--- a/src/main/java/com/minecolonies/coremod/entity/citizen/citizenhandlers/CitizenMournHandler.java
+++ b/src/main/java/com/minecolonies/coremod/entity/citizen/citizenhandlers/CitizenMournHandler.java
@@ -67,7 +67,8 @@ public class CitizenMournHandler implements ICitizenMournHandler
     }
 
     @Override
-    public Set<String> getDeceasedCitizens() {
+    public Set<String> getDeceasedCitizens()
+    {
     	return deceasedCitizens;
     }
 

--- a/src/main/resources/assets/minecolonies/lang/en_us.json
+++ b/src/main/resources/assets/minecolonies/lang/en_us.json
@@ -1651,7 +1651,7 @@
   "com.minecolonies.coremod.entity.citizen.sleep": "All colonists are tucked into bed.",
   "com.minecolonies.coremod.entity.citizen.raining": "I don't like staying out in the rain, my clothes are gonna get wet.",
   "com.minecolonies.coremod.entity.citizen.raid": "Help! The colony is being raided. I am running for shelter.",
-  "com.minecolonies.coremod.entity.citizen.sleeping": "zZzz... I'm sleeping... Why did you wake me up?",
+  "com.minecolonies.coremod.entity.citizen.sleeping": "zZzz... I want to sleep... Why are you bothering me?",
   "com.minecolonies.coremod.entity.citizen.mourning": "I'm still processing %ss death, I can't work today.",
 
   "com.minecolonies.coremod.gui.townhall.happiness.homelessness": "Housing",

--- a/src/main/resources/assets/minecolonies/lang/en_us.json
+++ b/src/main/resources/assets/minecolonies/lang/en_us.json
@@ -1651,6 +1651,8 @@
   "com.minecolonies.coremod.entity.citizen.sleep": "All colonists are tucked into bed.",
   "com.minecolonies.coremod.entity.citizen.raining": "I don't like staying out in the rain, my clothes are gonna get wet.",
   "com.minecolonies.coremod.entity.citizen.raid": "Help! The colony is being raided. I am running for shelter.",
+  "com.minecolonies.coremod.entity.citizen.sleeping": "zZzz... I'm sleeping... Why did you wake me up?",
+  "com.minecolonies.coremod.entity.citizen.mourning": "I'm still processing %ss death, I can't work today.",
 
   "com.minecolonies.coremod.gui.townhall.happiness.homelessness": "Housing",
   "com.minecolonies.coremod.gui.townhall.happiness.unemployment": "Unemployment",


### PR DESCRIPTION
Closes #
Closes #
Closes #

# Changes proposed in this pull request:
- Sleeping citizens will now have an interaction when you click on them asking you why you woke them up.
- The sleeping interaction text is `zZzz... I want to sleep... Why are you bothering me?`.
- This interaction does not cause the chat icon to appear above them.
- Mourning Citizens now have an interaction telling you why they aren't working.
- This interactions is currently `I'm still processing %ss death, I can't work today.` I am aware this isn't great, but wasn't able to come up with anything better.
- The rain interaction also no longer shows the icon.

Review please
