### PR TITLE
Stuckhandler/Raider Block break fixes

### DIFF
--- a/src/api/java/com/minecolonies/api/entity/combat/threat/ThreatTable.java
+++ b/src/api/java/com/minecolonies/api/entity/combat/threat/ThreatTable.java
@@ -150,8 +150,8 @@ public class ThreatTable<T extends LivingEntity & IThreatTableEntity>
             return null;
         }
 
-        /// Add ignore logic
-        final ThreatTableEntry current = threatList.get(currentTargetIndex);
+        // Threat value target change thresholds
+        ThreatTableEntry current = threatList.get(currentTargetIndex);
         final ThreatTableEntry top = threatList.get(0);
         if (top.getThreat() > current.getThreat())
         {
@@ -161,7 +161,7 @@ public class ThreatTable<T extends LivingEntity & IThreatTableEntity>
                 if (top.getThreat() > (current.getThreat() * 1.3))
                 {
                     currentTargetIndex = 0;
-                    return top;
+                    current = top;
                 }
             }
             else
@@ -170,27 +170,20 @@ public class ThreatTable<T extends LivingEntity & IThreatTableEntity>
                 if (top.getThreat() > (current.getThreat() * 1.1))
                 {
                     currentTargetIndex = 0;
-                    return top;
+                    current = top;
                 }
             }
-        }
-
-        if (current.getThreat() < 0)
-        {
-            return null;
         }
 
         if ((owner.level.getGameTime() - current.getLastSeen()) > MAX_TRACKING_TICKS || !current.getEntity().isAlive())
         {
             removeCurrentTarget();
-            if (threatList.isEmpty())
-            {
-                return null;
-            }
-            else
-            {
-                return threatList.get(currentTargetIndex);
-            }
+            return getTarget();
+        }
+
+        if (current.getThreat() < 0)
+        {
+            return null;
         }
 
         return current;

--- a/src/api/java/com/minecolonies/api/entity/combat/threat/ThreatTable.java
+++ b/src/api/java/com/minecolonies/api/entity/combat/threat/ThreatTable.java
@@ -175,7 +175,7 @@ public class ThreatTable<T extends LivingEntity & IThreatTableEntity>
             }
         }
 
-        if ((owner.level.getGameTime() - current.getLastSeen()) > MAX_TRACKING_TICKS || !current.getEntity().isAlive())
+        if (Math.abs(owner.level.getGameTime() - current.getLastSeen()) > MAX_TRACKING_TICKS || !current.getEntity().isAlive())
         {
             removeCurrentTarget();
             return getTarget();

--- a/src/api/java/com/minecolonies/api/entity/pathfinding/PathingStuckHandler.java
+++ b/src/api/java/com/minecolonies/api/entity/pathfinding/PathingStuckHandler.java
@@ -19,8 +19,6 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Random;
 
-import static com.minecolonies.api.util.constant.Constants.TICKS_SECOND;
-
 /**
  * Stuck handler for pathing
  */
@@ -39,7 +37,7 @@ public class PathingStuckHandler implements IStuckHandler
     /**
      * Constants related to tp.
      */
-    private static final int MAX_TP_DELAY    = 60 * TICKS_SECOND * 5;
+    private static final int MIN_TP_DELAY    = 120 * 20;
     private static final int MIN_DIST_FOR_TP = 10;
 
     /**
@@ -111,6 +109,11 @@ public class PathingStuckHandler implements IStuckHandler
     private int delayBeforeActions       = 10 * 20;
     private int delayToNextUnstuckAction = delayBeforeActions;
 
+    /**
+     * The start position of moving away unstuck
+     */
+    private BlockPos moveAwayStartPos = BlockPos.ZERO;
+
     private Random rand = new Random();
 
     private PathingStuckHandler()
@@ -137,12 +140,12 @@ public class PathingStuckHandler implements IStuckHandler
     {
         if (navigator.getDesiredPos() == null || navigator.getDesiredPos().equals(BlockPos.ZERO))
         {
-            resetGlobalStuckTimers();
             return;
         }
 
         if (navigator.getOurEntity() instanceof IStuckHandlerEntity && !((IStuckHandlerEntity) navigator.getOurEntity()).canBeStuck())
         {
+            resetGlobalStuckTimers();
             return;
         }
 
@@ -162,7 +165,7 @@ public class PathingStuckHandler implements IStuckHandler
             globalTimeout++;
 
             // Try path first, if path fits target pos
-            if (globalTimeout > Math.min(MAX_TP_DELAY, timePerBlockDistance * Math.max(MIN_DIST_FOR_TP, distanceToGoal)))
+            if (globalTimeout > Math.max(MIN_TP_DELAY, timePerBlockDistance * Math.max(MIN_DIST_FOR_TP, distanceToGoal)))
             {
                 completeStuckAction(navigator);
             }
@@ -172,6 +175,7 @@ public class PathingStuckHandler implements IStuckHandler
             resetGlobalStuckTimers();
         }
 
+        delayToNextUnstuckAction--;
         prevDestination = navigator.getDesiredPos();
 
         if (navigator.getPath() == null || navigator.getPath().isDone())
@@ -199,7 +203,7 @@ public class PathingStuckHandler implements IStuckHandler
                 {
                     progressedNodes = navigator.getPath().getNextNodeIndex() > lastPathIndex ? progressedNodes + 1 : progressedNodes - 1;
 
-                    if (progressedNodes > 5)
+                    if (progressedNodes > 5 && (navigator.getPath().getEndNode() == null || !moveAwayStartPos.equals(navigator.getPath().getEndNode().asBlockPos())))
                     {
                         // Not stuck when progressing
                         resetStuckTimers();
@@ -273,16 +277,17 @@ public class PathingStuckHandler implements IStuckHandler
      */
     private void tryUnstuck(final AbstractAdvancedPathNavigate navigator)
     {
-        if (delayToNextUnstuckAction-- > 0)
+        if (delayToNextUnstuckAction > 0)
         {
             return;
         }
+        delayToNextUnstuckAction = 50;
 
         // Clear path
         if (stuckLevel == 0)
         {
             stuckLevel++;
-            delayToNextUnstuckAction = 600;
+            delayToNextUnstuckAction = 200;
             navigator.stop();
             return;
         }
@@ -293,7 +298,8 @@ public class PathingStuckHandler implements IStuckHandler
             stuckLevel++;
             delayToNextUnstuckAction = 300;
             navigator.stop();
-            navigator.moveAwayFromXYZ(new BlockPos(navigator.getOurEntity().position()), 10, 1.0f);
+            navigator.moveAwayFromXYZ(navigator.getOurEntity().blockPosition(), 10, 1.0f);
+            moveAwayStartPos = navigator.getOurEntity().blockPosition();
             return;
         }
 
@@ -311,7 +317,7 @@ public class PathingStuckHandler implements IStuckHandler
         {
             if (canPlaceLadders && rand.nextBoolean())
             {
-                delayToNextUnstuckAction = 300;
+                delayToNextUnstuckAction = 200;
                 placeLadders(navigator);
             }
             else if (canBuildLeafBridges && rand.nextBoolean())
@@ -322,16 +328,17 @@ public class PathingStuckHandler implements IStuckHandler
         }
 
         // break blocks
-        if (stuckLevel == 6 && canBreakBlocks)
+        if (stuckLevel >= 6 && stuckLevel <= 8 && canBreakBlocks)
         {
-            delayToNextUnstuckAction = 300;
+            delayToNextUnstuckAction = 200;
             breakBlocks(navigator);
         }
 
         chanceStuckLevel();
 
-        if (stuckLevel == 8)
+        if (stuckLevel == 9)
         {
+            completeStuckAction(navigator);
             resetStuckTimers();
         }
     }
@@ -358,12 +365,14 @@ public class PathingStuckHandler implements IStuckHandler
         lastPathIndex = -1;
         progressedNodes = 0;
         stuckLevel = 0;
+        moveAwayStartPos = BlockPos.ZERO;
     }
 
     /**
      * Attempt to break blocks that are blocking the entity to reach its destination.
-     * @param world the world it is in.
-     * @param start the position the entity is at.
+     *
+     * @param world  the world it is in.
+     * @param start  the position the entity is at.
      * @param facing the direction the goal is in.
      */
     private void breakBlocksAhead(final World world, final BlockPos start, final Direction facing)
@@ -375,24 +384,25 @@ public class PathingStuckHandler implements IStuckHandler
             return;
         }
 
-        // In goal direction
-        if (!world.isEmptyBlock(start.relative(facing)))
-        {
-            setAirIfPossible(world, start.relative(facing));
-            return;
-        }
-
         // Goal direction up
         if (!world.isEmptyBlock(start.above().relative(facing)))
         {
             setAirIfPossible(world, start.above().relative(facing));
+            return;
+        }
+
+        // In goal direction
+        if (!world.isEmptyBlock(start.relative(facing)))
+        {
+            setAirIfPossible(world, start.relative(facing));
         }
     }
 
     /**
      * Check if the block at the position is indestructible, if not, attempt to break it.
+     *
      * @param world the world the block is in.
-     * @param pos the pos the block is at.
+     * @param pos   the pos the block is at.
      */
     private void setAirIfPossible(final World world, final BlockPos pos)
     {
@@ -436,7 +446,7 @@ public class PathingStuckHandler implements IStuckHandler
         final World world = navigator.getOurEntity().level;
         final MobEntity entity = navigator.getOurEntity();
 
-        final Direction badFacing = BlockPosUtil.getFacing(new BlockPos(entity.position()), navigator.getDesiredPos()).getOpposite();
+        final Direction badFacing = BlockPosUtil.getFacing(new BlockPos(entity.position()), navigator.getDesiredPos());
 
         for (final Direction dir : HORIZONTAL_DIRS)
         {

--- a/src/api/java/com/minecolonies/api/tileentities/TileEntityRack.java
+++ b/src/api/java/com/minecolonies/api/tileentities/TileEntityRack.java
@@ -260,10 +260,12 @@ public class TileEntityRack extends AbstractTileEntityRack
                 {
                     if (getOtherChest() != null && level.getBlockState(this.worldPosition.subtract(relativeNeighbor)).getBlock() instanceof AbstractBlockMinecoloniesRack)
                     {
-
-                        typeHere = level.getBlockState(worldPosition).setValue(AbstractBlockMinecoloniesRack.VARIANT, RackType.EMPTYAIR);
+                        final Direction dirToNeighbour = BlockPosUtil.getFacing(worldPosition, this.worldPosition.subtract(relativeNeighbor));
+                        typeHere = level.getBlockState(worldPosition)
+                                     .setValue(AbstractBlockMinecoloniesRack.VARIANT, RackType.EMPTYAIR)
+                                     .setValue(AbstractBlockMinecoloniesRack.FACING, dirToNeighbour);
                         typeNeighbor = level.getBlockState(this.worldPosition.subtract(relativeNeighbor)).setValue(AbstractBlockMinecoloniesRack.VARIANT, RackType.DEFAULTDOUBLE)
-                                         .setValue(AbstractBlockMinecoloniesRack.FACING, BlockPosUtil.getFacing(worldPosition, this.worldPosition.subtract(relativeNeighbor)));
+                                         .setValue(AbstractBlockMinecoloniesRack.FACING, dirToNeighbour.getOpposite());
                     }
                     else
                     {
@@ -275,9 +277,13 @@ public class TileEntityRack extends AbstractTileEntityRack
                 {
                     if (getOtherChest() != null && level.getBlockState(this.worldPosition.subtract(relativeNeighbor)).getBlock() instanceof AbstractBlockMinecoloniesRack)
                     {
-                        typeHere = level.getBlockState(worldPosition).setValue(AbstractBlockMinecoloniesRack.VARIANT, RackType.EMPTYAIR);
+                        final Direction dirToNeighbour = BlockPosUtil.getFacing(worldPosition, this.worldPosition.subtract(relativeNeighbor));
+                        typeHere = level.getBlockState(worldPosition)
+                                     .setValue(AbstractBlockMinecoloniesRack.VARIANT, RackType.EMPTYAIR)
+                                     .setValue(AbstractBlockMinecoloniesRack.FACING, dirToNeighbour);
+                        ;
                         typeNeighbor = level.getBlockState(this.worldPosition.subtract(relativeNeighbor)).setValue(AbstractBlockMinecoloniesRack.VARIANT, RackType.FULLDOUBLE)
-                                         .setValue(AbstractBlockMinecoloniesRack.FACING, BlockPosUtil.getFacing(worldPosition, this.worldPosition.subtract(relativeNeighbor)));
+                                         .setValue(AbstractBlockMinecoloniesRack.FACING, dirToNeighbour.getOpposite());
                     }
                     else
                     {

--- a/src/api/java/com/minecolonies/api/util/BlockPosUtil.java
+++ b/src/api/java/com/minecolonies/api/util/BlockPosUtil.java
@@ -669,7 +669,7 @@ public final class BlockPosUtil
     public static Direction getFacing(final BlockPos pos, final BlockPos neighbor)
     {
         final BlockPos vector = neighbor.subtract(pos);
-        return Direction.getNearest(vector.getX(), vector.getY(), -vector.getZ());
+        return Direction.getNearest(vector.getX(), vector.getY(), vector.getZ());
     }
 
     /**

--- a/src/main/java/com/minecolonies/coremod/blocks/BlockMinecoloniesRack.java
+++ b/src/main/java/com/minecolonies/coremod/blocks/BlockMinecoloniesRack.java
@@ -117,9 +117,10 @@ public class BlockMinecoloniesRack extends AbstractBlockMinecoloniesRack<BlockMi
         {
             if (rack.getOtherChest() != null)
             {
+                state.setValue(FACING, BlockPosUtil.getFacing(pos, rack.getNeighbor()));
                 if (rack.isMain())
                 {
-                    return state.setValue(AbstractBlockMinecoloniesRack.VARIANT, RackType.DEFAULTDOUBLE).setValue(FACING, BlockPosUtil.getFacing(rack.getNeighbor(), pos));
+                    return state.setValue(AbstractBlockMinecoloniesRack.VARIANT, RackType.DEFAULTDOUBLE);
                 }
                 else
                 {
@@ -135,10 +136,10 @@ public class BlockMinecoloniesRack extends AbstractBlockMinecoloniesRack<BlockMi
         {
             if (rack.getOtherChest() != null)
             {
+                state.setValue(FACING, BlockPosUtil.getFacing(pos, rack.getNeighbor()));
                 if (rack.isMain())
                 {
-                    return state.setValue(AbstractBlockMinecoloniesRack.VARIANT, RackType.FULLDOUBLE)
-                             .setValue(FACING, BlockPosUtil.getFacing(rack.getNeighbor(), pos));
+                    return state.setValue(AbstractBlockMinecoloniesRack.VARIANT, RackType.FULLDOUBLE);
                 }
                 else
                 {

--- a/src/main/java/com/minecolonies/coremod/entity/ai/combat/TargetAI.java
+++ b/src/main/java/com/minecolonies/coremod/entity/ai/combat/TargetAI.java
@@ -157,7 +157,7 @@ public class TargetAI<T extends LivingEntity & IThreatTableEntity> implements IS
                 return false;
             }
 
-            if (isEntityValidTarget(entity))
+            if (isEntityValidTarget(entity) && user.canSee(entity))
             {
                 user.getThreatTable().addThreat(entity, 0);
                 foundTarget = true;

--- a/src/main/java/com/minecolonies/coremod/entity/pathfinding/MinecoloniesAdvancedPathNavigate.java
+++ b/src/main/java/com/minecolonies/coremod/entity/pathfinding/MinecoloniesAdvancedPathNavigate.java
@@ -10,7 +10,6 @@ import com.minecolonies.api.util.BlockPosUtil;
 import com.minecolonies.api.util.CompatibilityUtils;
 import com.minecolonies.api.util.Log;
 import com.minecolonies.api.util.Tuple;
-import com.minecolonies.coremod.colony.buildings.workerbuildings.BuildingLumberjack;
 import com.minecolonies.coremod.entity.pathfinding.pathjobs.*;
 import com.minecolonies.coremod.util.WorkerUtil;
 import net.minecraft.block.AbstractRailBlock;
@@ -135,6 +134,7 @@ public class MinecoloniesAdvancedPathNavigate extends AbstractAdvancedPathNaviga
             return pathResult;
         }
 
+        desiredPos = BlockPos.ZERO;
         final int theRange = (int) (mob.getRandom().nextInt((int) range) + range / 2);
         @NotNull final BlockPos start = AbstractPathJob.prepareStart(ourEntity);
 
@@ -155,6 +155,7 @@ public class MinecoloniesAdvancedPathNavigate extends AbstractAdvancedPathNaviga
             return pathResult;
         }
 
+        desiredPos = BlockPos.ZERO;
         return setPathJob(new PathJobRandomPos(CompatibilityUtils.getWorldFromEntity(ourEntity),
           AbstractPathJob.prepareStart(ourEntity),
           3,

--- a/src/main/resources/assets/minecolonies/blockstates/blockminecoloniesrack.json
+++ b/src/main/resources/assets/minecolonies/blockstates/blockminecoloniesrack.json
@@ -1,14 +1,32 @@
 {
   "variants": {
-    "facing=east,variant=blockrackempty": {"model": "minecolonies:block/blockrackemptydouble","y": 180},
+    "facing=east,variant=blockrackempty": {
+      "model": "minecolonies:block/blockrackemptydouble",
+      "y": 0
+    },
     "facing=south,variant=blockrackempty": {"model": "minecolonies:block/blockrackemptydouble","y": 90},
-    "facing=west,variant=blockrackempty": {"model": "minecolonies:block/blockrackemptydouble","y": 0},
+    "facing=west,variant=blockrackempty": {
+      "model": "minecolonies:block/blockrackemptydouble",
+      "y": 180
+    },
     "facing=north,variant=blockrackempty": {"model": "minecolonies:block/blockrackemptydouble","y": 270},
     
     "facing=east,variant=blockrackfull": [
-      {"model": "minecolonies:block/blockrackfulldouble","y": 180,"weight": 40},
-      {"model": "minecolonies:block/blockrackfulldouble_1","y": 180,"weight": 30},
-      {"model": "minecolonies:block/blockrackfulldouble_2","y": 180,"weight": 30}
+      {
+        "model": "minecolonies:block/blockrackfulldouble",
+        "y": 0,
+        "weight": 40
+      },
+      {
+        "model": "minecolonies:block/blockrackfulldouble_1",
+        "y": 0,
+        "weight": 30
+      },
+      {
+        "model": "minecolonies:block/blockrackfulldouble_2",
+        "y": 0,
+        "weight": 30
+      }
     ],
     "facing=south,variant=blockrackfull": [
       {"model": "minecolonies:block/blockrackfulldouble","y": 90,"weight": 40},
@@ -16,25 +34,55 @@
       {"model": "minecolonies:block/blockrackfulldouble_2","y": 90,"weight": 30}
     ],
     "facing=west,variant=blockrackfull": [
-      {"model": "minecolonies:block/blockrackfulldouble","y": 0,"weight": 40},
-      {"model": "minecolonies:block/blockrackfulldouble_1","y": 0,"weight": 30},
-      {"model": "minecolonies:block/blockrackfulldouble_2","y": 0,"weight": 30}
+      {
+        "model": "minecolonies:block/blockrackfulldouble",
+        "y": 180,
+        "weight": 40
+      },
+      {
+        "model": "minecolonies:block/blockrackfulldouble_1",
+        "y": 180,
+        "weight": 30
+      },
+      {
+        "model": "minecolonies:block/blockrackfulldouble_2",
+        "y": 180,
+        "weight": 30
+      }
     ],
     "facing=north,variant=blockrackfull": [
       {"model": "minecolonies:block/blockrackfulldouble","y": 270,"weight": 40},
       {"model": "minecolonies:block/blockrackfulldouble_1","y": 270,"weight": 30},
       {"model": "minecolonies:block/blockrackfulldouble_2","y": 270,"weight": 30}
     ],
-    
-    "facing=east,variant=blockrackemptysingle": {"model": "minecolonies:block/blockrackempty","y": 180},
+
+    "facing=east,variant=blockrackemptysingle": {
+      "model": "minecolonies:block/blockrackempty",
+      "y": 0
+    },
     "facing=south,variant=blockrackemptysingle": {"model": "minecolonies:block/blockrackempty","y": 90},
-    "facing=west,variant=blockrackemptysingle": {"model": "minecolonies:block/blockrackempty","y": 0},
+    "facing=west,variant=blockrackemptysingle": {
+      "model": "minecolonies:block/blockrackempty",
+      "y": 180
+    },
     "facing=north,variant=blockrackemptysingle": {"model": "minecolonies:block/blockrackempty","y": 270},
     
     "facing=east,variant=blockrackfullsingle": [
-      {"model": "minecolonies:block/blockrackfull","y": 180,"weight":40},
-      {"model": "minecolonies:block/blockrackfull_1","y": 180,"weight":30},
-      {"model": "minecolonies:block/blockrackfull_2","y": 180,"weight":30}
+      {
+        "model": "minecolonies:block/blockrackfull",
+        "y": 0,
+        "weight": 40
+      },
+      {
+        "model": "minecolonies:block/blockrackfull_1",
+        "y": 0,
+        "weight": 30
+      },
+      {
+        "model": "minecolonies:block/blockrackfull_2",
+        "y": 0,
+        "weight": 30
+      }
     ],
     "facing=south,variant=blockrackfullsingle": [
       {"model": "minecolonies:block/blockrackfull","y": 90,"weight":40},
@@ -42,9 +90,21 @@
       {"model": "minecolonies:block/blockrackfull_2","y": 90,"weight":30}
     ],
     "facing=west,variant=blockrackfullsingle": [
-      {"model": "minecolonies:block/blockrackfull","y": 0,"weight":40},
-      {"model": "minecolonies:block/blockrackfull_1","y": 0,"weight":30},
-      {"model": "minecolonies:block/blockrackfull_2","y": 0,"weight":30}
+      {
+        "model": "minecolonies:block/blockrackfull",
+        "y": 180,
+        "weight": 40
+      },
+      {
+        "model": "minecolonies:block/blockrackfull_1",
+        "y": 180,
+        "weight": 30
+      },
+      {
+        "model": "minecolonies:block/blockrackfull_2",
+        "y": 180,
+        "weight": 30
+      }
     ],
     "facing=north,variant=blockrackfullsingle": [
       {"model": "minecolonies:block/blockrackfull","y": 270,"weight":40},


### PR DESCRIPTION
Closes #
Closes #
Closes #

# Changes proposed in this pull request:
Fix threatlist not dropping invalid marked targets on death or timeout
Fix stuck handler global timeout happening before other options could be tried, global timeout is now the last fallback if unstuck could not be detected in normal ways.
This also fixes raiders not breaking blocks as intended.
Fixed facing issues where the util inverted one of the axis to determine facing, leading to issues on raider trying to break blocks in the wrong directions.
The facing change also affected racks, updated their models to now have proper facing and not require the one axis inverted behaviour we had before.
Fixed Targeting AI to only consider visible targets on area searches

Review please
