### PR TITLE
Move the dynamic trees size setting to the forester's hut

### DIFF
--- a/src/api/java/com/minecolonies/api/entity/pathfinding/AbstractAdvancedPathNavigate.java
+++ b/src/api/java/com/minecolonies/api/entity/pathfinding/AbstractAdvancedPathNavigate.java
@@ -128,6 +128,7 @@ public abstract class AbstractAdvancedPathNavigate extends GroundPathNavigator
       final BlockPos endRestriction,
       final double speed,
       final List<ItemStorage> excludedTrees,
+      final int dyntreesize,
       final IColony colony);
 
     /**
@@ -138,7 +139,7 @@ public abstract class AbstractAdvancedPathNavigate extends GroundPathNavigator
      * @param excludedTrees the trees which should be cut.
      * @return the result of the search.
      */
-    public abstract TreePathResult moveToTree(final int range, final double speed, final List<ItemStorage> excludedTrees, final IColony colony);
+    public abstract TreePathResult moveToTree(final int range, final double speed, final List<ItemStorage> excludedTrees, final int dyntreesize, final IColony colony);
 
     /**
      * Used to move a living ourEntity with a speed.

--- a/src/main/java/com/minecolonies/apiimp/initializer/ModBuildingsInitializer.java
+++ b/src/main/java/com/minecolonies/apiimp/initializer/ModBuildingsInitializer.java
@@ -258,7 +258,8 @@ public final class ModBuildingsInitializer
                                     .addBuildingModuleProducer(() -> new SettingsModule()
                                                                        .with(BuildingLumberjack.REPLANT, new BoolSetting(true))
                                                                        .with(BuildingLumberjack.RESTRICT, new BoolSetting(false))
-                                                                       .with(AbstractCraftingBuildingModule.RECIPE_MODE, new CrafterRecipeSetting()), () -> SettingsModuleView::new)
+                                                                       .with(AbstractCraftingBuildingModule.RECIPE_MODE, new CrafterRecipeSetting())
+                                                                       .with(BuildingLumberjack.DYNAMIC_TREES_SIZE, new DynamicTreesSetting()), () -> SettingsModuleView::new)
                                     .addBuildingModuleViewProducer(() -> () -> new ToolModuleView(ModItems.scepterLumberjack))
                                     .addBuildingModuleProducer(MinimumStockModule::new, () -> MinimumStockModuleView::new)
                                     .createBuildingEntry();

--- a/src/main/java/com/minecolonies/coremod/colony/buildings/modules/settings/DynamicTreesSetting.java
+++ b/src/main/java/com/minecolonies/coremod/colony/buildings/modules/settings/DynamicTreesSetting.java
@@ -1,0 +1,27 @@
+package com.minecolonies.coremod.colony.buildings.modules.settings;
+
+import com.minecolonies.api.colony.buildings.modules.settings.ISettingsModuleView;
+import com.minecolonies.coremod.MineColonies;
+import net.minecraftforge.fml.ModList;
+
+public class DynamicTreesSetting extends IntSetting
+{
+    /**
+     *
+     */
+    public DynamicTreesSetting()
+    {
+        super(MineColonies.getConfig().getServer().dynamicTreeHarvestSize.get());
+    }
+
+    public DynamicTreesSetting(int value, int defaultValue)
+    {
+        super(value, defaultValue);
+    }
+
+    @Override
+    public boolean isActive(ISettingsModuleView module)
+    {
+        return ModList.get().isLoaded("dynamictrees");
+    }
+}

--- a/src/main/java/com/minecolonies/coremod/colony/buildings/modules/settings/DynamicTreesSetting.java
+++ b/src/main/java/com/minecolonies/coremod/colony/buildings/modules/settings/DynamicTreesSetting.java
@@ -7,18 +7,26 @@ import net.minecraftforge.fml.ModList;
 public class DynamicTreesSetting extends IntSetting
 {
     /**
-     *
+     * Create a new dynamic trees setting, using the config value as initial value.
      */
     public DynamicTreesSetting()
     {
         super(MineColonies.getConfig().getServer().dynamicTreeHarvestSize.get());
     }
 
+    /**
+     * Create a new dynamic tree setting
+     * @param value        the current value
+     * @param defaultValue the default value
+     */
     public DynamicTreesSetting(int value, int defaultValue)
     {
         super(value, defaultValue);
     }
 
+    /**
+     * @return whether the setting is active (i.e. whether dynamic trees is loaded)
+     */
     @Override
     public boolean isActive(ISettingsModuleView module)
     {

--- a/src/main/java/com/minecolonies/coremod/colony/buildings/modules/settings/SettingsFactories.java
+++ b/src/main/java/com/minecolonies/coremod/colony/buildings/modules/settings/SettingsFactories.java
@@ -26,7 +26,7 @@ public class SettingsFactories
     /**
      * Specific factory for the bool setting.
      */
-    public abstract static class AbstractBoolSettingFactory <T extends BoolSetting> implements IBoolSettingFactory<T>
+    public abstract static class AbstractBoolSettingFactory<T extends BoolSetting> implements IBoolSettingFactory<T>
     {
         /**
          * Compound tag for the value.
@@ -291,7 +291,7 @@ public class SettingsFactories
     /**
      * Specific factory for the bool setting.
      */
-    public static class IntSettingFactory implements IIntSettingFactory<IntSetting>
+    public static abstract class AbstractIntSettingFactory<T extends IntSetting> implements IIntSettingFactory<T>
     {
         /**
          * Compound tag for the value.
@@ -305,23 +305,9 @@ public class SettingsFactories
 
         @NotNull
         @Override
-        public TypeToken<IntSetting> getFactoryOutputType()
-        {
-            return TypeToken.of(IntSetting.class);
-        }
-
-        @NotNull
-        @Override
         public TypeToken<FactoryVoidInput> getFactoryInputType()
         {
             return TypeConstants.FACTORYVOIDINPUT;
-        }
-
-        @NotNull
-        @Override
-        public IntSetting getNewInstance(final int value, final int def)
-        {
-            return new IntSetting(value, def);
         }
 
         @NotNull
@@ -336,7 +322,7 @@ public class SettingsFactories
 
         @NotNull
         @Override
-        public IntSetting deserialize(@NotNull final IFactoryController controller, @NotNull final CompoundNBT nbt)
+        public T deserialize(@NotNull final IFactoryController controller, @NotNull final CompoundNBT nbt)
         {
             return this.getNewInstance(nbt.getInt(TAG_VALUE), nbt.getInt(TAG_DEFAULT));
         }
@@ -350,9 +336,26 @@ public class SettingsFactories
 
         @NotNull
         @Override
-        public IntSetting deserialize(@NotNull final IFactoryController controller, @NotNull final PacketBuffer buffer) throws Throwable
+        public T deserialize(@NotNull final IFactoryController controller, @NotNull final PacketBuffer buffer) throws Throwable
         {
             return this.getNewInstance(buffer.readInt(), buffer.readInt());
+        }
+    }
+
+    public static class IntSettingFactory extends AbstractIntSettingFactory<IntSetting>
+    {
+        @NotNull
+        @Override
+        public TypeToken<IntSetting> getFactoryOutputType()
+        {
+            return TypeToken.of(IntSetting.class);
+        }
+
+        @NotNull
+        @Override
+        public IntSetting getNewInstance(final int value, final int def)
+        {
+            return new IntSetting(value, def);
         }
 
         @Override
@@ -567,6 +570,30 @@ public class SettingsFactories
         public short getSerializationId()
         {
             return 56;
+        }
+    }
+
+    public static class DynamicTreesSettingFactory extends AbstractIntSettingFactory<DynamicTreesSetting>
+    {
+
+        @NotNull
+        @Override
+        public DynamicTreesSetting getNewInstance(int def, int current)
+        {
+            return new DynamicTreesSetting(def, current);
+        }
+
+        @NotNull
+        @Override
+        public TypeToken<DynamicTreesSetting> getFactoryOutputType()
+        {
+            return TypeToken.of(DynamicTreesSetting.class);
+        }
+
+        @Override
+        public short getSerializationId()
+        {
+            return 57;
         }
     }
 }

--- a/src/main/java/com/minecolonies/coremod/colony/buildings/workerbuildings/BuildingLumberjack.java
+++ b/src/main/java/com/minecolonies/coremod/colony/buildings/workerbuildings/BuildingLumberjack.java
@@ -24,6 +24,7 @@ import com.minecolonies.coremod.colony.buildings.AbstractBuildingWorker;
 import com.minecolonies.coremod.colony.buildings.modules.AbstractCraftingBuildingModule;
 import com.minecolonies.coremod.colony.buildings.modules.ItemListModule;
 import com.minecolonies.coremod.colony.buildings.modules.settings.BoolSetting;
+import com.minecolonies.coremod.colony.buildings.modules.settings.DynamicTreesSetting;
 import com.minecolonies.coremod.colony.buildings.modules.settings.SettingKey;
 import com.minecolonies.coremod.colony.buildings.views.AbstractBuildingWorkerView;
 import com.minecolonies.coremod.colony.jobs.JobLumberjack;
@@ -64,6 +65,7 @@ public class BuildingLumberjack extends AbstractBuildingWorker implements IBuild
      */
     public static final ISettingKey<BoolSetting> REPLANT = new SettingKey<>(BoolSetting.class, new ResourceLocation(com.minecolonies.api.util.constant.Constants.MOD_ID, "replant"));
     public static final ISettingKey<BoolSetting> RESTRICT = new SettingKey<>(BoolSetting.class, new ResourceLocation(com.minecolonies.api.util.constant.Constants.MOD_ID, "restrict"));
+    public static final ISettingKey<DynamicTreesSetting> DYNAMIC_TREES_SIZE = new SettingKey<>(DynamicTreesSetting.class, new ResourceLocation(com.minecolonies.api.util.constant.Constants.MOD_ID, "dynamictreeharvestsize"));
 
     /**
      * NBT tag for lj restriction start

--- a/src/main/java/com/minecolonies/coremod/colony/requestsystem/init/StandardFactoryControllerInitializer.java
+++ b/src/main/java/com/minecolonies/coremod/colony/requestsystem/init/StandardFactoryControllerInitializer.java
@@ -93,6 +93,7 @@ public final class StandardFactoryControllerInitializer
         StandardFactoryController.getInstance().registerNewFactory(new SettingsFactories.GuardJobSettingFactory());
         StandardFactoryController.getInstance().registerNewFactory(new SettingsFactories.CrafterRecipeSettingFactory());
         StandardFactoryController.getInstance().registerNewFactory(new SettingsFactories.BuilderModeSettingFactory());
+        StandardFactoryController.getInstance().registerNewFactory(new SettingsFactories.DynamicTreesSettingFactory());
 
         StandardFactoryController.getInstance().registerNewTypeOverrideHandler(new TypeTokenFactory.TypeTokenSubTypeOverrideHandler());
 

--- a/src/main/java/com/minecolonies/coremod/entity/ai/citizen/lumberjack/EntityAIWorkLumberjack.java
+++ b/src/main/java/com/minecolonies/coremod/entity/ai/citizen/lumberjack/EntityAIWorkLumberjack.java
@@ -348,6 +348,7 @@ public class EntityAIWorkLumberjack extends AbstractEntityAICrafting<JobLumberja
                                  endPos,
                                  1.0D,
                                  building.getModuleMatching(ItemListModule.class, m -> m.getId().equals(SAPLINGS_LIST)).getList(),
+                                 building.getSetting(BuildingLumberjack.DYNAMIC_TREES_SIZE).getValue(),
                                  worker.getCitizenColonyHandler().getColony());
             }
             else
@@ -356,6 +357,7 @@ public class EntityAIWorkLumberjack extends AbstractEntityAICrafting<JobLumberja
                                .moveToTree(SEARCH_RANGE + searchIncrement,
                                  1.0D,
                                  building.getModuleMatching(ItemListModule.class, m -> m.getId().equals(SAPLINGS_LIST)).getList(),
+                                 building.getSetting(BuildingLumberjack.DYNAMIC_TREES_SIZE).getValue(),
                                  worker.getCitizenColonyHandler().getColony());
             }
             return getState();

--- a/src/main/java/com/minecolonies/coremod/entity/ai/citizen/lumberjack/Tree.java
+++ b/src/main/java/com/minecolonies/coremod/entity/ai/citizen/lumberjack/Tree.java
@@ -10,6 +10,7 @@ import com.minecolonies.api.util.BlockStateUtils;
 import com.minecolonies.api.util.ItemStackUtils;
 import com.minecolonies.coremod.MineColonies;
 import com.minecolonies.coremod.colony.Colony;
+import com.minecolonies.coremod.colony.buildings.workerbuildings.BuildingLumberjack;
 import net.minecraft.block.Block;
 import net.minecraft.block.BlockState;
 import net.minecraft.block.Blocks;
@@ -341,7 +342,7 @@ public class Tree
      * @param treesToNotCut the trees the lumberjack is not supposed to cut.
      * @return true if the log is part of a tree.
      */
-    public static boolean checkTree(@NotNull final IWorldReader world, final BlockPos pos, final List<ItemStorage> treesToNotCut)
+    public static boolean checkTree(@NotNull final IWorldReader world, final BlockPos pos, final List<ItemStorage> treesToNotCut, @Nullable final BuildingLumberjack building)
     {
         //Is the first block a log?
         final BlockState state = world.getBlockState(pos);
@@ -352,9 +353,13 @@ public class Tree
         }
 
         // Only harvest nearly fully grown dynamic trees(8 max)
+        int treeSize = 0;
+        if(building != null) {
+            treeSize = building.getSetting(BuildingLumberjack.DYNAMIC_TREES_SIZE).getValue();
+        }
         if (Compatibility.isDynamicBlock(block)
               && BlockStateUtils.getPropertyByNameFromState(state, DYNAMICTREERADIUS) != null
-              && ((Integer) state.getValue(BlockStateUtils.getPropertyByNameFromState(state, DYNAMICTREERADIUS)) < MineColonies.getConfig().getServer().dynamicTreeHarvestSize.get()))
+              && ((Integer) state.getValue(BlockStateUtils.getPropertyByNameFromState(state, DYNAMICTREERADIUS)) < treeSize))
         {
             return false;
         }

--- a/src/main/java/com/minecolonies/coremod/entity/ai/citizen/lumberjack/Tree.java
+++ b/src/main/java/com/minecolonies/coremod/entity/ai/citizen/lumberjack/Tree.java
@@ -340,9 +340,10 @@ public class Tree
      * @param world         the world.
      * @param pos           The coordinates.
      * @param treesToNotCut the trees the lumberjack is not supposed to cut.
+     * @param dyntreesize   the radius a dynamic tree must have in order to get cut down.
      * @return true if the log is part of a tree.
      */
-    public static boolean checkTree(@NotNull final IWorldReader world, final BlockPos pos, final List<ItemStorage> treesToNotCut, @Nullable final BuildingLumberjack building)
+    public static boolean checkTree(@NotNull final IWorldReader world, final BlockPos pos, final List<ItemStorage> treesToNotCut, final int dyntreesize)
     {
         //Is the first block a log?
         final BlockState state = world.getBlockState(pos);
@@ -353,13 +354,9 @@ public class Tree
         }
 
         // Only harvest nearly fully grown dynamic trees(8 max)
-        int treeSize = 0;
-        if(building != null) {
-            treeSize = building.getSetting(BuildingLumberjack.DYNAMIC_TREES_SIZE).getValue();
-        }
         if (Compatibility.isDynamicBlock(block)
               && BlockStateUtils.getPropertyByNameFromState(state, DYNAMICTREERADIUS) != null
-              && ((Integer) state.getValue(BlockStateUtils.getPropertyByNameFromState(state, DYNAMICTREERADIUS)) < treeSize))
+              && ((Integer) state.getValue(BlockStateUtils.getPropertyByNameFromState(state, DYNAMICTREERADIUS)) < dyntreesize))
         {
             return false;
         }

--- a/src/main/java/com/minecolonies/coremod/entity/pathfinding/MinecoloniesAdvancedPathNavigate.java
+++ b/src/main/java/com/minecolonies/coremod/entity/pathfinding/MinecoloniesAdvancedPathNavigate.java
@@ -10,6 +10,7 @@ import com.minecolonies.api.util.BlockPosUtil;
 import com.minecolonies.api.util.CompatibilityUtils;
 import com.minecolonies.api.util.Log;
 import com.minecolonies.api.util.Tuple;
+import com.minecolonies.coremod.colony.buildings.workerbuildings.BuildingLumberjack;
 import com.minecolonies.coremod.entity.pathfinding.pathjobs.*;
 import com.minecolonies.coremod.util.WorkerUtil;
 import net.minecraft.block.AbstractRailBlock;
@@ -935,7 +936,7 @@ public class MinecoloniesAdvancedPathNavigate extends AbstractAdvancedPathNaviga
     }
 
     @Override
-    public TreePathResult moveToTree(final BlockPos startRestriction, final BlockPos endRestriction, final double speed, final List<ItemStorage> excludedTrees, final IColony colony)
+    public TreePathResult moveToTree(final BlockPos startRestriction, final BlockPos endRestriction, final double speed, final List<ItemStorage> excludedTrees, final int dyntreesize, final IColony colony)
     {
         @NotNull final BlockPos start = AbstractPathJob.prepareStart(ourEntity);
         final BlockPos buildingPos = ((AbstractEntityCitizen) mob).getCitizenColonyHandler().getWorkBuilding().getPosition();
@@ -943,13 +944,13 @@ public class MinecoloniesAdvancedPathNavigate extends AbstractAdvancedPathNaviga
         final BlockPos furthestRestriction = BlockPosUtil.getFurthestCorner(start, startRestriction, endRestriction);
 
         final PathJobFindTree job =
-          new PathJobFindTree(CompatibilityUtils.getWorldFromEntity(mob), start, buildingPos, startRestriction, endRestriction, furthestRestriction, excludedTrees, colony, ourEntity);
+          new PathJobFindTree(CompatibilityUtils.getWorldFromEntity(mob), start, buildingPos, startRestriction, endRestriction, furthestRestriction, excludedTrees, dyntreesize, colony, ourEntity);
 
         return (TreePathResult) setPathJob(job, null, speed);
     }
 
     @Override
-    public TreePathResult moveToTree(final int range, final double speed, final List<ItemStorage> excludedTrees, final IColony colony)
+    public TreePathResult moveToTree(final int range, final double speed, final List<ItemStorage> excludedTrees, final int dyntreesize, final IColony colony)
     {
         @NotNull BlockPos start = AbstractPathJob.prepareStart(ourEntity);
         final BlockPos buildingPos = ((AbstractEntityCitizen) mob).getCitizenColonyHandler().getWorkBuilding().getPosition();
@@ -960,7 +961,7 @@ public class MinecoloniesAdvancedPathNavigate extends AbstractAdvancedPathNaviga
         }
 
         return (TreePathResult) setPathJob(
-          new PathJobFindTree(CompatibilityUtils.getWorldFromEntity(mob), start, buildingPos, range, excludedTrees, colony, ourEntity), null, speed);
+          new PathJobFindTree(CompatibilityUtils.getWorldFromEntity(mob), start, buildingPos, range, excludedTrees, dyntreesize, colony, ourEntity), null, speed);
     }
 
     @Nullable

--- a/src/main/java/com/minecolonies/coremod/entity/pathfinding/pathjobs/PathJobFindTree.java
+++ b/src/main/java/com/minecolonies/coremod/entity/pathfinding/pathjobs/PathJobFindTree.java
@@ -3,9 +3,13 @@ package com.minecolonies.coremod.entity.pathfinding.pathjobs;
 import com.minecolonies.api.colony.IColony;
 import com.minecolonies.api.compatibility.Compatibility;
 import com.minecolonies.api.crafting.ItemStorage;
+import com.minecolonies.api.entity.citizen.AbstractEntityCitizen;
 import com.minecolonies.api.entity.pathfinding.TreePathResult;
 import com.minecolonies.api.util.BlockPosUtil;
+import com.minecolonies.coremod.colony.buildings.workerbuildings.BuildingLumberjack;
+import com.minecolonies.coremod.entity.ai.citizen.lumberjack.EntityAIWorkLumberjack;
 import com.minecolonies.coremod.entity.ai.citizen.lumberjack.Tree;
+import com.minecolonies.coremod.entity.citizen.EntityCitizen;
 import com.minecolonies.coremod.entity.pathfinding.Node;
 import net.minecraft.block.BlockState;
 import net.minecraft.entity.LivingEntity;
@@ -154,7 +158,14 @@ public class PathJobFindTree extends AbstractPathJob
 
     private boolean isTree(final BlockPos pos)
     {
-        if (Tree.checkTree(world, pos, excludedTrees) && Tree.checkIfInColonyAndNotInBuilding(pos, colony))
+        final LivingEntity entity = this.entity.get();
+        BuildingLumberjack building = null;
+
+        if (entity instanceof AbstractEntityCitizen && ((EntityCitizen) entity).getCitizenColonyHandler().getWorkBuilding() instanceof BuildingLumberjack)
+        {
+            building = (BuildingLumberjack) ((AbstractEntityCitizen) entity).getCitizenColonyHandler().getWorkBuilding();
+        }
+        if (Tree.checkTree(world, pos, excludedTrees, building) && Tree.checkIfInColonyAndNotInBuilding(pos, colony))
         {
             getResult().treeLocation = pos;
             return true;

--- a/src/main/java/com/minecolonies/coremod/entity/pathfinding/pathjobs/PathJobFindTree.java
+++ b/src/main/java/com/minecolonies/coremod/entity/pathfinding/pathjobs/PathJobFindTree.java
@@ -55,17 +55,19 @@ public class PathJobFindTree extends AbstractPathJob
      * Fake goal when using restricted area
      */
     private final BlockPos boxCenter;
+    private final int dyntreesize;
 
     /**
      * AbstractPathJob constructor.
      *
-     * @param world      the world within which to path.
-     * @param start      the start position from which to path from.
-     * @param home       the position of the worker hut.
-     * @param range      maximum path range.
-     * @param treesToCut the trees the lj is supposed to cut.
-     * @param entity     the entity.
-     * @param colony     the colony.
+     * @param world       the world within which to path.
+     * @param start       the start position from which to path from.
+     * @param home        the position of the worker hut.
+     * @param range       maximum path range.
+     * @param treesToCut  the trees the lj is supposed to cut.
+     * @param entity      the entity.
+     * @param dyntreesize the radius a dynamic tree must have
+     * @param colony      the colony.
      */
     public PathJobFindTree(
       final World world,
@@ -73,6 +75,7 @@ public class PathJobFindTree extends AbstractPathJob
       final BlockPos home,
       final int range,
       final List<ItemStorage> treesToCut,
+      final int dyntreesize,
       final IColony colony,
       final LivingEntity entity)
     {
@@ -81,6 +84,7 @@ public class PathJobFindTree extends AbstractPathJob
         this.hutLocation = home;
         this.colony = colony;
         this.boxCenter = null;
+        this.dyntreesize = dyntreesize;
     }
 
     /**
@@ -92,6 +96,7 @@ public class PathJobFindTree extends AbstractPathJob
      * @param startRestriction start of the restricted area.
      * @param endRestriction   end of the restricted area.
      * @param excludedTrees       the trees the lj is not supposed to cut.
+     * @param dyntreesize      the radius a dynamic tree must have
      * @param entity           the entity.
      * @param colony           the colony.
      */
@@ -103,6 +108,7 @@ public class PathJobFindTree extends AbstractPathJob
       final BlockPos endRestriction,
       final BlockPos furthestRestriction,
       final List<ItemStorage> excludedTrees,
+      final int dyntreesize,
       final IColony colony,
       final LivingEntity entity)
     {
@@ -118,6 +124,7 @@ public class PathJobFindTree extends AbstractPathJob
         this.excludedTrees = excludedTrees;
         this.hutLocation = home;
         this.colony = colony;
+        this.dyntreesize = dyntreesize;
 
         final BlockPos size = startRestriction.subtract(endRestriction);
         this.boxCenter = endRestriction.offset(size.getX()/2, size.getY()/2, size.getZ()/2);
@@ -158,14 +165,8 @@ public class PathJobFindTree extends AbstractPathJob
 
     private boolean isTree(final BlockPos pos)
     {
-        final LivingEntity entity = this.entity.get();
-        BuildingLumberjack building = null;
 
-        if (entity instanceof AbstractEntityCitizen && ((EntityCitizen) entity).getCitizenColonyHandler().getWorkBuilding() instanceof BuildingLumberjack)
-        {
-            building = (BuildingLumberjack) ((AbstractEntityCitizen) entity).getCitizenColonyHandler().getWorkBuilding();
-        }
-        if (Tree.checkTree(world, pos, excludedTrees, building) && Tree.checkIfInColonyAndNotInBuilding(pos, colony))
+        if (Tree.checkTree(world, pos, excludedTrees, dyntreesize) && Tree.checkIfInColonyAndNotInBuilding(pos, colony))
         {
             getResult().treeLocation = pos;
             return true;

--- a/src/main/resources/assets/minecolonies/lang/en_us.json
+++ b/src/main/resources/assets/minecolonies/lang/en_us.json
@@ -1975,6 +1975,7 @@
   "com.minecolonies.coremod.gui.workerhuts.switch": "Switch",
   "com.minecolonies.coremod.gui.workerhuts.tools": "Selection Tools",
   "com.minecolonies.coremod.gui.tooldesc.scepterbeekeeper": "Right-click a beehive with the tool to add it to the hut. Right-click any other block to discard the tool.",
+  "com.minecolonies.coremod.setting.minecolonies:dynamictreeharvestsize": "Dynamic trees radius:",
   "com.minecolonies.coremod.setting.minecolonies:replant": "Replanting:",
   "com.minecolonies.coremod.setting.minecolonies:restrict": "Zoning Mode:",
   "com.minecolonies.coremod.gui.tooldesc.scepterlumberjack": "Restrict the Forester's working area by right-clicking one corner and left-clicking the opposite corner with the tool.",


### PR DESCRIPTION
Closes a discussion on discord
Closes #
Closes #

# Changes proposed in this pull request:
- Create a new setting in the Forester's hut for the dynamic trees radius
- It uses the current config setting as default value and is only visible when dynamic trees is actually loaded
-

Review please
