### PR TITLE
Fix recipe comparison for enchanter JEI

### DIFF
--- a/src/main/java/com/minecolonies/coremod/colony/crafting/CustomRecipe.java
+++ b/src/main/java/com/minecolonies/coremod/colony/crafting/CustomRecipe.java
@@ -619,7 +619,7 @@ public class CustomRecipe
     @Override
     public int hashCode()
     {
-        return Objects.hash(result, researchId, excludedResearchId, inputs);
+        return Objects.hash(result, researchId, excludedResearchId, lootTable, inputs);
     }
 
     @Override
@@ -640,6 +640,7 @@ public class CustomRecipe
         return ItemStackUtils.compareItemStacksIgnoreStackSize(result, that.result)
             && Objects.equals(researchId, that.researchId)
             && Objects.equals(excludedResearchId, that.excludedResearchId)
+            && Objects.equals(lootTable, that.lootTable)
             && inputs.equals(that.inputs);
     }
 


### PR DESCRIPTION
# Changes proposed in this pull request:
- Minimal fix for CustomRecipe comparison to unbreak JEI loot-table-based recipe lookup (such as enchanter)

Review please

I only added the one property that was critical to disambiguate the loot based recipes (the problem was that `CustomRecipeManager.getRecipes` returns a Set rather than a List).  I'm not sure why it does that or why the equals/hash implementations don't compare *all* the properties of CustomRecipe, but this fixes the immediate bug at least.

Edit: actually, looking at this again this won't have just affected JEI, it would have broken the enchanter's real AI as well.  The net effect is that only exactly one level of enchanter building would be able to make tome enchantments (not sure if this will change over time, it depends how the hash worked.  It does seem to be a different level between 1.16 and 1.17 at least).

(The sifter, the other main loot-based crafter, would have been ok because they have different input items, which were included in the hash.)