### PR TITLE
Hotfix Forge dependency after bump

### DIFF
--- a/build.properties
+++ b/build.properties
@@ -5,7 +5,7 @@
 minecraft_version=1.16.5
 minecraft_range=[1.16.5, 1.17)
 forge_version=36.2.4
-forge_range=[36.1.0,)
+forge_range=[36.2.4,)
 fml_range=[36,)
 mappings_channel=official
 mappings_version=1.16.5

--- a/src/main/resources/META-INF/mods.toml
+++ b/src/main/resources/META-INF/mods.toml
@@ -41,7 +41,7 @@ MineColonies is a colony simulator within Minecraft! There are numerous types of
     # Does this dependency have to exist - if not, ordering below must be specified
     mandatory=true #mandatory
     # The version range of the dependency
-    versionRange="[36.1.0,)" #mandatory
+    versionRange="[36.2.4,)" #mandatory
     # An ordering relationship for the dependency - BEFORE or AFTER required if the relationship is not mandatory
     ordering="NONE"
     # Side this dependency is applied on - BOTH, CLIENT or SERVER


### PR DESCRIPTION
# Changes proposed in this pull request:
- Update Forge dependency version properly after #7764

Review please

I got out of the habit of checking this file because I thought it still had the automatic build.properties replacements, but it looks like that got rolled back to manual updates at some point...