### PR TITLE
Integrate shape tool into survival/builder

### DIFF
--- a/build.properties
+++ b/build.properties
@@ -10,7 +10,8 @@ fml_range=[36,)
 mappings_channel=official
 mappings_version=1.16.5
 # Dependencies
-structurize_version=0.13.210-ALPHA
+#structurize_version=0.13.210-ALPHA
+structurize_version=unspecified
 datagen_version=0.1.48-ALPHA
 jei_mcversion=1.16.5
 jei_version=7.6.4.90

--- a/build.properties
+++ b/build.properties
@@ -10,8 +10,7 @@ fml_range=[36,)
 mappings_channel=official
 mappings_version=1.16.5
 # Dependencies
-#structurize_version=0.13.210-ALPHA
-structurize_version=unspecified
+structurize_version=0.13.219-ALPHA
 datagen_version=0.1.48-ALPHA
 jei_mcversion=1.16.5
 jei_version=7.6.4.90

--- a/src/main/java/com/minecolonies/coremod/client/gui/WindowMinecoloniesBuildTool.java
+++ b/src/main/java/com/minecolonies/coremod/client/gui/WindowMinecoloniesBuildTool.java
@@ -62,7 +62,7 @@ public class WindowMinecoloniesBuildTool extends WindowBuildTool
 
         BuildToolPlaceMessage msg = new BuildToolPlaceMessage(
           structureName.toString(),
-          structureName.toString(),
+          structureName.getLocalizedName(),
           Settings.instance.getPosition(),
           Settings.instance.getRotation(),
           structureName.isHut(),

--- a/src/main/java/com/minecolonies/coremod/client/gui/WindowMinecoloniesShapeTool.java
+++ b/src/main/java/com/minecolonies/coremod/client/gui/WindowMinecoloniesShapeTool.java
@@ -1,0 +1,43 @@
+package com.minecolonies.coremod.client.gui;
+
+import com.ldtteam.structures.helpers.Settings;
+import com.ldtteam.structurize.client.gui.WindowShapeTool;
+import com.ldtteam.structurize.management.StructureName;
+import com.minecolonies.coremod.network.messages.server.BuildToolPlaceMessage;
+import net.minecraft.block.Blocks;
+import net.minecraft.client.Minecraft;
+import net.minecraft.util.Mirror;
+import net.minecraft.util.math.BlockPos;
+import org.jetbrains.annotations.Nullable;
+
+public class WindowMinecoloniesShapeTool extends WindowShapeTool
+{
+    public WindowMinecoloniesShapeTool(@Nullable BlockPos pos)
+    {
+        super(pos);
+    }
+
+    @Override
+    public boolean hasPermission()
+    {
+        return true;
+    }
+
+    @Override
+    protected void place()
+    {
+        final StructureName sn = save();
+
+        // rotation/mirroring already happened server side
+        final BuildToolPlaceMessage msg = new BuildToolPlaceMessage(
+                sn.toString(),
+                Settings.instance.getShape().toString(),
+                Settings.instance.getPosition(),
+                0,
+                false,
+                Mirror.NONE,
+                Blocks.AIR.defaultBlockState());
+
+        Minecraft.getInstance().tell(new WindowBuildDecoration(msg, Settings.instance.getPosition(), sn)::open);
+    }
+}

--- a/src/main/java/com/minecolonies/coremod/event/EventHandler.java
+++ b/src/main/java/com/minecolonies/coremod/event/EventHandler.java
@@ -665,6 +665,18 @@ public class EventHandler
             }
             event.setCanceled(true);
         }
+
+        if (!event.isCanceled() && event.getItemStack().getItem() == ModItems.shapeTool.get())
+        {
+            if (event.getWorld().isClientSide())
+            {
+                if (event.getUseBlock() == Event.Result.DEFAULT && event.getFace() != null)
+                {
+                    MineColonies.proxy.openShapeToolWindow(event.getPos().relative(event.getFace()));
+                }
+            }
+            event.setCanceled(true);
+        }
     }
 
     /**
@@ -682,6 +694,12 @@ public class EventHandler
                 Settings.instance.setStyle(view.getStyle());
             }
             MineColonies.proxy.openBuildToolWindow(null);
+            event.setCanceled(true);
+        }
+
+        if (!event.isCanceled() && event.getItemStack().getItem() == ModItems.shapeTool.get() && event.getWorld().isClientSide)
+        {
+            MineColonies.proxy.openShapeToolWindow(null);
             event.setCanceled(true);
         }
     }

--- a/src/main/java/com/minecolonies/coremod/proxy/ClientProxy.java
+++ b/src/main/java/com/minecolonies/coremod/proxy/ClientProxy.java
@@ -63,6 +63,18 @@ public class ClientProxy extends CommonProxy
     }
 
     @Override
+    public void openShapeToolWindow(@Nullable final BlockPos pos)
+    {
+        if (pos == null && Settings.instance.getActiveStructure() == null)
+        {
+            return;
+        }
+
+        @Nullable final WindowMinecoloniesShapeTool window = new WindowMinecoloniesShapeTool(pos);
+        window.open();
+    }
+
+    @Override
     public void openDecorationControllerWindow(@Nullable final BlockPos pos)
     {
         if (pos == null)

--- a/src/main/java/com/minecolonies/coremod/proxy/CommonProxy.java
+++ b/src/main/java/com/minecolonies/coremod/proxy/CommonProxy.java
@@ -189,6 +189,14 @@ public abstract class CommonProxy implements IProxy
     }
 
     @Override
+    public void openShapeToolWindow(final BlockPos pos)
+    {
+        /*
+         * Intentionally left empty.
+         */
+    }
+
+    @Override
     public void openSuggestionWindow(@NotNull BlockPos pos, @NotNull BlockState state, @NotNull final ItemStack stack)
     {
         /*

--- a/src/main/java/com/minecolonies/coremod/proxy/IProxy.java
+++ b/src/main/java/com/minecolonies/coremod/proxy/IProxy.java
@@ -47,6 +47,13 @@ public interface IProxy
     void openBuildToolWindow(final BlockPos pos);
 
     /**
+     * Opens a shape tool window.
+     *
+     * @param pos coordinates.
+     */
+    void openShapeToolWindow(final BlockPos pos);
+
+    /**
      * Open the suggestion window.
      *
      * @param pos   the position to open it at.

--- a/src/main/resources/data/minecolonies/recipes/shapetool.json
+++ b/src/main/resources/data/minecolonies/recipes/shapetool.json
@@ -1,0 +1,19 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "pattern": [
+    "  X",
+    " S ",
+    "S  "
+  ],
+  "key": {
+    "X": {
+      "item": "minecraft:emerald"
+    },
+    "S": {
+      "item": "minecraft:stick"
+    }
+  },
+  "result": {
+    "item": "structurize:shapetool"
+  }
+}


### PR DESCRIPTION
Depends on ldtteam/Structurize#435

# Changes proposed in this pull request:
- Allows the Shape Tool to be used in MineColonies survival (it triggers a deco build)
    - If you're in creative, then you can use the new paste button to still do an instant free paste of the shape
    - Otherwise the tick will request that a builder do the build instead of doing a paste as in Structurize alone (regardless of your mode)
    - If you're not in creative, then the undo/paste buttons are hidden.
- Fixes the schematic name shown in builder chat and in the town hall (now uses a compact name instead of the full path)

Review please

- TODO: there is ~not yet~ a crafting recipe for the Shape Tool, and there probably should be one now.  Any suggestions?
    - I'm thinking that this should be a recipe added by MineColonies alone, not one in Structurize itself, since it remains a creative-only item over there.
    - The obvious recipe would probably be an emerald on a pair of sticks, similar to the build/scan tool recipes.
- Caveat: if you set the shape tool to RANDOM from a MineColonies dev environment then it crashes with the same error as ldtteam/Structurize#213.  This does not affect a Structurize dev environment nor normal in-game use.  Not sure what's behind that other than "weird gradle things", but I don't think it's a new issue.