### PR TITLE
Fix weird behaviour when building a guard tower or barracks

### DIFF
--- a/src/api/java/com/minecolonies/api/colony/buildings/IBuilding.java
+++ b/src/api/java/com/minecolonies/api/colony/buildings/IBuilding.java
@@ -253,10 +253,9 @@ public interface IBuilding extends IBuildingContainer, IRequestResolverProvider,
     boolean isGuardBuildingNear();
 
     /**
-     * Sets whether this building has a guard building nearby
-     * @param guardBuildingNear
+     * Requests recalculation of whether this building has a guard building nearby
      */
-    void setGuardBuildingNear(boolean guardBuildingNear);
+    void resetGuardBuildingNear();
 
     /**
      * Check if the worker requires a certain amount of that item and the alreadykept list contains it. Always leave one stack behind if the worker requires a certain amount of it.

--- a/src/api/java/com/minecolonies/api/util/BlockPosUtil.java
+++ b/src/api/java/com/minecolonies/api/util/BlockPosUtil.java
@@ -20,6 +20,7 @@ import net.minecraft.util.Rotation;
 import net.minecraft.util.Tuple;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.math.MathHelper;
+import net.minecraft.util.math.MutableBoundingBox;
 import net.minecraft.util.math.vector.Vector3d;
 import net.minecraft.world.IBlockReader;
 import net.minecraft.world.World;
@@ -457,6 +458,24 @@ public final class BlockPosUtil
                                               + xDiff + " | " + zDiff);
         }
         return result;
+    }
+
+    /**
+     * Returns a radial bounding box aligned to chunk boundaries.  Note that the Y coordinate
+     * is also aligned to chunk-like sizes; this does not return full world height.  (It also
+     * might return Y coordinates outside the world limits, so clip before using if needed.)
+     * @param pos A position inside the center chunk.
+     * @param chunkRadius 0 for one chunk, 1 for nine chunks, etc.
+     * @return The specified bounding box.
+     */
+    public static MutableBoundingBox getChunkAlignedBB(final BlockPos pos, final int chunkRadius)
+    {
+        final int blockRadius = chunkRadius * 16;
+        final int x1 = pos.getX() & ~15;
+        final int y1 = pos.getY() & ~15;
+        final int z1 = pos.getZ() & ~15;
+        return new MutableBoundingBox(x1 - blockRadius, y1 - blockRadius, z1 - blockRadius,
+                x1 + blockRadius + 15, y1 + blockRadius + 15, z1 + blockRadius + 15);
     }
 
     /**

--- a/src/main/java/com/minecolonies/coremod/colony/buildings/AbstractBuilding.java
+++ b/src/main/java/com/minecolonies/coremod/colony/buildings/AbstractBuilding.java
@@ -983,9 +983,9 @@ public abstract class AbstractBuilding extends AbstractBuildingContainer
     }
 
     @Override
-    public void setGuardBuildingNear(final boolean guardBuildingNear)
+    public void resetGuardBuildingNear()
     {
-        this.guardBuildingNear = guardBuildingNear;
+        this.recheckGuardBuildingNear = true;
     }
 
     //------------------------- Starting Required Tools/Item handling -------------------------//

--- a/src/main/java/com/minecolonies/coremod/colony/managers/BuildingManager.java
+++ b/src/main/java/com/minecolonies/coremod/colony/managers/BuildingManager.java
@@ -41,6 +41,7 @@ import net.minecraft.nbt.CompoundNBT;
 import net.minecraft.nbt.ListNBT;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.math.BlockPos;
+import net.minecraft.util.math.MutableBoundingBox;
 import net.minecraft.world.World;
 import net.minecraft.world.chunk.Chunk;
 import net.minecraftforge.common.util.Constants;
@@ -615,10 +616,13 @@ public class BuildingManager implements IBuildingManager
 
         for (final IBuilding colonyBuilding : getBuildings().values())
         {
-            if (colonyBuilding instanceof IGuardBuilding
-                  && (colonyBuilding.getClaimRadius(colonyBuilding.getBuildingLevel()) * 16) > building.getID().distManhattan(colonyBuilding.getID()))
+            if (colonyBuilding instanceof IGuardBuilding)
             {
-                return true;
+                final MutableBoundingBox guardedRegion = BlockPosUtil.getChunkAlignedBB(colonyBuilding.getPosition(), colonyBuilding.getClaimRadius(colonyBuilding.getBuildingLevel()));
+                if (guardedRegion.isInside(colonyBuilding.getPosition()))
+                {
+                    return true;
+                }
             }
         }
 
@@ -628,10 +632,11 @@ public class BuildingManager implements IBuildingManager
     @Override
     public void guardBuildingChangedAt(final IBuilding guardBuilding, final int newLevel)
     {
-        final int claimRadius = guardBuilding.getClaimRadius(Math.max(guardBuilding.getBuildingLevel(), newLevel)) * 16;
+        final int claimRadius = guardBuilding.getClaimRadius(Math.max(guardBuilding.getBuildingLevel(), newLevel));
+        final MutableBoundingBox guardedRegion = BlockPosUtil.getChunkAlignedBB(guardBuilding.getPosition(), claimRadius);
         for (final IBuilding building : getBuildings().values())
         {
-            if (claimRadius > building.getID().distManhattan(guardBuilding.getID()))
+            if (guardedRegion.isInside(building.getPosition()))
             {
                 building.resetGuardBuildingNear();
             }

--- a/src/main/java/com/minecolonies/coremod/colony/managers/BuildingManager.java
+++ b/src/main/java/com/minecolonies/coremod/colony/managers/BuildingManager.java
@@ -628,20 +628,9 @@ public class BuildingManager implements IBuildingManager
     @Override
     public void guardBuildingChangedAt(final IBuilding guardBuilding, final int newLevel)
     {
-        for (final IBuilding building : colony.getBuildingManager().getBuildings().values())
+        for (final IBuilding building : getBuildings().values())
         {
-            if (building.getPosition().getX() <= guardBuilding.getPosition().getX() + 16 * guardBuilding.getClaimRadius(newLevel)
-                  && building.getPosition().getZ() <= guardBuilding.getPosition().getZ() + 16 * guardBuilding.getClaimRadius(newLevel))
-            {
-                if (newLevel > 0)
-                {
-                    building.setGuardBuildingNear(true);
-                }
-                else
-                {
-                    building.setGuardBuildingNear(hasGuardBuildingNear(building));
-                }
-            }
+            building.resetGuardBuildingNear();
         }
     }
 

--- a/src/main/java/com/minecolonies/coremod/colony/managers/BuildingManager.java
+++ b/src/main/java/com/minecolonies/coremod/colony/managers/BuildingManager.java
@@ -619,7 +619,7 @@ public class BuildingManager implements IBuildingManager
             if (colonyBuilding instanceof IGuardBuilding)
             {
                 final MutableBoundingBox guardedRegion = BlockPosUtil.getChunkAlignedBB(colonyBuilding.getPosition(), colonyBuilding.getClaimRadius(colonyBuilding.getBuildingLevel()));
-                if (guardedRegion.isInside(colonyBuilding.getPosition()))
+                if (guardedRegion.isInside(building.getPosition()))
                 {
                     return true;
                 }

--- a/src/main/java/com/minecolonies/coremod/colony/managers/BuildingManager.java
+++ b/src/main/java/com/minecolonies/coremod/colony/managers/BuildingManager.java
@@ -628,9 +628,13 @@ public class BuildingManager implements IBuildingManager
     @Override
     public void guardBuildingChangedAt(final IBuilding guardBuilding, final int newLevel)
     {
+        final int claimRadius = guardBuilding.getClaimRadius(Math.max(guardBuilding.getBuildingLevel(), newLevel)) * 16;
         for (final IBuilding building : getBuildings().values())
         {
-            building.resetGuardBuildingNear();
+            if (claimRadius > building.getID().distManhattan(guardBuilding.getID()))
+            {
+                building.resetGuardBuildingNear();
+            }
         }
     }
 


### PR DESCRIPTION
# Changes proposed in this pull request:
- When building or upgrading a guard tower or barracks, now correctly calculates the "am I near a guard tower" state on other buildings.
- Reverts to a chunk-aligned cubic range around the guard tower, but does still limit Y distance.

Review please

Previously, this would force an entire quadrant of the world to think it was guarded, even when it wasn't.  It would be fixed automatically after reloading the world or upgrading/repairing the building in question, however, thanks to a recent change by someaddons (#7458).

~~This does a recalculation on all buildings, which is an O(n²) evaluation (though it's deferred until the next time the building wants to know, which should smear out the time a bit).  It might be possible to optimize that a bit more (which is what the previous code was attempting) but doing it properly requires the old level of the guard building, which is not available at this point.  (And this is the same thing that occurs when loading the world anyway.)~~