### PR TITLE
Improvements to feeding

### DIFF
--- a/src/main/java/com/minecolonies/apiimp/initializer/ModBuildingsInitializer.java
+++ b/src/main/java/com/minecolonies/apiimp/initializer/ModBuildingsInitializer.java
@@ -138,7 +138,8 @@ public final class ModBuildingsInitializer
                                        .setRegistryName(new ResourceLocation(Constants.MOD_ID, ModBuildings.CHICKENHERDER_ID))
                                        .addBuildingModuleProducer(() -> new WorkerBuildingModule(ModJobs.chickenHerder, Skill.Adaptability, Skill.Agility, false, (b) -> 1), () -> WorkerBuildingModuleView::new)
                                        .addBuildingModuleProducer(MinimumStockModule::new, () -> MinimumStockModuleView::new)
-                                       .addBuildingModuleProducer(() -> new SettingsModule().with(AbstractBuilding.BREEDING, new BoolSetting(true)), () -> SettingsModuleView::new)
+                                       .addBuildingModuleProducer(() -> new SettingsModule().with(AbstractBuilding.BREEDING, new BoolSetting(true))
+                                                                                            .with(AbstractBuilding.FEEDING, new BoolSetting(true)), () -> SettingsModuleView::new)
                                        .addBuildingModuleProducer(BuildingChickenHerder.HerdingModule::new)
                                        .createBuildingEntry();
 
@@ -190,6 +191,7 @@ public final class ModBuildingsInitializer
                                 .addBuildingModuleProducer(() -> new WorkerBuildingModule(ModJobs.cowboy, Skill.Athletics, Skill.Stamina, false, (b) -> 1), () -> WorkerBuildingModuleView::new)
                                 .addBuildingModuleProducer(MinimumStockModule::new, () -> MinimumStockModuleView::new)
                                 .addBuildingModuleProducer(() -> new SettingsModule().with(AbstractBuilding.BREEDING, new BoolSetting(true))
+                                                                                     .with(AbstractBuilding.FEEDING, new BoolSetting(true))
                                                                                      .with(BuildingCowboy.MILKING, new BoolSetting(false)), () -> SettingsModuleView::new)
                                 .addBuildingModuleProducer(() -> new AnimalHerdingModule(ModJobs.cowboy, EntityType.COW, new ItemStack(Items.WHEAT, 2)))
                                 .addBuildingModuleProducer(BuildingCowboy.MilkingModule::new)
@@ -335,6 +337,7 @@ public final class ModBuildingsInitializer
                                   .addBuildingModuleProducer(() -> new WorkerBuildingModule(ModJobs.shepherd, Skill.Focus, Skill.Strength, false, (b) -> 1), () -> WorkerBuildingModuleView::new)
                                   .addBuildingModuleProducer(MinimumStockModule::new, () -> MinimumStockModuleView::new)
                                   .addBuildingModuleProducer(() -> new SettingsModule().with(AbstractBuilding.BREEDING, new BoolSetting(true))
+                                                                                       .with(AbstractBuilding.FEEDING, new BoolSetting(true))
                                                                                        .with(BuildingShepherd.DYEING, new BoolSetting(true))
                                                                                        .with(BuildingShepherd.SHEARING, new BoolSetting(true)), () -> SettingsModuleView::new)
                                   .addBuildingModuleProducer(BuildingShepherd.HerdingModule::new)
@@ -399,7 +402,8 @@ public final class ModBuildingsInitializer
                                      .setRegistryName(new ResourceLocation(Constants.MOD_ID, ModBuildings.SWINE_HERDER_ID))
                                      .addBuildingModuleProducer(() -> new WorkerBuildingModule(ModJobs.swineHerder, Skill.Strength, Skill.Athletics, true, (b) -> 1), () -> WorkerBuildingModuleView::new)
                                      .addBuildingModuleProducer(MinimumStockModule::new, () -> MinimumStockModuleView::new)
-                                     .addBuildingModuleProducer(() -> new SettingsModule().with(AbstractBuilding.BREEDING, new BoolSetting(true)), () -> SettingsModuleView::new)
+                                     .addBuildingModuleProducer(() -> new SettingsModule().with(AbstractBuilding.BREEDING, new BoolSetting(true))
+                                                                                          .with(AbstractBuilding.FEEDING, new BoolSetting(true)), () -> SettingsModuleView::new)
                                      .addBuildingModuleProducer(() -> new AnimalHerdingModule(ModJobs.swineHerder, EntityType.PIG, new ItemStack(Items.CARROT, 2)))
                                      .createBuildingEntry();
 
@@ -568,7 +572,8 @@ public final class ModBuildingsInitializer
                                      .setRegistryName(new ResourceLocation(Constants.MOD_ID, ModBuildings.RABBIT_ID))
                                      .addBuildingModuleProducer(() -> new WorkerBuildingModule(ModJobs.rabbitHerder, Skill.Agility, Skill.Athletics, false, (b) -> 1), () -> WorkerBuildingModuleView::new)
                                      .addBuildingModuleProducer(MinimumStockModule::new, () -> MinimumStockModuleView::new)
-                                     .addBuildingModuleProducer(() -> new SettingsModule().with(AbstractBuilding.BREEDING, new BoolSetting(true)), () -> SettingsModuleView::new)
+                                     .addBuildingModuleProducer(() -> new SettingsModule().with(AbstractBuilding.BREEDING, new BoolSetting(true))
+                                                                                          .with(AbstractBuilding.FEEDING, new BoolSetting(true)), () -> SettingsModuleView::new)
                                      .addBuildingModuleProducer(() -> new AnimalHerdingModule(ModJobs.rabbitHerder, EntityType.RABBIT, new ItemStack(Items.CARROT, 2)))
                                      .createBuildingEntry();
 

--- a/src/main/java/com/minecolonies/coremod/colony/buildings/AbstractBuilding.java
+++ b/src/main/java/com/minecolonies/coremod/colony/buildings/AbstractBuilding.java
@@ -85,6 +85,7 @@ import java.util.stream.Collectors;
 import static com.minecolonies.api.colony.requestsystem.requestable.deliveryman.AbstractDeliverymanRequestable.getPlayerActionPriority;
 import static com.minecolonies.api.util.constant.BuildingConstants.CONST_DEFAULT_MAX_BUILDING_LEVEL;
 import static com.minecolonies.api.util.constant.BuildingConstants.NO_WORK_ORDER;
+import static com.minecolonies.api.util.constant.Constants.MOD_ID;
 import static com.minecolonies.api.util.constant.NbtTagConstants.*;
 import static com.minecolonies.api.util.constant.Suppression.GENERIC_WILDCARD;
 import static com.minecolonies.api.util.constant.Suppression.UNCHECKED;
@@ -104,7 +105,12 @@ public abstract class AbstractBuilding extends AbstractBuildingContainer
     /**
      * Breeding setting.
      */
-    public static final ISettingKey<BoolSetting> BREEDING = new SettingKey<>(BoolSetting.class, new ResourceLocation(com.minecolonies.api.util.constant.Constants.MOD_ID, "breeding"));
+    public static final ISettingKey<BoolSetting> BREEDING = new SettingKey<>(BoolSetting.class, new ResourceLocation(MOD_ID, "breeding"));
+
+    /**
+     * Feeding setting.
+     */
+    public static final ISettingKey<BoolSetting> FEEDING = new SettingKey<>(BoolSetting.class, new ResourceLocation(MOD_ID, "feeding"));
 
     public static final int MAX_BUILD_HEIGHT = 256;
     public static final int MIN_BUILD_HEIGHT = 1;

--- a/src/main/java/com/minecolonies/coremod/entity/ai/citizen/herders/AbstractEntityAIHerder.java
+++ b/src/main/java/com/minecolonies/coremod/entity/ai/citizen/herders/AbstractEntityAIHerder.java
@@ -270,7 +270,7 @@ public abstract class AbstractEntityAIHerder<J extends AbstractJob<?, J>, B exte
     }
 
     /**
-     * Butcher some animals (Preferably Adults) that the herder looks after.
+     * Butcher some animals (Preferably Adults & not recently fed) that the herder looks after.
      *
      * @return The next {@link IAIState}.
      */
@@ -290,7 +290,7 @@ public abstract class AbstractEntityAIHerder<J extends AbstractJob<?, J>, B exte
 
         final Animal animal = animals
                                       .stream()
-                                      .filter(animalToButcher -> !animalToButcher.isBaby())
+                                      .filter(animalToButcher -> !animalToButcher.isBaby() && !animalToButcher.isInLove())
                                       .findFirst()
                                       .orElse(null);
 

--- a/src/main/java/com/minecolonies/coremod/entity/ai/citizen/herders/AbstractEntityAIHerder.java
+++ b/src/main/java/com/minecolonies/coremod/entity/ai/citizen/herders/AbstractEntityAIHerder.java
@@ -222,7 +222,7 @@ public abstract class AbstractEntityAIHerder<J extends AbstractJob<?, J>, B exte
      */
     protected boolean canFeedChildren()
     {
-        return false;
+        return getSecondarySkillLevel() >= LIMIT_TO_FEED_CHILDREN;
     }
 
     /**

--- a/src/main/java/com/minecolonies/coremod/entity/ai/citizen/herders/AbstractEntityAIHerder.java
+++ b/src/main/java/com/minecolonies/coremod/entity/ai/citizen/herders/AbstractEntityAIHerder.java
@@ -1,6 +1,5 @@
 package com.minecolonies.coremod.entity.ai.citizen.herders;
 
-import com.minecolonies.api.colony.buildings.modules.ISettingsModule;
 import com.minecolonies.api.entity.ai.statemachine.AITarget;
 import com.minecolonies.api.entity.ai.statemachine.states.IAIState;
 import com.minecolonies.api.entity.citizen.VisibleCitizenStatus;
@@ -12,16 +11,16 @@ import com.minecolonies.api.util.constant.TranslationConstants;
 import com.minecolonies.coremod.colony.buildings.AbstractBuilding;
 import com.minecolonies.coremod.colony.jobs.AbstractJob;
 import com.minecolonies.coremod.entity.ai.basic.AbstractEntityAIInteract;
-import net.minecraft.world.entity.item.ItemEntity;
-import net.minecraft.world.entity.animal.Animal;
-import net.minecraft.world.item.Item;
-import net.minecraft.world.item.ItemStack;
-import net.minecraft.world.damagesource.DamageSource;
-import net.minecraft.world.InteractionHand;
-import net.minecraft.sounds.SoundEvents;
 import net.minecraft.core.BlockPos;
 import net.minecraft.network.chat.TranslatableComponent;
 import net.minecraft.server.level.ServerLevel;
+import net.minecraft.sounds.SoundEvents;
+import net.minecraft.world.InteractionHand;
+import net.minecraft.world.damagesource.DamageSource;
+import net.minecraft.world.entity.animal.Animal;
+import net.minecraft.world.entity.item.ItemEntity;
+import net.minecraft.world.item.Item;
+import net.minecraft.world.item.ItemStack;
 import net.minecraftforge.common.util.FakePlayer;
 import net.minecraftforge.common.util.FakePlayerFactory;
 import org.jetbrains.annotations.NotNull;
@@ -119,7 +118,8 @@ public abstract class AbstractEntityAIHerder<J extends AbstractJob<?, J>, B exte
     protected List<ItemStack> itemsNiceToHave()
     {
         final List<ItemStack> list = super.itemsNiceToHave();
-        if (getOwnBuilding().getSetting(AbstractBuilding.BREEDING).getValue())
+        if (getOwnBuilding().getSetting(AbstractBuilding.BREEDING).getValue() ||
+                getOwnBuilding().getSetting(AbstractBuilding.FEEDING).getValue())
         {
             list.add(getRequestBreedingItems());
         }
@@ -194,11 +194,11 @@ public abstract class AbstractEntityAIHerder<J extends AbstractJob<?, J>, B exte
         {
             return HERDER_BUTCHER;
         }
-        else if (getOwnBuilding().getFirstOptionalModuleOccurance(ISettingsModule.class).map(m-> m.getSetting(AbstractBuilding.BREEDING).getValue()).orElse(true) && numOfBreedableAnimals >= NUM_OF_ANIMALS_TO_BREED && hasBreedingItem)
+        else if (canBreedChildren() && numOfBreedableAnimals >= NUM_OF_ANIMALS_TO_BREED && hasBreedingItem)
         {
             return HERDER_BREED;
         }
-        else if (canFeedChildren() && numOfFeedableAnimals > 0)
+        else if (canFeedChildren() && numOfFeedableAnimals > 0 && hasBreedingItem)
         {
             return HERDER_FEED;
         }
@@ -217,12 +217,22 @@ public abstract class AbstractEntityAIHerder<J extends AbstractJob<?, J>, B exte
     }
 
     /**
+     * Whether or not this one can feed adults to breed children.
+     * @return true if so.
+     */
+    protected boolean canBreedChildren()
+    {
+        return getOwnBuilding().getSetting(AbstractBuilding.BREEDING).getValue();
+    }
+
+    /**
      * Whether or not this one can feed children to speed up growth.
      * @return true if so.
      */
     protected boolean canFeedChildren()
     {
-        return getSecondarySkillLevel() >= LIMIT_TO_FEED_CHILDREN;
+        return getOwnBuilding().getSetting(AbstractBuilding.FEEDING).getValue() &&
+                getSecondarySkillLevel() >= LIMIT_TO_FEED_CHILDREN;
     }
 
     /**
@@ -255,7 +265,8 @@ public abstract class AbstractEntityAIHerder<J extends AbstractJob<?, J>, B exte
             }
         }
 
-        if (getOwnBuilding().getSetting(AbstractBuilding.BREEDING).getValue())
+        if (getOwnBuilding().getSetting(AbstractBuilding.BREEDING).getValue() ||
+                getOwnBuilding().getSetting(AbstractBuilding.FEEDING).getValue())
         {
             final ItemStack breedingItem = getBreedingItem();
             checkIfRequestForItemExistOrCreateAsynch(breedingItem, breedingItem.getMaxStackSize(), breedingItem.getCount());

--- a/src/main/java/com/minecolonies/coremod/entity/ai/citizen/herders/EntityAIWorkCowboy.java
+++ b/src/main/java/com/minecolonies/coremod/entity/ai/citizen/herders/EntityAIWorkCowboy.java
@@ -148,12 +148,6 @@ public class EntityAIWorkCowboy extends AbstractEntityAIHerder<JobCowboy, Buildi
     }
 
     @Override
-    protected boolean canFeedChildren()
-    {
-        return getSecondarySkillLevel() >= LIMIT_TO_FEED_CHILDREN;
-    }
-
-    @Override
     public double getButcheringAttackDamage()
     {
         return Math.max(1.0, getPrimarySkillLevel() / 10.0);

--- a/src/main/java/com/minecolonies/coremod/entity/ai/citizen/herders/EntityAIWorkRabbitHerder.java
+++ b/src/main/java/com/minecolonies/coremod/entity/ai/citizen/herders/EntityAIWorkRabbitHerder.java
@@ -54,12 +54,6 @@ public class EntityAIWorkRabbitHerder extends AbstractEntityAIHerder<JobRabbitHe
     }
 
     @Override
-    protected boolean canFeedChildren()
-    {
-        return getSecondarySkillLevel() >= LIMIT_TO_FEED_CHILDREN;
-    }
-
-    @Override
     public int getMaxAnimalMultiplier()
     {
         return MAX_ANIMALS_PER_LEVEL;

--- a/src/main/java/com/minecolonies/coremod/entity/ai/citizen/herders/EntityAIWorkSwineHerder.java
+++ b/src/main/java/com/minecolonies/coremod/entity/ai/citizen/herders/EntityAIWorkSwineHerder.java
@@ -54,12 +54,6 @@ public class EntityAIWorkSwineHerder extends AbstractEntityAIHerder<JobSwineHerd
     }
 
     @Override
-    protected boolean canFeedChildren()
-    {
-        return getSecondarySkillLevel() >= LIMIT_TO_FEED_CHILDREN;
-    }
-
-    @Override
     public Class<Pig> getAnimalClass()
     {
         return Pig.class;

--- a/src/main/resources/assets/minecolonies/lang/manual_en_us.json
+++ b/src/main/resources/assets/minecolonies/lang/manual_en_us.json
@@ -1913,6 +1913,7 @@
   "com.minecolonies.coremod.gui.maintab": "Main",
   "com.minecolonies.coremod.setting.minecolonies:producedirt": "Produce Dirt:",
   "com.minecolonies.coremod.setting.minecolonies:breeding": "Breeding:",
+  "com.minecolonies.coremod.setting.minecolonies:feeding": "Feeding:",
   "com.minecolonies.coremod.setting.minecolonies:milking": "Milking:",
   "com.minecolonies.coremod.setting.minecolonies:dyeing": "Dyeing:",
   "com.minecolonies.coremod.setting.minecolonies:shearing": "Shearing:",


### PR DESCRIPTION
# Changes proposed in this pull request:
- Allow chicken herder and shepherd to force-feed babies to increase growth rate too.
- Prevent butchering adults that have been recently fed (avoid wasting food).
- Add "feeding" setting to allow disabling force-feeding baby animals to reduce food usage.

Review please

Regarding the first, I can sort of see why disabling this for sheep might have been deliberate since they will also self-feed via eating grass blocks to improve their own growth rate -- but it's still possible for the player to hand-feed baby sheep, so it should be possible for the shepherd too.  I can't think of any reason why chickens might have been deliberate.

Having said that, there doesn't really seem to be any sort of rate limit on it -- once over the necessary (low) skill threshold they'll just keep using food to age them up until they're all fully grown or they run out of food.  While there's no limit in vanilla either, a player is probably less likely to always age up the babies.  Perhaps this needs a limit or a setting or both (~~not included here~~ setting now added, but perhaps still could use rate).

Regarding the second, I never directly observed this happening (and I'm not sure how likely it is based on timing) but the scenario to imagine is this:

1. A level 2 herder with 4 adult animals (at max limit).
2. They feed all the animals; this is two breeding pairs and so should result in two babies being born.
3. As soon as the first baby is born, there's now 5 animals in the pen and so the herder will start looking for animals to slaughter.
4. Previously, they could have selected one of the breeding pair that had not yet produced a baby (because they were still trying to path to each other, but the herder got there first).
    * The net result of this is that there will now be three adults (two just-bred, one just-fed and looking for a partner), and just one baby.
    * This is a waste of two units of food -- for the one killed while fed and also the one fed without being able to find a partner, as the "fed" state will wear off over time.  (And the herder will only ever feed two adults at a time, so even if another adult is introduced before it wears off, they won't feed the new adult until the old one is no longer fed.)

The change will refuse to slaughter just-fed animals (or babies, as before); the herder will still start looking for an animal to slaughter as soon as the first baby is born but will always choose one not just-fed (i.e. usually one of the parents of the new baby).

This should cause a clean sweep in the breeding cycle -- they will feed all the adults, kill all the parents as soon as they produce babies, feed the babies to grow them up faster, then repeat.  (In practice they'll probably get out of sync due to pathfinding delays and other reasons.)

It's possibly also worth mentioning that the beekeeper doesn't force-feed baby bees (which is why they lack that setting), even though it's possible for the player to do that, because they're using different AI from the other herders.  This hasn't been changed here.