### PR TITLE
Allow [un]claiming a single chunk

### DIFF
--- a/src/main/java/com/minecolonies/coremod/commands/colonycommands/CommandClaimChunks.java
+++ b/src/main/java/com/minecolonies/coremod/commands/colonycommands/CommandClaimChunks.java
@@ -90,7 +90,7 @@ public class CommandClaimChunks implements IMCOPCommand
     {
         return IMCCommand.newLiteral(getName())
                  .then(IMCCommand.newArgument(COLONYID_ARG, IntegerArgumentType.integer(1))
-                         .then(IMCCommand.newArgument(RANGE_ARG, IntegerArgumentType.integer(1, 10))
+                         .then(IMCCommand.newArgument(RANGE_ARG, IntegerArgumentType.integer(0, 10))
                                  .then(IMCCommand.newArgument(ADD_ARG, BoolArgumentType.bool()).executes(this::checkPreConditionAndExecute))));
     }
 }


### PR DESCRIPTION
# Changes proposed in this pull request:
- Allows `/mc colony claim` to use a range of `0`, to claim/unclaim a single chunk (the previous minimum size was 3x3 chunks)

Review please

(This should be backported too, but I happened to have a 1.17 worktree handy.)