### PR TITLE
Fix PVP related chat messages.

### DIFF
--- a/src/api/java/com/minecolonies/api/util/constant/TranslationConstants.java
+++ b/src/api/java/com/minecolonies/api/util/constant/TranslationConstants.java
@@ -286,6 +286,12 @@ public final class TranslationConstants
     @NonNls
     public static final String TOWNHALL_BREAKING_MESSAGE                                            = "com.minecolonies.coremod.pvp.townhall.broke";
     @NonNls
+    public static final String COLONY_DEFENDED_SUCCESS_MESSAGE                                      = "com.minecolonies.coremod.pvp.defended.success";
+    @NonNls
+    public static final String COLONY_ATTACK_START_MESSAGE                                          = "com.minecolonies.coremod.pvp.attack.start";
+    @NonNls
+    public static final String COLONY_ATTACK_GUARD_GROUP_SIZE_MESSAGE                               = "com.minecolonies.coremod.pvp.attack.guardgroupsize";
+    @NonNls
     public static final String ON_STRING                                                            = "com.minecolonies.coremod.gui.townHall.on";
     @NonNls
     public static final String OFF_STRING                                                           = "com.minecolonies.coremod.gui.townHall.off";

--- a/src/main/java/com/minecolonies/coremod/colony/Colony.java
+++ b/src/main/java/com/minecolonies/coremod/colony/Colony.java
@@ -599,7 +599,7 @@ public class Colony implements IColony
                 player.refreshList(this);
                 if (player.getGuards().isEmpty())
                 {
-                    LanguageHandler.sendPlayersMessage(getImportantMessageEntityPlayers(), "You successfully defended your colony against, " + player.getPlayer().getName());
+                    LanguageHandler.sendPlayersMessage(getImportantMessageEntityPlayers(), COLONY_DEFENDED_SUCCESS_MESSAGE, player.getPlayer().getName().getString());
                 }
             }
         }
@@ -1688,8 +1688,8 @@ public class Colony implements IColony
             {
                 if (attackingPlayer.addGuard(IEntityCitizen))
                 {
-                    LanguageHandler.sendPlayersMessage(getImportantMessageEntityPlayers(),
-                      "Beware, " + attackingPlayer.getPlayer().getName() + " has now: " + attackingPlayer.getGuards().size() + " guards!");
+                    LanguageHandler.sendPlayersMessage(getImportantMessageEntityPlayers(), COLONY_ATTACK_GUARD_GROUP_SIZE_MESSAGE,
+                            attackingPlayer.getPlayer().getName().getString(), attackingPlayer.getGuards().size());
                 }
                 return;
             }
@@ -1702,7 +1702,7 @@ public class Colony implements IColony
                 final AttackingPlayer attackingPlayer = new AttackingPlayer(visitingPlayer);
                 attackingPlayer.addGuard(IEntityCitizen);
                 attackingPlayers.add(attackingPlayer);
-                LanguageHandler.sendPlayersMessage(getImportantMessageEntityPlayers(), "Beware, " + visitingPlayer.getName() + " is attacking you and he brought guards.");
+                LanguageHandler.sendPlayersMessage(getImportantMessageEntityPlayers(), COLONY_ATTACK_START_MESSAGE, visitingPlayer.getName().getString());
             }
         }
     }

--- a/src/main/resources/assets/minecolonies/lang/en_us.json
+++ b/src/main/resources/assets/minecolonies/lang/en_us.json
@@ -978,6 +978,9 @@
   "com.minecolonies.coremod.status.fillingbarrels": "Filling the barrels",
   "com.minecolonies.coremod.status.harvestingbarrels": "Harvesting the barrels",
 
+  "com.minecolonies.coremod.pvp.attack.start": "§cBeware, %s§c is attacking you and he brought guards!",
+  "com.minecolonies.coremod.pvp.defended.success": "§aYou successfully defended your colony against %s§a.",
+  "com.minecolonies.coremod.pvp.attack.guardgroupsize": "§eBeware, %s §ehas now: %d §eguards!",
   "com.minecolonies.coremod.pvp.townhall.break.start": "Beware! %s started breaking your Town Hall!",
   "com.minecolonies.coremod.pvp.townhall.broke": "Beware!!! %s broke your Town Hall by over %d%%! At 100%% it will be lost!!!",
   "com.minecolonies.coremod.gui.townhall.pickteamcolor": "Pick Team Color:",


### PR DESCRIPTION
PVP related messages on chat before changes:

- ![attack-message](https://img.bymarcin.com/2021-10-16_22-26-17_WRA0ke06ChyakeVb.png)
- ![defend-success-message](https://img.bymarcin.com/2021-10-02_02-13-35_0mLQrAGUfleUzI6n.png)

and after changes:

- ![attack-message-fixed](https://img.bymarcin.com/2021-10-16_22-27-27_lVjE9TRHGh1nLTye.png)
- ![defend-success-message-fixed](https://img.bymarcin.com/2021-10-16_22-27-50_3uvDjk88dENC1U2R.png)
- ![guard-group-size-message-fixed](https://img.bymarcin.com/2021-10-16_22-28-01_WZI9GV4UEZNejfJA.png)