### PR TITLE
Hut block as anchor in decoration

### DIFF
--- a/src/main/java/com/minecolonies/coremod/client/gui/huts/WindowHutCrusherModule.java
+++ b/src/main/java/com/minecolonies/coremod/client/gui/huts/WindowHutCrusherModule.java
@@ -45,7 +45,7 @@ public class WindowHutCrusherModule extends AbstractWindowWorkerModuleBuilding<B
     /**
      * Constructor for the window of the miner hut.
      *
-     * @param building {@link BuildingMiner.View}.
+     * @param building {@link BuildingCrusher.View}.
      */
     public WindowHutCrusherModule(final BuildingCrusher.View building)
     {

--- a/src/main/java/com/minecolonies/coremod/client/gui/modules/FarmerFieldsModuleWindow.java
+++ b/src/main/java/com/minecolonies/coremod/client/gui/modules/FarmerFieldsModuleWindow.java
@@ -113,7 +113,7 @@ public class FarmerFieldsModuleWindow extends AbstractModuleWindow
     /**
      * Constructor for the window of the farmer.
      *
-     * @param building {@link BuildingFarmer.View}.
+     * @param moduleView {@link FarmerFieldModuleView}.
      */
     public FarmerFieldsModuleWindow(final IBuildingView building, final FarmerFieldModuleView moduleView)
     {

--- a/src/main/java/com/minecolonies/coremod/client/gui/modules/GraveyardManagementWindow.java
+++ b/src/main/java/com/minecolonies/coremod/client/gui/modules/GraveyardManagementWindow.java
@@ -72,7 +72,7 @@ public class GraveyardManagementWindow extends AbstractModuleWindow
     /**
      * Constructor for the window of the graveyard.
      *
-     * @param building {@link BuildingGraveyard.View}.
+     * @param moduleView {@link GraveyardManagementModuleView}.
      */
     public GraveyardManagementWindow(final IBuildingView building, GraveyardManagementModuleView moduleView)
     {

--- a/src/main/java/com/minecolonies/coremod/client/gui/modules/WindowHutMinerModule.java
+++ b/src/main/java/com/minecolonies/coremod/client/gui/modules/WindowHutMinerModule.java
@@ -41,7 +41,7 @@ public class WindowHutMinerModule extends AbstractModuleWindow
     /**
      * Constructor for the window of the miner hut.
      *
-     * @param building {@link BuildingMiner.View}.
+     * @param moduleView {@link MinerLevelManagementModuleView}.
      */
     public WindowHutMinerModule(final IBuildingView building, final MinerLevelManagementModuleView moduleView)
     {

--- a/src/main/java/com/minecolonies/coremod/client/gui/modules/WindowMineGuardModule.java
+++ b/src/main/java/com/minecolonies/coremod/client/gui/modules/WindowMineGuardModule.java
@@ -36,7 +36,7 @@ public class WindowMineGuardModule  extends AbstractModuleWindow
     /**
      * Constructor for the window of the miner hut.
      *
-     * @param building {@link BuildingMiner.View}.
+     * @param building {@link IBuildingView}.
      */
     public WindowMineGuardModule(final IBuildingView building)
     {

--- a/src/main/java/com/minecolonies/coremod/entity/ai/basic/AbstractEntityAIStructure.java
+++ b/src/main/java/com/minecolonies/coremod/entity/ai/basic/AbstractEntityAIStructure.java
@@ -98,7 +98,8 @@ public abstract class AbstractEntityAIStructure<J extends AbstractJobStructure<?
 
         return worldState.getBlock() instanceof IBuilderUndestroyable
                  || worldState.getBlock() == Blocks.BEDROCK
-                 || (info.getBlockInfo().getState().getBlock() instanceof AbstractBlockHut && handler.getWorldPos().equals(worldPos));
+                 || (info.getBlockInfo().getState().getBlock() instanceof AbstractBlockHut && handler.getWorldPos().equals(worldPos)
+                       && worldState.getBlock() instanceof AbstractBlockHut);
     };
 
     /**


### PR DESCRIPTION
# Changes proposed in this pull request:
- Let a builder place a hut block on the anchor position of a decoration.
- This fixes the netherguard decoration of fortress, and allows custom building schematics be used as parent buildings in a cluster.
- Solve the javadoc issues, that lets the build server think the build failed the last week(s).

At the moment, it seems like the hut that gets placed try to find their schematics in the "wooden" style.
I tested it with Decorations -> fortressalternative -> netherguard1, and it was searching for schematics/wooden/netherguard2.
I haven't found yet why it defaults to wooden there and what can be done to correct that.

Review please
