### PR TITLE
Fix Journeymap tick performance issue

### DIFF
--- a/src/main/java/com/minecolonies/coremod/compatibility/journeymap/ColonyBorderMapping.java
+++ b/src/main/java/com/minecolonies/coremod/compatibility/journeymap/ColonyBorderMapping.java
@@ -62,14 +62,6 @@ public class ColonyBorderMapping
     }
 
     /**
-     * Clear overlay cache.  Note this does *not* remove the overlays from jmap
-     */
-    public static void clear()
-    {
-        overlays.clear();
-    }
-
-    /**
      * Loads cached colony data, if any.  Also starts tracking data for a dimension.
      */
     public static void load(@NotNull final Journeymap jmap,
@@ -105,6 +97,10 @@ public class ColonyBorderMapping
             {
                 overlay.unload(jmap);
             }
+
+            final Path dataPath = jmap.getDataPath(dimension).resolve("border.json");
+            jmap.saveData(dataPath, "colony border data", DIM_BORDER_CODEC,
+                    new ArrayList<>(dimensionOverlays.values()));
         }
     }
 
@@ -146,13 +142,6 @@ public class ColonyBorderMapping
                     .computeIfAbsent(id, k -> new ColonyBorderOverlay(dimension, id));
             changed |= overlay.updateChunks(Collections.singleton(chunk.getPos()), Collections.emptySet());
             changed |= overlay.updateInfo(colony, JourneymapOptions.getShowColonyName(jmap.getOptions()));
-        }
-
-        if (changed)
-        {
-            final Path dataPath = jmap.getDataPath(dimension).resolve("border.json");
-            jmap.saveData(dataPath, "colony border data", DIM_BORDER_CODEC,
-                    new ArrayList<>(dimensionOverlays.values()));
         }
     }
 

--- a/src/main/java/com/minecolonies/coremod/compatibility/journeymap/EventListener.java
+++ b/src/main/java/com/minecolonies/coremod/compatibility/journeymap/EventListener.java
@@ -51,7 +51,6 @@ public class EventListener
     @SubscribeEvent
     public void onPlayerLogout(@NotNull final ClientPlayerNetworkEvent.LoggedOutEvent event)
     {
-        ColonyBorderMapping.clear();
         ColonyDeathpoints.clear();
         this.jmap.getApi().removeAll(MOD_ID);
     }


### PR DESCRIPTION
Closes [discord report](https://discord.com/channels/139070364159311872/915411380268580864/938197610399936513)

# Changes proposed in this pull request:
- Save JourneyMap border data only on unload, not data change.

Review please

I don't think this would cause any _significant_ performance issues (would just be a slightly longer client tick when loading a never-before-loaded claimed chunk or expanding a colony border), but it shows up in spark reports, so let's kill it anyway.