### PR TITLE
Add excluded_food tag for food excluded from the restaurant by default

### DIFF
--- a/src/api/java/com/minecolonies/api/colony/buildings/modules/AbstractBuildingModule.java
+++ b/src/api/java/com/minecolonies/api/colony/buildings/modules/AbstractBuildingModule.java
@@ -21,7 +21,10 @@ public abstract class AbstractBuildingModule implements IBuildingModule
     public void markDirty()
     {
         this.isDirty = true;
-        building.markDirty();
+        if (building != null)
+        {
+            building.markDirty();
+        }
     }
 
     @Override

--- a/src/api/java/com/minecolonies/api/colony/buildings/modules/IItemListModule.java
+++ b/src/api/java/com/minecolonies/api/colony/buildings/modules/IItemListModule.java
@@ -45,9 +45,14 @@ public interface IItemListModule
     String getListIdentifier();
 
     /**
-     * Clear all in the list to reset to default.
+     * Clear all in the list.
      */
     void clearItems();
+
+    /**
+     * Reset to defaults (usually but not necessarily the same as {@link #clearItems()}).
+     */
+    void resetToDefaults();
 
     /**
      * Get the unique id of this module.

--- a/src/api/java/com/minecolonies/api/items/ModTags.java
+++ b/src/api/java/com/minecolonies/api/items/ModTags.java
@@ -1,12 +1,12 @@
 package com.minecolonies.api.items;
 
-import java.util.HashMap;
-import java.util.Map;
-
 import net.minecraft.block.Block;
 import net.minecraft.entity.EntityType;
 import net.minecraft.item.Item;
 import net.minecraft.tags.ITag;
+
+import java.util.HashMap;
+import java.util.Map;
 
 public class ModTags
 {
@@ -30,6 +30,7 @@ public class ModTags
     public static ITag<Item> meshes;
 
     public static ITag<Item> floristFlowers;
+    public static ITag<Item> excludedFood;
 
     public static ITag<EntityType<?>> hostile;
 

--- a/src/api/java/com/minecolonies/api/util/constant/TagConstants.java
+++ b/src/api/java/com/minecolonies/api/util/constant/TagConstants.java
@@ -12,6 +12,7 @@ public final class TagConstants
     public static final ResourceLocation CONCRETE_BLOCK  = new ResourceLocation(MOD_ID, "concrete");
     public static final ResourceLocation PATHING_BLOCKS = new ResourceLocation(MOD_ID, "pathblocks");
     public static final ResourceLocation FLORIST_FLOWERS = new ResourceLocation(MOD_ID, "florist_flowers");
+    public static final ResourceLocation EXCLUDED_FOOD = new ResourceLocation(MOD_ID, "excluded_food");
     public static final ResourceLocation ORECHANCEBLOCKS = new ResourceLocation(MOD_ID, "orechanceblocks");
     public static final ResourceLocation COLONYPROTECTIONEXCEPTION = new ResourceLocation(MOD_ID, "protectionexception");
     public static final ResourceLocation FUNGI = new ResourceLocation(MOD_ID, "fungi");

--- a/src/main/java/com/minecolonies/apiimp/initializer/ModBuildingsInitializer.java
+++ b/src/main/java/com/minecolonies/apiimp/initializer/ModBuildingsInitializer.java
@@ -172,7 +172,7 @@ public final class ModBuildingsInitializer
                               .addBuildingModuleProducer(FurnaceUserModule::new)
                               .addBuildingModuleProducer(() -> new ItemListModule(FUEL_LIST), () -> () -> new ItemListModuleView(FUEL_LIST, COM_MINECOLONIES_REQUESTS_BURNABLE, false,
                                 (buildingView) -> IColonyManager.getInstance().getCompatibilityManager().getFuel()))
-                              .addBuildingModuleProducer(() -> new ItemListModule(FOOD_EXCLUSION_LIST), () -> () -> new ItemListModuleView(FOOD_EXCLUSION_LIST, COM_MINECOLONIES_REQUESTS_FOOD, true,
+                              .addBuildingModuleProducer(() -> new ItemListModule(FOOD_EXCLUSION_LIST).onResetToDefaults(BuildingCook::onResetFoodExclusionList), () -> () -> new ItemListModuleView(FOOD_EXCLUSION_LIST, COM_MINECOLONIES_REQUESTS_FOOD, true,
                                 (buildingView) -> IColonyManager.getInstance().getCompatibilityManager().getEdibles()))
                               .addBuildingModuleViewProducer(() -> CrafterTaskModuleView::new)
                               .createBuildingEntry();

--- a/src/main/java/com/minecolonies/apiimp/initializer/ModTagsInitializer.java
+++ b/src/main/java/com/minecolonies/apiimp/initializer/ModTagsInitializer.java
@@ -53,6 +53,7 @@ public class ModTagsInitializer
         ModTags.concreteBlock = getBlockTags(CONCRETE_BLOCK, supplier);
         ModTags.pathingBlocks = getBlockTags(PATHING_BLOCKS, supplier);
         ModTags.floristFlowers = getItemTags(FLORIST_FLOWERS, supplier);
+        ModTags.excludedFood = getItemTags(EXCLUDED_FOOD, supplier);
         ModTags.fungi = getItemTags(FUNGI, supplier);
         ModTags.meshes = getItemTags(MESHES, supplier);
         ModTags.oreChanceBlocks = getBlockTags(ORECHANCEBLOCKS, supplier);

--- a/src/main/java/com/minecolonies/coremod/colony/buildings/workerbuildings/BuildingCook.java
+++ b/src/main/java/com/minecolonies/coremod/colony/buildings/workerbuildings/BuildingCook.java
@@ -6,7 +6,6 @@ import com.minecolonies.api.MinecoloniesAPIProxy;
 import com.minecolonies.api.colony.ICitizenData;
 import com.minecolonies.api.colony.IColony;
 import com.minecolonies.api.colony.IColonyView;
-
 import com.minecolonies.api.colony.jobs.ModJobs;
 import com.minecolonies.api.colony.jobs.registry.JobEntry;
 import com.minecolonies.api.colony.requestsystem.token.IToken;
@@ -14,6 +13,7 @@ import com.minecolonies.api.crafting.GenericRecipe;
 import com.minecolonies.api.crafting.IGenericRecipe;
 import com.minecolonies.api.crafting.IRecipeStorage;
 import com.minecolonies.api.crafting.ItemStorage;
+import com.minecolonies.api.items.ModTags;
 import com.minecolonies.api.util.CraftingUtils;
 import com.minecolonies.api.util.ItemStackUtils;
 import com.minecolonies.coremod.client.gui.huts.WindowHutWorkerModulePlaceholder;
@@ -25,6 +25,7 @@ import com.minecolonies.coremod.colony.buildings.modules.MinimumStockModule;
 import com.minecolonies.coremod.colony.buildings.views.AbstractBuildingView;
 import com.minecolonies.coremod.colony.jobs.AbstractJobCrafter;
 import com.minecolonies.coremod.util.FurnaceRecipes;
+import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
 import net.minecraft.item.Items;
 import net.minecraft.util.Tuple;
@@ -144,6 +145,20 @@ public class BuildingCook extends AbstractBuilding
     {
         super.onUpgradeComplete(newLevel);
         initTags = false;
+    }
+
+    /**
+     * On initial construction or reset request, excludes the tagged food by default.
+     *
+     * @param listModule The food exclusion module.
+     */
+    public static void onResetFoodExclusionList(final ItemListModule listModule)
+    {
+        listModule.clearItems();
+        for (final Item item : ModTags.excludedFood.getValues())
+        {
+            listModule.addItem(new ItemStorage(new ItemStack(item)));
+        }
     }
 
     /**

--- a/src/main/java/com/minecolonies/coremod/network/messages/server/BuildToolPasteMessage.java
+++ b/src/main/java/com/minecolonies/coremod/network/messages/server/BuildToolPasteMessage.java
@@ -1,6 +1,5 @@
 package com.minecolonies.coremod.network.messages.server;
 
-import com.ldtteam.structures.blueprints.v1.Blueprint;
 import com.ldtteam.structurize.management.StructureName;
 import com.ldtteam.structurize.management.Structures;
 import com.ldtteam.structurize.placement.StructurePlacementUtils;
@@ -324,18 +323,11 @@ public class BuildToolPasteMessage implements IMessage
                     building.getTileEntity().setColony(colony);
                 }
             }
-            String name = sn.toString();
-            name = name.substring(name.length() - 1);
 
-            try
-            {
-                final int level = Integer.parseInt(name);
-                building.setBuildingLevel(level);
-            }
-            catch (final NumberFormatException e)
-            {
-                Log.getLogger().warn("Couldn't parse the level.", e);
-            }
+            // Don't set the building level here; that will be set later in
+            // readSchematicDataFromNBT (provided that the schematic has
+            // TAG_BLUEPRINTDATA, but buildings always should).  This allows
+            // level 0 -> N upgrade events to properly be triggered on paste.
 
             building.setStyle(sn.getStyle());
 

--- a/src/main/java/com/minecolonies/coremod/network/messages/server/colony/building/ResetFilterableItemMessage.java
+++ b/src/main/java/com/minecolonies/coremod/network/messages/server/colony/building/ResetFilterableItemMessage.java
@@ -57,7 +57,7 @@ public class ResetFilterableItemMessage extends AbstractBuildingServerMessage<Ab
     {
         if (building.hasModule(ItemListModule.class))
         {
-            building.getModuleMatching(ItemListModule.class, m -> m.getId().equals(id)).clearItems();
+            building.getModuleMatching(ItemListModule.class, m -> m.getId().equals(id)).resetToDefaults();
         }
     }
 }

--- a/src/main/resources/data/minecolonies/tags/items/excluded_food.json
+++ b/src/main/resources/data/minecolonies/tags/items/excluded_food.json
@@ -1,0 +1,10 @@
+{
+  "replace": false,
+  "values": [
+    "minecraft:enchanted_golden_apple",
+    "minecraft:poisonous_potato",
+    "minecraft:rotten_flesh",
+    "minecolonies:chorus_bread",
+    "minecolonies:golden_bread"
+  ]
+}


### PR DESCRIPTION
Closes #7804

# Changes proposed in this pull request:
- Adds `excluded_food` tag.  Foods in this list will be disabled by default in newly-constructed restaurants, but still appear in the list and can be manually enabled if desired.  Existing and upgraded restaurants are unaffected.
- Sets most of the unhealthy vanilla foods and the expensive Minecolonies breads to excluded.  (Golden and Chorus bread are out; Milky and Sweet bread are in.  Golden apples are still in, but enchanted golden apples are out.)
- Provides an easy mechanism for other huts to have custom defaults different from "clear everything".
- Changes the creative paste to trigger an `onUpgradeComplete` 0 -> N rather than N -> N (was needed by an earlier version of this code; not actually needed by the final version but seemed like a good idea anyway so left it in).
  - Noticed but not investigated: `onUpgradeComplete` gets called twice for creative paste.
- Noticed in code review but not changed: `IItemListModule` is almost entirely unused; it should probably either be removed or used more.

Review please
