### PR TITLE
Fix cobble/ladder deserialization

### DIFF
--- a/src/api/java/com/minecolonies/api/util/BlockPosUtil.java
+++ b/src/api/java/com/minecolonies/api/util/BlockPosUtil.java
@@ -75,6 +75,24 @@ public final class BlockPosUtil
     }
 
     /**
+     * Writes a chunk coordinate to a CompoundNBT, but only if not null.
+     * @param compound Compound to write to.
+     * @param name     Name of the tag.
+     * @param value    Coordinates to write; if null, the tag is not written.
+     * @return the resulting compound.
+     */
+    @NotNull
+    public static CompoundNBT writeOptional(@NotNull final CompoundNBT compound, @NotNull final String name,
+                                            @Nullable final BlockPos value)
+    {
+        if (value != null)
+        {
+            write(compound, name, value);
+        }
+        return compound;
+    }
+
+    /**
      * Searches a random direction.
      *
      * @param random a random object.
@@ -141,6 +159,19 @@ public final class BlockPosUtil
         final int y = coordsCompound.getInt("y");
         final int z = coordsCompound.getInt("z");
         return new BlockPos(x, y, z);
+    }
+
+    /**
+     * Reads chunk coordinates from a CompoundNBT, but returns null if zero or absent.
+     * @param compound Compound to read data from.
+     * @param name     Tag name to read data from.
+     * @return Chunk coordinates read from the compound, or null if it was zero or absent.
+     */
+    @Nullable
+    public static BlockPos readOrNull(@NotNull final CompoundNBT compound, @NotNull final String name)
+    {
+        final BlockPos result = read(compound, name);
+        return result.equals(BlockPos.ZERO) ? null : result;
     }
 
     /**

--- a/src/api/java/com/minecolonies/api/util/constant/BuildingConstants.java
+++ b/src/api/java/com/minecolonies/api/util/constant/BuildingConstants.java
@@ -33,11 +33,6 @@ public final class BuildingConstants
     public static final String TAG_LEVELS = "levels";
 
     /**
-     * The NBT Tag to store if the shaft has been cleared.
-     */
-    public static final String TAG_CLEARED = "clearedShaft";
-
-    /**
      * The NBT Tag to store the location of the cobblestone at the shaft.
      */
     public static final String TAG_CLOCATION = "cobblelocation";

--- a/src/main/java/com/minecolonies/coremod/colony/buildings/workerbuildings/BuildingMiner.java
+++ b/src/main/java/com/minecolonies/coremod/colony/buildings/workerbuildings/BuildingMiner.java
@@ -71,11 +71,6 @@ public class BuildingMiner extends AbstractBuildingStructureBuilder
     private static final String MINER = "miner";
 
     /**
-     * True if shaft is at bottom limit.
-     */
-    private boolean clearedShaft = false;
-
-    /**
      * The location of the topmost cobblestone the ladder starts at.
      */
     private BlockPos cobbleLocation;
@@ -180,7 +175,6 @@ public class BuildingMiner extends AbstractBuildingStructureBuilder
     {
         super.deserializeNBT(compound);
 
-        clearedShaft = compound.getBoolean(TAG_CLEARED);
         ladderLocation = BlockPosUtil.readOrNull(compound, TAG_LLOCATION);
         cobbleLocation = BlockPosUtil.readOrNull(compound, TAG_CLOCATION);
     }
@@ -189,7 +183,6 @@ public class BuildingMiner extends AbstractBuildingStructureBuilder
     public CompoundNBT serializeNBT()
     {
         final CompoundNBT compound = super.serializeNBT();
-        compound.putBoolean(TAG_CLEARED, clearedShaft);
 
         BlockPosUtil.writeOptional(compound, TAG_CLOCATION, cobbleLocation);
         BlockPosUtil.writeOptional(compound, TAG_LLOCATION, ladderLocation);
@@ -294,26 +287,6 @@ public class BuildingMiner extends AbstractBuildingStructureBuilder
         }
         cobbleLocation = cobblePos.iterator().next();
         ladderLocation = ladderPos.iterator().next();
-    }
-
-    /**
-     * Getter to check if the shaft has been cleared.
-     *
-     * @return true if so.
-     */
-    public boolean hasClearedShaft()
-    {
-        return clearedShaft;
-    }
-
-    /**
-     * Setter if the shaft has been cleared.
-     *
-     * @param clearedShaft true if so.
-     */
-    public void setClearedShaft(final boolean clearedShaft)
-    {
-        this.clearedShaft = clearedShaft;
     }
 
     @Override

--- a/src/main/java/com/minecolonies/coremod/colony/buildings/workerbuildings/BuildingMiner.java
+++ b/src/main/java/com/minecolonies/coremod/colony/buildings/workerbuildings/BuildingMiner.java
@@ -28,6 +28,7 @@ import net.minecraft.util.Tuple;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.World;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 import java.util.*;
 
@@ -176,8 +177,8 @@ public class BuildingMiner extends AbstractBuildingStructureBuilder
         super.deserializeNBT(compound);
 
         clearedShaft = compound.getBoolean(TAG_CLEARED);
-        ladderLocation = BlockPosUtil.read(compound, TAG_LLOCATION);
-        cobbleLocation = BlockPosUtil.read(compound, TAG_CLOCATION);
+        ladderLocation = readOptionalBlockPos(compound, TAG_LLOCATION);
+        cobbleLocation = readOptionalBlockPos(compound, TAG_CLOCATION);
     }
 
     @Override
@@ -186,16 +187,28 @@ public class BuildingMiner extends AbstractBuildingStructureBuilder
         final CompoundNBT compound = super.serializeNBT();
         compound.putBoolean(TAG_CLEARED, clearedShaft);
 
-        if (cobbleLocation != null)
-        {
-            BlockPosUtil.write(compound, TAG_CLOCATION, cobbleLocation);
-        }
+        writeOptionalBlockPos(compound, TAG_CLOCATION, cobbleLocation);
+        writeOptionalBlockPos(compound, TAG_LLOCATION, ladderLocation);
 
-        if (ladderLocation != null)
-        {
-            BlockPosUtil.write(compound, TAG_LLOCATION, ladderLocation);
-        }
         return compound;
+    }
+
+    @Nullable
+    private static BlockPos readOptionalBlockPos(@NotNull final CompoundNBT compound,
+                                                 @NotNull final String name)
+    {
+        final BlockPos result = BlockPosUtil.read(compound, name);
+        return result.equals(BlockPos.ZERO) ? null : result;
+    }
+
+    private static void writeOptionalBlockPos(@NotNull final CompoundNBT compound,
+                                              @NotNull final String name,
+                                              @Nullable final BlockPos value)
+    {
+        if (value != null)
+        {
+            BlockPosUtil.write(compound, name, value);
+        }
     }
 
     @NotNull

--- a/src/main/java/com/minecolonies/coremod/colony/buildings/workerbuildings/BuildingMiner.java
+++ b/src/main/java/com/minecolonies/coremod/colony/buildings/workerbuildings/BuildingMiner.java
@@ -3,7 +3,9 @@ package com.minecolonies.coremod.colony.buildings.workerbuildings;
 import com.ldtteam.blockout.views.Window;
 import com.ldtteam.structurize.management.Structures;
 import com.ldtteam.structurize.util.PlacementSettings;
-import com.minecolonies.api.colony.*;
+import com.minecolonies.api.colony.ICitizenData;
+import com.minecolonies.api.colony.IColony;
+import com.minecolonies.api.colony.IColonyView;
 import com.minecolonies.api.colony.buildings.ModBuildings;
 import com.minecolonies.api.colony.buildings.registry.BuildingEntry;
 import com.minecolonies.api.colony.jobs.IJob;
@@ -28,9 +30,11 @@ import net.minecraft.util.Tuple;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.World;
 import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
 
-import java.util.*;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
 
 import static com.minecolonies.api.util.constant.BuildingConstants.*;
 import static com.minecolonies.api.util.constant.Constants.STACKSIZE;
@@ -177,8 +181,8 @@ public class BuildingMiner extends AbstractBuildingStructureBuilder
         super.deserializeNBT(compound);
 
         clearedShaft = compound.getBoolean(TAG_CLEARED);
-        ladderLocation = readOptionalBlockPos(compound, TAG_LLOCATION);
-        cobbleLocation = readOptionalBlockPos(compound, TAG_CLOCATION);
+        ladderLocation = BlockPosUtil.readOrNull(compound, TAG_LLOCATION);
+        cobbleLocation = BlockPosUtil.readOrNull(compound, TAG_CLOCATION);
     }
 
     @Override
@@ -187,28 +191,10 @@ public class BuildingMiner extends AbstractBuildingStructureBuilder
         final CompoundNBT compound = super.serializeNBT();
         compound.putBoolean(TAG_CLEARED, clearedShaft);
 
-        writeOptionalBlockPos(compound, TAG_CLOCATION, cobbleLocation);
-        writeOptionalBlockPos(compound, TAG_LLOCATION, ladderLocation);
+        BlockPosUtil.writeOptional(compound, TAG_CLOCATION, cobbleLocation);
+        BlockPosUtil.writeOptional(compound, TAG_LLOCATION, ladderLocation);
 
         return compound;
-    }
-
-    @Nullable
-    private static BlockPos readOptionalBlockPos(@NotNull final CompoundNBT compound,
-                                                 @NotNull final String name)
-    {
-        final BlockPos result = BlockPosUtil.read(compound, name);
-        return result.equals(BlockPos.ZERO) ? null : result;
-    }
-
-    private static void writeOptionalBlockPos(@NotNull final CompoundNBT compound,
-                                              @NotNull final String name,
-                                              @Nullable final BlockPos value)
-    {
-        if (value != null)
-        {
-            BlockPosUtil.write(compound, name, value);
-        }
     }
 
     @NotNull

--- a/src/main/java/com/minecolonies/coremod/entity/ai/citizen/miner/EntityAIStructureMiner.java
+++ b/src/main/java/com/minecolonies/coremod/entity/ai/citizen/miner/EntityAIStructureMiner.java
@@ -1,7 +1,6 @@
 package com.minecolonies.coremod.entity.ai.citizen.miner;
 
 import com.minecolonies.api.advancements.AdvancementTriggers;
-import com.minecolonies.api.colony.IColony;
 import com.minecolonies.api.colony.IColonyManager;
 import com.minecolonies.api.colony.interactionhandling.ChatPriority;
 import com.minecolonies.api.entity.ai.statemachine.AITarget;
@@ -34,7 +33,8 @@ import java.util.List;
 import static com.minecolonies.api.entity.ai.statemachine.states.AIWorkerState.*;
 import static com.minecolonies.api.research.util.ResearchConstants.MORE_ORES;
 import static com.minecolonies.api.util.constant.Constants.TICKS_SECOND;
-import static com.minecolonies.api.util.constant.TranslationConstants.*;
+import static com.minecolonies.api.util.constant.TranslationConstants.INVALID_MINESHAFT;
+import static com.minecolonies.api.util.constant.TranslationConstants.NEEDS_BETTER_HUT;
 import static com.minecolonies.coremod.colony.buildings.workerbuildings.BuildingMiner.initStructure;
 import static com.minecolonies.coremod.util.WorkerUtil.getLastLadder;
 
@@ -362,15 +362,12 @@ public class EntityAIStructureMiner extends AbstractEntityAIStructureWithWorkOrd
             if (buildingMiner.getFirstModuleOccurance(MinerLevelManagementModule.class).getNumberOfLevels() == 0)
             {
                 worker.getCitizenData().triggerInteraction(new StandardInteraction(new TranslationTextComponent(NEEDS_BETTER_HUT), ChatPriority.BLOCKING));
-                buildingMiner.setClearedShaft(false);
                 return IDLE;
             }
             worker.getCitizenData().setVisibleStatus(MINING);
-            buildingMiner.setClearedShaft(true);
             return MINER_MINING_NODE;
         }
         worker.getCitizenData().setVisibleStatus(MINING);
-        buildingMiner.setClearedShaft(false);
         return MINER_MINING_SHAFT;
     }
 


### PR DESCRIPTION
Closes #7386

# Changes proposed in this pull request:
- Teach miners hired to a previously unused miner building which direction is down, and to not claim early victory.

Review please

This fixes the miners refusing to dig the shaft and immediately earning the Rock Bottom advancement despite not digging the shaft; caused by deserializing a `BlockPos.ZERO` instead of a `null` for these positions.  (The positions aren't calculated until a worker starts working for the first time.)

Simplest way to reproduce this happening is to set hiring to manual (so no miner is assigned), build a mine, then save and reload the world, then finally hire someone (who will then refuse to work).