### PR TITLE
Increase maximum tool level for level 5 huts to integer limit

### DIFF
--- a/src/api/java/com/minecolonies/api/util/constant/ToolLevelConstants.java
+++ b/src/api/java/com/minecolonies/api/util/constant/ToolLevelConstants.java
@@ -51,13 +51,13 @@ public final class ToolLevelConstants
      * Armor level for diamond.
      */
     @NonNls
-    public static final int ARMOR_LEVEL_MAX = 100;
+    public static final int ARMOR_LEVEL_MAX = Integer.MAX_VALUE;
 
     /**
      * Tool level for maximum.
      */
     @NonNls
-    public static final int TOOL_LEVEL_MAXIMUM = Integer.SIZE;
+    public static final int TOOL_LEVEL_MAXIMUM = Integer.MAX_VALUE;
 
     private ToolLevelConstants()
     {


### PR DESCRIPTION
Closes #7712

# Changes proposed in this pull request:
-Increases the upper limit of usable tool level and armor level for level 5 huts to integer limit, effectively removing the hidden cap for modded tool levels.
