### PR TITLE
Fix multiple permission issues

### DIFF
--- a/src/api/java/com/minecolonies/api/colony/permissions/IPermissions.java
+++ b/src/api/java/com/minecolonies/api/colony/permissions/IPermissions.java
@@ -107,12 +107,15 @@ public interface IPermissions
     boolean isColonyMember(Player player);
 
     /**
-     * Toggle permission for a specific rank.
-     * @param actor the acting rank.
-     * @param rank   Rank to toggle permission.
-     * @param action Action to toggle permission.
+     * Alters the permission through an actor, checks for allowance before altering.
+     *
+     * @param actor  to check
+     * @param rank   rank to edit
+     * @param action action to set
+     * @param enable add/remove permission
+     * @return success/failure
      */
-    void togglePermission(final Rank actor, Rank rank, @NotNull Action action);
+    boolean alterPermission(final Rank actor, Rank rank, @NotNull Action action, final boolean enable);
 
     @Nullable
     Map.Entry<UUID, ColonyPlayer> getOwnerEntry();
@@ -167,14 +170,21 @@ public interface IPermissions
 
     void restoreOwnerIfNull();
 
-    boolean setPermission(Rank rank, Action action);
-
-    boolean removePermission(Rank rank, Action action);
+    /**
+     * Sets a permission to a rank, does not include allowance checks
+     *
+     * @param rank   Rank to modify
+     * @param action permission to set
+     * @param enable or disable permission
+     * @return
+     */
+    boolean setPermission(Rank rank, Action action, boolean enable);
 
     boolean removePlayer(UUID playerID);
 
     /**
      * Adds a rink with the given name to the colony
+     *
      * @param name the chosen name
      */
     void addRank(String name);

--- a/src/api/java/com/minecolonies/api/colony/permissions/Rank.java
+++ b/src/api/java/com/minecolonies/api/colony/permissions/Rank.java
@@ -1,5 +1,7 @@
 package com.minecolonies.api.colony.permissions;
 
+import com.minecolonies.api.util.Utils;
+
 import java.util.Objects;
 
 public class Rank
@@ -33,15 +35,22 @@ public class Rank
     private boolean isHostile;
 
     /**
-     * Rank constructor
-     * @param id the id of the rank
-     * @param name the name of the rank
-     * @param isSubscriber whether the rank is a subscriber
-     * @param isInitial whether the rank is an initial rank
+     * Holds all bits indicating given permissions
      */
-    public Rank(int id, String name, boolean isSubscriber, boolean isInitial, boolean isColonyManager, boolean isHostile)
+    private long permissionData = 0;
+
+    /**
+     * Rank constructor
+     *
+     * @param id           the id of the rank
+     * @param name         the name of the rank
+     * @param isSubscriber whether the rank is a subscriber
+     * @param isInitial    whether the rank is an initial rank
+     */
+    public Rank(int id, long permissionData, String name, boolean isSubscriber, boolean isInitial, boolean isColonyManager, boolean isHostile)
     {
         this.id = id;
+        this.permissionData = permissionData;
         this.name = name;
         this.isSubscriber = isSubscriber;
         this.isInitial = isInitial;
@@ -51,7 +60,7 @@ public class Rank
 
     public Rank(int id, String name, boolean isSubscriber, boolean isInitial)
     {
-        this(id, name, isSubscriber, isInitial, false, false);
+        this(id, 0L, name, isSubscriber, isInitial, false, false);
     }
 
     /**
@@ -147,5 +156,44 @@ public class Rank
     public int compareTo(Rank rank)
     {
         return this.getId() - rank.getId();
+    }
+
+    /**
+     * Adds the given action permission if it is not set yet
+     *
+     * @param action
+     * @return
+     */
+    public boolean addPermission(final Action action)
+    {
+        if (!Utils.testFlag(permissionData, action.getFlag()))
+        {
+            permissionData = Utils.setFlag(permissionData, action.getFlag());
+            return true;
+        }
+
+        return false;
+    }
+
+    /**
+     * Adds the given action permission if it is not set yet
+     *
+     * @param action
+     * @return
+     */
+    public boolean removePermission(final Action action)
+    {
+        if (Utils.testFlag(permissionData, action.getFlag()))
+        {
+            permissionData = Utils.unsetFlag(permissionData, action.getFlag());
+            return true;
+        }
+
+        return false;
+    }
+
+    public long getPermissions()
+    {
+        return permissionData;
     }
 }

--- a/src/main/java/com/minecolonies/coremod/client/gui/townhall/WindowPermissionsPage.java
+++ b/src/main/java/com/minecolonies/coremod/client/gui/townhall/WindowPermissionsPage.java
@@ -9,23 +9,23 @@ import com.ldtteam.blockui.views.ScrollingList;
 import com.ldtteam.blockui.views.SwitchView;
 import com.ldtteam.structurize.util.LanguageHandler;
 import com.minecolonies.api.colony.permissions.Action;
-import com.minecolonies.api.colony.permissions.IPermissions;
 import com.minecolonies.api.colony.permissions.ColonyPlayer;
+import com.minecolonies.api.colony.permissions.IPermissions;
 import com.minecolonies.api.colony.permissions.Rank;
 import com.minecolonies.api.util.BlockPosUtil;
 import com.minecolonies.api.util.Log;
 import com.minecolonies.coremod.Network;
 import com.minecolonies.coremod.colony.buildings.workerbuildings.BuildingTownHall;
 import com.minecolonies.coremod.network.messages.PermissionsMessage;
-import com.minecolonies.coremod.network.messages.server.colony.*;
+import com.minecolonies.coremod.network.messages.server.colony.ChangeFreeToInteractBlockMessage;
+import net.minecraft.ResourceLocationException;
+import net.minecraft.client.Minecraft;
 import net.minecraft.client.player.LocalPlayer;
+import net.minecraft.core.BlockPos;
 import net.minecraft.network.chat.TranslatableComponent;
+import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.level.block.Block;
-import net.minecraft.client.Minecraft;
-import net.minecraft.resources.ResourceLocation;
-import net.minecraft.ResourceLocationException;
-import net.minecraft.core.BlockPos;
 import net.minecraftforge.registries.ForgeRegistries;
 import org.jetbrains.annotations.NotNull;
 
@@ -68,7 +68,7 @@ public class WindowPermissionsPage extends AbstractWindowTownHall
     /**
      * A list of ranks (excluding owner)
      */
-    private final List<Rank> rankList = new LinkedList<>();
+    private final List<Rank> rankList    = new LinkedList<>();
     private final List<Rank> allRankList = new LinkedList<>();
 
     /**
@@ -124,17 +124,21 @@ public class WindowPermissionsPage extends AbstractWindowTownHall
     /**
      * Toggle the subscriber flag on client
      * Send message to change it on server
+     *
      * @param button the button clicked
      */
     private void setSubscriber(Button button)
     {
         Network.getNetwork().sendToServer(new PermissionsMessage.SetSubscriber(building.getColony(), actionsRank, !actionsRank.isSubscriber()));
         actionsRank.setSubscriber(!actionsRank.isSubscriber());
-        button.setText(new TranslatableComponent(actionsRank.isSubscriber() ? COM_MINECOLONIES_COREMOD_GUI_WORKERHUTS_RETRIEVE_ON : COM_MINECOLONIES_COREMOD_GUI_WORKERHUTS_RETRIEVE_OFF));
+        button.setText(new TranslatableComponent(actionsRank.isSubscriber()
+                                                   ? COM_MINECOLONIES_COREMOD_GUI_WORKERHUTS_RETRIEVE_ON
+                                                   : COM_MINECOLONIES_COREMOD_GUI_WORKERHUTS_RETRIEVE_OFF));
     }
 
     /**
      * Send message to the server to change the rank type
+     *
      * @param dropdown the index of the type
      */
     private void changeRankMode(DropDownList dropdown)
@@ -144,6 +148,7 @@ public class WindowPermissionsPage extends AbstractWindowTownHall
 
     /**
      * Switch the view on the rank view (between permissions and settings)
+     *
      * @param button the button clicked
      */
     private void togglePermMode(Button button)
@@ -153,7 +158,8 @@ public class WindowPermissionsPage extends AbstractWindowTownHall
         if (permSwitch.getCurrentView().getID().equals(TOWNHALL_PERM_SETTINGS))
         {
             DropDownList dropdown = findPaneOfTypeByID(TOWNHALL_RANK_TYPE_PICKER, DropDownList.class);
-            dropdown.setDataProvider(new DropDownList.DataProvider() {
+            dropdown.setDataProvider(new DropDownList.DataProvider()
+            {
                 @Override
                 public int getElementCount()
                 {
@@ -168,7 +174,9 @@ public class WindowPermissionsPage extends AbstractWindowTownHall
             });
             dropdown.setHandler(this::changeRankMode);
             dropdown.setSelectedIndex(actionsRank.isColonyManager() ? 0 : (actionsRank.isHostile() ? 1 : 2));
-            findPaneOfTypeByID(TOWNHALL_BUTTON_SUBSCRIBER, Button.class).setText(new TranslatableComponent(actionsRank.isSubscriber() ? COM_MINECOLONIES_COREMOD_GUI_WORKERHUTS_RETRIEVE_ON : COM_MINECOLONIES_COREMOD_GUI_WORKERHUTS_RETRIEVE_OFF));
+            findPaneOfTypeByID(TOWNHALL_BUTTON_SUBSCRIBER, Button.class).setText(new TranslatableComponent(actionsRank.isSubscriber()
+                                                                                                             ? COM_MINECOLONIES_COREMOD_GUI_WORKERHUTS_RETRIEVE_ON
+                                                                                                             : COM_MINECOLONIES_COREMOD_GUI_WORKERHUTS_RETRIEVE_OFF));
         }
     }
 
@@ -196,6 +204,7 @@ public class WindowPermissionsPage extends AbstractWindowTownHall
     /**
      * Validates whether the given name is a valid rank name
      * If name is empty or already in use for a rank within this colony, it is invalid
+     *
      * @param name the name
      * @return true if name is valid
      */
@@ -219,6 +228,7 @@ public class WindowPermissionsPage extends AbstractWindowTownHall
      * Send message to server to remove the currently selected rank
      * Remove rank from view
      * Set currently selected rank to officer and disable button
+     *
      * @param button the clicked button
      */
     private void onRemoveRankButtonClicked(Button button)
@@ -292,7 +302,8 @@ public class WindowPermissionsPage extends AbstractWindowTownHall
      */
     private void fillRanks()
     {
-        rankButtonList.setDataProvider(new ScrollingList.DataProvider() {
+        rankButtonList.setDataProvider(new ScrollingList.DataProvider()
+        {
             @Override
             public int getElementCount()
             {
@@ -313,6 +324,7 @@ public class WindowPermissionsPage extends AbstractWindowTownHall
 
     /**
      * Change to currently selected rank to the one belonging to the clicked button
+     *
      * @param button the clicked button
      */
     private void onRankButtonClicked(@NotNull final Button button)
@@ -433,16 +445,15 @@ public class WindowPermissionsPage extends AbstractWindowTownHall
 
         final IPermissions permissions = building.getColony().getPermissions();
         final Player playerEntity = Minecraft.getInstance().player;
-        if (!permissions.hasPermission(playerEntity, Action.EDIT_PERMISSIONS) || !permissions.canAlterPermission(permissions.getRank(playerEntity), actionsRank, action))
+        final boolean enable = !LanguageHandler.format(COM_MINECOLONIES_COREMOD_GUI_WORKERHUTS_RETRIEVE_ON).equals(button.getTextAsString());
+        button.disable();
+        if (!permissions.alterPermission(permissions.getRank(playerEntity), actionsRank, action, enable))
         {
             return;
         }
+        Network.getNetwork().sendToServer(new PermissionsMessage.Permission(building.getColony(), enable, actionsRank, action));
 
-        final boolean trigger = LanguageHandler.format(COM_MINECOLONIES_COREMOD_GUI_WORKERHUTS_RETRIEVE_ON).equals(button.getTextAsString());
-        Network.getNetwork().sendToServer(new PermissionsMessage.Permission(building.getColony(), PermissionsMessage.MessageType.TOGGLE_PERMISSION, actionsRank, action));
-        building.getColony().getPermissions().togglePermission(permissions.getRank(playerEntity), actionsRank, action);
-
-        if (trigger)
+        if (!enable)
         {
             button.setText(new TranslatableComponent(COM_MINECOLONIES_COREMOD_GUI_WORKERHUTS_RETRIEVE_OFF));
         }
@@ -479,10 +490,19 @@ public class WindowPermissionsPage extends AbstractWindowTownHall
 
                 rowPane.findPaneOfTypeByID(NAME_LABEL, Text.class).setText(name);
                 final boolean isTriggered = building.getColony().getPermissions().hasPermission(actionsRank, action);
-                rowPane.findPaneOfTypeByID("trigger", Button.class)
-                  .setText(isTriggered ? new TranslatableComponent(COM_MINECOLONIES_COREMOD_GUI_WORKERHUTS_RETRIEVE_ON)
-                              : new TranslatableComponent(COM_MINECOLONIES_COREMOD_GUI_WORKERHUTS_RETRIEVE_OFF));
+                final Button onOffButton = rowPane.findPaneOfTypeByID("trigger", Button.class);
+                onOffButton.setText(isTriggered ? new TranslatableComponent(COM_MINECOLONIES_COREMOD_GUI_WORKERHUTS_RETRIEVE_ON)
+                                      : new TranslatableComponent(COM_MINECOLONIES_COREMOD_GUI_WORKERHUTS_RETRIEVE_OFF));
                 rowPane.findPaneOfTypeByID("index", Text.class).setText(Integer.toString(index));
+
+                if (!building.getColony().getPermissions().canAlterPermission(building.getColony().getPermissions().getRank(Minecraft.getInstance().player), actionsRank, action))
+                {
+                    onOffButton.disable();
+                }
+                else
+                {
+                    onOffButton.enable();
+                }
             }
         });
     }
@@ -516,7 +536,8 @@ public class WindowPermissionsPage extends AbstractWindowTownHall
                 }
                 else
                 {
-                    dropdown.setDataProvider(new DropDownList.DataProvider() {
+                    dropdown.setDataProvider(new DropDownList.DataProvider()
+                    {
                         @Override
                         public int getElementCount()
                         {
@@ -541,6 +562,7 @@ public class WindowPermissionsPage extends AbstractWindowTownHall
      * When the selected index in the rank dropdown is updated,
      * check if the rank is different to the current one
      * if so, change the rank client side and send a message to the server
+     *
      * @param dropdown the rank dropdown
      */
     private void onRankSelected(final DropDownList dropdown)
@@ -554,8 +576,6 @@ public class WindowPermissionsPage extends AbstractWindowTownHall
             Network.getNetwork().sendToServer(new PermissionsMessage.ChangePlayerRank(building.getColony(), player.getID(), rank));
         }
     }
-
-
 
     @Override
     public void onUpdate()

--- a/src/main/java/com/minecolonies/coremod/colony/permissions/Permissions.java
+++ b/src/main/java/com/minecolonies/coremod/colony/permissions/Permissions.java
@@ -23,8 +23,8 @@ import java.util.*;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
-import static com.minecolonies.api.util.constant.NbtTagConstants.TAG_NAME;
 import static com.minecolonies.api.colony.IColony.CLOSE_COLONY_CAP;
+import static com.minecolonies.api.util.constant.NbtTagConstants.TAG_NAME;
 
 /**
  * Colony Permissions System.
@@ -56,19 +56,18 @@ public class Permissions implements IPermissions
     /**
      * All defined ranks
      */
-    private static final Map<Integer, Rank> ranks = new LinkedHashMap<>();
+    private final Map<Integer, Rank> ranks = new LinkedHashMap<>();
 
     /**
      * A flag for all the permissions unlocked in a fully abandoned colony.
      */
     private static int fullyAbandonedPermissionsFlag = 0;
-
     static
     {
         /*
          * Generate the fully abandoned flag.
          */
-        for (Action a:Action.values())
+        for (Action a : Action.values())
         {
             if (a != Action.GUARDS_ATTACK
                   && a != Action.EDIT_PERMISSIONS && a != Action.MANAGE_HUTS
@@ -93,12 +92,6 @@ public class Permissions implements IPermissions
     private final Map<UUID, ColonyPlayer> players = new HashMap<>();
 
     /**
-     * Permissions of these players.
-     */
-    @NotNull
-    private final Map<Rank, Long> permissionMap = new HashMap<>();
-
-    /**
      * Used to check if the permissions have to by synchronized.
      */
     private boolean dirty = false;
@@ -111,7 +104,7 @@ public class Permissions implements IPermissions
     /**
      * The UUID of the owner.
      */
-    private UUID   ownerUUID = null;
+    private UUID ownerUUID = null;
 
     /**
      * True if this character has no owner or officer left and thus can be mined by anyone.
@@ -141,57 +134,55 @@ public class Permissions implements IPermissions
     private void loadRanks()
     {
         ranks.clear();
-        permissionMap.clear();
         for (OldRank oldRank : OldRank.values())
         {
             String name = oldRank.name();
-            name = name.substring(0,1).toUpperCase(Locale.ENGLISH) + name.substring(1).toLowerCase(Locale.ENGLISH);
+            name = name.substring(0, 1).toUpperCase(Locale.ENGLISH) + name.substring(1).toLowerCase(Locale.ENGLISH);
             Rank rank = new Rank(oldRank.ordinal(), name, oldRank.isSubscriber, true);
             ranks.put(rank.getId(), rank);
-            permissionMap.put(rank, 0L);
             switch (oldRank)
             {
                 case OWNER:
-                    this.setPermission(rank, Action.EDIT_PERMISSIONS);
-                    this.setPermission(rank, Action.MAP_BORDER);
-                    this.setPermission(rank, Action.MAP_DEATHS);
+                    rank.addPermission(Action.EDIT_PERMISSIONS);
+                    rank.addPermission(Action.MAP_BORDER);
+                    rank.addPermission(Action.MAP_DEATHS);
                 case OFFICER:
-                    this.setPermission(rank, Action.PLACE_HUTS);
-                    this.setPermission(rank, Action.BREAK_HUTS);
-                    this.setPermission(rank, Action.MANAGE_HUTS);
-                    this.setPermission(rank, Action.RECEIVE_MESSAGES);
-                    this.setPermission(rank, Action.PLACE_BLOCKS);
-                    this.setPermission(rank, Action.BREAK_BLOCKS);
-                    this.setPermission(rank, Action.FILL_BUCKET);
-                    this.setPermission(rank, Action.OPEN_CONTAINER);
-                    this.setPermission(rank, Action.RECEIVE_MESSAGES_FAR_AWAY);
-                    this.setPermission(rank, Action.CAN_KEEP_COLONY_ACTIVE_WHILE_AWAY);
-                    this.setPermission(rank, Action.RALLY_GUARDS);
-                    this.setPermission(rank, Action.MAP_BORDER);
-                    this.setPermission(rank, Action.MAP_DEATHS);
+                    rank.addPermission(Action.PLACE_HUTS);
+                    rank.addPermission(Action.BREAK_HUTS);
+                    rank.addPermission(Action.MANAGE_HUTS);
+                    rank.addPermission(Action.RECEIVE_MESSAGES);
+                    rank.addPermission(Action.PLACE_BLOCKS);
+                    rank.addPermission(Action.BREAK_BLOCKS);
+                    rank.addPermission(Action.FILL_BUCKET);
+                    rank.addPermission(Action.OPEN_CONTAINER);
+                    rank.addPermission(Action.RECEIVE_MESSAGES_FAR_AWAY);
+                    rank.addPermission(Action.CAN_KEEP_COLONY_ACTIVE_WHILE_AWAY);
+                    rank.addPermission(Action.RALLY_GUARDS);
+                    rank.addPermission(Action.MAP_BORDER);
+                    rank.addPermission(Action.MAP_DEATHS);
                     rank.setColonyManager(true);
                 case FRIEND:
-                    this.setPermission(rank, Action.ACCESS_HUTS);
-                    this.setPermission(rank, Action.USE_SCAN_TOOL);
-                    this.setPermission(rank, Action.TOSS_ITEM);
-                    this.setPermission(rank, Action.PICKUP_ITEM);
-                    this.setPermission(rank, Action.RIGHTCLICK_BLOCK);
-                    this.setPermission(rank, Action.RIGHTCLICK_ENTITY);
-                    this.setPermission(rank, Action.THROW_POTION);
-                    this.setPermission(rank, Action.SHOOT_ARROW);
-                    this.setPermission(rank, Action.ATTACK_CITIZEN);
-                    this.setPermission(rank, Action.ATTACK_ENTITY);
-                    this.setPermission(rank, Action.TELEPORT_TO_COLONY);
-                    this.setPermission(rank, Action.MAP_BORDER);
+                    rank.addPermission(Action.ACCESS_HUTS);
+                    rank.addPermission(Action.USE_SCAN_TOOL);
+                    rank.addPermission(Action.TOSS_ITEM);
+                    rank.addPermission(Action.PICKUP_ITEM);
+                    rank.addPermission(Action.RIGHTCLICK_BLOCK);
+                    rank.addPermission(Action.RIGHTCLICK_ENTITY);
+                    rank.addPermission(Action.THROW_POTION);
+                    rank.addPermission(Action.SHOOT_ARROW);
+                    rank.addPermission(Action.ATTACK_CITIZEN);
+                    rank.addPermission(Action.ATTACK_ENTITY);
+                    rank.addPermission(Action.TELEPORT_TO_COLONY);
+                    rank.addPermission(Action.MAP_BORDER);
                 case NEUTRAL:
-                    this.setPermission(rank, Action.ACCESS_FREE_BLOCKS);
-                    this.setPermission(rank, Action.MAP_BORDER);
+                    rank.addPermission(Action.ACCESS_FREE_BLOCKS);
+                    rank.addPermission(Action.MAP_BORDER);
                     break;
                 case HOSTILE:
-                    this.setPermission(rank, Action.GUARDS_ATTACK);
-                    this.setPermission(rank, Action.HURT_CITIZEN);
-                    this.setPermission(rank, Action.HURT_VISITOR);
-                    this.setPermission(rank, Action.MAP_BORDER);
+                    rank.addPermission(Action.GUARDS_ATTACK);
+                    rank.addPermission(Action.HURT_CITIZEN);
+                    rank.addPermission(Action.HURT_VISITOR);
+                    rank.addPermission(Action.MAP_BORDER);
                     rank.setHostile(true);
                     break;
                 default:
@@ -200,6 +191,12 @@ public class Permissions implements IPermissions
         }
     }
 
+    /**
+     * Data version/correctness upgrades
+     *
+     * @param version
+     * @param rank
+     */
     private void upgradePermissions(final int version, final Rank rank)
     {
         // keep this consistent with loadRanks(), as that's still used for new colonies
@@ -208,19 +205,27 @@ public class Permissions implements IPermissions
         {
             if (rank.isHostile())
             {
-                this.setPermission(rank, Action.HURT_CITIZEN);
-                this.setPermission(rank, Action.HURT_VISITOR);
+                this.setPermission(rank, Action.HURT_CITIZEN, true);
+                this.setPermission(rank, Action.HURT_VISITOR, true);
             }
 
             if (rank.isColonyManager())
             {
-                this.setPermission(rank, Action.MAP_DEATHS);
+                this.setPermission(rank, Action.MAP_DEATHS, true);
             }
 
-            this.setPermission(rank, Action.MAP_BORDER);
+            this.setPermission(rank, Action.MAP_BORDER, true);
         }
 
         // if (version < 5) ...
+
+        // Fix bad saved values
+        if (rank == getRankOwner())
+        {
+            rank.addPermission(Action.EDIT_PERMISSIONS);
+            rank.addPermission(Action.ACCESS_HUTS);
+            rank.addPermission(Action.MANAGE_HUTS);
+        }
     }
 
     /**
@@ -229,20 +234,24 @@ public class Permissions implements IPermissions
      * @param rank   Desired rank.
      * @param action Action that should have desired rank.
      */
-    public final boolean setPermission(final Rank rank, @NotNull final Action action)
+    @Override
+    public final boolean setPermission(final Rank rank, @NotNull final Action action, boolean enable)
     {
-        final long flags = permissionMap.get(rank);
-
-        //check that flag isn't set
-        if (!Utils.testFlag(flags, action.getFlag()))
+        boolean changed;
+        if (enable)
         {
-            permissionMap.put(rank, Utils.setFlag(flags, action.getFlag()));
-            markDirty();
-
-            return true;
+            changed = rank.addPermission(action);
+        }
+        else
+        {
+            changed = rank.removePermission(action);
         }
 
-        return false;
+        if (changed)
+        {
+            markDirty();
+        }
+        return changed;
     }
 
     /**
@@ -258,14 +267,14 @@ public class Permissions implements IPermissions
     }
 
     @Override
-    public void togglePermission(final Rank actor, final Rank rank, @NotNull final Action action)
+    public boolean alterPermission(final Rank actor, final Rank rank, @NotNull final Action action, final boolean enable)
     {
         if (!canAlterPermission(actor, rank, action))
         {
-            return;
+            return false;
         }
-        permissionMap.put(rank, Utils.toggleFlag(permissionMap.get(rank), action.getFlag()));
-        markDirty();
+
+        return setPermission(rank, action, enable);
     }
 
     @Override
@@ -275,7 +284,8 @@ public class Permissions implements IPermissions
         {
             return false;
         }
-        return rank != getRankOwner() || (action != Action.EDIT_PERMISSIONS && action != Action.MANAGE_HUTS && action != Action.GUARDS_ATTACK  && action != Action.ACCESS_HUTS);
+
+        return hasPermission(actor, Action.EDIT_PERMISSIONS) && (actor != rank || action != Action.EDIT_PERMISSIONS && action != Action.MANAGE_HUTS && action != Action.ACCESS_HUTS);
     }
 
     /**
@@ -285,10 +295,12 @@ public class Permissions implements IPermissions
      */
     public void loadPermissions(@NotNull final CompoundTag compound)
     {
+        final int version = compound.getInt(TAG_VERSION);
         // Ranks
         if (compound.contains(TAG_RANKS))
         {
             ranks.clear();
+            final ListTag permissionsTagList = compound.getList(TAG_PERMISSIONS, Tag.TAG_COMPOUND);
             final ListTag rankTagList = compound.getList(TAG_RANKS, Tag.TAG_COMPOUND);
             for (int i = 0; i < rankTagList.size(); ++i)
             {
@@ -299,18 +311,44 @@ public class Permissions implements IPermissions
                 final boolean isInitial = rankCompound.getBoolean(TAG_INITIAL);
                 final boolean isColonyManager = rankCompound.getBoolean(TAG_COLONY_MANAGER);
                 final boolean isHostile = rankCompound.getBoolean(TAG_HOSTILE);
-                final Rank rank = new Rank(id, name, isSubscriber, isInitial, isColonyManager, isHostile);
+
+                long permissionData = 0L;
+                if (i < permissionsTagList.size())
+                {
+                    final CompoundTag permissionsCompound = permissionsTagList.getCompound(i);
+                    final ListTag flagsTagList = permissionsCompound.getList(TAG_FLAGS, Tag.TAG_STRING);
+
+                    long flags = 0;
+
+                    for (int j = 0; j < flagsTagList.size(); ++j)
+                    {
+                        final String flag = flagsTagList.getString(j);
+                        try
+                        {
+                            flags = Utils.setFlag(flags, Action.valueOf(flag).getFlag());
+                        }
+                        catch (IllegalArgumentException ex)
+                        {
+                            // noop, this can happen with backwards compat.
+                        }
+                    }
+                    permissionData = flags;
+                }
+
+                final Rank rank = new Rank(id, permissionData, name, isSubscriber, isInitial, isColonyManager, isHostile);
                 ranks.put(id, rank);
+
+                upgradePermissions(version, rank);
             }
         }
         else
         {
             this.loadRanks();
         }
+
         players.clear();
         //  Owners
         final ListTag ownerTagList = compound.getList(TAG_OWNERS, Tag.TAG_COMPOUND);
-        final int version = compound.getInt(TAG_VERSION);
         for (int i = 0; i < ownerTagList.size(); ++i)
         {
             final CompoundTag ownerCompound = ownerTagList.getCompound(i);
@@ -343,67 +381,31 @@ public class Permissions implements IPermissions
             }
         }
 
-        //Permissions
-        if (version >= 3)
+        if (compound.contains(TAG_OWNER))
         {
-            permissionMap.clear();
-            final ListTag permissionsTagList = compound.getList(TAG_PERMISSIONS, Tag.TAG_COMPOUND);
-            for (int i = 0; i < permissionsTagList.size(); ++i)
+            ownerName = compound.getString(TAG_OWNER);
+        }
+        if (compound.contains(TAG_OWNER_ID))
+        {
+            try
             {
-                final CompoundTag permissionsCompound = permissionsTagList.getCompound(i);
-                final Rank rank = ranks.get(permissionsCompound.getInt(TAG_RANK));
-                if (rank != null)
-                {
-                    final ListTag flagsTagList = permissionsCompound.getList(TAG_FLAGS, Tag.TAG_STRING);
+                ownerUUID = UUID.fromString(compound.getString(TAG_OWNER_ID));
+            }
+            catch (final IllegalArgumentException e)
+            {
+                /*
+                 * Intentionally left empty. Happens when the UUID hasn't been saved yet.
+                 */
+            }
+        }
 
-                    long flags = 0;
-
-                    for (int j = 0; j < flagsTagList.size(); ++j)
-                    {
-                        final String flag = flagsTagList.getString(j);
-                        try
-                        {
-                            if (Action.valueOf(flag) != null)
-                            {
-                                flags = Utils.setFlag(flags, Action.valueOf(flag).getFlag());
-                            }
-                        }
-                        catch (IllegalArgumentException ex)
-                        {
-                            // noop, this can happen with backwards compat.
-                        }
-                    }
-                    permissionMap.put(rank, flags);
-                    upgradePermissions(version, rank);
-                }
-            }
-
-            if (compound.contains(TAG_OWNER))
-            {
-                ownerName = compound.getString(TAG_OWNER);
-            }
-            if (compound.contains(TAG_OWNER_ID))
-            {
-                try
-                {
-                    ownerUUID = UUID.fromString(compound.getString(TAG_OWNER_ID));
-                }
-                catch (final IllegalArgumentException e)
-                {
-                    /*
-                     * Intentionally left empty. Happens when the UUID hasn't been saved yet.
-                     */
-                }
-            }
-
-            if (compound.contains(TAG_FULLY_ABANDONED))
-            {
-                fullyAbandoned = compound.getBoolean(TAG_FULLY_ABANDONED);
-            }
-            else
-            {
-                checkFullyAbandoned();
-            }
+        if (compound.contains(TAG_FULLY_ABANDONED))
+        {
+            fullyAbandoned = compound.getBoolean(TAG_FULLY_ABANDONED);
+        }
+        else
+        {
+            checkFullyAbandoned();
         }
 
         restoreOwnerIfNull();
@@ -546,18 +548,15 @@ public class Permissions implements IPermissions
 
         // Permissions
         @NotNull final ListTag permissionsTagList = new ListTag();
-        for (@NotNull final Map.Entry<Rank, Long> entry : permissionMap.entrySet())
+        for (@NotNull final Rank rank : ranks.values())
         {
             @NotNull final CompoundTag permissionsCompound = new CompoundTag();
-            if (entry.getKey() != null)
-            {
-                permissionsCompound.putInt(TAG_RANK, entry.getKey().getId());
-            }
+            permissionsCompound.putInt(TAG_RANK, rank.getId());
 
             @NotNull final ListTag flagsTagList = new ListTag();
             for (@NotNull final Action action : Action.values())
             {
-                if (Utils.testFlag(entry.getValue(), action.getFlag()))
+                if (Utils.testFlag(rank.getPermissions(), action.getFlag()))
                 {
                     flagsTagList.add(StringTag.valueOf(action.name()));
                 }
@@ -566,6 +565,7 @@ public class Permissions implements IPermissions
 
             permissionsTagList.add(permissionsCompound);
         }
+
         compound.put(TAG_PERMISSIONS, permissionsTagList);
 
         if (!ownerName.isEmpty())
@@ -599,7 +599,7 @@ public class Permissions implements IPermissions
     @Override
     public boolean hasPermission(final Rank rank, @NotNull final Action action)
     {
-        return Utils.testFlag(permissionMap.get(rank), action.getFlag())
+        return Utils.testFlag(rank.getPermissions(), action.getFlag())
                  || (fullyAbandoned && Utils.testFlag(fullyAbandonedPermissionsFlag, action.getFlag()));
     }
 
@@ -613,8 +613,8 @@ public class Permissions implements IPermissions
     public Set<ColonyPlayer> getPlayersByRank(final Rank rank)
     {
         return this.players.values().stream()
-                 .filter(player -> player.getRank() != null && player.getRank().equals(rank))
-                 .collect(Collectors.toSet());
+          .filter(player -> player.getRank() != null && player.getRank().equals(rank))
+          .collect(Collectors.toSet());
     }
 
     /**
@@ -627,8 +627,8 @@ public class Permissions implements IPermissions
     public Set<ColonyPlayer> getPlayersByRank(@NotNull final Set<Rank> ranks)
     {
         return this.players.values().stream()
-                 .filter(player -> ranks.contains(player.getRank()))
-                 .collect(Collectors.toSet());
+          .filter(player -> ranks.contains(player.getRank()))
+          .collect(Collectors.toSet());
     }
 
     @Override
@@ -637,17 +637,6 @@ public class Permissions implements IPermissions
         return this.players.values().stream()
           .filter(player -> predicate.test(player.getRank()))
           .collect(Collectors.toSet());
-    }
-
-    /**
-     * Returns the map of permissionMap and ranks.
-     *
-     * @return map of permissionMap.
-     */
-    @NotNull
-    public Map<Rank, Long> getPermissionMap()
-    {
-        return permissionMap;
     }
 
     /**
@@ -667,26 +656,6 @@ public class Permissions implements IPermissions
     public Rank getRank(@NotNull final Player player)
     {
         return getRank(player.getGameProfile().getId());
-    }
-
-    /**
-     * Remove permission for a specific rank.
-     *
-     * @param rank   Rank to remove permission.
-     * @param action Action to remove from rank.
-     */
-    public boolean removePermission(final Rank rank, @NotNull final Action action)
-    {
-        final long flags = permissionMap.get(rank);
-        if (Utils.testFlag(flags, action.getFlag()))
-        {
-            permissionMap.put(rank, Utils.unsetFlag(flags, action.getFlag()));
-            markDirty();
-
-            return true;
-        }
-
-        return false;
     }
 
     /**
@@ -939,6 +908,7 @@ public class Permissions implements IPermissions
         for (Rank rank : ranks.values())
         {
             buf.writeVarInt(rank.getId());
+            buf.writeLong(rank.getPermissions());
             buf.writeUtf(rank.getName());
             buf.writeBoolean(rank.isSubscriber());
             buf.writeBoolean(rank.isInitial());
@@ -955,14 +925,6 @@ public class Permissions implements IPermissions
             PacketUtils.writeUUID(buf, player.getKey());
             buf.writeUtf(player.getValue().getName());
             buf.writeVarInt(player.getValue().getRank().getId());
-        }
-
-        // Permissions
-        buf.writeVarInt(permissionMap.size());
-        for (@NotNull final Map.Entry<Rank, Long> entry : permissionMap.entrySet())
-        {
-            buf.writeVarLong(entry.getKey().getId());
-            buf.writeVarLong(entry.getValue());
         }
     }
 
@@ -986,6 +948,7 @@ public class Permissions implements IPermissions
 
     /**
      * Get rank instance of owner
+     *
      * @return the rank
      */
     @Override
@@ -996,6 +959,7 @@ public class Permissions implements IPermissions
 
     /**
      * Get rank instance of officer
+     *
      * @return the rank
      */
     @Override
@@ -1006,6 +970,7 @@ public class Permissions implements IPermissions
 
     /**
      * Get rank instance of hostile
+     *
      * @return the rank
      */
     @Override
@@ -1016,6 +981,7 @@ public class Permissions implements IPermissions
 
     /**
      * Get rank instance of friend
+     *
      * @return the rank
      */
     @Override
@@ -1026,6 +992,7 @@ public class Permissions implements IPermissions
 
     /**
      * Get rank instance of neutral
+     *
      * @return the rank
      */
     @Override
@@ -1042,6 +1009,7 @@ public class Permissions implements IPermissions
 
     /**
      * Get a map of all ranks with their according ID as key
+     *
      * @return the ranks
      */
     @Override
@@ -1052,6 +1020,7 @@ public class Permissions implements IPermissions
 
     /**
      * Create a new rank instance with the given name, auto assign lowest unused ID, no permissions
+     *
      * @param name the name of the rank
      */
     @Override
@@ -1069,16 +1038,17 @@ public class Permissions implements IPermissions
         }
         Rank rank = new Rank(id, name, false, false);
         ranks.put(id, rank);
-        permissionMap.put(rank, 0L);
         markDirty();
     }
 
     /**
      * Remove the given rank, if it is not an initial rank
      * Set all players with the given rank to neutral
+     *
      * @param rank the rank to remove
      */
-    @Override public void removeRank(Rank rank)
+    @Override
+    public void removeRank(Rank rank)
     {
         if (rank.isInitial())
         {
@@ -1089,7 +1059,6 @@ public class Permissions implements IPermissions
             player.setRank(getRankNeutral());
         }
         ranks.remove(rank.getId());
-        permissionMap.remove(rank);
         markDirty();
     }
 }

--- a/src/main/java/com/minecolonies/coremod/colony/permissions/PermissionsView.java
+++ b/src/main/java/com/minecolonies/coremod/colony/permissions/PermissionsView.java
@@ -1,11 +1,14 @@
 package com.minecolonies.coremod.colony.permissions;
 
-import com.minecolonies.api.colony.permissions.*;
+import com.minecolonies.api.colony.permissions.Action;
+import com.minecolonies.api.colony.permissions.ColonyPlayer;
+import com.minecolonies.api.colony.permissions.IPermissions;
+import com.minecolonies.api.colony.permissions.Rank;
 import com.minecolonies.api.network.PacketUtils;
 import com.minecolonies.api.util.Utils;
 import com.mojang.authlib.GameProfile;
-import net.minecraft.world.entity.player.Player;
 import net.minecraft.network.FriendlyByteBuf;
+import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.level.Level;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -21,8 +24,6 @@ public class PermissionsView implements IPermissions
 {
     @NotNull
     private final Map<UUID, ColonyPlayer>  players     = new HashMap<>();
-    @NotNull
-    private final Map<Rank, Long>    permissions = new HashMap<>();
     private       Rank               userRank;
     private final Map<Integer, Rank> ranks = new LinkedHashMap<>();
 
@@ -98,12 +99,6 @@ public class PermissionsView implements IPermissions
           .collect(Collectors.toSet()));
     }
 
-    @NotNull
-    public Map<Rank, Long> getPermissions()
-    {
-        return permissions;
-    }
-
     /**
      * Checks if the player has the permission to do an action.
      *
@@ -125,7 +120,7 @@ public class PermissionsView implements IPermissions
      */
     public boolean hasPermission(final Rank rank, @NotNull final Action action)
     {
-        return permissions != null && action != null && permissions.containsKey(rank) && Utils.testFlag(permissions.get(rank), action.getFlag());
+        return Utils.testFlag(rank.getPermissions(), action.getFlag());
     }
 
     /**
@@ -135,35 +130,19 @@ public class PermissionsView implements IPermissions
      * @param action the action he is trying to execute.
      * @return true if so.
      */
-    public boolean setPermission(final Rank rank, @NotNull final Action action)
+    public boolean setPermission(final Rank rank, @NotNull final Action action, final boolean enable)
     {
-        final long flags = permissions.get(rank);
-
-        //check that flag isn't set
-        if (!Utils.testFlag(flags, action.getFlag()))
+        boolean changed;
+        if (enable)
         {
-            permissions.put(rank, Utils.setFlag(flags, action.getFlag()));
-            return true;
+            changed = rank.addPermission(action);
         }
-        return false;
-    }
-
-    /**
-     * Remove if the rank has the permission to do an action.
-     *
-     * @param rank   the rank to set.
-     * @param action the action he is trying to execute.
-     * @return true if so.
-     */
-    public boolean removePermission(final Rank rank, @NotNull final Action action)
-    {
-        final long flags = permissions.get(rank);
-        if (Utils.testFlag(flags, action.getFlag()))
+        else
         {
-            permissions.put(rank, Utils.unsetFlag(flags, action.getFlag()));
-            return true;
+            changed = rank.removePermission(action);
         }
-        return false;
+
+        return changed;
     }
 
     @Override
@@ -173,13 +152,14 @@ public class PermissionsView implements IPermissions
     }
 
     @Override
-    public void togglePermission(final Rank actor, final Rank rank, @NotNull final Action action)
+    public boolean alterPermission(final Rank actor, final Rank rank, @NotNull final Action action, final boolean enable)
     {
         if (!canAlterPermission(actor, rank, action))
         {
-            return;
+            return false;
         }
-        permissions.put(rank, Utils.toggleFlag(permissions.get(rank), action.getFlag()));
+
+        return setPermission(rank, action, enable);
     }
 
     @Override
@@ -190,7 +170,8 @@ public class PermissionsView implements IPermissions
             return false;
         }
 
-        return rank != getRankOwner() || (action != Action.EDIT_PERMISSIONS && action != Action.MANAGE_HUTS && action != Action.GUARDS_ATTACK && action != Action.ACCESS_HUTS);
+        return hasPermission(actor, Action.EDIT_PERMISSIONS) && (actor != rank
+                                                                   || action != Action.EDIT_PERMISSIONS && action != Action.MANAGE_HUTS && action != Action.ACCESS_HUTS);
     }
 
     @Nullable
@@ -248,7 +229,7 @@ public class PermissionsView implements IPermissions
         for (int i = 0; i < ranksSize; ++i)
         {
             final int id = buf.readVarInt();
-            final Rank rank = new Rank(id, buf.readUtf(32767), buf.readBoolean(), buf.readBoolean(), buf.readBoolean(), buf.readBoolean());
+            final Rank rank = new Rank(id, buf.readLong(), buf.readUtf(32767), buf.readBoolean(), buf.readBoolean(), buf.readBoolean(), buf.readBoolean());
             ranks.put(id, rank);
         }
         userRank = ranks.get(buf.readVarInt());
@@ -267,16 +248,6 @@ public class PermissionsView implements IPermissions
             }
 
             players.put(id, new ColonyPlayer(id, name, rank));
-        }
-
-        //Permissions
-        permissions.clear();
-        final int numPermissions = buf.readVarInt();
-        for (int i = 0; i < numPermissions; ++i)
-        {
-            final Rank rank = ranks.get(buf.readVarInt());
-            final long flags = buf.readVarLong();
-            permissions.put(rank, flags);
         }
     }
 
@@ -395,7 +366,6 @@ public class PermissionsView implements IPermissions
         if (!rank.isInitial())
         {
             ranks.remove(rank.getId());
-            permissions.remove(rank);
         }
     }
 }

--- a/src/main/java/com/minecolonies/coremod/network/messages/PermissionsMessage.java
+++ b/src/main/java/com/minecolonies/coremod/network/messages/PermissionsMessage.java
@@ -11,10 +11,10 @@ import com.minecolonies.api.network.PacketUtils;
 import com.minecolonies.api.util.Log;
 import com.minecolonies.coremod.colony.Colony;
 import io.netty.buffer.Unpooled;
+import net.minecraft.core.Registry;
 import net.minecraft.network.FriendlyByteBuf;
 import net.minecraft.resources.ResourceKey;
 import net.minecraft.resources.ResourceLocation;
-import net.minecraft.core.Registry;
 import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.level.Level;
@@ -33,18 +33,6 @@ import java.util.UUID;
 public class PermissionsMessage
 {
     private static final String COLONY_DOES_NOT_EXIST = "Colony #%d does not exist.";
-
-    /**
-     * Enums for Message Type for the permission
-     * <p>
-     * SET_PERMISSION       Setting a permission. REMOVE_PERMISSION    Removing a permission. TOGGLE_PERMISSION    Toggeling a permission.
-     */
-    public enum MessageType
-    {
-        SET_PERMISSION,
-        REMOVE_PERMISSION,
-        TOGGLE_PERMISSION
-    }
 
     /**
      * Client side presentation of the
@@ -119,10 +107,10 @@ public class PermissionsMessage
      */
     public static class Permission implements IMessage
     {
-        private int         colonyID;
-        private MessageType type;
-        private Rank        rank;
-        private Action      action;
+        private int     colonyID;
+        private boolean enable;
+        private Rank    rank;
+        private Action  action;
 
         /**
          * The dimension of the
@@ -141,15 +129,15 @@ public class PermissionsMessage
          * {@link Permission}.
          *
          * @param colony Colony the permission is set in
-         * @param type   Type of permission {@link MessageType}
+         * @param enable Whether the permission gets enabled or disabled
          * @param rank   Rank of the permission {@link Rank}
          * @param action Action of the permission {@link Action}
          */
-        public Permission(@NotNull final IColonyView colony, final MessageType type, final Rank rank, final Action action)
+        public Permission(@NotNull final IColonyView colony, final boolean enable, final Rank rank, final Action action)
         {
             super();
             this.colonyID = colony.getID();
-            this.type = type;
+            this.enable = enable;
             this.rank = rank;
             this.action = action;
             this.dimension = colony.getDimension();
@@ -172,33 +160,14 @@ public class PermissionsMessage
                 return;
             }
 
-            //Verify player has permission to do edit permissions
-            if (!colony.getPermissions().hasPermission(ctxIn.getSender(), Action.EDIT_PERMISSIONS))
-            {
-                return;
-            }
-
-            switch (type)
-            {
-                case SET_PERMISSION:
-                    colony.getPermissions().setPermission(rank, action);
-                    break;
-                case REMOVE_PERMISSION:
-                    colony.getPermissions().removePermission(rank, action);
-                    break;
-                case TOGGLE_PERMISSION:
-                    colony.getPermissions().togglePermission(colony.getPermissions().getRank(ctxIn.getSender()), rank, action);
-                    break;
-                default:
-                    Log.getLogger().error(String.format("Invalid MessageType %s", type.toString()), new Exception());
-            }
+            colony.getPermissions().alterPermission(colony.getPermissions().getRank(ctxIn.getSender()), rank, action, enable);
         }
 
         @Override
         public void toBytes(@NotNull final FriendlyByteBuf buf)
         {
             buf.writeInt(colonyID);
-            buf.writeUtf(type.name());
+            buf.writeBoolean(enable);
             buf.writeInt(rank.getId());
             buf.writeUtf(action.name());
             buf.writeUtf(dimension.location().toString());
@@ -208,7 +177,7 @@ public class PermissionsMessage
         public void fromBytes(@NotNull final FriendlyByteBuf buf)
         {
             colonyID = buf.readInt();
-            type = MessageType.valueOf(buf.readUtf(32767));
+            enable = buf.readBoolean();
             final int rankId = buf.readInt();
             action = Action.valueOf(buf.readUtf(32767));
             dimension = ResourceKey.create(Registry.DIMENSION_REGISTRY, new ResourceLocation(buf.readUtf(32767)));


### PR DESCRIPTION
# Changes proposed in this pull request:
Ranks are no longer a static map, which was used as a per-colony map thus causing crashes and desyncs. If the last colony loaded had a custom rank, all other colonies would crash out due to not matching permissions for that rank.
Permission/Rank seperation is removed, permission flag is now part of the rank instead of an externally synced map, which also auto-corrects bad stored data to default permissions.
UI now has non-changeable permission buttons disabled.

Review please
