### PR TITLE
Add config to disable supply placement restrictions

### DIFF
--- a/src/api/java/com/minecolonies/api/configuration/ServerConfiguration.java
+++ b/src/api/java/com/minecolonies/api/configuration/ServerConfiguration.java
@@ -62,6 +62,7 @@ public class ServerConfiguration extends AbstractConfiguration
     public final ForgeConfigSpec.IntValue     badVisitorsChance;
     public final ForgeConfigSpec.BooleanValue generateSupplyLoot;
     public final ForgeConfigSpec.IntValue     maxTreeSize;
+    public final ForgeConfigSpec.BooleanValue noSupplyPlacementRestrictions;
 
     /*  --------------------------------------------------------------------------- *
      *  ------------------- ######## Research settings ######## ------------------- *
@@ -213,6 +214,7 @@ public class ServerConfiguration extends AbstractConfiguration
         badVisitorsChance = defineInteger(builder, "badvisitorchance", 2, 1, 100);
         generateSupplyLoot = defineBoolean(builder, "generatesupplyloot", true);
         maxTreeSize = defineInteger(builder, "maxtreesize", 400, 1, 1000);
+        noSupplyPlacementRestrictions = defineBoolean(builder, "nosupplyplacementrestrictions", false);
 
         swapToCategory(builder, "research");
         researchCreativeCompletion = defineBoolean(builder, "researchcreativecompletion", true);

--- a/src/main/java/com/minecolonies/coremod/items/ItemSupplyCampDeployer.java
+++ b/src/main/java/com/minecolonies/coremod/items/ItemSupplyCampDeployer.java
@@ -152,6 +152,11 @@ public class ItemSupplyCampDeployer extends AbstractItemMinecolonies
       @NotNull final List<PlacementError> placementErrorList,
       final PlayerEntity placer)
     {
+        if (MineColonies.getConfig().getServer().noSupplyPlacementRestrictions.get())
+        {
+            return true;
+        }
+
         final BlockPos zeroPos = pos.subtract(Settings.instance.getActiveStructure().getPrimaryBlockOffset());
         final int sizeX = Settings.instance.getActiveStructure().getSizeX();
         final int sizeZ = Settings.instance.getActiveStructure().getSizeZ();

--- a/src/main/java/com/minecolonies/coremod/items/ItemSupplyChestDeployer.java
+++ b/src/main/java/com/minecolonies/coremod/items/ItemSupplyChestDeployer.java
@@ -165,6 +165,11 @@ public class ItemSupplyChestDeployer extends AbstractItemMinecolonies
       @NotNull final World world, @NotNull final BlockPos pos, final Blueprint ship, @NotNull final List<PlacementError> placementErrorList, final
     PlayerEntity placer)
     {
+        if (MineColonies.getConfig().getServer().noSupplyPlacementRestrictions.get())
+        {
+            return true;
+        }
+
         final BlockPos anchorPos = ship.getPrimaryBlockOffset();
         final BlockPos zeroPos = pos.subtract(anchorPos);
         final int sizeX = ship.getSizeX();


### PR DESCRIPTION
Closes #
Closes #
Closes #

# Changes proposed in this pull request:
- Allow to place supplycamps/ships without placement restrictions depending on a config.
- The reason for this a skyblock worlds
-

Review please
