### PR TITLE
Fix following guards idling on player death

### DIFF
--- a/src/main/java/com/minecolonies/coremod/colony/buildings/AbstractBuildingGuards.java
+++ b/src/main/java/com/minecolonies/coremod/colony/buildings/AbstractBuildingGuards.java
@@ -531,7 +531,7 @@ public abstract class AbstractBuildingGuards extends AbstractBuilding implements
     public BlockPos getPositionToFollow()
     {
         PlayerEntity followPlayer = getPlayerFromUUID(followPlayerUUID, this.colony.getWorld());
-        if (getSetting(GUARD_TASK).getValue().equals(GuardTaskSetting.FOLLOW) && followPlayer != null)
+        if (getSetting(GUARD_TASK).getValue().equals(GuardTaskSetting.FOLLOW) && followPlayer != null && followPlayer.level.dimension() == this.colony.getDimension())
         {
             return new BlockPos(followPlayer.position());
         }

--- a/src/main/java/com/minecolonies/coremod/colony/buildings/AbstractBuildingGuards.java
+++ b/src/main/java/com/minecolonies/coremod/colony/buildings/AbstractBuildingGuards.java
@@ -49,6 +49,7 @@ import java.util.*;
 import static com.minecolonies.api.research.util.ResearchConstants.ARCHER_USE_ARROWS;
 import static com.minecolonies.api.util.constant.CitizenConstants.*;
 import static com.minecolonies.api.util.constant.ToolLevelConstants.TOOL_LEVEL_WOOD_OR_GOLD;
+import static com.minecolonies.coremod.util.ServerUtils.getPlayerFromUUID;
 
 /**
  * Abstract class for Guard huts.
@@ -115,9 +116,9 @@ public abstract class AbstractBuildingGuards extends AbstractBuilding implements
     protected List<BlockPos> patrolTargets = new ArrayList<>();
 
     /**
-     * The player the guard has been set to follow.
+     * The UUID of the player the guard has been set to follow.
      */
-    private PlayerEntity followPlayer;
+    private UUID followPlayerUUID;
 
     /**
      * The location the guard has been set to rally to.
@@ -290,7 +291,7 @@ public abstract class AbstractBuildingGuards extends AbstractBuilding implements
     @Nullable
     public PlayerEntity getPlayerToFollowOrRally()
     {
-        return rallyLocation != null && rallyLocation instanceof EntityLocation ? ((EntityLocation) rallyLocation).getPlayerEntity() : followPlayer;
+        return rallyLocation != null && rallyLocation instanceof EntityLocation ? ((EntityLocation) rallyLocation).getPlayerEntity() : getPlayerFromUUID(followPlayerUUID, this.colony.getWorld());
     }
 
     /**
@@ -529,6 +530,7 @@ public abstract class AbstractBuildingGuards extends AbstractBuilding implements
     @Override
     public BlockPos getPositionToFollow()
     {
+        PlayerEntity followPlayer = getPlayerFromUUID(followPlayerUUID, this.colony.getWorld());
         if (getSetting(GUARD_TASK).getValue().equals(GuardTaskSetting.FOLLOW) && followPlayer != null)
         {
             return new BlockPos(followPlayer.position());
@@ -616,7 +618,7 @@ public abstract class AbstractBuildingGuards extends AbstractBuilding implements
     @Override
     public void setPlayerToFollow(final PlayerEntity player)
     {
-        this.followPlayer = player;
+        this.followPlayerUUID = player.getUUID();
 
         for (final ICitizenData iCitizenData : getAllAssignedCitizen())
         {


### PR DESCRIPTION
Prior to this, guards that were set to follow the player from their building's hut block would stop following the player and instead idle around the player's spawn if the player died.

The problem was that the PlayerEntity object of the player to follow before and after dying was not the same and it wasn't null. It seems like the old PlayerEntity is sent to the player's spawn instead of being deleted while the player is given a new PlayerEntity to control. This makes the building guards refer to the wrong entity.

This fix works by keeping track of the player's UUID (which doesn't change after death) and resolving that into the correct PlayerEntity object when needed.

Closes #
Closes #
Closes #

# Changes proposed in this pull request:
- Make AbstractBuildingGuards store the UUID of the player to follow instead of PlayerEntity, then get the correct PlayerEntity object when needed
-
-

Review please
