### PR TITLE
Fix groundlevel again

### DIFF
--- a/build.properties
+++ b/build.properties
@@ -10,7 +10,7 @@ fml_range=[36,)
 mappings_channel=official
 mappings_version=1.16.5
 # Dependencies
-structurize_version=0.13.230-ALPHA
+structurize_version=0.13.242-ALPHA
 datagen_version=0.1.48-ALPHA
 jei_mcversion=1.16.5
 jei_version=7.6.4.90

--- a/src/main/java/com/minecolonies/coremod/client/gui/WindowMinecoloniesBuildTool.java
+++ b/src/main/java/com/minecolonies/coremod/client/gui/WindowMinecoloniesBuildTool.java
@@ -41,20 +41,22 @@ public class WindowMinecoloniesBuildTool extends WindowBuildTool
      * @param pos           the position.
      * @param structureName the structure name.
      * @param rotation      the rotation.
+     * @param groundstyle   one of the GROUNDSTYLE_ values.
      */
-    public WindowMinecoloniesBuildTool(@Nullable final BlockPos pos, final String structureName, final int rotation)
+    public WindowMinecoloniesBuildTool(@Nullable final BlockPos pos, final String structureName, final int rotation, final int groundstyle)
     {
-        super(pos, structureName, rotation);
+        super(pos, structureName, rotation, groundstyle);
     }
 
     /**
      * Creates a window build tool. This requires X, Y and Z coordinates. If a structure is active, recalculates the X Y Z with offset. Otherwise the given parameters are used.
      *
      * @param pos coordinate.
+     * @param groundstyle one of the GROUNDSTYLE_ values.
      */
-    public WindowMinecoloniesBuildTool(@Nullable final BlockPos pos)
+    public WindowMinecoloniesBuildTool(@Nullable final BlockPos pos, final int groundstyle)
     {
-        super(pos);
+        super(pos, groundstyle);
     }
 
     @Override

--- a/src/main/java/com/minecolonies/coremod/client/gui/WindowSuggestBuildTool.java
+++ b/src/main/java/com/minecolonies/coremod/client/gui/WindowSuggestBuildTool.java
@@ -14,6 +14,7 @@ import net.minecraft.util.math.BlockPos;
 import net.minecraftforge.items.wrapper.InvWrapper;
 import org.jetbrains.annotations.NotNull;
 
+import static com.ldtteam.structurize.api.util.constant.Constants.GROUNDSTYLE_RELATIVE;
 import static com.minecolonies.api.util.constant.WindowConstants.*;
 
 /**
@@ -74,7 +75,7 @@ public class WindowSuggestBuildTool extends AbstractWindowSkeleton
         if (InventoryUtils.findFirstSlotInItemHandlerWith(new InvWrapper(Minecraft.getInstance().player.inventory), ModItems.buildTool.get()) != -1)
         {
             Network.getNetwork().sendToServer(new SwitchBuildingWithToolMessage(stack));
-            new WindowMinecoloniesBuildTool(this.pos).open();
+            new WindowMinecoloniesBuildTool(this.pos, GROUNDSTYLE_RELATIVE).open();
             return;
         }
         LanguageHandler.sendPlayerMessage(Minecraft.getInstance().player, "item.buildtool.missing");

--- a/src/main/java/com/minecolonies/coremod/colony/managers/EventStructureManager.java
+++ b/src/main/java/com/minecolonies/coremod/colony/managers/EventStructureManager.java
@@ -1,12 +1,11 @@
 package com.minecolonies.coremod.colony.managers;
 
 import com.ldtteam.structures.blueprints.v1.Blueprint;
+import com.ldtteam.structures.lib.BlueprintTagUtils;
 import com.ldtteam.structurize.Structurize;
-import com.ldtteam.structurize.blocks.interfaces.IBlueprintDataProvider;
 import com.ldtteam.structurize.items.ItemScanTool;
 import com.ldtteam.structurize.management.StructureName;
 import com.ldtteam.structurize.management.Structures;
-import com.ldtteam.structurize.util.BlockInfo;
 import com.minecolonies.api.colony.IColony;
 import com.minecolonies.api.colony.colonyEvents.IColonyRaidEvent;
 import com.minecolonies.api.colony.managers.interfaces.IEventStructureManager;
@@ -17,7 +16,6 @@ import com.minecolonies.coremod.util.CreativeRaiderStructureHandler;
 import net.minecraft.nbt.CompoundNBT;
 import net.minecraft.nbt.INBT;
 import net.minecraft.nbt.ListNBT;
-import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.Mirror;
 import net.minecraft.util.Rotation;
 import net.minecraft.util.math.BlockPos;
@@ -27,10 +25,8 @@ import org.jetbrains.annotations.NotNull;
 
 import java.util.HashMap;
 import java.util.Iterator;
-import java.util.List;
 import java.util.Map;
 
-import static com.ldtteam.structurize.blocks.interfaces.IBlueprintDataProvider.TAG_BLUEPRINTDATA;
 import static com.ldtteam.structurize.management.Structures.SCHEMATIC_EXTENSION_NEW;
 import static com.minecolonies.api.util.constant.NbtTagConstants.*;
 
@@ -92,31 +88,11 @@ public class EventStructureManager implements IEventStructureManager
 
         final World world = colony.getWorld();
 
-        int y = 3;
+        final int y = BlueprintTagUtils.getNumberOfGroundLevels(structure, 4) - 1;
 
-        final BlockInfo info = structure.getBlockInfoAsMap().getOrDefault(structure.getPrimaryBlockOffset(), null);
-        if (info.getTileEntityData() != null)
-        {
-            final CompoundNBT teData = structure.getTileEntityData(targetSpawnPoint, structure.getPrimaryBlockOffset());
-            if (teData != null && teData.contains(TAG_BLUEPRINTDATA))
-            {
-                final TileEntity entity = TileEntity.loadStatic(info.getState(), info.getTileEntityData());
-                if (entity instanceof IBlueprintDataProvider)
-                {
-                    for (final Map.Entry<BlockPos, List<String>> entry : ((IBlueprintDataProvider) entity).getPositionedTags().entrySet())
-                    {
-                        if (entry.getValue().contains("groundlevel"))
-                        {
-                            y = entry.getKey().getY();
-                        }
-                    }
-                }
-            }
-        }
+        final BlockPos spawnPos = targetSpawnPoint.offset(0, -y, 0).offset(structure.getPrimaryBlockOffset());
 
-        final BlockPos spawnPos = targetSpawnPoint.offset(0, -y, 0);
-
-        final BlockPos zeroPos = targetSpawnPoint.subtract(structure.getPrimaryBlockOffset()).offset(0, -y, 0);
+        final BlockPos zeroPos = spawnPos.subtract(structure.getPrimaryBlockOffset());
         final BlockPos cornerPos = new BlockPos(zeroPos.getX() + structure.getSizeX() - 1, zeroPos.getY() + structure.getSizeY(), zeroPos.getZ() + structure.getSizeZ() - 1);
 
         final BlockPos anchor = new BlockPos(zeroPos.getX() + structure.getSizeX() / 2, zeroPos.getY(), zeroPos.getZ() + structure.getSizeZ() / 2);

--- a/src/main/java/com/minecolonies/coremod/items/ItemSupplyCampDeployer.java
+++ b/src/main/java/com/minecolonies/coremod/items/ItemSupplyCampDeployer.java
@@ -25,6 +25,7 @@ import org.jetbrains.annotations.Nullable;
 
 import java.util.List;
 
+import static com.ldtteam.structurize.api.util.constant.Constants.GROUNDSTYLE_LEGACY_CAMP;
 import static com.minecolonies.api.util.constant.Constants.*;
 import static com.minecolonies.api.util.constant.TranslationConstants.CANT_PLACE_COLONY_IN_OTHER_DIM;
 
@@ -108,7 +109,7 @@ public class ItemSupplyCampDeployer extends AbstractItemMinecolonies
     {
         if (pos == null)
         {
-            MineColonies.proxy.openBuildToolWindow(null, SUPPLY_CAMP_STRUCTURE_NAME, 0);
+            MineColonies.proxy.openBuildToolWindow(null, SUPPLY_CAMP_STRUCTURE_NAME, 0, GROUNDSTYLE_LEGACY_CAMP);
             return;
         }
 
@@ -133,7 +134,7 @@ public class ItemSupplyCampDeployer extends AbstractItemMinecolonies
                 rotations = ROTATE_0_TIMES;
                 break;
         }
-        MineColonies.proxy.openBuildToolWindow(tempPos, SUPPLY_CAMP_STRUCTURE_NAME, rotations);
+        MineColonies.proxy.openBuildToolWindow(tempPos, SUPPLY_CAMP_STRUCTURE_NAME, rotations, GROUNDSTYLE_LEGACY_CAMP);
     }
 
     /**
@@ -141,7 +142,6 @@ public class ItemSupplyCampDeployer extends AbstractItemMinecolonies
      *
      * @param world              the world.
      * @param pos                the position.
-     * @param size               the size.
      * @param placementErrorList the list of placement errors.
      * @param placer             the placer.
      * @return true if so.
@@ -155,13 +155,7 @@ public class ItemSupplyCampDeployer extends AbstractItemMinecolonies
         final BlockPos zeroPos = pos.subtract(Settings.instance.getActiveStructure().getPrimaryBlockOffset());
         final int sizeX = Settings.instance.getActiveStructure().getSizeX();
         final int sizeZ = Settings.instance.getActiveStructure().getSizeZ();
-
-        int groundLevel = zeroPos.getY();
-        final BlockPos groundLevelPos = BlueprintTagUtils.getFirstPosForTag(Settings.instance.getActiveStructure(), "groundlevel");
-        if (groundLevelPos != null)
-        {
-            groundLevel = groundLevelPos.getY();
-        }
+        final int groundLevel = zeroPos.getY() + BlueprintTagUtils.getNumberOfGroundLevels(Settings.instance.getActiveStructure(), 1);
 
         for (int z = zeroPos.getZ(); z < zeroPos.getZ() + sizeZ; z++)
         {

--- a/src/main/java/com/minecolonies/coremod/items/ItemSupplyCampDeployer.java
+++ b/src/main/java/com/minecolonies/coremod/items/ItemSupplyCampDeployer.java
@@ -74,7 +74,7 @@ public class ItemSupplyCampDeployer extends AbstractItemMinecolonies
                 LanguageHandler.sendPlayerMessage(ctx.getPlayer(), CANT_PLACE_COLONY_IN_OTHER_DIM);
                 return ActionResultType.FAIL;
             }
-            placeSupplyCamp(ctx.getClickedPos(), ctx.getPlayer().getDirection());
+            placeSupplyCamp(ctx.getClickedPos().relative(ctx.getClickedFace()), ctx.getPlayer().getDirection());
         }
 
         return ActionResultType.FAIL;

--- a/src/main/java/com/minecolonies/coremod/items/ItemSupplyChestDeployer.java
+++ b/src/main/java/com/minecolonies/coremod/items/ItemSupplyChestDeployer.java
@@ -85,7 +85,7 @@ public class ItemSupplyChestDeployer extends AbstractItemMinecolonies
             {
                 return ActionResultType.FAIL;
             }
-            placeSupplyShip(ctx.getLevel(), ctx.getClickedPos(), ctx.getPlayer().getDirection());
+            placeSupplyShip(ctx.getLevel(), ctx.getClickedPos().relative(ctx.getClickedFace()), ctx.getPlayer().getDirection());
         }
 
         return ActionResultType.FAIL;

--- a/src/main/java/com/minecolonies/coremod/proxy/ClientProxy.java
+++ b/src/main/java/com/minecolonies/coremod/proxy/ClientProxy.java
@@ -26,6 +26,8 @@ import org.jetbrains.annotations.Nullable;
 
 import java.io.File;
 
+import static com.ldtteam.structurize.api.util.constant.Constants.GROUNDSTYLE_RELATIVE;
+
 /**
  * Client side proxy.
  */
@@ -58,7 +60,7 @@ public class ClientProxy extends CommonProxy
             return;
         }
 
-        @Nullable final WindowMinecoloniesBuildTool window = new WindowMinecoloniesBuildTool(pos);
+        @Nullable final WindowMinecoloniesBuildTool window = new WindowMinecoloniesBuildTool(pos, GROUNDSTYLE_RELATIVE);
         window.open();
     }
 
@@ -99,14 +101,14 @@ public class ClientProxy extends CommonProxy
     }
 
     @Override
-    public void openBuildToolWindow(final BlockPos pos, final String structureName, final int rotation)
+    public void openBuildToolWindow(final BlockPos pos, final String structureName, final int rotation, final int groundstyle)
     {
         if (pos == null && Settings.instance.getActiveStructure() == null)
         {
             return;
         }
 
-        @Nullable final WindowMinecoloniesBuildTool window = new WindowMinecoloniesBuildTool(pos, structureName, rotation);
+        @Nullable final WindowMinecoloniesBuildTool window = new WindowMinecoloniesBuildTool(pos, structureName, rotation, groundstyle);
         window.open();
     }
 

--- a/src/main/java/com/minecolonies/coremod/proxy/CommonProxy.java
+++ b/src/main/java/com/minecolonies/coremod/proxy/CommonProxy.java
@@ -205,7 +205,7 @@ public abstract class CommonProxy implements IProxy
     }
 
     @Override
-    public void openBuildToolWindow(final BlockPos pos, final String structureName, final int rotation)
+    public void openBuildToolWindow(final BlockPos pos, final String structureName, final int rotation, final int groundstyle)
     {
         /*
          * Intentionally left empty.

--- a/src/main/java/com/minecolonies/coremod/proxy/IProxy.java
+++ b/src/main/java/com/minecolonies/coremod/proxy/IProxy.java
@@ -64,12 +64,12 @@ public interface IProxy
 
     /**
      * Opens a build tool window for a specific structure.
-     *
-     * @param pos           the position.
+     *  @param pos           the position.
      * @param structureName the structure name.
      * @param rotation      the rotation.
+     * @param groundstyle   one of the GROUNDSTYLE_ values.
      */
-    void openBuildToolWindow(final BlockPos pos, final String structureName, final int rotation);
+    void openBuildToolWindow(final BlockPos pos, final String structureName, final int rotation, final int groundstyle);
 
     /**
      * Opens a rally banner window.

--- a/src/main/resources/assets/minecolonies/lang/en_us.json
+++ b/src/main/resources/assets/minecolonies/lang/en_us.json
@@ -748,7 +748,7 @@
   "item.supply.error.inside_colony": "Inside colony",
   "item.supply.error.needs_air_above": "Need air above",
   "item.supply.error.not_water": "Not a Fluid",
-  "item.supply.badblocks": "Not all blocks in the area do meet the requirements! Recheck the highlighted blocks",
+  "item.supply.badblocks": "Not all blocks in the area meet the requirements! Recheck the highlighted blocks",
   "item.supplycampdeployer.invalid.inside_existing_colony": "You cannot place your Supply Camp or Ship near an existing colony.",
   "item.minecolonies.supplychestdeployer": "Supply Ship",
   "item.minecolonies.supplycampdeployer": "Supply Camp",


### PR DESCRIPTION
Depends on ldtteam/Structurize#443

# Changes proposed in this pull request:
- Makes the supply camp/ship tools consistent with build/shape tool behaviour (selection of initial anchor and groundlevel)
  - ~~Caveat: they will now appear one block above ground by default unless someone rescans them with a tag anchor on top of the ground (and optionally a groundlevel tag, but just the anchor is sufficient if placed correctly --~~ best position is close to the centre and directly sitting on the "ground", but can be anywhere on the centre line if also using a groundlevel tag [and doesn't strictly need to be centred, but that helps rotation])

Review please

(Just waiting on a structurize version bump for the linked PR before mergeable)
