### PR TITLE
Move loot table analysis to later in the load sequence

### DIFF
--- a/build.properties
+++ b/build.properties
@@ -4,7 +4,7 @@
 # Minecraft / Forge.
 minecraft_version=1.16.5
 minecraft_range=[1.16.5, 1.17)
-forge_version=36.1.24
+forge_version=36.2.4
 forge_range=[36.1.0,)
 fml_range=[36,)
 mappings_channel=official

--- a/src/api/java/com/minecolonies/api/compatibility/CompatibilityManager.java
+++ b/src/api/java/com/minecolonies/api/compatibility/CompatibilityManager.java
@@ -163,7 +163,7 @@ public class CompatibilityManager implements ICompatibilityManager
     }
 
     @Override
-    public void discover()
+    public void discover(@NotNull final RecipeManager recipeManager)
     {
         saplings.clear();
         oreBlocks.clear();
@@ -172,6 +172,7 @@ public class CompatibilityManager implements ICompatibilityManager
         food.clear();
         edibles.clear();
         fuel.clear();
+        compostRecipes.clear();
 
         luckyOres.clear();
         recruitmentCostsWeights.clear();
@@ -189,6 +190,7 @@ public class CompatibilityManager implements ICompatibilityManager
         discoverFood();
         discoverFuel();
         discoverMobs();
+        discoverCompostRecipes(recipeManager);
 
         discoverLuckyOres();
         discoverRecruitCosts();
@@ -385,13 +387,6 @@ public class CompatibilityManager implements ICompatibilityManager
     public boolean isFreePos(final BlockPos block)
     {
         return freePositions.contains(block);
-    }
-
-    @Override
-    public void invalidateRecipes(@NotNull final RecipeManager recipeManager)
-    {
-        compostRecipes.clear();
-        discoverCompostRecipes(recipeManager);
     }
 
     @Override

--- a/src/api/java/com/minecolonies/api/compatibility/ICompatibilityManager.java
+++ b/src/api/java/com/minecolonies/api/compatibility/ICompatibilityManager.java
@@ -26,8 +26,10 @@ public interface ICompatibilityManager
 {
     /**
      * Method called to instantiate internal data.
+     *
+     * @param recipeManager The vanilla recipe manager.
      */
-    void discover();
+    void discover(@NotNull final RecipeManager recipeManager);
 
     /**
      * Gets the sapling matching a leave.
@@ -217,9 +219,4 @@ public interface ICompatibilityManager
      * @return true if so.
      */
     boolean isFreePos(BlockPos block);
-
-    /**
-     * Called when recipes are reloaded and cached info needs to be discarded.
-     */
-    void invalidateRecipes(@NotNull final RecipeManager recipeManager);
 }

--- a/src/main/java/com/minecolonies/coremod/datalistener/CrafterRecipeListener.java
+++ b/src/main/java/com/minecolonies/coremod/datalistener/CrafterRecipeListener.java
@@ -1,19 +1,15 @@
 package com.minecolonies.coremod.datalistener;
 
 import com.google.gson.*;
-import com.minecolonies.api.IMinecoloniesAPI;
 import com.minecolonies.api.util.Log;
 import com.minecolonies.coremod.colony.crafting.CustomRecipe;
 import com.minecolonies.coremod.colony.crafting.CustomRecipeManager;
 import net.minecraft.client.resources.JsonReloadListener;
-import net.minecraft.entity.player.ServerPlayerEntity;
 import net.minecraft.profiler.IProfiler;
 import net.minecraft.resources.DataPackRegistries;
 import net.minecraft.resources.IResourceManager;
-import net.minecraft.server.MinecraftServer;
 import net.minecraft.util.JSONUtils;
 import net.minecraft.util.ResourceLocation;
-import net.minecraftforge.fml.server.ServerLifecycleHooks;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.Map;
@@ -74,20 +70,7 @@ public class CrafterRecipeListener extends JsonReloadListener
             }
         }
 
-        recipeManager.buildLootData(dataPackRegistries.getLootTables());
-
         final int totalRecipes = recipeManager.getAllRecipes().values().stream().mapToInt(Map::size).sum();
         Log.getLogger().info("Loaded " + totalRecipes + " recipes for " + recipeManager.getAllRecipes().size() + " crafters");
-
-        IMinecoloniesAPI.getInstance().getColonyManager().getCompatibilityManager().invalidateRecipes(dataPackRegistries.getRecipeManager());
-
-        MinecraftServer server = ServerLifecycleHooks.getCurrentServer();
-        if(server != null)
-        {
-            for (ServerPlayerEntity player : server.getPlayerList().getPlayers())
-            {
-                recipeManager.sendCustomRecipeManagerPackets(player);
-            }
-        }
     }
 }


### PR DESCRIPTION
Closes #7762

# Changes proposed in this pull request:
- Bump min Forge to 36.2.4 for `OnDatapackSyncEvent`
- Moves loot table analysis and various other recipe-related things to this event and `FMLServerStartedEvent` to improve compatibility with mods that check tags.

Review please

~~(There is some additional code tidy-up that could be done now that more things are happening in the same place, such as merging the two method calls on `CompatibilityManager`.  Holding off on that for now so that the logic of the moves are more obvious / can be reverted if I've made a bad assumption somewhere.)~~

I have not verified actually altering tag contents on reload (but I _think_ it should still work).  I have verified that basic recipe/JEI stuff appears to be working in both SP and MP, and that this resolves the startup crash in the linked issue (at least in SP; I couldn't get those mods to behave in MP).

FWIW, the sequence of events (considering only the event handlers we already have, so ignoring some extra ones we're not currently listening to) appear to be as follows; we might be able to do a bit more consolidation based on this:

SP startup:
- AddReloadListenerEvent
- JsonReloadListener::apply
- TagsUpdatedEvent.VanillaTagTypes
- FMLServerAboutToStartEvent
- WorldEvent.Load [server, called three times?]
- FMLServerStartedEvent
- OnDatapackSyncEvent [player]
- WorldEvent.Load, PlayerEvent.PlayerLoggedInEvent [client, either order]
- RecipesUpdatedEvent

SP /reload:
- AddReloadListenerEvent
- JsonReloadListener::apply
- TagsUpdatedEvent.VanillaTagTypes
- OnDatapackSyncEvent [null]
- RecipesUpdatedEvent

MP startup:
- AddReloadListenerEvent
- JsonReloadListener::apply
- TagsUpdatedEvent.VanillaTagTypes
- FMLServerAboutToStartEvent
- WorldEvent.Load [server, called three times]
- FMLServerStartedEvent

MP player login:
- OnDatapackSyncEvent [server, player]
- PlayerEvent.PlayerLoggedInEvent [server]
- WorldEvent.Load [client]
- RecipesUpdatedEvent [client]
- TagsUpdatedEvent.VanillaTagTypes [client]

MP /reload:
- AddReloadListenerEvent
- JsonReloadListener::apply
- TagsUpdatedEvent.VanillaTagTypes [server]
- OnDatapackSyncEvent [server, null]
- TagsUpdatedEvent.VanillaTagTypes [client]
- RecipesUpdatedEvent [client]
