### PR TITLE
propperly handle mineshaft changes 7294

### DIFF
--- a/src/api/java/com/minecolonies/api/colony/requestsystem/requestable/Stack.java
+++ b/src/api/java/com/minecolonies/api/colony/requestsystem/requestable/Stack.java
@@ -129,7 +129,7 @@ public class Stack implements IConcreteDeliverable
      * Create a Stack deliverable.
      *
      * @param stack       the required stack.
-     * @param matchMeta   if damage has to be matched.
+     * @param matchDamage   if damage has to be matched.
      * @param matchNBT    if NBT has to be matched.
      * @param matchOreDic if the oredict has to be matched.
      * @param result      the result stack.
@@ -138,7 +138,7 @@ public class Stack implements IConcreteDeliverable
      */
     public Stack(
       @NotNull final ItemStack stack,
-      final boolean matchMeta,
+      final boolean matchDamage,
       final boolean matchNBT,
       final boolean matchOreDic,
       @NotNull final ItemStack result,
@@ -151,7 +151,7 @@ public class Stack implements IConcreteDeliverable
         }
 
         this.theStack = stack.copy();
-        this.matchDamage = matchMeta;
+        this.matchDamage = matchDamage;
         this.matchNBT = matchNBT;
         this.matchOreDic = matchOreDic;
         this.result = result;

--- a/src/api/java/com/minecolonies/api/colony/requestsystem/requestable/Stack.java
+++ b/src/api/java/com/minecolonies/api/colony/requestsystem/requestable/Stack.java
@@ -42,9 +42,9 @@ public class Stack implements IConcreteDeliverable
     private final ItemStack theStack;
 
     /**
-     * If meta should match.
+     * If damage should match.
      */
-    private boolean matchMeta;
+    private boolean matchDamage;
 
     /**
      * If NBT should match.
@@ -129,7 +129,7 @@ public class Stack implements IConcreteDeliverable
      * Create a Stack deliverable.
      *
      * @param stack       the required stack.
-     * @param matchMeta   if meta has to be matched.
+     * @param matchMeta   if damage has to be matched.
      * @param matchNBT    if NBT has to be matched.
      * @param matchOreDic if the oredict has to be matched.
      * @param result      the result stack.
@@ -151,7 +151,7 @@ public class Stack implements IConcreteDeliverable
         }
 
         this.theStack = stack.copy();
-        this.matchMeta = matchMeta;
+        this.matchDamage = matchMeta;
         this.matchNBT = matchNBT;
         this.matchOreDic = matchOreDic;
         this.result = result;
@@ -170,7 +170,7 @@ public class Stack implements IConcreteDeliverable
     {
         final CompoundNBT compound = new CompoundNBT();
         compound.put(NBT_STACK, input.theStack.serializeNBT());
-        compound.putBoolean(NBT_MATCHMETA, input.matchMeta);
+        compound.putBoolean(NBT_MATCHMETA, input.matchDamage);
         compound.putBoolean(NBT_MATCHNBT, input.matchNBT);
         compound.putBoolean(NBT_MATCHOREDIC, input.matchOreDic);
         if (!ItemStackUtils.isEmpty(input.result))
@@ -219,7 +219,7 @@ public class Stack implements IConcreteDeliverable
     public static void serialize(final IFactoryController controller, final PacketBuffer buffer, final Stack input)
     {
         buffer.writeItem(input.theStack);
-        buffer.writeBoolean(input.matchMeta);
+        buffer.writeBoolean(input.matchDamage);
         buffer.writeBoolean(input.matchNBT);
         buffer.writeBoolean(input.matchOreDic);
 
@@ -265,7 +265,7 @@ public class Stack implements IConcreteDeliverable
             }
         }
 
-        return ItemStackUtils.compareItemStacksIgnoreStackSize(getStack(), stack, matchMeta, matchNBT);
+        return ItemStackUtils.compareItemStacksIgnoreStackSize(getStack(), stack, matchDamage, matchNBT);
     }
 
     @Override
@@ -301,10 +301,19 @@ public class Stack implements IConcreteDeliverable
         return matchNBT;
     }
 
+    /**
+     * Check if damage should be matched.
+     * @return true if so.
+     */
+    public boolean matchDamage()
+    {
+        return matchDamage;
+    }
+
     @Override
     public IDeliverable copyWithCount(final int newCount)
     {
-        return new Stack(this.theStack, this.matchMeta, this.matchNBT, this.matchOreDic, this.result, newCount, this.minCount);
+        return new Stack(this.theStack, this.matchDamage, this.matchNBT, this.matchOreDic, this.result, newCount, this.minCount);
     }
 
     @NotNull
@@ -328,7 +337,7 @@ public class Stack implements IConcreteDeliverable
 
         final Stack stack1 = (Stack) o;
 
-        if (matchMeta != stack1.matchMeta)
+        if (matchDamage != stack1.matchDamage)
         {
             return false;
         }
@@ -351,7 +360,7 @@ public class Stack implements IConcreteDeliverable
     public int hashCode()
     {
         int result1 = getStack().hashCode();
-        result1 = 31 * result1 + (matchMeta ? 1 : 0);
+        result1 = 31 * result1 + (matchDamage ? 1 : 0);
         result1 = 31 * result1 + (matchNBT ? 1 : 0);
         result1 = 31 * result1 + (matchOreDic ? 1 : 0);
         result1 = 31 * result1 + getResult().hashCode();

--- a/src/api/java/com/minecolonies/api/tileentities/AbstractTileEntityRack.java
+++ b/src/api/java/com/minecolonies/api/tileentities/AbstractTileEntityRack.java
@@ -6,6 +6,7 @@ import com.minecolonies.api.colony.IColony;
 import com.minecolonies.api.colony.IColonyManager;
 import com.minecolonies.api.colony.buildings.IBuilding;
 import com.minecolonies.api.colony.requestsystem.requestable.IDeliverable;
+import com.minecolonies.api.crafting.ItemStorage;
 import com.minecolonies.api.util.ItemStackUtils;
 import net.minecraft.inventory.container.INamedContainerProvider;
 import net.minecraft.item.ItemStack;
@@ -174,6 +175,14 @@ public abstract class AbstractTileEntityRack extends TileEntity implements IName
      * @return the quantity or 0.
      */
     public abstract int getCount(ItemStack stack, boolean ignoreDamageValue, final boolean ignoreNBT);
+
+    /**
+     * Check if a similar/same item as the stack is in the inventory. And return the count if so.
+     *
+     * @param storage the storage to match.
+     * @return the quantity or 0.
+     */
+    public abstract int getCount(ItemStorage storage);
 
     /**
      * Check if a similar/same item as the stack is in the inventory. This method checks the content list, it is therefore extremely fast.

--- a/src/api/java/com/minecolonies/api/tileentities/AbstractTileEntityWareHouse.java
+++ b/src/api/java/com/minecolonies/api/tileentities/AbstractTileEntityWareHouse.java
@@ -49,6 +49,18 @@ public abstract class AbstractTileEntityWareHouse extends TileEntityColonyBuildi
     /**
      * Method used to check if this warehouse holds any of the requested itemstacks.
      *
+     * @param itemStack The stack to check with to check with.
+     * @param count the min count.
+     * @param ignoreNBT if the nbt value should be ignored.
+     * @param ignoreDamage the ignore damage.
+     * @param leftOver the leftover to keep at the warehouse at all times.
+     * @return True when the warehouse holds a stack, false when not.
+     */
+    public abstract boolean hasMatchingItemStackInWarehouse(@NotNull final ItemStack itemStack, final int count, final boolean ignoreNBT, final boolean ignoreDamage, final int leftOver);
+
+    /**
+     * Method used to check if this warehouse holds any of the requested itemstacks.
+     *
      * @param itemStackSelectionPredicate The predicate to check with.
      * @return True when the warehouse holds a stack, false when not.
      */

--- a/src/api/java/com/minecolonies/api/tileentities/TileEntityRack.java
+++ b/src/api/java/com/minecolonies/api/tileentities/TileEntityRack.java
@@ -100,7 +100,31 @@ public class TileEntityRack extends AbstractTileEntityRack
     public int getCount(final ItemStack stack, final boolean ignoreDamageValue, final boolean ignoreNBT)
     {
         final ItemStorage checkItem = new ItemStorage(stack, ignoreDamageValue, ignoreNBT);
-        return content.getOrDefault(checkItem, 0);
+        return getCount(checkItem);
+    }
+
+    @Override
+    public int getCount(final ItemStorage storage)
+    {
+        if (storage.ignoreDamageValue() || storage.ignoreNBT())
+        {
+            if (!content.containsKey(storage))
+            {
+                return 0;
+            }
+
+            int count = 0;
+            for (final Map.Entry<ItemStorage, Integer> contentStorage : content.entrySet())
+            {
+                if (contentStorage.getKey().equals(storage))
+                {
+                    count += contentStorage.getValue();
+                }
+            }
+            return count;
+        }
+
+        return content.getOrDefault(storage, 0);
     }
 
     @Override

--- a/src/api/java/com/minecolonies/api/tileentities/TileEntityRack.java
+++ b/src/api/java/com/minecolonies/api/tileentities/TileEntityRack.java
@@ -1,6 +1,5 @@
 package com.minecolonies.api.tileentities;
 
-import com.minecolonies.api.MinecoloniesAPIProxy;
 import com.minecolonies.api.blocks.AbstractBlockMinecoloniesRack;
 import com.minecolonies.api.blocks.types.RackType;
 import com.minecolonies.api.crafting.ItemStorage;
@@ -21,7 +20,6 @@ import net.minecraft.network.play.server.SUpdateTileEntityPacket;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraft.tileentity.TileEntityType;
 import net.minecraft.util.Direction;
-import net.minecraft.util.ResourceLocation;
 import net.minecraft.util.Rotation;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.text.ITextComponent;
@@ -121,7 +119,7 @@ public class TileEntityRack extends AbstractTileEntityRack
     @Override
     public boolean hasSimilarStack(@NotNull final ItemStack stack)
     {
-        final ItemStorage checkItem = new ItemStorage(stack, true);
+        final ItemStorage checkItem = new ItemStorage(stack, true, true);
         if (content.containsKey(checkItem))
         {
             return true;
@@ -129,13 +127,9 @@ public class TileEntityRack extends AbstractTileEntityRack
 
         for (final ItemStorage storage : content.keySet())
         {
-            for (final ResourceLocation tag : stack.getItem().getTags())
+            if (checkItem.getPrimaryCreativeTabIndex() == storage.getPrimaryCreativeTabIndex())
             {
-                if (MinecoloniesAPIProxy.getInstance().getConfig().getServer().enabledModTags.get().contains(tag.toString())
-                      && storage.getItemStack().getItem().getTags().contains(tag))
-                {
-                    return true;
-                }
+                return true;
             }
         }
 

--- a/src/api/java/com/minecolonies/api/util/InventoryUtils.java
+++ b/src/api/java/com/minecolonies/api/util/InventoryUtils.java
@@ -740,7 +740,7 @@ public class InventoryUtils
                 final TileEntity entity = world.getBlockEntity(pos);
                 if (entity instanceof TileEntityRack)
                 {
-                    totalCount += ((TileEntityRack) entity).getAllContent().getOrDefault(stack, 0);
+                    totalCount += ((TileEntityRack) entity).getCount(stack);
                 }
                 else if (entity instanceof ChestTileEntity)
                 {
@@ -795,7 +795,7 @@ public class InventoryUtils
                 final TileEntity entity = world.getBlockEntity(pos);
                 if (entity instanceof TileEntityRack)
                 {
-                    totalCount += ((TileEntityRack) entity).getAllContent().getOrDefault(stack, 0);
+                    totalCount += ((TileEntityRack) entity).getCount(stack);
                 }
                 else if (entity instanceof ChestTileEntity)
                 {

--- a/src/main/java/com/minecolonies/coremod/colony/requestsystem/resolvers/WarehouseConcreteRequestResolver.java
+++ b/src/main/java/com/minecolonies/coremod/colony/requestsystem/resolvers/WarehouseConcreteRequestResolver.java
@@ -34,9 +34,17 @@ public class WarehouseConcreteRequestResolver extends AbstractWarehouseRequestRe
         if(deliverable instanceof IConcreteDeliverable)
         {
             boolean ignoreNBT = false;
-            if (deliverable instanceof Stack && !((Stack) requestToCheck.getRequest()).matchNBT())
+            boolean ignoreDamage = false;
+            if (deliverable instanceof Stack)
             {
-                ignoreNBT = true;
+                if (!((Stack) requestToCheck.getRequest()).matchNBT())
+                {
+                    ignoreNBT = true;
+                }
+                if (!((Stack) requestToCheck.getRequest()).matchDamage())
+                {
+                    ignoreDamage = true;
+                }
             }
             for(final ItemStack possible : ((IConcreteDeliverable) deliverable).getRequestedItems())
             {
@@ -44,14 +52,14 @@ public class WarehouseConcreteRequestResolver extends AbstractWarehouseRequestRe
                 {
                     if (requestToCheck.getRequest() instanceof INonExhaustiveDeliverable)
                     {
-                        if (wareHouse.hasMatchingItemStackInWarehouse(possible, requestToCheck.getRequest().getMinimumCount(), ignoreNBT, false, ((INonExhaustiveDeliverable) requestToCheck.getRequest()).getLeftOver()))
+                        if (wareHouse.hasMatchingItemStackInWarehouse(possible, requestToCheck.getRequest().getMinimumCount(), ignoreNBT, ignoreDamage, ((INonExhaustiveDeliverable) requestToCheck.getRequest()).getLeftOver()))
                         {
                             return true;
                         }
                     }
                     else
                     {
-                        if (wareHouse.hasMatchingItemStackInWarehouse(possible, requestToCheck.getRequest().getMinimumCount(), ignoreNBT, false, 0))
+                        if (wareHouse.hasMatchingItemStackInWarehouse(possible, requestToCheck.getRequest().getMinimumCount(), ignoreNBT, ignoreDamage, 0))
                         {
                             return true;
                         }

--- a/src/main/java/com/minecolonies/coremod/colony/requestsystem/resolvers/WarehouseConcreteRequestResolver.java
+++ b/src/main/java/com/minecolonies/coremod/colony/requestsystem/resolvers/WarehouseConcreteRequestResolver.java
@@ -44,14 +44,14 @@ public class WarehouseConcreteRequestResolver extends AbstractWarehouseRequestRe
                 {
                     if (requestToCheck.getRequest() instanceof INonExhaustiveDeliverable)
                     {
-                        if (wareHouse.hasMatchingItemStackInWarehouse(possible, requestToCheck.getRequest().getMinimumCount(), ignoreNBT, ((INonExhaustiveDeliverable) requestToCheck.getRequest()).getLeftOver()))
+                        if (wareHouse.hasMatchingItemStackInWarehouse(possible, requestToCheck.getRequest().getMinimumCount(), ignoreNBT, false, ((INonExhaustiveDeliverable) requestToCheck.getRequest()).getLeftOver()))
                         {
                             return true;
                         }
                     }
                     else
                     {
-                        if (wareHouse.hasMatchingItemStackInWarehouse(possible, requestToCheck.getRequest().getMinimumCount(), ignoreNBT))
+                        if (wareHouse.hasMatchingItemStackInWarehouse(possible, requestToCheck.getRequest().getMinimumCount(), ignoreNBT, false, 0))
                         {
                             return true;
                         }

--- a/src/main/java/com/minecolonies/coremod/entity/ai/basic/AbstractEntityAICrafting.java
+++ b/src/main/java/com/minecolonies/coremod/entity/ai/basic/AbstractEntityAICrafting.java
@@ -188,7 +188,7 @@ public abstract class AbstractEntityAICrafting<J extends AbstractJobCrafter<?, J
 
         currentRequest = currentTask;
         job.setMaxCraftingCount(currentRequest.getRequest().getCount());
-        final int currentCount = InventoryUtils.getItemCountInItemHandler(worker.getInventoryCitizen(), stack -> stack.sameItemStackIgnoreDurability(currentRecipeStorage.getPrimaryOutput()));
+        final int currentCount = InventoryUtils.getItemCountInItemHandler(worker.getInventoryCitizen(), stack -> ItemStackUtils.compareItemStacksIgnoreStackSize(stack, currentRecipeStorage.getPrimaryOutput()));
         final int inProgressCount = getExtendedCount(currentRecipeStorage.getPrimaryOutput());
 
         final int countPerIteration = currentRecipeStorage.getPrimaryOutput().getCount();

--- a/src/main/java/com/minecolonies/coremod/entity/ai/citizen/miner/EntityAIStructureMiner.java
+++ b/src/main/java/com/minecolonies/coremod/entity/ai/citizen/miner/EntityAIStructureMiner.java
@@ -633,7 +633,11 @@ public class EntityAIStructureMiner extends AbstractEntityAIStructureWithWorkOrd
 
             if (workingNode == null)
             {
-                module.setCurrentLevel(module.getLevelId(currentLevel) + 1);
+                final int levelId = module.getLevelId(currentLevel);
+                if (levelId > 0)
+                {
+                    module.setCurrentLevel(levelId - 1);
+                }
             }
             return MINER_CHECK_MINESHAFT;
         }

--- a/src/main/java/com/minecolonies/coremod/entity/ai/citizen/miner/EntityAIStructureMiner.java
+++ b/src/main/java/com/minecolonies/coremod/entity/ai/citizen/miner/EntityAIStructureMiner.java
@@ -630,6 +630,11 @@ public class EntityAIStructureMiner extends AbstractEntityAIStructureWithWorkOrd
         {
             workingNode = module.getActiveNode();
             module.setActiveNode(workingNode);
+
+            if (workingNode == null)
+            {
+                module.setCurrentLevel(module.getLevelId(currentLevel) + 1);
+            }
             return MINER_CHECK_MINESHAFT;
         }
 
@@ -677,6 +682,13 @@ public class EntityAIStructureMiner extends AbstractEntityAIStructureWithWorkOrd
         }
         @NotNull final BlockPos standingPosition = new BlockPos(workingNode.getParent().getX(), currentLevel.getDepth(), workingNode.getParent().getZ());
         currentStandingPosition = standingPosition;
+        if (workingNode != null && currentLevel.getNode(new Vec2i(workingNode.getX(), workingNode.getZ())) == null)
+        {
+            module.setActiveNode(null);
+            module.setOldNode(null);
+            return MINER_MINING_SHAFT;
+        }
+
         if ((workingNode.getStatus() == Node.NodeStatus.AVAILABLE || workingNode.getStatus() == Node.NodeStatus.IN_PROGRESS) && !walkToBlock(standingPosition))
         {
             workingNode.setRot(rotation);

--- a/src/main/java/com/minecolonies/coremod/entity/ai/citizen/miner/Level.java
+++ b/src/main/java/com/minecolonies/coremod/entity/ai/citizen/miner/Level.java
@@ -197,6 +197,11 @@ public class Level
     public Node getRandomNode(@Nullable final Node node)
     {
         Node nextNode = null;
+        if (!nodes.containsKey(new Vec2i(node.getX(), node.getZ())))
+        {
+            return openNodes.peek();
+        }
+
         if (node != null && getNumberOfBuiltNodes() > MINIMUM_NODES_FOR_RANDOM && rand.nextInt(RANDOM_TYPES) > 0)
         {
             nextNode = node.getRandomNextNode(this, 0);

--- a/src/main/java/com/minecolonies/coremod/entity/ai/minimal/EntityAIEatTask.java
+++ b/src/main/java/com/minecolonies/coremod/entity/ai/minimal/EntityAIEatTask.java
@@ -60,7 +60,7 @@ public class EntityAIEatTask extends Goal
     /**
      * Min distance in blocks to placeToPath block.
      */
-    private static final int MIN_DISTANCE_TO_RESTAURANT = 10;
+    private static final int MIN_DISTANCE_TO_RESTAURANT = 3;
 
     /**
      * Time required to eat in seconds.

--- a/src/main/java/com/minecolonies/coremod/entity/ai/util/BuildingStructureHandler.java
+++ b/src/main/java/com/minecolonies/coremod/entity/ai/util/BuildingStructureHandler.java
@@ -238,16 +238,15 @@ public class BuildingStructureHandler<J extends AbstractJobStructure<?, J>, B ex
         final List<ItemStack> itemList = new ArrayList<>();
         for (final ItemStack stack : requiredItems)
         {
-            for (final ToolType toolType : ToolType.values())
+            if (ItemStackUtils.isTool(stack, ToolType.FLINT_N_STEEL))
             {
-                if (ItemStackUtils.isTool(stack, toolType))
+                //todo after 1.17 port try to find a generic way to handle this in Structurize.
+                if (structureAI.checkForToolOrWeapon(ToolType.FLINT_N_STEEL))
                 {
-                    if (structureAI.checkForToolOrWeapon(toolType))
-                    {
-                        return false;
-                    }
+                    return false;
                 }
             }
+
             itemList.add(stack);
         }
 

--- a/src/main/java/com/minecolonies/coremod/tileentities/TileEntityWareHouse.java
+++ b/src/main/java/com/minecolonies/coremod/tileentities/TileEntityWareHouse.java
@@ -55,7 +55,7 @@ public class TileEntityWareHouse extends AbstractTileEntityWareHouse
     }
 
     @Override
-    public boolean hasMatchingItemStackInWarehouse(@NotNull final ItemStack itemStack, final int count, final boolean ignoreNBT, final int leftOver)
+    public boolean hasMatchingItemStackInWarehouse(@NotNull final ItemStack itemStack, final int count, final boolean ignoreNBT, final boolean ignoreDamage, final int leftOver)
     {
         int totalCountFound = 0 - leftOver;
         for (@NotNull final BlockPos pos : getBuilding().getContainers())
@@ -65,17 +65,7 @@ public class TileEntityWareHouse extends AbstractTileEntityWareHouse
                 final TileEntity entity = getLevel().getBlockEntity(pos);
                 if (entity instanceof TileEntityRack && !((AbstractTileEntityRack) entity).isEmpty())
                 {
-                    totalCountFound += ((AbstractTileEntityRack) entity).getCount(itemStack, true, ignoreNBT);
-                    if (totalCountFound >= count)
-                    {
-                        return true;
-                    }
-                }
-
-                if (entity instanceof ChestTileEntity)
-                {
-                    totalCountFound += InventoryUtils.getItemCountInItemHandler(entity.getCapability(ITEM_HANDLER_CAPABILITY, null).orElseGet(null),
-                      item -> item.sameItemStackIgnoreDurability(itemStack) && item.getCount() >= itemStack.getCount());
+                    totalCountFound += ((AbstractTileEntityRack) entity).getCount(itemStack, ignoreDamage, ignoreNBT);
                     if (totalCountFound >= count)
                     {
                         return true;
@@ -84,6 +74,12 @@ public class TileEntityWareHouse extends AbstractTileEntityWareHouse
             }
         }
         return false;
+    }
+
+    @Override
+    public boolean hasMatchingItemStackInWarehouse(@NotNull final ItemStack itemStack, final int count, final boolean ignoreNBT, final int leftOver)
+    {
+        return hasMatchingItemStackInWarehouse(itemStack, count, ignoreNBT, true, leftOver);
     }
 
     @Override

--- a/src/main/resources/assets/minecolonies/lang/en_us.json
+++ b/src/main/resources/assets/minecolonies/lang/en_us.json
@@ -472,7 +472,7 @@
   "com.minecolonies.coremod.gui.workerhuts.cowboyhut": "Cowhand's Hut",
   "com.minecolonies.coremod.gui.workerhuts.chickenherderhut": "Chicken Farmer's Hut",
   "com.minecolonies.coremod.gui.workerhuts.rabbithutch": "Rabbit Hutch",
-  "com.minecolonies.coremod.gui.workerhuts.beekeeperhut": "Apiary",
+  "com.minecolonies.coremod.gui.workerhuts.beekeeper": "Apiary",
   "com.minecolonies.coremod.gui.workerhuts.homehut": "House",
   "com.minecolonies.coremod.gui.workerhuts.tavern": "Tavern",
   "com.minecolonies.coremod.gui.workerhuts.buildershut": "Builder's Hut",


### PR DESCRIPTION
Closes #7294
Closes #6537
Closes #7525
Closes #7529
Closes #7531

# Changes proposed in this pull request:
- Miner should properly switch Mineshaft when they can't mine on the current anymore
- Miner should reset old target if the old target is not on the current level.
- Solve issues with tool like requests in schematics
- Solve issues with damagable requests
- Port sorting handling from Storageracks
- Not so shy at the restaurant

Review please
