### PR TITLE
Fix colony permissions with enabled pvp

### DIFF
--- a/src/main/java/com/minecolonies/coremod/permissions/ColonyPermissionEventHandler.java
+++ b/src/main/java/com/minecolonies/coremod/permissions/ColonyPermissionEventHandler.java
@@ -421,12 +421,9 @@ public class ColonyPermissionEventHandler
               && colony.isCoordInColony(player.getCommandSenderWorld(), positionToCheck)
               && !colony.getPermissions().hasPermission(player, action))
         {
-            if (MineColonies.getConfig().getServer().pvp_mode.get())
+            if (MineColonies.getConfig().getServer().pvp_mode.get() && !world.isClientSide && colony.isValidAttackingPlayer(playerIn))
             {
-                if (!world.isClientSide && colony.isValidAttackingPlayer(playerIn))
-                {
-                    return false;
-                }
+                return false;
             }
             else
             {


### PR DESCRIPTION

# Changes proposed in this pull request:
- Fix colony permissions when pvp is enabled. It was possible to break blocks regardless of permission settings.

Review please
