### PR TITLE
Fixes crash if creative-fancy-pasting a tag-anchored schematic

### DIFF
--- a/src/api/java/com/minecolonies/api/util/CreativeBuildingStructureHandler.java
+++ b/src/api/java/com/minecolonies/api/util/CreativeBuildingStructureHandler.java
@@ -80,9 +80,12 @@ public final class CreativeBuildingStructureHandler extends CreativeStructureHan
         if (teData != null && teData.contains(TAG_BLUEPRINTDATA))
         {
             final TileEntity te = getWorld().getBlockEntity(worldPos);
-            ((IBlueprintDataProvider) te).readSchematicDataFromNBT(teData);
-            ((ServerWorld) getWorld()).getChunkSource().blockChanged(worldPos);
-            te.setChanged();
+            if (te != null)
+            {
+                ((IBlueprintDataProvider) te).readSchematicDataFromNBT(teData);
+                ((ServerWorld) getWorld()).getChunkSource().blockChanged(worldPos);
+                te.setChanged();
+            }
         }
 
         if (building != null)


### PR DESCRIPTION
# Changes proposed in this pull request:
- Fixes a server crash if someone fancy-pastes a schematic containing a tag anchor
    - Could also happen if pasting a schem containing a hut that no longer exists (e.g. missing addon mod)

Review please

This was also found in 1.17 with some versions of the Frontier supply camp (not that you should need to be fancy-pasting that, but still...).