### PR TITLE
Fix mojang banner loot tables

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -78,3 +78,5 @@ usesCrowdInTranslationManagement=true
 crowdInDownloadDirectory=src/main/resources/assets/minecolonies/lang
 usesCrowdInBuildingWithFilteredBranches=true
 usesCrowdInUploadWithFilteredBranches=true
+
+additionalModsInDataGen=structurize

--- a/src/datagen/generated/minecolonies/data/minecraft/loot_tables/blocks/black_banner.json
+++ b/src/datagen/generated/minecolonies/data/minecraft/loot_tables/blocks/black_banner.json
@@ -1,0 +1,42 @@
+{
+  "type": "minecraft:block",
+  "pools": [
+    {
+      "rolls": 1.0,
+      "bonus_rolls": 0.0,
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "minecraft:black_banner"
+        }
+      ],
+      "conditions": [
+        {
+          "condition": "minecraft:survives_explosion"
+        }
+      ],
+      "functions": [
+        {
+          "function": "minecraft:copy_name",
+          "source": "block_entity"
+        },
+        {
+          "function": "minecraft:copy_nbt",
+          "source": "block_entity",
+          "ops": [
+            {
+              "source": "Patterns",
+              "target": "BlockEntityTag.Patterns",
+              "op": "replace"
+            },
+            {
+              "source": "id",
+              "target": "BlockEntityTag.id",
+              "op": "replace"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/src/datagen/generated/minecolonies/data/minecraft/loot_tables/blocks/black_wall_banner.json
+++ b/src/datagen/generated/minecolonies/data/minecraft/loot_tables/blocks/black_wall_banner.json
@@ -1,0 +1,42 @@
+{
+  "type": "minecraft:block",
+  "pools": [
+    {
+      "rolls": 1.0,
+      "bonus_rolls": 0.0,
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "minecraft:black_banner"
+        }
+      ],
+      "conditions": [
+        {
+          "condition": "minecraft:survives_explosion"
+        }
+      ],
+      "functions": [
+        {
+          "function": "minecraft:copy_name",
+          "source": "block_entity"
+        },
+        {
+          "function": "minecraft:copy_nbt",
+          "source": "block_entity",
+          "ops": [
+            {
+              "source": "Patterns",
+              "target": "BlockEntityTag.Patterns",
+              "op": "replace"
+            },
+            {
+              "source": "id",
+              "target": "BlockEntityTag.id",
+              "op": "replace"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/src/datagen/generated/minecolonies/data/minecraft/loot_tables/blocks/blue_banner.json
+++ b/src/datagen/generated/minecolonies/data/minecraft/loot_tables/blocks/blue_banner.json
@@ -1,0 +1,42 @@
+{
+  "type": "minecraft:block",
+  "pools": [
+    {
+      "rolls": 1.0,
+      "bonus_rolls": 0.0,
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "minecraft:blue_banner"
+        }
+      ],
+      "conditions": [
+        {
+          "condition": "minecraft:survives_explosion"
+        }
+      ],
+      "functions": [
+        {
+          "function": "minecraft:copy_name",
+          "source": "block_entity"
+        },
+        {
+          "function": "minecraft:copy_nbt",
+          "source": "block_entity",
+          "ops": [
+            {
+              "source": "Patterns",
+              "target": "BlockEntityTag.Patterns",
+              "op": "replace"
+            },
+            {
+              "source": "id",
+              "target": "BlockEntityTag.id",
+              "op": "replace"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/src/datagen/generated/minecolonies/data/minecraft/loot_tables/blocks/blue_wall_banner.json
+++ b/src/datagen/generated/minecolonies/data/minecraft/loot_tables/blocks/blue_wall_banner.json
@@ -1,0 +1,42 @@
+{
+  "type": "minecraft:block",
+  "pools": [
+    {
+      "rolls": 1.0,
+      "bonus_rolls": 0.0,
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "minecraft:blue_banner"
+        }
+      ],
+      "conditions": [
+        {
+          "condition": "minecraft:survives_explosion"
+        }
+      ],
+      "functions": [
+        {
+          "function": "minecraft:copy_name",
+          "source": "block_entity"
+        },
+        {
+          "function": "minecraft:copy_nbt",
+          "source": "block_entity",
+          "ops": [
+            {
+              "source": "Patterns",
+              "target": "BlockEntityTag.Patterns",
+              "op": "replace"
+            },
+            {
+              "source": "id",
+              "target": "BlockEntityTag.id",
+              "op": "replace"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/src/datagen/generated/minecolonies/data/minecraft/loot_tables/blocks/brown_banner.json
+++ b/src/datagen/generated/minecolonies/data/minecraft/loot_tables/blocks/brown_banner.json
@@ -1,0 +1,42 @@
+{
+  "type": "minecraft:block",
+  "pools": [
+    {
+      "rolls": 1.0,
+      "bonus_rolls": 0.0,
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "minecraft:brown_banner"
+        }
+      ],
+      "conditions": [
+        {
+          "condition": "minecraft:survives_explosion"
+        }
+      ],
+      "functions": [
+        {
+          "function": "minecraft:copy_name",
+          "source": "block_entity"
+        },
+        {
+          "function": "minecraft:copy_nbt",
+          "source": "block_entity",
+          "ops": [
+            {
+              "source": "Patterns",
+              "target": "BlockEntityTag.Patterns",
+              "op": "replace"
+            },
+            {
+              "source": "id",
+              "target": "BlockEntityTag.id",
+              "op": "replace"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/src/datagen/generated/minecolonies/data/minecraft/loot_tables/blocks/brown_wall_banner.json
+++ b/src/datagen/generated/minecolonies/data/minecraft/loot_tables/blocks/brown_wall_banner.json
@@ -1,0 +1,42 @@
+{
+  "type": "minecraft:block",
+  "pools": [
+    {
+      "rolls": 1.0,
+      "bonus_rolls": 0.0,
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "minecraft:brown_banner"
+        }
+      ],
+      "conditions": [
+        {
+          "condition": "minecraft:survives_explosion"
+        }
+      ],
+      "functions": [
+        {
+          "function": "minecraft:copy_name",
+          "source": "block_entity"
+        },
+        {
+          "function": "minecraft:copy_nbt",
+          "source": "block_entity",
+          "ops": [
+            {
+              "source": "Patterns",
+              "target": "BlockEntityTag.Patterns",
+              "op": "replace"
+            },
+            {
+              "source": "id",
+              "target": "BlockEntityTag.id",
+              "op": "replace"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/src/datagen/generated/minecolonies/data/minecraft/loot_tables/blocks/cyan_banner.json
+++ b/src/datagen/generated/minecolonies/data/minecraft/loot_tables/blocks/cyan_banner.json
@@ -1,0 +1,42 @@
+{
+  "type": "minecraft:block",
+  "pools": [
+    {
+      "rolls": 1.0,
+      "bonus_rolls": 0.0,
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "minecraft:cyan_banner"
+        }
+      ],
+      "conditions": [
+        {
+          "condition": "minecraft:survives_explosion"
+        }
+      ],
+      "functions": [
+        {
+          "function": "minecraft:copy_name",
+          "source": "block_entity"
+        },
+        {
+          "function": "minecraft:copy_nbt",
+          "source": "block_entity",
+          "ops": [
+            {
+              "source": "Patterns",
+              "target": "BlockEntityTag.Patterns",
+              "op": "replace"
+            },
+            {
+              "source": "id",
+              "target": "BlockEntityTag.id",
+              "op": "replace"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/src/datagen/generated/minecolonies/data/minecraft/loot_tables/blocks/cyan_wall_banner.json
+++ b/src/datagen/generated/minecolonies/data/minecraft/loot_tables/blocks/cyan_wall_banner.json
@@ -1,0 +1,42 @@
+{
+  "type": "minecraft:block",
+  "pools": [
+    {
+      "rolls": 1.0,
+      "bonus_rolls": 0.0,
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "minecraft:cyan_banner"
+        }
+      ],
+      "conditions": [
+        {
+          "condition": "minecraft:survives_explosion"
+        }
+      ],
+      "functions": [
+        {
+          "function": "minecraft:copy_name",
+          "source": "block_entity"
+        },
+        {
+          "function": "minecraft:copy_nbt",
+          "source": "block_entity",
+          "ops": [
+            {
+              "source": "Patterns",
+              "target": "BlockEntityTag.Patterns",
+              "op": "replace"
+            },
+            {
+              "source": "id",
+              "target": "BlockEntityTag.id",
+              "op": "replace"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/src/datagen/generated/minecolonies/data/minecraft/loot_tables/blocks/gray_banner.json
+++ b/src/datagen/generated/minecolonies/data/minecraft/loot_tables/blocks/gray_banner.json
@@ -1,0 +1,42 @@
+{
+  "type": "minecraft:block",
+  "pools": [
+    {
+      "rolls": 1.0,
+      "bonus_rolls": 0.0,
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "minecraft:gray_banner"
+        }
+      ],
+      "conditions": [
+        {
+          "condition": "minecraft:survives_explosion"
+        }
+      ],
+      "functions": [
+        {
+          "function": "minecraft:copy_name",
+          "source": "block_entity"
+        },
+        {
+          "function": "minecraft:copy_nbt",
+          "source": "block_entity",
+          "ops": [
+            {
+              "source": "Patterns",
+              "target": "BlockEntityTag.Patterns",
+              "op": "replace"
+            },
+            {
+              "source": "id",
+              "target": "BlockEntityTag.id",
+              "op": "replace"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/src/datagen/generated/minecolonies/data/minecraft/loot_tables/blocks/gray_wall_banner.json
+++ b/src/datagen/generated/minecolonies/data/minecraft/loot_tables/blocks/gray_wall_banner.json
@@ -1,0 +1,42 @@
+{
+  "type": "minecraft:block",
+  "pools": [
+    {
+      "rolls": 1.0,
+      "bonus_rolls": 0.0,
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "minecraft:gray_banner"
+        }
+      ],
+      "conditions": [
+        {
+          "condition": "minecraft:survives_explosion"
+        }
+      ],
+      "functions": [
+        {
+          "function": "minecraft:copy_name",
+          "source": "block_entity"
+        },
+        {
+          "function": "minecraft:copy_nbt",
+          "source": "block_entity",
+          "ops": [
+            {
+              "source": "Patterns",
+              "target": "BlockEntityTag.Patterns",
+              "op": "replace"
+            },
+            {
+              "source": "id",
+              "target": "BlockEntityTag.id",
+              "op": "replace"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/src/datagen/generated/minecolonies/data/minecraft/loot_tables/blocks/green_banner.json
+++ b/src/datagen/generated/minecolonies/data/minecraft/loot_tables/blocks/green_banner.json
@@ -1,0 +1,42 @@
+{
+  "type": "minecraft:block",
+  "pools": [
+    {
+      "rolls": 1.0,
+      "bonus_rolls": 0.0,
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "minecraft:green_banner"
+        }
+      ],
+      "conditions": [
+        {
+          "condition": "minecraft:survives_explosion"
+        }
+      ],
+      "functions": [
+        {
+          "function": "minecraft:copy_name",
+          "source": "block_entity"
+        },
+        {
+          "function": "minecraft:copy_nbt",
+          "source": "block_entity",
+          "ops": [
+            {
+              "source": "Patterns",
+              "target": "BlockEntityTag.Patterns",
+              "op": "replace"
+            },
+            {
+              "source": "id",
+              "target": "BlockEntityTag.id",
+              "op": "replace"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/src/datagen/generated/minecolonies/data/minecraft/loot_tables/blocks/green_wall_banner.json
+++ b/src/datagen/generated/minecolonies/data/minecraft/loot_tables/blocks/green_wall_banner.json
@@ -1,0 +1,42 @@
+{
+  "type": "minecraft:block",
+  "pools": [
+    {
+      "rolls": 1.0,
+      "bonus_rolls": 0.0,
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "minecraft:green_banner"
+        }
+      ],
+      "conditions": [
+        {
+          "condition": "minecraft:survives_explosion"
+        }
+      ],
+      "functions": [
+        {
+          "function": "minecraft:copy_name",
+          "source": "block_entity"
+        },
+        {
+          "function": "minecraft:copy_nbt",
+          "source": "block_entity",
+          "ops": [
+            {
+              "source": "Patterns",
+              "target": "BlockEntityTag.Patterns",
+              "op": "replace"
+            },
+            {
+              "source": "id",
+              "target": "BlockEntityTag.id",
+              "op": "replace"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/src/datagen/generated/minecolonies/data/minecraft/loot_tables/blocks/light_blue_banner.json
+++ b/src/datagen/generated/minecolonies/data/minecraft/loot_tables/blocks/light_blue_banner.json
@@ -1,0 +1,42 @@
+{
+  "type": "minecraft:block",
+  "pools": [
+    {
+      "rolls": 1.0,
+      "bonus_rolls": 0.0,
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "minecraft:light_blue_banner"
+        }
+      ],
+      "conditions": [
+        {
+          "condition": "minecraft:survives_explosion"
+        }
+      ],
+      "functions": [
+        {
+          "function": "minecraft:copy_name",
+          "source": "block_entity"
+        },
+        {
+          "function": "minecraft:copy_nbt",
+          "source": "block_entity",
+          "ops": [
+            {
+              "source": "Patterns",
+              "target": "BlockEntityTag.Patterns",
+              "op": "replace"
+            },
+            {
+              "source": "id",
+              "target": "BlockEntityTag.id",
+              "op": "replace"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/src/datagen/generated/minecolonies/data/minecraft/loot_tables/blocks/light_blue_wall_banner.json
+++ b/src/datagen/generated/minecolonies/data/minecraft/loot_tables/blocks/light_blue_wall_banner.json
@@ -1,0 +1,42 @@
+{
+  "type": "minecraft:block",
+  "pools": [
+    {
+      "rolls": 1.0,
+      "bonus_rolls": 0.0,
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "minecraft:light_blue_banner"
+        }
+      ],
+      "conditions": [
+        {
+          "condition": "minecraft:survives_explosion"
+        }
+      ],
+      "functions": [
+        {
+          "function": "minecraft:copy_name",
+          "source": "block_entity"
+        },
+        {
+          "function": "minecraft:copy_nbt",
+          "source": "block_entity",
+          "ops": [
+            {
+              "source": "Patterns",
+              "target": "BlockEntityTag.Patterns",
+              "op": "replace"
+            },
+            {
+              "source": "id",
+              "target": "BlockEntityTag.id",
+              "op": "replace"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/src/datagen/generated/minecolonies/data/minecraft/loot_tables/blocks/light_gray_banner.json
+++ b/src/datagen/generated/minecolonies/data/minecraft/loot_tables/blocks/light_gray_banner.json
@@ -1,0 +1,42 @@
+{
+  "type": "minecraft:block",
+  "pools": [
+    {
+      "rolls": 1.0,
+      "bonus_rolls": 0.0,
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "minecraft:light_gray_banner"
+        }
+      ],
+      "conditions": [
+        {
+          "condition": "minecraft:survives_explosion"
+        }
+      ],
+      "functions": [
+        {
+          "function": "minecraft:copy_name",
+          "source": "block_entity"
+        },
+        {
+          "function": "minecraft:copy_nbt",
+          "source": "block_entity",
+          "ops": [
+            {
+              "source": "Patterns",
+              "target": "BlockEntityTag.Patterns",
+              "op": "replace"
+            },
+            {
+              "source": "id",
+              "target": "BlockEntityTag.id",
+              "op": "replace"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/src/datagen/generated/minecolonies/data/minecraft/loot_tables/blocks/light_gray_wall_banner.json
+++ b/src/datagen/generated/minecolonies/data/minecraft/loot_tables/blocks/light_gray_wall_banner.json
@@ -1,0 +1,42 @@
+{
+  "type": "minecraft:block",
+  "pools": [
+    {
+      "rolls": 1.0,
+      "bonus_rolls": 0.0,
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "minecraft:light_gray_banner"
+        }
+      ],
+      "conditions": [
+        {
+          "condition": "minecraft:survives_explosion"
+        }
+      ],
+      "functions": [
+        {
+          "function": "minecraft:copy_name",
+          "source": "block_entity"
+        },
+        {
+          "function": "minecraft:copy_nbt",
+          "source": "block_entity",
+          "ops": [
+            {
+              "source": "Patterns",
+              "target": "BlockEntityTag.Patterns",
+              "op": "replace"
+            },
+            {
+              "source": "id",
+              "target": "BlockEntityTag.id",
+              "op": "replace"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/src/datagen/generated/minecolonies/data/minecraft/loot_tables/blocks/lime_banner.json
+++ b/src/datagen/generated/minecolonies/data/minecraft/loot_tables/blocks/lime_banner.json
@@ -1,0 +1,42 @@
+{
+  "type": "minecraft:block",
+  "pools": [
+    {
+      "rolls": 1.0,
+      "bonus_rolls": 0.0,
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "minecraft:lime_banner"
+        }
+      ],
+      "conditions": [
+        {
+          "condition": "minecraft:survives_explosion"
+        }
+      ],
+      "functions": [
+        {
+          "function": "minecraft:copy_name",
+          "source": "block_entity"
+        },
+        {
+          "function": "minecraft:copy_nbt",
+          "source": "block_entity",
+          "ops": [
+            {
+              "source": "Patterns",
+              "target": "BlockEntityTag.Patterns",
+              "op": "replace"
+            },
+            {
+              "source": "id",
+              "target": "BlockEntityTag.id",
+              "op": "replace"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/src/datagen/generated/minecolonies/data/minecraft/loot_tables/blocks/lime_wall_banner.json
+++ b/src/datagen/generated/minecolonies/data/minecraft/loot_tables/blocks/lime_wall_banner.json
@@ -1,0 +1,42 @@
+{
+  "type": "minecraft:block",
+  "pools": [
+    {
+      "rolls": 1.0,
+      "bonus_rolls": 0.0,
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "minecraft:lime_banner"
+        }
+      ],
+      "conditions": [
+        {
+          "condition": "minecraft:survives_explosion"
+        }
+      ],
+      "functions": [
+        {
+          "function": "minecraft:copy_name",
+          "source": "block_entity"
+        },
+        {
+          "function": "minecraft:copy_nbt",
+          "source": "block_entity",
+          "ops": [
+            {
+              "source": "Patterns",
+              "target": "BlockEntityTag.Patterns",
+              "op": "replace"
+            },
+            {
+              "source": "id",
+              "target": "BlockEntityTag.id",
+              "op": "replace"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/src/datagen/generated/minecolonies/data/minecraft/loot_tables/blocks/magenta_banner.json
+++ b/src/datagen/generated/minecolonies/data/minecraft/loot_tables/blocks/magenta_banner.json
@@ -1,0 +1,42 @@
+{
+  "type": "minecraft:block",
+  "pools": [
+    {
+      "rolls": 1.0,
+      "bonus_rolls": 0.0,
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "minecraft:magenta_banner"
+        }
+      ],
+      "conditions": [
+        {
+          "condition": "minecraft:survives_explosion"
+        }
+      ],
+      "functions": [
+        {
+          "function": "minecraft:copy_name",
+          "source": "block_entity"
+        },
+        {
+          "function": "minecraft:copy_nbt",
+          "source": "block_entity",
+          "ops": [
+            {
+              "source": "Patterns",
+              "target": "BlockEntityTag.Patterns",
+              "op": "replace"
+            },
+            {
+              "source": "id",
+              "target": "BlockEntityTag.id",
+              "op": "replace"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/src/datagen/generated/minecolonies/data/minecraft/loot_tables/blocks/magenta_wall_banner.json
+++ b/src/datagen/generated/minecolonies/data/minecraft/loot_tables/blocks/magenta_wall_banner.json
@@ -1,0 +1,42 @@
+{
+  "type": "minecraft:block",
+  "pools": [
+    {
+      "rolls": 1.0,
+      "bonus_rolls": 0.0,
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "minecraft:magenta_banner"
+        }
+      ],
+      "conditions": [
+        {
+          "condition": "minecraft:survives_explosion"
+        }
+      ],
+      "functions": [
+        {
+          "function": "minecraft:copy_name",
+          "source": "block_entity"
+        },
+        {
+          "function": "minecraft:copy_nbt",
+          "source": "block_entity",
+          "ops": [
+            {
+              "source": "Patterns",
+              "target": "BlockEntityTag.Patterns",
+              "op": "replace"
+            },
+            {
+              "source": "id",
+              "target": "BlockEntityTag.id",
+              "op": "replace"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/src/datagen/generated/minecolonies/data/minecraft/loot_tables/blocks/orange_banner.json
+++ b/src/datagen/generated/minecolonies/data/minecraft/loot_tables/blocks/orange_banner.json
@@ -1,0 +1,42 @@
+{
+  "type": "minecraft:block",
+  "pools": [
+    {
+      "rolls": 1.0,
+      "bonus_rolls": 0.0,
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "minecraft:orange_banner"
+        }
+      ],
+      "conditions": [
+        {
+          "condition": "minecraft:survives_explosion"
+        }
+      ],
+      "functions": [
+        {
+          "function": "minecraft:copy_name",
+          "source": "block_entity"
+        },
+        {
+          "function": "minecraft:copy_nbt",
+          "source": "block_entity",
+          "ops": [
+            {
+              "source": "Patterns",
+              "target": "BlockEntityTag.Patterns",
+              "op": "replace"
+            },
+            {
+              "source": "id",
+              "target": "BlockEntityTag.id",
+              "op": "replace"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/src/datagen/generated/minecolonies/data/minecraft/loot_tables/blocks/orange_wall_banner.json
+++ b/src/datagen/generated/minecolonies/data/minecraft/loot_tables/blocks/orange_wall_banner.json
@@ -1,0 +1,42 @@
+{
+  "type": "minecraft:block",
+  "pools": [
+    {
+      "rolls": 1.0,
+      "bonus_rolls": 0.0,
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "minecraft:orange_banner"
+        }
+      ],
+      "conditions": [
+        {
+          "condition": "minecraft:survives_explosion"
+        }
+      ],
+      "functions": [
+        {
+          "function": "minecraft:copy_name",
+          "source": "block_entity"
+        },
+        {
+          "function": "minecraft:copy_nbt",
+          "source": "block_entity",
+          "ops": [
+            {
+              "source": "Patterns",
+              "target": "BlockEntityTag.Patterns",
+              "op": "replace"
+            },
+            {
+              "source": "id",
+              "target": "BlockEntityTag.id",
+              "op": "replace"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/src/datagen/generated/minecolonies/data/minecraft/loot_tables/blocks/pink_banner.json
+++ b/src/datagen/generated/minecolonies/data/minecraft/loot_tables/blocks/pink_banner.json
@@ -1,0 +1,42 @@
+{
+  "type": "minecraft:block",
+  "pools": [
+    {
+      "rolls": 1.0,
+      "bonus_rolls": 0.0,
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "minecraft:pink_banner"
+        }
+      ],
+      "conditions": [
+        {
+          "condition": "minecraft:survives_explosion"
+        }
+      ],
+      "functions": [
+        {
+          "function": "minecraft:copy_name",
+          "source": "block_entity"
+        },
+        {
+          "function": "minecraft:copy_nbt",
+          "source": "block_entity",
+          "ops": [
+            {
+              "source": "Patterns",
+              "target": "BlockEntityTag.Patterns",
+              "op": "replace"
+            },
+            {
+              "source": "id",
+              "target": "BlockEntityTag.id",
+              "op": "replace"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/src/datagen/generated/minecolonies/data/minecraft/loot_tables/blocks/pink_wall_banner.json
+++ b/src/datagen/generated/minecolonies/data/minecraft/loot_tables/blocks/pink_wall_banner.json
@@ -1,0 +1,42 @@
+{
+  "type": "minecraft:block",
+  "pools": [
+    {
+      "rolls": 1.0,
+      "bonus_rolls": 0.0,
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "minecraft:pink_banner"
+        }
+      ],
+      "conditions": [
+        {
+          "condition": "minecraft:survives_explosion"
+        }
+      ],
+      "functions": [
+        {
+          "function": "minecraft:copy_name",
+          "source": "block_entity"
+        },
+        {
+          "function": "minecraft:copy_nbt",
+          "source": "block_entity",
+          "ops": [
+            {
+              "source": "Patterns",
+              "target": "BlockEntityTag.Patterns",
+              "op": "replace"
+            },
+            {
+              "source": "id",
+              "target": "BlockEntityTag.id",
+              "op": "replace"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/src/datagen/generated/minecolonies/data/minecraft/loot_tables/blocks/purple_banner.json
+++ b/src/datagen/generated/minecolonies/data/minecraft/loot_tables/blocks/purple_banner.json
@@ -1,0 +1,42 @@
+{
+  "type": "minecraft:block",
+  "pools": [
+    {
+      "rolls": 1.0,
+      "bonus_rolls": 0.0,
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "minecraft:purple_banner"
+        }
+      ],
+      "conditions": [
+        {
+          "condition": "minecraft:survives_explosion"
+        }
+      ],
+      "functions": [
+        {
+          "function": "minecraft:copy_name",
+          "source": "block_entity"
+        },
+        {
+          "function": "minecraft:copy_nbt",
+          "source": "block_entity",
+          "ops": [
+            {
+              "source": "Patterns",
+              "target": "BlockEntityTag.Patterns",
+              "op": "replace"
+            },
+            {
+              "source": "id",
+              "target": "BlockEntityTag.id",
+              "op": "replace"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/src/datagen/generated/minecolonies/data/minecraft/loot_tables/blocks/purple_wall_banner.json
+++ b/src/datagen/generated/minecolonies/data/minecraft/loot_tables/blocks/purple_wall_banner.json
@@ -1,0 +1,42 @@
+{
+  "type": "minecraft:block",
+  "pools": [
+    {
+      "rolls": 1.0,
+      "bonus_rolls": 0.0,
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "minecraft:purple_banner"
+        }
+      ],
+      "conditions": [
+        {
+          "condition": "minecraft:survives_explosion"
+        }
+      ],
+      "functions": [
+        {
+          "function": "minecraft:copy_name",
+          "source": "block_entity"
+        },
+        {
+          "function": "minecraft:copy_nbt",
+          "source": "block_entity",
+          "ops": [
+            {
+              "source": "Patterns",
+              "target": "BlockEntityTag.Patterns",
+              "op": "replace"
+            },
+            {
+              "source": "id",
+              "target": "BlockEntityTag.id",
+              "op": "replace"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/src/datagen/generated/minecolonies/data/minecraft/loot_tables/blocks/red_banner.json
+++ b/src/datagen/generated/minecolonies/data/minecraft/loot_tables/blocks/red_banner.json
@@ -1,0 +1,42 @@
+{
+  "type": "minecraft:block",
+  "pools": [
+    {
+      "rolls": 1.0,
+      "bonus_rolls": 0.0,
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "minecraft:red_banner"
+        }
+      ],
+      "conditions": [
+        {
+          "condition": "minecraft:survives_explosion"
+        }
+      ],
+      "functions": [
+        {
+          "function": "minecraft:copy_name",
+          "source": "block_entity"
+        },
+        {
+          "function": "minecraft:copy_nbt",
+          "source": "block_entity",
+          "ops": [
+            {
+              "source": "Patterns",
+              "target": "BlockEntityTag.Patterns",
+              "op": "replace"
+            },
+            {
+              "source": "id",
+              "target": "BlockEntityTag.id",
+              "op": "replace"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/src/datagen/generated/minecolonies/data/minecraft/loot_tables/blocks/red_wall_banner.json
+++ b/src/datagen/generated/minecolonies/data/minecraft/loot_tables/blocks/red_wall_banner.json
@@ -1,0 +1,42 @@
+{
+  "type": "minecraft:block",
+  "pools": [
+    {
+      "rolls": 1.0,
+      "bonus_rolls": 0.0,
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "minecraft:red_banner"
+        }
+      ],
+      "conditions": [
+        {
+          "condition": "minecraft:survives_explosion"
+        }
+      ],
+      "functions": [
+        {
+          "function": "minecraft:copy_name",
+          "source": "block_entity"
+        },
+        {
+          "function": "minecraft:copy_nbt",
+          "source": "block_entity",
+          "ops": [
+            {
+              "source": "Patterns",
+              "target": "BlockEntityTag.Patterns",
+              "op": "replace"
+            },
+            {
+              "source": "id",
+              "target": "BlockEntityTag.id",
+              "op": "replace"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/src/datagen/generated/minecolonies/data/minecraft/loot_tables/blocks/white_banner.json
+++ b/src/datagen/generated/minecolonies/data/minecraft/loot_tables/blocks/white_banner.json
@@ -1,0 +1,42 @@
+{
+  "type": "minecraft:block",
+  "pools": [
+    {
+      "rolls": 1.0,
+      "bonus_rolls": 0.0,
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "minecraft:white_banner"
+        }
+      ],
+      "conditions": [
+        {
+          "condition": "minecraft:survives_explosion"
+        }
+      ],
+      "functions": [
+        {
+          "function": "minecraft:copy_name",
+          "source": "block_entity"
+        },
+        {
+          "function": "minecraft:copy_nbt",
+          "source": "block_entity",
+          "ops": [
+            {
+              "source": "Patterns",
+              "target": "BlockEntityTag.Patterns",
+              "op": "replace"
+            },
+            {
+              "source": "id",
+              "target": "BlockEntityTag.id",
+              "op": "replace"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/src/datagen/generated/minecolonies/data/minecraft/loot_tables/blocks/white_wall_banner.json
+++ b/src/datagen/generated/minecolonies/data/minecraft/loot_tables/blocks/white_wall_banner.json
@@ -1,0 +1,42 @@
+{
+  "type": "minecraft:block",
+  "pools": [
+    {
+      "rolls": 1.0,
+      "bonus_rolls": 0.0,
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "minecraft:white_banner"
+        }
+      ],
+      "conditions": [
+        {
+          "condition": "minecraft:survives_explosion"
+        }
+      ],
+      "functions": [
+        {
+          "function": "minecraft:copy_name",
+          "source": "block_entity"
+        },
+        {
+          "function": "minecraft:copy_nbt",
+          "source": "block_entity",
+          "ops": [
+            {
+              "source": "Patterns",
+              "target": "BlockEntityTag.Patterns",
+              "op": "replace"
+            },
+            {
+              "source": "id",
+              "target": "BlockEntityTag.id",
+              "op": "replace"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/src/datagen/generated/minecolonies/data/minecraft/loot_tables/blocks/yellow_banner.json
+++ b/src/datagen/generated/minecolonies/data/minecraft/loot_tables/blocks/yellow_banner.json
@@ -1,0 +1,42 @@
+{
+  "type": "minecraft:block",
+  "pools": [
+    {
+      "rolls": 1.0,
+      "bonus_rolls": 0.0,
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "minecraft:yellow_banner"
+        }
+      ],
+      "conditions": [
+        {
+          "condition": "minecraft:survives_explosion"
+        }
+      ],
+      "functions": [
+        {
+          "function": "minecraft:copy_name",
+          "source": "block_entity"
+        },
+        {
+          "function": "minecraft:copy_nbt",
+          "source": "block_entity",
+          "ops": [
+            {
+              "source": "Patterns",
+              "target": "BlockEntityTag.Patterns",
+              "op": "replace"
+            },
+            {
+              "source": "id",
+              "target": "BlockEntityTag.id",
+              "op": "replace"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/src/datagen/generated/minecolonies/data/minecraft/loot_tables/blocks/yellow_wall_banner.json
+++ b/src/datagen/generated/minecolonies/data/minecraft/loot_tables/blocks/yellow_wall_banner.json
@@ -1,0 +1,42 @@
+{
+  "type": "minecraft:block",
+  "pools": [
+    {
+      "rolls": 1.0,
+      "bonus_rolls": 0.0,
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "minecraft:yellow_banner"
+        }
+      ],
+      "conditions": [
+        {
+          "condition": "minecraft:survives_explosion"
+        }
+      ],
+      "functions": [
+        {
+          "function": "minecraft:copy_name",
+          "source": "block_entity"
+        },
+        {
+          "function": "minecraft:copy_nbt",
+          "source": "block_entity",
+          "ops": [
+            {
+              "source": "Patterns",
+              "target": "BlockEntityTag.Patterns",
+              "op": "replace"
+            },
+            {
+              "source": "id",
+              "target": "BlockEntityTag.id",
+              "op": "replace"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/src/main/java/com/minecolonies/coremod/generation/defaults/DefaultBlockLootTableProvider.java
+++ b/src/main/java/com/minecolonies/coremod/generation/defaults/DefaultBlockLootTableProvider.java
@@ -7,13 +7,16 @@ import com.minecolonies.coremod.generation.SimpleLootTableProvider;
 import net.minecraft.data.DataGenerator;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.level.block.Block;
+import net.minecraft.world.level.block.Blocks;
 import net.minecraft.world.level.storage.loot.LootPool;
 import net.minecraft.world.level.storage.loot.LootTable;
 import net.minecraft.world.level.storage.loot.entries.LootItem;
 import net.minecraft.world.level.storage.loot.entries.LootPoolSingletonContainer;
 import net.minecraft.world.level.storage.loot.functions.CopyNameFunction;
+import net.minecraft.world.level.storage.loot.functions.CopyNbtFunction;
 import net.minecraft.world.level.storage.loot.parameters.LootContextParamSets;
 import net.minecraft.world.level.storage.loot.predicates.ExplosionCondition;
+import net.minecraft.world.level.storage.loot.providers.nbt.ContextNbtProvider;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.Arrays;
@@ -50,6 +53,40 @@ public class DefaultBlockLootTableProvider extends SimpleLootTableProvider
         saveBlock(ModBlocks.blockColonyBanner, registrar);
         saveBlock(ModBlocks.blockIronGate, registrar);
         saveBlock(ModBlocks.blockWoodenGate, registrar);
+
+        saveBannerBlock(Blocks.BLACK_BANNER, registrar);
+        saveBannerBlock(Blocks.BLUE_BANNER, registrar);
+        saveBannerBlock(Blocks.BROWN_BANNER, registrar);
+        saveBannerBlock(Blocks.WHITE_BANNER, registrar);
+        saveBannerBlock(Blocks.CYAN_BANNER, registrar);
+        saveBannerBlock(Blocks.GRAY_BANNER, registrar);
+        saveBannerBlock(Blocks.GREEN_BANNER, registrar);
+        saveBannerBlock(Blocks.LIGHT_BLUE_BANNER, registrar);
+        saveBannerBlock(Blocks.LIGHT_GRAY_BANNER, registrar);
+        saveBannerBlock(Blocks.LIME_BANNER, registrar);
+        saveBannerBlock(Blocks.MAGENTA_BANNER, registrar);
+        saveBannerBlock(Blocks.ORANGE_BANNER, registrar);
+        saveBannerBlock(Blocks.PINK_BANNER, registrar);
+        saveBannerBlock(Blocks.PURPLE_BANNER, registrar);
+        saveBannerBlock(Blocks.RED_BANNER, registrar);
+        saveBannerBlock(Blocks.YELLOW_BANNER, registrar);
+
+        saveBannerBlock(Blocks.BLACK_WALL_BANNER, registrar);
+        saveBannerBlock(Blocks.BLUE_WALL_BANNER, registrar);
+        saveBannerBlock(Blocks.BROWN_WALL_BANNER, registrar);
+        saveBannerBlock(Blocks.WHITE_WALL_BANNER, registrar);
+        saveBannerBlock(Blocks.CYAN_WALL_BANNER, registrar);
+        saveBannerBlock(Blocks.GRAY_WALL_BANNER, registrar);
+        saveBannerBlock(Blocks.GREEN_WALL_BANNER, registrar);
+        saveBannerBlock(Blocks.LIGHT_BLUE_WALL_BANNER, registrar);
+        saveBannerBlock(Blocks.LIGHT_GRAY_WALL_BANNER, registrar);
+        saveBannerBlock(Blocks.LIME_WALL_BANNER, registrar);
+        saveBannerBlock(Blocks.MAGENTA_WALL_BANNER, registrar);
+        saveBannerBlock(Blocks.ORANGE_WALL_BANNER, registrar);
+        saveBannerBlock(Blocks.PINK_WALL_BANNER, registrar);
+        saveBannerBlock(Blocks.PURPLE_WALL_BANNER, registrar);
+        saveBannerBlock(Blocks.RED_WALL_BANNER, registrar);
+        saveBannerBlock(Blocks.YELLOW_WALL_BANNER, registrar);
     }
 
     private <T extends Block> void saveBlocks(@NotNull final List<T> blocks, @NotNull final LootTableRegistrar registrar)
@@ -78,6 +115,20 @@ public class DefaultBlockLootTableProvider extends SimpleLootTableProvider
                             .add(item)
                             .when(ExplosionCondition.survivesExplosion())
                     ));
+        }
+    }
+
+    private void saveBannerBlock(@NotNull final Block block, @NotNull final LootTableRegistrar registrar)
+    {
+        if (block.getRegistryName() != null)
+        {
+            registrar.register(new ResourceLocation(block.getRegistryName().getNamespace(), "blocks/" + block.getRegistryName().getPath()), LootContextParamSets.BLOCK,
+              LootTable.lootTable().withPool(LootPool.lootPool()
+                                               .add(LootItem.lootTableItem(block))
+                                               .apply(CopyNameFunction.copyName(CopyNameFunction.NameSource.BLOCK_ENTITY))
+                                               .apply(CopyNbtFunction.copyData(ContextNbtProvider.BLOCK_ENTITY).copy("Patterns", "BlockEntityTag.Patterns").copy("id", "BlockEntityTag.id"))
+                                               .when(ExplosionCondition.survivesExplosion())
+              ));
         }
     }
 }


### PR DESCRIPTION
Closes #
Closes #
Closes #

# Changes proposed in this pull request:
- Add the missing id tag to banners when broken, allows builders to recognize them
-
-

Review please
