### PR TITLE
Expands adventure tokens into corresponding mob loot

### DIFF
--- a/src/datagen/generated/minecolonies/data/minecolonies/crafterrecipes/netherworker_custom/trip1.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/crafterrecipes/netherworker_custom/trip1.json
@@ -19,6 +19,15 @@
   ],
   "additional-output": [
     {
+      "item": "minecraft:gold_ingot"
+    },
+    {
+      "item": "minecraft:rotten_flesh"
+    },
+    {
+      "item": "minecraft:gold_nugget"
+    },
+    {
       "item": "minecraft:netherrack"
     },
     {
@@ -32,6 +41,27 @@
     },
     {
       "item": "minecraft:soul_soil"
+    },
+    {
+      "item": "minecraft:porkchop"
+    },
+    {
+      "item": "minecraft:leather"
+    },
+    {
+      "item": "minecraft:gunpowder"
+    },
+    {
+      "item": "minecraft:magma_cream"
+    },
+    {
+      "item": "minecraft:ghast_tear"
+    },
+    {
+      "item": "minecraft:ender_pearl"
+    },
+    {
+      "item": "minecraft:blaze_rod"
     }
   ],
   "loot-table": "minecolonies:recipes/netherworker/trip1",

--- a/src/datagen/generated/minecolonies/data/minecolonies/crafterrecipes/netherworker_custom/trip2.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/crafterrecipes/netherworker_custom/trip2.json
@@ -19,6 +19,15 @@
   ],
   "additional-output": [
     {
+      "item": "minecraft:gold_ingot"
+    },
+    {
+      "item": "minecraft:rotten_flesh"
+    },
+    {
+      "item": "minecraft:gold_nugget"
+    },
+    {
       "item": "minecraft:netherrack"
     },
     {
@@ -40,6 +49,9 @@
       "item": "minecraft:soul_soil"
     },
     {
+      "item": "minecraft:porkchop"
+    },
+    {
       "item": "minecraft:glowstone"
     },
     {
@@ -52,7 +64,25 @@
       "item": "minecraft:crimson_stem"
     },
     {
+      "item": "minecraft:leather"
+    },
+    {
+      "item": "minecraft:gunpowder"
+    },
+    {
       "item": "minecraft:nether_wart"
+    },
+    {
+      "item": "minecraft:magma_cream"
+    },
+    {
+      "item": "minecraft:ghast_tear"
+    },
+    {
+      "item": "minecraft:ender_pearl"
+    },
+    {
+      "item": "minecraft:blaze_rod"
     }
   ],
   "loot-table": "minecolonies:recipes/netherworker/trip2",

--- a/src/datagen/generated/minecolonies/data/minecolonies/crafterrecipes/netherworker_custom/trip3.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/crafterrecipes/netherworker_custom/trip3.json
@@ -19,6 +19,15 @@
   ],
   "additional-output": [
     {
+      "item": "minecraft:gold_ingot"
+    },
+    {
+      "item": "minecraft:rotten_flesh"
+    },
+    {
+      "item": "minecraft:gold_nugget"
+    },
+    {
       "item": "minecraft:netherrack"
     },
     {
@@ -35,6 +44,9 @@
     },
     {
       "item": "minecraft:red_mushroom"
+    },
+    {
+      "item": "minecraft:porkchop"
     },
     {
       "item": "minecraft:soul_soil"
@@ -64,7 +76,25 @@
       "item": "minecraft:warped_stem"
     },
     {
+      "item": "minecraft:leather"
+    },
+    {
+      "item": "minecraft:gunpowder"
+    },
+    {
       "item": "minecraft:nether_wart"
+    },
+    {
+      "item": "minecraft:magma_cream"
+    },
+    {
+      "item": "minecraft:ghast_tear"
+    },
+    {
+      "item": "minecraft:ender_pearl"
+    },
+    {
+      "item": "minecraft:blaze_rod"
     }
   ],
   "loot-table": "minecolonies:recipes/netherworker/trip3",

--- a/src/datagen/generated/minecolonies/data/minecolonies/crafterrecipes/netherworker_custom/trip4.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/crafterrecipes/netherworker_custom/trip4.json
@@ -19,10 +19,22 @@
   ],
   "additional-output": [
     {
+      "item": "minecraft:gold_ingot"
+    },
+    {
+      "item": "minecraft:rotten_flesh"
+    },
+    {
+      "item": "minecraft:gold_nugget"
+    },
+    {
       "item": "minecraft:netherrack"
     },
     {
       "item": "minecraft:nether_quartz_ore"
+    },
+    {
+      "item": "minecraft:porkchop"
     },
     {
       "item": "minecraft:soul_sand"
@@ -38,6 +50,9 @@
     },
     {
       "item": "minecraft:soul_soil"
+    },
+    {
+      "item": "minecraft:leather"
     },
     {
       "item": "minecraft:glowstone"
@@ -70,7 +85,22 @@
       "item": "minecraft:blackstone"
     },
     {
+      "item": "minecraft:gunpowder"
+    },
+    {
+      "item": "minecraft:magma_cream"
+    },
+    {
+      "item": "minecraft:ghast_tear"
+    },
+    {
+      "item": "minecraft:ender_pearl"
+    },
+    {
       "item": "minecraft:nether_wart"
+    },
+    {
+      "item": "minecraft:blaze_rod"
     }
   ],
   "loot-table": "minecolonies:recipes/netherworker/trip4",

--- a/src/datagen/generated/minecolonies/data/minecolonies/crafterrecipes/netherworker_custom/trip5.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/crafterrecipes/netherworker_custom/trip5.json
@@ -19,10 +19,22 @@
   ],
   "additional-output": [
     {
+      "item": "minecraft:gold_ingot"
+    },
+    {
+      "item": "minecraft:rotten_flesh"
+    },
+    {
+      "item": "minecraft:gold_nugget"
+    },
+    {
       "item": "minecraft:netherrack"
     },
     {
       "item": "minecraft:nether_quartz_ore"
+    },
+    {
+      "item": "minecraft:porkchop"
     },
     {
       "item": "minecraft:soul_sand"
@@ -38,6 +50,9 @@
     },
     {
       "item": "minecraft:soul_soil"
+    },
+    {
+      "item": "minecraft:leather"
     },
     {
       "item": "minecraft:glowstone"
@@ -70,7 +85,22 @@
       "item": "minecraft:blackstone"
     },
     {
+      "item": "minecraft:gunpowder"
+    },
+    {
+      "item": "minecraft:magma_cream"
+    },
+    {
+      "item": "minecraft:ghast_tear"
+    },
+    {
+      "item": "minecraft:ender_pearl"
+    },
+    {
       "item": "minecraft:nether_wart"
+    },
+    {
+      "item": "minecraft:blaze_rod"
     },
     {
       "item": "minecraft:ancient_debris"

--- a/src/main/java/com/minecolonies/coremod/event/GatherDataHandler.java
+++ b/src/main/java/com/minecolonies/coremod/event/GatherDataHandler.java
@@ -1,7 +1,9 @@
 package com.minecolonies.coremod.event;
 
+import com.minecolonies.coremod.generation.DatagenLootTableManager;
 import com.minecolonies.coremod.generation.defaults.*;
 import net.minecraft.data.DataGenerator;
+import net.minecraft.loot.LootTableManager;
 import net.minecraftforge.fml.event.lifecycle.GatherDataEvent;
 
 public class GatherDataHandler
@@ -14,14 +16,16 @@ public class GatherDataHandler
     public static void dataGeneratorSetup(final GatherDataEvent event)
     {
         final DataGenerator generator = event.getGenerator();
+        final LootTableManager lootTableManager = new DatagenLootTableManager(event.getExistingFileHelper());
+
         generator.addProvider(new DefaultBlockLootTableProvider(generator));
         generator.addProvider(new DefaultSoundProvider(generator));
         generator.addProvider(new DefaultResearchProvider(generator));
         generator.addProvider(new SawmillTimberFrameRecipeProvider(generator));
-        generator.addProvider(new DefaultSifterCraftingProvider(generator));
+        generator.addProvider(new DefaultSifterCraftingProvider(generator, lootTableManager));
         generator.addProvider(new DefaultEnchanterCraftingProvider(generator));
         generator.addProvider(new DefaultFishermanLootProvider(generator));
         generator.addProvider(new DefaultConcreteMixerCraftingProvider(generator));
-        generator.addProvider(new DefaultNetherWorkerLootProvider(generator));
+        generator.addProvider(new DefaultNetherWorkerLootProvider(generator, lootTableManager));
     }
 }

--- a/src/main/java/com/minecolonies/coremod/generation/DatagenLootTableManager.java
+++ b/src/main/java/com/minecolonies/coremod/generation/DatagenLootTableManager.java
@@ -1,0 +1,72 @@
+package com.minecolonies.coremod.generation;
+
+import com.google.gson.Gson;
+import com.google.gson.JsonObject;
+import net.minecraft.loot.LootPredicateManager;
+import net.minecraft.loot.LootSerializers;
+import net.minecraft.loot.LootTable;
+import net.minecraft.loot.LootTableManager;
+import net.minecraft.resources.IResource;
+import net.minecraft.resources.ResourcePackType;
+import net.minecraft.util.JSONUtils;
+import net.minecraft.util.ResourceLocation;
+import net.minecraftforge.common.ForgeHooks;
+import net.minecraftforge.common.data.ExistingFileHelper;
+import org.jetbrains.annotations.NotNull;
+
+import java.io.BufferedReader;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.io.Reader;
+import java.nio.charset.StandardCharsets;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * This is a LootTableManager that's populated on-demand during datagen, so that we
+ * can look up other tables for {@link com.minecolonies.coremod.colony.crafting.LootTableAnalyzer}.
+ */
+public class DatagenLootTableManager extends LootTableManager
+{
+    private static final Gson GSON = LootSerializers.createLootTableSerializer().create();
+    private final ExistingFileHelper existingFileHelper;
+    private final Map<ResourceLocation, LootTable> tables = new HashMap<>();
+
+    public DatagenLootTableManager(@NotNull final ExistingFileHelper existingFileHelper)
+    {
+        super(new LootPredicateManager());  // in theory we should load these too; in practice vanilla doesn't seem to use it
+
+        this.existingFileHelper = existingFileHelper;
+    }
+
+    @NotNull
+    @Override
+    public LootTable get(@NotNull final ResourceLocation location)
+    {
+        final LootTable table = this.tables.get(location);
+        if (table != null) return table;
+
+        try
+        {
+            final IResource resource = existingFileHelper.getResource(getPreparedPath(location), ResourcePackType.SERVER_DATA);
+            try (final InputStream inputstream = resource.getInputStream();
+                 final Reader reader = new BufferedReader(new InputStreamReader(inputstream, StandardCharsets.UTF_8));
+            )
+            {
+                final JsonObject jsonobject = JSONUtils.fromJson(GSON, reader, JsonObject.class);
+                final LootTable loottable = ForgeHooks.loadLootTable(GSON, location, jsonobject, false, this);
+                if (loottable != null)
+                {
+                    this.tables.put(location, loottable);
+                    return loottable;
+                }
+            }
+        }
+        catch (final Throwable e)
+        {
+            e.printStackTrace();
+        }
+
+        return LootTable.EMPTY;
+    }
+}

--- a/src/main/java/com/minecolonies/coremod/generation/defaults/DefaultNetherWorkerLootProvider.java
+++ b/src/main/java/com/minecolonies/coremod/generation/defaults/DefaultNetherWorkerLootProvider.java
@@ -40,7 +40,8 @@ public class DefaultNetherWorkerLootProvider implements IDataProvider
     private final NetherWorkerLootTableProvider lootTableProvider;
     private final List<LootTable.Builder> levels;
 
-    public DefaultNetherWorkerLootProvider(@NotNull final DataGenerator generatorIn)
+    public DefaultNetherWorkerLootProvider(@NotNull final DataGenerator generatorIn,
+                                           @NotNull final LootTableManager lootTableManager)
     {
         levels = new ArrayList<>();
 
@@ -49,7 +50,7 @@ public class DefaultNetherWorkerLootProvider implements IDataProvider
             levels.add(createTripLoot(buildingLevel));
         }
 
-        recipeProvider = new NetherWorkerRecipeProvider(generatorIn);
+        recipeProvider = new NetherWorkerRecipeProvider(generatorIn, lootTableManager);
         lootTableProvider = new NetherWorkerLootTableProvider(generatorIn);
     }
 
@@ -219,9 +220,14 @@ public class DefaultNetherWorkerLootProvider implements IDataProvider
 
     private class NetherWorkerRecipeProvider extends CustomRecipeProvider
     {
-        public NetherWorkerRecipeProvider(@NotNull final DataGenerator generatorIn)
+        private final LootTableManager lootTableManager;
+
+        public NetherWorkerRecipeProvider(@NotNull final DataGenerator generatorIn,
+                                          @NotNull LootTableManager lootTableManager)
         {
             super(generatorIn);
+            
+            this.lootTableManager = lootTableManager;
         }
 
         @NotNull
@@ -244,9 +250,8 @@ public class DefaultNetherWorkerLootProvider implements IDataProvider
             {
                 final int buildingLevel = i + 1;
 
-                final List<LootTableAnalyzer.LootDrop> drops = LootTableAnalyzer.toDrops(null, levels.get(i).build());
-                final Stream<Item> loot = drops.stream().flatMap(drop -> drop.getItemStacks().stream().map(ItemStack::getItem))
-                        .filter(item -> !item.equals(ModItems.adventureToken));
+                final List<LootTableAnalyzer.LootDrop> drops = LootTableAnalyzer.toDrops(lootTableManager, levels.get(i).build());
+                final Stream<Item> loot = drops.stream().flatMap(drop -> drop.getItemStacks().stream().map(ItemStack::getItem));
 
                 CustomRecipeBuilder.create(ModJobs.NETHERWORKER_ID.getPath() + "_custom", "trip" + buildingLevel)
                         .minBuildingLevel(buildingLevel)

--- a/src/main/java/com/minecolonies/coremod/generation/defaults/DefaultSifterCraftingProvider.java
+++ b/src/main/java/com/minecolonies/coremod/generation/defaults/DefaultSifterCraftingProvider.java
@@ -34,7 +34,8 @@ public class DefaultSifterCraftingProvider implements IDataProvider
     private final SifterLootTableProvider lootTableProvider;
     private final Map<Item, List<SifterMeshDetails>> inputs = new HashMap<>();
 
-    public DefaultSifterCraftingProvider(@NotNull final DataGenerator generatorIn)
+    public DefaultSifterCraftingProvider(@NotNull final DataGenerator generatorIn,
+                                         @NotNull final LootTableManager lootTableManager)
     {
         inputs.put(Items.DIRT, Arrays.asList(
                 new SifterMeshDetails(ModItems.sifterMeshString, 1, LootTable.lootTable()
@@ -224,7 +225,7 @@ public class DefaultSifterCraftingProvider implements IDataProvider
 
                 ));
 
-        recipeProvider = new SifterRecipeProvider(generatorIn);
+        recipeProvider = new SifterRecipeProvider(generatorIn, lootTableManager);
         lootTableProvider = new SifterLootTableProvider(generatorIn);
     }
 
@@ -271,9 +272,14 @@ public class DefaultSifterCraftingProvider implements IDataProvider
 
     private class SifterRecipeProvider extends CustomRecipeProvider
     {
-        public SifterRecipeProvider(@NotNull final DataGenerator generatorIn)
+        private final LootTableManager lootTableManager;
+
+        public SifterRecipeProvider(@NotNull final DataGenerator generatorIn,
+                                    @NotNull final LootTableManager lootTableManager)
         {
             super(generatorIn);
+
+            this.lootTableManager = lootTableManager;
         }
 
         @NotNull
@@ -292,7 +298,7 @@ public class DefaultSifterCraftingProvider implements IDataProvider
                 {
                     final String name = mesh.getName() + "/" + inputEntry.getKey().getRegistryName().getPath();
 
-                    final List<LootTableAnalyzer.LootDrop> drops = LootTableAnalyzer.toDrops(null, mesh.getLootTable().build());
+                    final List<LootTableAnalyzer.LootDrop> drops = LootTableAnalyzer.toDrops(lootTableManager, mesh.getLootTable().build());
                     final Stream<Item> loot = drops.stream().flatMap(drop -> drop.getItemStacks().stream().map(ItemStack::getItem));
 
                     CustomRecipeBuilder.create(ModJobs.SIFTER_ID.getPath() + "_custom", name)

--- a/src/main/resources/assets/minecolonies/lang/manual_en_us.json
+++ b/src/main/resources/assets/minecolonies/lang/manual_en_us.json
@@ -1552,7 +1552,7 @@
   "com.minecolonies.coremod.jei.stonemason": "Crafts things made from various kinds of stone.",
   "com.minecolonies.coremod.jei.stonesmeltery": "Smelts various kinds of stone and terracotta.",
   "com.minecolonies.coremod.jei.swineherder": "Just happy with pigs in mud.",
-  "com.minecolonies.coremod.jei.netherworker": "Makes periodic trips to the nether to retrieve materials, but it's a very dangerous job, and requires significant supplies",
+  "com.minecolonies.coremod.jei.netherworker": "Makes periodic trips to the nether to retrieve materials, but it's a very dangerous job, and requires significant supplies.",
 
   "com.minecolonies.coremod.journeymap.deathpoint_name": "Death: %s",
   "com.minecolonies.coremod.journeymap.deathpoint_namejob": "Death: %s - %s",


### PR DESCRIPTION
# Changes proposed in this pull request:
- Expands adventure tokens in loot analysis to the corresponding mob loot instead.

Review please

For example, this allows you to press R (or click) on "pork chops" in JEI to see that you can get them both from the nether miner and the pig herder.