### PR TITLE
Allows requesting items from the player's inventory as well

### DIFF
--- a/src/api/java/com/minecolonies/api/compatibility/CompatibilityManager.java
+++ b/src/api/java/com/minecolonies/api/compatibility/CompatibilityManager.java
@@ -135,7 +135,12 @@ public class CompatibilityManager implements ICompatibilityManager
     /**
      * List of all blocks.
      */
-    private static ImmutableList<ItemStack> allItems = ImmutableList.<ItemStack>builder().build();
+    private static ImmutableList<ItemStack> allItems = ImmutableList.of();
+
+    /**
+     * Set of all items.  Uses ItemStorage mostly for better equals/hash.
+     */
+    private static ImmutableSet<ItemStorage> allItemsSet = ImmutableSet.of();
 
     /**
      * Free block positions everyone can interact with.
@@ -208,6 +213,12 @@ public class CompatibilityManager implements ICompatibilityManager
     public List<ItemStack> getListOfAllItems()
     {
         return allItems;
+    }
+
+    @Override
+    public Set<ItemStorage> getSetOfAllItems()
+    {
+        return allItemsSet;
     }
 
     @Override
@@ -424,15 +435,23 @@ public class CompatibilityManager implements ICompatibilityManager
      */
     private void discoverAllItems()
     {
-        final ImmutableList.Builder<ItemStack> builder = new ImmutableList.Builder<>();
-        for(Item item : ForgeRegistries.ITEMS.getValues())
+        final ImmutableList.Builder<ItemStack> listBuilder = new ImmutableList.Builder<>();
+        final ImmutableSet.Builder<ItemStorage> setBuilder = new ImmutableSet.Builder<>();
+
+        for (final Item item : ForgeRegistries.ITEMS.getValues())
         {
             final NonNullList<ItemStack> list = NonNullList.create();
             item.fillItemCategory(ItemGroup.TAB_SEARCH, list);
-            builder.addAll(list);
+            listBuilder.addAll(list);
+
+            for (final ItemStack stack : list)
+            {
+                setBuilder.add(new ItemStorage(stack, true));
+            }
         }
 
-        allItems = builder.build();
+        allItems = listBuilder.build();
+        allItemsSet = setBuilder.build();
     }
 
     /**

--- a/src/api/java/com/minecolonies/api/compatibility/ICompatibilityManager.java
+++ b/src/api/java/com/minecolonies/api/compatibility/ICompatibilityManager.java
@@ -161,6 +161,13 @@ public interface ICompatibilityManager
     List<ItemStack> getListOfAllItems();
 
     /**
+     * Get a set of all items (marked to ignore damage but not NBT).
+     *
+     * @return the immutable set.
+     */
+    Set<ItemStorage> getSetOfAllItems();
+
+    /**
      * Write colonies to NBT data for saving.
      *
      * @param compound NBT-Tag.

--- a/src/api/java/com/minecolonies/api/util/ItemStackUtils.java
+++ b/src/api/java/com/minecolonies/api/util/ItemStackUtils.java
@@ -1016,7 +1016,7 @@ public final class ItemStackUtils
             if (stack.isDamageableItem() && stack.isDamaged())
             {
                 pristine = stack.copy();
-                stack.setDamageValue(0);
+                pristine.setDamageValue(0);
                 // in case the item wasn't already in the set, we want to only store a pristine one!
             }
             allItems.add(new ItemStorage(pristine, true));

--- a/src/api/java/com/minecolonies/api/util/ItemStackUtils.java
+++ b/src/api/java/com/minecolonies/api/util/ItemStackUtils.java
@@ -998,14 +998,8 @@ public final class ItemStackUtils
      */
     public static Set<ItemStack> allItemsPlusInventory(@NotNull final PlayerEntity player)
     {
-        // using ItemStorage for better hashing
-        final Set<ItemStorage> allItems = new HashSet<>();
-
-        // all known items
-        for (final ItemStack stack : IColonyManager.getInstance().getCompatibilityManager().getListOfAllItems())
-        {
-            allItems.add(new ItemStorage(stack, true));
-        }
+        // get all known items first
+        final Set<ItemStorage> allItems = new HashSet<>(IColonyManager.getInstance().getCompatibilityManager().getSetOfAllItems());
 
         // plus all items from the player's inventory not already listed (adds items with extra NBT)
         for (final ItemStack stack : player.inventory.items)

--- a/src/api/java/com/minecolonies/api/util/ItemStackUtils.java
+++ b/src/api/java/com/minecolonies/api/util/ItemStackUtils.java
@@ -2,6 +2,7 @@ package com.minecolonies.api.util;
 
 import com.google.common.collect.Lists;
 import com.minecolonies.api.MinecoloniesAPIProxy;
+import com.minecolonies.api.colony.IColonyManager;
 import com.minecolonies.api.compatibility.Compatibility;
 import com.minecolonies.api.crafting.ItemStorage;
 import com.minecolonies.api.entity.citizen.AbstractEntityCitizen;
@@ -9,12 +10,12 @@ import com.minecolonies.api.items.ModItems;
 import com.minecolonies.api.util.constant.IToolType;
 import com.minecolonies.api.util.constant.ToolType;
 import com.mojang.brigadier.exceptions.CommandSyntaxException;
-
 import net.minecraft.block.Block;
 import net.minecraft.entity.Entity;
 import net.minecraft.entity.EntityType;
 import net.minecraft.entity.item.ArmorStandEntity;
 import net.minecraft.entity.item.ItemFrameEntity;
+import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.inventory.EquipmentSlotType;
 import net.minecraft.item.*;
 import net.minecraft.nbt.CompoundNBT;
@@ -26,20 +27,16 @@ import net.minecraft.util.ResourceLocation;
 import net.minecraft.util.math.EntityRayTraceResult;
 import net.minecraft.world.World;
 import net.minecraftforge.registries.ForgeRegistries;
-
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
-import java.util.Optional;
+import java.util.*;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
+import static com.minecolonies.api.items.ModTags.fungi;
 import static com.minecolonies.api.util.constant.Constants.FUEL_SLOT;
 import static com.minecolonies.api.util.constant.Constants.SMELTABLE_SLOT;
-import static com.minecolonies.api.items.ModTags.fungi;
 
 /**
  * Utility methods for the inventories.
@@ -990,6 +987,42 @@ public final class ItemStackUtils
             Log.getLogger().warn("Parsed item definition returned empty: " + itemData);
         }
         return stack;
+    }
+
+    /**
+     * Obtains a list of all basic items in the game, plus any extra items present in the player's
+     * inventory (allowing for items with custom NBT, e.g. DO blocks or dyed armour).
+     *
+     * @param player The player whose inventory to check.
+     * @return The set of items.
+     */
+    public static Set<ItemStack> allItemsPlusInventory(@NotNull final PlayerEntity player)
+    {
+        // using ItemStorage for better hashing
+        final Set<ItemStorage> allItems = new HashSet<>();
+
+        // all known items
+        for (final ItemStack stack : IColonyManager.getInstance().getCompatibilityManager().getListOfAllItems())
+        {
+            allItems.add(new ItemStorage(stack, true));
+        }
+
+        // plus all items from the player's inventory not already listed (adds items with extra NBT)
+        for (final ItemStack stack : player.inventory.items)
+        {
+            if (stack.isEmpty()) continue;
+
+            ItemStack pristine = stack;
+            if (stack.isDamageableItem() && stack.isDamaged())
+            {
+                pristine = stack.copy();
+                stack.setDamageValue(0);
+                // in case the item wasn't already in the set, we want to only store a pristine one!
+            }
+            allItems.add(new ItemStorage(pristine, true));
+        }
+
+        return allItems.stream().map(ItemStorage::getItemStack).collect(Collectors.toSet());
     }
 }
 

--- a/src/main/java/com/minecolonies/coremod/client/gui/WindowPostBox.java
+++ b/src/main/java/com/minecolonies/coremod/client/gui/WindowPostBox.java
@@ -6,12 +6,13 @@ import com.ldtteam.blockout.controls.ItemIcon;
 import com.ldtteam.blockout.controls.Text;
 import com.ldtteam.blockout.controls.TextField;
 import com.ldtteam.blockout.views.ScrollingList;
-import com.minecolonies.api.colony.IColonyManager;
+import com.minecolonies.api.util.ItemStackUtils;
 import com.minecolonies.api.util.constant.Constants;
 import com.minecolonies.coremod.Network;
 import com.minecolonies.coremod.colony.buildings.views.AbstractBuildingView;
 import com.minecolonies.coremod.network.messages.server.colony.OpenInventoryMessage;
 import com.minecolonies.coremod.network.messages.server.colony.building.postbox.PostBoxRequestMessage;
+import net.minecraft.client.Minecraft;
 import net.minecraft.item.EnchantedBookItem;
 import net.minecraft.item.ItemStack;
 import org.apache.commons.lang3.StringUtils;
@@ -183,11 +184,13 @@ public class WindowPostBox extends AbstractWindowRequestTree
      */
     private Collection<? extends ItemStack> getBlockList(final Predicate<ItemStack> filterPredicate)
     {
+        final Set<ItemStack> allItems = ItemStackUtils.allItemsPlusInventory(Minecraft.getInstance().player);
+
         if (filter.isEmpty())
         {
-            return IColonyManager.getInstance().getCompatibilityManager().getListOfAllItems();
+            return allItems;
         }
-        return IColonyManager.getInstance().getCompatibilityManager().getListOfAllItems().stream().filter(filterPredicate).collect(Collectors.toList());
+        return allItems.stream().filter(filterPredicate).collect(Collectors.toList());
     }
 
     /**

--- a/src/main/java/com/minecolonies/coremod/client/gui/WindowSelectRes.java
+++ b/src/main/java/com/minecolonies/coremod/client/gui/WindowSelectRes.java
@@ -8,19 +8,24 @@ import com.ldtteam.blockout.controls.Text;
 import com.ldtteam.blockout.controls.TextField;
 import com.ldtteam.blockout.views.ScrollingList;
 import com.ldtteam.blockout.views.Window;
-import com.minecolonies.api.colony.IColonyManager;
 import com.minecolonies.api.colony.buildings.views.IBuildingView;
+import com.minecolonies.api.util.ItemStackUtils;
 import com.minecolonies.api.util.Log;
+import net.minecraft.client.Minecraft;
 import net.minecraft.item.ItemStack;
 import net.minecraft.item.Items;
 import org.apache.commons.lang3.StringUtils;
 import org.jetbrains.annotations.NotNull;
 
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Locale;
 import java.util.function.BiConsumer;
 import java.util.function.Predicate;
 
-import static com.minecolonies.api.util.constant.WindowConstants.*;
+import static com.minecolonies.api.util.constant.WindowConstants.BUTTON_SELECT;
+import static com.minecolonies.api.util.constant.WindowConstants.NAME_LABEL;
 
 public class WindowSelectRes extends AbstractWindowSkeleton
 {
@@ -151,7 +156,7 @@ public class WindowSelectRes extends AbstractWindowSkeleton
     {
         this.allItems.clear();
 
-        for (final ItemStack stack : IColonyManager.getInstance().getCompatibilityManager().getListOfAllItems())
+        for (final ItemStack stack : ItemStackUtils.allItemsPlusInventory(Minecraft.getInstance().player))
         {
             if (test.test(stack) && (this.filter.isEmpty()
                                        || stack.getDescriptionId().toLowerCase(Locale.US).contains(this.filter.toLowerCase(Locale.US))


### PR DESCRIPTION
Related to #7899
Closes [discord request](https://discord.com/channels/139070364159311872/372217492547829762/928869704859279441)

# Changes proposed in this pull request:
- Adds unique items from the player inventory to the postbox and minimum stock requestables list (this allows things like dyed armor and DO blocks)

Review please

This was relatively straightforward and is consistent with how the scan tool replace feature supports DO blocks, although it's perhaps not the ideal solution -- it would be better to read the list of possible recipe outputs currently taught to any colony building and use that to augment the default item list **instead** of the player inventory.  However this is client side and the colony recipe data is all server side AFAIK (and the recipe manager is global, not per-colony, so there isn't any existing list of "all local craftables"), so that does not seem straightforward.