### PR TITLE
Don't do "ore" tag substring matching

### DIFF
--- a/src/api/java/com/minecolonies/api/compatibility/CompatibilityManager.java
+++ b/src/api/java/com/minecolonies/api/compatibility/CompatibilityManager.java
@@ -44,7 +44,6 @@ import java.util.stream.Collectors;
 
 import static com.minecolonies.api.util.ItemStackUtils.*;
 import static com.minecolonies.api.util.constant.Constants.ONE_HUNDRED_PERCENT;
-import static com.minecolonies.api.util.constant.Constants.ORE_STRING;
 import static com.minecolonies.api.util.constant.NbtTagConstants.TAG_SAP_LEAF;
 
 /**
@@ -323,22 +322,9 @@ public class CompatibilityManager implements ICompatibilityManager
     @Override
     public boolean isOre(@NotNull final ItemStack stack)
     {
-        if (isEmpty(stack))
-        {
-            return false;
-        }
-
-        if (stack.getItem().is(Tags.Items.ORES))
+        if (isMineableOre(stack))
         {
             return !MinecoloniesAPIProxy.getInstance().getFurnaceRecipes().getSmeltingResult(stack).isEmpty();
-        }
-
-        for (final ResourceLocation tag : stack.getItem().getTags())
-        {
-            if (tag.getPath().contains(ORE_STRING))
-            {
-                return !MinecoloniesAPIProxy.getInstance().getFurnaceRecipes().getSmeltingResult(stack).isEmpty();
-            }
         }
 
         return false;
@@ -347,25 +333,7 @@ public class CompatibilityManager implements ICompatibilityManager
     @Override
     public boolean isMineableOre(@NotNull final ItemStack stack)
     {
-        if (isEmpty(stack))
-        {
-            return false;
-        }
-
-        if (stack.getItem().is(Tags.Items.ORES))
-        {
-            return true;
-        }
-
-        for (final ResourceLocation tag : stack.getItem().getTags())
-        {
-            if (tag.getPath().contains(ORE_STRING))
-            {
-                return true;
-            }
-        }
-
-        return false;
+        return !isEmpty(stack) && stack.getItem().is(Tags.Items.ORES);
     }
 
     @Override

--- a/src/api/java/com/minecolonies/api/util/constant/Constants.java
+++ b/src/api/java/com/minecolonies/api/util/constant/Constants.java
@@ -97,11 +97,6 @@ public final class Constants
     public static String INSTANT_PLACEMENT = "instant";
 
     /**
-     * The oredict entry of an ore.
-     */
-    public static final String ORE_STRING = "ore";
-
-    /**
      * Max crafting cycle depth.
      */
     public static final int MAX_CRAFTING_CYCLE_DEPTH = 20;


### PR DESCRIPTION
# Changes proposed in this pull request:
- Don't consider a potato as a smeltable ore.  (Due to "ore" substring match from `industrialforegoing:bioreactor`.)

Review please

There's a chance that this may revert some cross-mod compatibility.  But they really ought to be tagging their ores correctly, and it can be worked around in modpacks via a custom datapack if needed, so this seems the sensible choice.