### PR TITLE
Wall mode

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -28,7 +28,8 @@ mappingsVersion=1.18
 
 dataGeneratorsVersion=0.1.48-ALPHA
 blockUI_version=1.18-0.0.42-ALPHA
-structurize_version=1.18.1-1.0.342-RELEASE
+#structurize_version=1.18.1-1.0.342-RELEASE
+structurize_version=1.18.1-0.0.1-SNAPSHOT
 domumOrnamentumVersion=1.18.1-1.0.39-ALPHA
 multiPistonVersion=1.18-1.2.2-ALPHA
 jei_mcversion=1.18

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -1,4 +1,5 @@
 repositories {
+    mavenLocal()
     maven {
         name "JEI"
         url 'https://dvs1.progwml6.com/files/maven/'

--- a/src/api/java/com/minecolonies/api/tileentities/TileEntityColonyBuilding.java
+++ b/src/api/java/com/minecolonies/api/tileentities/TileEntityColonyBuilding.java
@@ -1,10 +1,10 @@
 package com.minecolonies.api.tileentities;
 
 import com.ldtteam.structurize.blueprints.v1.Blueprint;
+import com.ldtteam.structurize.blueprints.v1.BlueprintUtil;
 import com.ldtteam.structurize.management.StructureName;
 import com.ldtteam.structurize.management.Structures;
 import com.ldtteam.structurize.util.BlockInfo;
-import com.ldtteam.structurize.util.LanguageHandler;
 import com.ldtteam.structurize.util.PlacementSettings;
 import com.minecolonies.api.blocks.AbstractBlockHut;
 import com.minecolonies.api.colony.IColony;
@@ -17,24 +17,23 @@ import com.minecolonies.api.colony.permissions.Action;
 import com.minecolonies.api.inventory.api.CombinedItemHandler;
 import com.minecolonies.api.inventory.container.ContainerBuildingInventory;
 import com.minecolonies.api.util.*;
-import net.minecraft.network.chat.TranslatableComponent;
-import net.minecraft.world.level.block.Mirror;
-import net.minecraft.world.level.block.state.BlockState;
-import net.minecraft.world.entity.player.Player;
-import net.minecraft.world.entity.player.Inventory;
-import net.minecraft.world.inventory.AbstractContainerMenu;
-import net.minecraft.world.item.ItemStack;
+import net.minecraft.core.BlockPos;
+import net.minecraft.core.Direction;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.network.Connection;
+import net.minecraft.network.chat.Component;
+import net.minecraft.network.chat.TranslatableComponent;
 import net.minecraft.network.protocol.game.ClientboundBlockEntityDataPacket;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.world.entity.player.Inventory;
+import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.inventory.AbstractContainerMenu;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.level.Level;
+import net.minecraft.world.level.block.Mirror;
 import net.minecraft.world.level.block.entity.BlockEntity;
 import net.minecraft.world.level.block.entity.BlockEntityType;
-import net.minecraft.core.Direction;
-import net.minecraft.resources.ResourceLocation;
-import net.minecraft.core.BlockPos;
-import net.minecraft.network.chat.Component;
-import net.minecraft.network.chat.TextComponent;
-import net.minecraft.world.level.Level;
+import net.minecraft.world.level.block.state.BlockState;
 import net.minecraftforge.common.capabilities.Capability;
 import net.minecraftforge.common.util.LazyOptional;
 import net.minecraftforge.items.CapabilityItemHandler;
@@ -540,7 +539,7 @@ public class TileEntityColonyBuilding extends AbstractTileEntityColonyBuilding i
         String structureName = new StructureName(Structures.SCHEMATICS_PREFIX, this.getStyle(), this.getSchematicName()).toString();
 
         final LoadOnlyStructureHandler structure = new LoadOnlyStructureHandler(level, this.getPosition(), structureName, new PlacementSettings(), true);
-        final Blueprint blueprint = structure.getBluePrint();
+        Blueprint blueprint = structure.getBluePrint();
 
         final BlockState structureState = structure.getBluePrint().getBlockInfoAsMap().get(structure.getBluePrint().getPrimaryBlockOffset()).getState();
         if (structureState != null)
@@ -564,6 +563,7 @@ public class TileEntityColonyBuilding extends AbstractTileEntityColonyBuilding i
             }
 
             blueprint.rotateWithMirror(BlockPosUtil.getRotationFromRotations(rotation), this.isMirrored() ? Mirror.FRONT_BACK : Mirror.NONE, level);
+            blueprint = BlueprintUtil.createWall(blueprint, structure.getSettings().getWallExtents());
             final BlockInfo info = blueprint.getBlockInfoAsMap().getOrDefault(blueprint.getPrimaryBlockOffset(), null);
             if (info.getTileEntityData() != null)
             {

--- a/src/api/java/com/minecolonies/api/util/CreativeBuildingStructureHandler.java
+++ b/src/api/java/com/minecolonies/api/util/CreativeBuildingStructureHandler.java
@@ -1,10 +1,9 @@
 package com.minecolonies.api.util;
 
-import com.ldtteam.structurize.blueprints.v1.Blueprint;
 import com.ldtteam.structurize.api.util.Log;
 import com.ldtteam.structurize.blocks.interfaces.IBlueprintDataProvider;
+import com.ldtteam.structurize.blueprints.v1.Blueprint;
 import com.ldtteam.structurize.blueprints.v1.BlueprintUtil;
-import com.ldtteam.structurize.helpers.WallExtents;
 import com.ldtteam.structurize.management.Manager;
 import com.ldtteam.structurize.placement.StructurePlacer;
 import com.ldtteam.structurize.placement.structure.CreativeStructureHandler;
@@ -15,19 +14,17 @@ import com.minecolonies.api.blocks.ModBlocks;
 import com.minecolonies.api.colony.IColony;
 import com.minecolonies.api.colony.IColonyManager;
 import com.minecolonies.api.colony.buildings.IBuilding;
-import net.minecraft.world.level.block.Block;
-import net.minecraft.world.level.block.state.BlockState;
-import net.minecraft.world.level.block.Blocks;
-import net.minecraft.server.level.ServerPlayer;
-import net.minecraft.world.item.ItemStack;
-import net.minecraft.nbt.CompoundTag;
-import net.minecraft.tags.ItemTags;
-import net.minecraft.world.level.block.entity.BlockEntity;
-import net.minecraft.world.level.block.Mirror;
-import net.minecraft.world.level.block.Rotation;
 import net.minecraft.core.BlockPos;
-import net.minecraft.world.level.Level;
+import net.minecraft.nbt.CompoundTag;
 import net.minecraft.server.level.ServerLevel;
+import net.minecraft.server.level.ServerPlayer;
+import net.minecraft.tags.ItemTags;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.level.Level;
+import net.minecraft.world.level.block.Block;
+import net.minecraft.world.level.block.Blocks;
+import net.minecraft.world.level.block.entity.BlockEntity;
+import net.minecraft.world.level.block.state.BlockState;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -131,28 +128,24 @@ public final class CreativeBuildingStructureHandler extends CreativeStructureHan
      * @param worldObj       the world to load it in
      * @param name           the structures name
      * @param pos            coordinates
-     * @param rotation       the rotation.
-     * @param mirror         the mirror used.
-     * @param wall           the wall extents.
+     * @param settings       the placement settings.
      * @param fancyPlacement if fancy or complete.
      * @param player         the placing player.
      * @return the placed blueprint.
      */
     public static Blueprint loadAndPlaceStructureWithRotation(
             final Level worldObj, @NotNull final String name,
-            @NotNull final BlockPos pos, final Rotation rotation,
-            @NotNull final Mirror mirror,
-            @NotNull final WallExtents wall,
+            @NotNull final BlockPos pos, final PlacementSettings settings,
             final boolean fancyPlacement,
             @Nullable final ServerPlayer player)
     {
         try
         {
-            @NotNull final IStructureHandler structure = new CreativeBuildingStructureHandler(worldObj, pos, name, new PlacementSettings(mirror, rotation, wall), fancyPlacement);
+            @NotNull final IStructureHandler structure = new CreativeBuildingStructureHandler(worldObj, pos, name, settings, fancyPlacement);
             if (structure.hasBluePrint())
             {
-                structure.getBluePrint().rotateWithMirror(rotation, mirror, worldObj);
-                structure.setBlueprint(BlueprintUtil.createWall(structure.getBluePrint(), wall));
+                structure.getBluePrint().rotateWithMirror(settings.getRotation(), settings.getMirror(), worldObj);
+                structure.setBlueprint(BlueprintUtil.createWall(structure.getBluePrint(), settings.getWallExtents()));
 
                 @NotNull final StructurePlacer instantPlacer = new StructurePlacer(structure);
                 Manager.addToQueue(new TickedWorldOperation(instantPlacer, player));

--- a/src/api/java/com/minecolonies/api/util/CreativeBuildingStructureHandler.java
+++ b/src/api/java/com/minecolonies/api/util/CreativeBuildingStructureHandler.java
@@ -3,6 +3,8 @@ package com.minecolonies.api.util;
 import com.ldtteam.structurize.blueprints.v1.Blueprint;
 import com.ldtteam.structurize.api.util.Log;
 import com.ldtteam.structurize.blocks.interfaces.IBlueprintDataProvider;
+import com.ldtteam.structurize.blueprints.v1.BlueprintUtil;
+import com.ldtteam.structurize.helpers.WallExtents;
 import com.ldtteam.structurize.management.Manager;
 import com.ldtteam.structurize.placement.StructurePlacer;
 import com.ldtteam.structurize.placement.structure.CreativeStructureHandler;
@@ -131,23 +133,26 @@ public final class CreativeBuildingStructureHandler extends CreativeStructureHan
      * @param pos            coordinates
      * @param rotation       the rotation.
      * @param mirror         the mirror used.
+     * @param wall           the wall extents.
      * @param fancyPlacement if fancy or complete.
      * @param player         the placing player.
      * @return the placed blueprint.
      */
     public static Blueprint loadAndPlaceStructureWithRotation(
-      final Level worldObj, @NotNull final String name,
-      @NotNull final BlockPos pos, final Rotation rotation,
-      @NotNull final Mirror mirror,
-      final boolean fancyPlacement,
-      @Nullable final ServerPlayer player)
+            final Level worldObj, @NotNull final String name,
+            @NotNull final BlockPos pos, final Rotation rotation,
+            @NotNull final Mirror mirror,
+            @NotNull final WallExtents wall,
+            final boolean fancyPlacement,
+            @Nullable final ServerPlayer player)
     {
         try
         {
-            @NotNull final IStructureHandler structure = new CreativeBuildingStructureHandler(worldObj, pos, name, new PlacementSettings(mirror, rotation), fancyPlacement);
+            @NotNull final IStructureHandler structure = new CreativeBuildingStructureHandler(worldObj, pos, name, new PlacementSettings(mirror, rotation, wall), fancyPlacement);
             if (structure.hasBluePrint())
             {
                 structure.getBluePrint().rotateWithMirror(rotation, mirror, worldObj);
+                structure.setBlueprint(BlueprintUtil.createWall(structure.getBluePrint(), wall));
 
                 @NotNull final StructurePlacer instantPlacer = new StructurePlacer(structure);
                 Manager.addToQueue(new TickedWorldOperation(instantPlacer, player));

--- a/src/main/java/com/minecolonies/apiimp/initializer/ModGuardTypesInitializer.java
+++ b/src/main/java/com/minecolonies/apiimp/initializer/ModGuardTypesInitializer.java
@@ -23,7 +23,7 @@ public final class ModGuardTypesInitializer
         final IForgeRegistry<GuardType> reg = event.getRegistry();
 
         ModGuardTypes.knight = new GuardType.Builder()
-                                 .setJobTranslationKey("com.minecolonies.coremod.job.knight")
+                                 .setJobTranslationKey("com.minecolonies.job.knight")
                                  .setButtonTranslationKey("com.minecolonies.coremod.gui.workerhuts.knight")
                                  .setPrimarySkill(Skill.Adaptability)
                                  .setSecondarySkill(Skill.Stamina)
@@ -34,7 +34,7 @@ public final class ModGuardTypesInitializer
                                  .createGuardType();
 
         ModGuardTypes.ranger = new GuardType.Builder()
-                                 .setJobTranslationKey("com.minecolonies.coremod.job.ranger")
+                                 .setJobTranslationKey("com.minecolonies.job.ranger")
                                  .setButtonTranslationKey("com.minecolonies.coremod.gui.workerhuts.ranger")
                                  .setPrimarySkill(Skill.Agility)
                                  .setSecondarySkill(Skill.Adaptability)

--- a/src/main/java/com/minecolonies/coremod/MineColonies.java
+++ b/src/main/java/com/minecolonies/coremod/MineColonies.java
@@ -146,6 +146,7 @@ public class MineColonies
         StructureLoadingUtils.addOriginMod(Constants.MOD_ID);
         StructureName.registerSectionName("roads", new TranslatableComponent("com.minecolonies.schematics.roads"));
         StructureName.registerSectionName("rail", new TranslatableComponent("com.minecolonies.schematics.rails"));
+        StructureName.registerSectionName("walls", new TranslatableComponent("com.minecolonies.schematics.walls"));
         StructureName.registerSectionName("fields", new TranslatableComponent("com.minecolonies.schematics.fields"));
 
         Network.getNetwork().registerCommonMessages();

--- a/src/main/java/com/minecolonies/coremod/MineColonies.java
+++ b/src/main/java/com/minecolonies/coremod/MineColonies.java
@@ -27,12 +27,12 @@ import com.minecolonies.coremod.proxy.CommonProxy;
 import com.minecolonies.coremod.proxy.IProxy;
 import com.minecolonies.coremod.proxy.ServerProxy;
 import com.minecolonies.coremod.structures.EmptyColonyStructure;
-import com.minecolonies.coremod.structures.MineColoniesConfiguredStructures;
 import com.minecolonies.coremod.structures.MineColoniesStructures;
 import net.minecraft.client.renderer.texture.TextureAtlas;
-import net.minecraft.world.entity.ai.attributes.Attribute;
+import net.minecraft.network.chat.TranslatableComponent;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.sounds.SoundEvent;
+import net.minecraft.world.entity.ai.attributes.Attribute;
 import net.minecraftforge.api.distmarker.Dist;
 import net.minecraftforge.api.distmarker.OnlyIn;
 import net.minecraftforge.client.event.TextureStitchEvent;
@@ -144,6 +144,9 @@ public class MineColonies
     public static void preInit(@NotNull final FMLCommonSetupEvent event)
     {
         StructureLoadingUtils.addOriginMod(Constants.MOD_ID);
+        StructureName.registerSectionName("roads", new TranslatableComponent("com.minecolonies.schematics.roads"));
+        StructureName.registerSectionName("rail", new TranslatableComponent("com.minecolonies.schematics.rails"));
+        StructureName.registerSectionName("fields", new TranslatableComponent("com.minecolonies.schematics.fields"));
 
         Network.getNetwork().registerCommonMessages();
 

--- a/src/main/java/com/minecolonies/coremod/client/gui/WindowBannerRallyGuards.java
+++ b/src/main/java/com/minecolonies/coremod/client/gui/WindowBannerRallyGuards.java
@@ -6,7 +6,6 @@ import com.ldtteam.blockui.controls.ButtonImage;
 import com.ldtteam.blockui.controls.ItemIcon;
 import com.ldtteam.blockui.controls.Text;
 import com.ldtteam.blockui.views.ScrollingList;
-import com.ldtteam.structurize.util.LanguageHandler;
 import com.minecolonies.api.colony.guardtype.registry.ModGuardTypes;
 import com.minecolonies.api.colony.requestsystem.location.ILocation;
 import com.minecolonies.api.util.constant.Constants;
@@ -21,7 +20,6 @@ import net.minecraft.world.item.Items;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.List;
-import java.util.Locale;
 
 import static com.minecolonies.api.util.constant.TranslationConstants.*;
 import static com.minecolonies.coremod.items.ItemBannerRallyGuards.*;
@@ -122,10 +120,9 @@ public class WindowBannerRallyGuards extends AbstractWindowSkeleton
             if (guardTowerView != null)
             {
                 exampleStackDisplay.setItem(new ItemStack(Items.IRON_SWORD));
-                rowPane.findPaneOfTypeByID(LABEL_GUARDTYPE, Text.class).setText(LanguageHandler.format(ModGuardTypes.knight.getJobTranslationKey())
-                                                                                  + "|"
-                                                                                  + LanguageHandler.format(ModGuardTypes.ranger.getJobTranslationKey())
-                                                                                  + ": " + guardTowerView.getGuards().size());
+                rowPane.findPaneOfTypeByID(LABEL_GUARDTYPE, Text.class).setText(new TranslatableComponent(ModGuardTypes.knight.getJobTranslationKey())
+                        .append("|").append(new TranslatableComponent(ModGuardTypes.ranger.getJobTranslationKey()))
+                        .append(": " + guardTowerView.getGuards().size()));
                 rowPane.findPaneOfTypeByID(LABEL_POSITION, Text.class).setText(guardTower.getFirst().toString());
             }
             else

--- a/src/main/java/com/minecolonies/coremod/client/gui/WindowBuildBuilding.java
+++ b/src/main/java/com/minecolonies/coremod/client/gui/WindowBuildBuilding.java
@@ -9,6 +9,7 @@ import com.ldtteam.blockui.views.DropDownList;
 import com.ldtteam.blockui.views.ScrollingList;
 import com.ldtteam.structurize.blocks.interfaces.IBlueprintDataProvider;
 import com.ldtteam.structurize.helpers.Settings;
+import com.ldtteam.structurize.helpers.WallExtents;
 import com.ldtteam.structurize.management.StructureName;
 import com.ldtteam.structurize.management.Structures;
 import com.ldtteam.structurize.network.messages.SchematicRequestMessage;
@@ -25,7 +26,6 @@ import com.minecolonies.api.colony.buildings.views.IBuildingView;
 import com.minecolonies.api.colony.jobs.ModJobs;
 import com.minecolonies.api.crafting.ItemStorage;
 import com.minecolonies.api.entity.ai.citizen.builder.IBuilderUndestroyable;
-import com.minecolonies.api.util.BlockPosUtil;
 import com.minecolonies.api.util.ItemStackUtils;
 import com.minecolonies.api.util.LoadOnlyStructureHandler;
 import com.minecolonies.api.util.Log;
@@ -42,7 +42,6 @@ import net.minecraft.util.Tuple;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.Blocks;
-import net.minecraft.world.level.block.Mirror;
 import net.minecraft.world.level.block.entity.BlockEntity;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraftforge.common.util.TriPredicate;
@@ -349,8 +348,10 @@ public class WindowBuildBuilding extends AbstractWindowSkeleton
             return;
         }
 
-        structure.getBluePrint().rotateWithMirror(BlockPosUtil.getRotationFromRotations(building.getRotation()), building.isMirrored() ? Mirror.FRONT_BACK : Mirror.NONE, world);
         // buildings should never use "wall" mode
+        final PlacementSettings settings = new PlacementSettings(building.isMirrored(), building.getRotation(), new WallExtents());
+        structure.getBluePrint().rotateWithMirror(settings.getRotation(), settings.getMirror(), world);
+
         StructurePlacer placer = new StructurePlacer(structure);
         StructurePhasePlacementResult result;
         BlockPos progressPos = NULL_POS;

--- a/src/main/java/com/minecolonies/coremod/client/gui/WindowBuildBuilding.java
+++ b/src/main/java/com/minecolonies/coremod/client/gui/WindowBuildBuilding.java
@@ -35,16 +35,16 @@ import com.minecolonies.coremod.colony.buildings.views.AbstractBuildingBuilderVi
 import com.minecolonies.coremod.network.messages.server.colony.building.BuildPickUpMessage;
 import com.minecolonies.coremod.network.messages.server.colony.building.BuildRequestMessage;
 import com.minecolonies.coremod.network.messages.server.colony.building.BuildingSetStyleMessage;
-import net.minecraft.world.level.block.state.BlockState;
-import net.minecraft.world.level.block.Blocks;
 import net.minecraft.client.Minecraft;
-import net.minecraft.world.item.ItemStack;
-import net.minecraft.world.level.block.entity.BlockEntity;
-import net.minecraft.world.level.block.Mirror;
-import net.minecraft.util.Tuple;
 import net.minecraft.core.BlockPos;
 import net.minecraft.network.chat.TranslatableComponent;
+import net.minecraft.util.Tuple;
+import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.level.Level;
+import net.minecraft.world.level.block.Blocks;
+import net.minecraft.world.level.block.Mirror;
+import net.minecraft.world.level.block.entity.BlockEntity;
+import net.minecraft.world.level.block.state.BlockState;
 import net.minecraftforge.common.util.TriPredicate;
 import net.minecraftforge.server.ServerLifecycleHooks;
 import org.jetbrains.annotations.NotNull;
@@ -350,6 +350,7 @@ public class WindowBuildBuilding extends AbstractWindowSkeleton
         }
 
         structure.getBluePrint().rotateWithMirror(BlockPosUtil.getRotationFromRotations(building.getRotation()), building.isMirrored() ? Mirror.FRONT_BACK : Mirror.NONE, world);
+        // buildings should never use "wall" mode
         StructurePlacer placer = new StructurePlacer(structure);
         StructurePhasePlacementResult result;
         BlockPos progressPos = NULL_POS;

--- a/src/main/java/com/minecolonies/coremod/client/gui/WindowBuildDecoration.java
+++ b/src/main/java/com/minecolonies/coremod/client/gui/WindowBuildDecoration.java
@@ -7,6 +7,8 @@ import com.ldtteam.blockui.controls.ItemIcon;
 import com.ldtteam.blockui.controls.Text;
 import com.ldtteam.blockui.views.DropDownList;
 import com.ldtteam.blockui.views.ScrollingList;
+import com.ldtteam.structurize.blueprints.v1.BlueprintUtil;
+import com.ldtteam.structurize.helpers.WallExtents;
 import com.ldtteam.structurize.management.StructureName;
 import com.ldtteam.structurize.management.Structures;
 import com.ldtteam.structurize.network.messages.SchematicRequestMessage;
@@ -88,14 +90,20 @@ public class WindowBuildDecoration extends AbstractWindowSkeleton
     private final BlockPos structurePos;
 
     /**
+     * The wall extents.
+     */
+    private final WallExtents wall;
+
+    /**
      * Constructs the decoration build confirmation dialog
      */
-    public WindowBuildDecoration(BuildToolPlaceMessage msg, BlockPos pos, StructureName structure)
+    public WindowBuildDecoration(BuildToolPlaceMessage msg, BlockPos pos, StructureName structure, WallExtents extents)
     {
         super(Constants.MOD_ID + BUILDING_NAME_RESOURCE_SUFFIX);
         placementMessage = msg;
         structureName = structure;
         structurePos = pos;
+        wall = extents;
 
         registerButton(BUTTON_BUILD, this::confirmedBuild);
         registerButton(BUTTON_CANCEL, this::close);
@@ -220,6 +228,7 @@ public class WindowBuildDecoration extends AbstractWindowSkeleton
             }
         }
 
+        structure.setBlueprint(BlueprintUtil.createWall(structure.getBluePrint(), wall));
         StructurePlacer placer = new StructurePlacer(structure);
         StructurePhasePlacementResult result;
         BlockPos progressPos = NULL_POS;

--- a/src/main/java/com/minecolonies/coremod/client/gui/WindowDecorationController.java
+++ b/src/main/java/com/minecolonies/coremod/client/gui/WindowDecorationController.java
@@ -3,6 +3,8 @@ package com.minecolonies.coremod.client.gui;
 import com.ldtteam.blockui.controls.Button;
 import com.ldtteam.blockui.controls.Text;
 import com.ldtteam.blockui.controls.TextField;
+import com.ldtteam.structurize.helpers.WallExtents;
+import com.ldtteam.structurize.management.StructureName;
 import com.ldtteam.structurize.util.LanguageHandler;
 import com.ldtteam.structurize.util.PlacementSettings;
 import com.minecolonies.api.colony.IColonyManager;
@@ -145,6 +147,12 @@ public class WindowDecorationController extends AbstractWindowSkeleton
         {
             findPaneOfTypeByID("nameLabel", Text.class).setText(new TranslatableComponent("com.minecolonies.coremod.gui.deco.namescan"));
         }
+
+        final WallExtents wall = controller.getWallExtents();
+        if (wall.isEnabled() && findPaneByID(BUTTON_REPAIR).isVisible())
+        {
+            findPaneOfTypeByID("infotextwallmode", Text.class).setText(new TranslatableComponent("com.minecolonies.coremod.gui.deco.wallmode", wall.getTotalCopies(), wall.getNegative(), wall.getPositive()));
+        }
     }
 
     /**
@@ -191,12 +199,12 @@ public class WindowDecorationController extends AbstractWindowSkeleton
      */
     private void confirmClicked()
     {
-        Network.getNetwork()
-          .sendToServer(new DecorationBuildRequestMessage(controller.getBlockPos(),
-            controller.getSchematicPath().replaceAll("\\d$", ""),
-            controller.getTier() + 1,
-            world.dimension()));
-        close();
+        final String name = controller.getSchematicPath().replaceAll("\\d$", "");
+        final StructureName structureName = new StructureName(name + (controller.getTier() + 1));
+        final DecorationBuildRequestMessage msg = new DecorationBuildRequestMessage(controller.getBlockPos(),
+                name, controller.getTier() + 1);
+
+        Minecraft.getInstance().tell(new WindowBuildDecoration(msg, controller.getBlockPos(), structureName, controller::calculatePlacementSettings)::open);
     }
 
     /**
@@ -204,11 +212,17 @@ public class WindowDecorationController extends AbstractWindowSkeleton
      */
     private void repairClicked()
     {
-        Network.getNetwork()
-          .sendToServer(new DecorationBuildRequestMessage(controller.getBlockPos(),
-            controller.getSchematicPath().replaceAll("\\d$", ""),
-            controller.getTier(),
-            world.dimension()));
-        close();
+        final String name = controller.getSchematicPath().replaceAll("\\d$", "");
+        final StructureName structureName = new StructureName(name + controller.getTier());
+        final DecorationBuildRequestMessage msg = new DecorationBuildRequestMessage(controller.getBlockPos(),
+                name, controller.getTier());
+
+        Minecraft.getInstance().tell(new WindowBuildDecoration(msg, controller.getBlockPos(), structureName, controller::calculatePlacementSettings)::open);
+
+//        Network.getNetwork()
+//          .sendToServer(new DecorationBuildRequestMessage(controller.getBlockPos(),
+//            controller.getSchematicPath().replaceAll("\\d$", ""),
+//            controller.getTier()));
+//        close();
     }
 }

--- a/src/main/java/com/minecolonies/coremod/client/gui/WindowDecorationController.java
+++ b/src/main/java/com/minecolonies/coremod/client/gui/WindowDecorationController.java
@@ -95,17 +95,17 @@ public class WindowDecorationController extends AbstractWindowSkeleton
                 {
                     if (controller.getTier() == 0)
                     {
-                        buttonBuild.setText(new TranslatableComponent("com.minecolonies.coremod.gui.workerhuts.cancelBuild"));
+                        buttonBuild.setText(new TranslatableComponent("com.minecolonies.coremod.gui.workerhuts.cancelbuild"));
                     }
                     else
                     {
-                        buttonBuild.setText(new TranslatableComponent("com.minecolonies.coremod.gui.workerhuts.cancelUpgrade"));
+                        buttonBuild.setText(new TranslatableComponent("com.minecolonies.coremod.gui.workerhuts.cancelupgrade"));
                     }
                     findPaneByID(BUTTON_REPAIR).hide();
                 }
                 else if (wo.get().getType() == WorkOrderType.BUILD)
                 {
-                    buttonBuild.setText(new TranslatableComponent("com.minecolonies.coremod.gui.workerhuts.cancelRepair"));
+                    buttonBuild.setText(new TranslatableComponent("com.minecolonies.coremod.gui.workerhuts.cancelrepair"));
                     findPaneByID(BUTTON_REPAIR).hide();
                 }
             }

--- a/src/main/java/com/minecolonies/coremod/client/gui/WindowMinecoloniesBuildTool.java
+++ b/src/main/java/com/minecolonies/coremod/client/gui/WindowMinecoloniesBuildTool.java
@@ -27,8 +27,6 @@ import org.jetbrains.annotations.Nullable;
 import java.util.ArrayList;
 import java.util.List;
 
-import static com.ldtteam.structurize.management.StructureName.HUTS;
-
 /**
  * BuildTool window.
  */
@@ -180,7 +178,6 @@ public class WindowMinecoloniesBuildTool extends WindowBuildTool
         final String name = hut.equals("citizen") ? "home" : hut;
         return InventoryUtils.hasItemInProvider(inventory.player,
           item -> item.getItem() instanceof BlockItem
-                    && StructureName.HUTS.contains(hut)
                     && ((BlockItem) item.getItem()).getBlock() == IBuildingRegistry.getInstance().getValue(new ResourceLocation(Constants.MOD_ID, name)).getBuildingBlock());
     }
 }

--- a/src/main/java/com/minecolonies/coremod/client/gui/WindowMinecoloniesBuildTool.java
+++ b/src/main/java/com/minecolonies/coremod/client/gui/WindowMinecoloniesBuildTool.java
@@ -5,7 +5,6 @@ import com.ldtteam.structurize.helpers.Settings;
 import com.ldtteam.structurize.management.StructureName;
 import com.ldtteam.structurize.placement.handlers.placement.PlacementError;
 import com.ldtteam.structurize.util.LanguageHandler;
-import com.minecolonies.api.blocks.AbstractBlockHut;
 import com.minecolonies.api.colony.buildings.registry.IBuildingRegistry;
 import com.minecolonies.api.util.InventoryUtils;
 import com.minecolonies.api.util.constant.Constants;
@@ -15,10 +14,10 @@ import com.minecolonies.coremod.items.ItemSupplyCampDeployer;
 import com.minecolonies.coremod.items.ItemSupplyChestDeployer;
 import com.minecolonies.coremod.network.messages.server.BuildToolPasteMessage;
 import com.minecolonies.coremod.network.messages.server.BuildToolPlaceMessage;
-import net.minecraft.resources.ResourceLocation;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.screens.Screen;
 import net.minecraft.core.BlockPos;
+import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.entity.player.Inventory;
 import net.minecraft.world.item.BlockItem;
 import net.minecraft.world.level.block.state.BlockState;
@@ -74,10 +73,8 @@ public class WindowMinecoloniesBuildTool extends WindowBuildTool
           structureName.toString(),
           structureName.getLocalizedName(),
           Settings.instance.getPosition(),
-          Settings.instance.getRotation(),
+          Settings.instance.getPlacement(),
           structureName.isHut(),
-          Settings.instance.getMirror(),
-          Settings.instance.getWallExtents(),
           state);
 
         if (structureName.isHut())
@@ -86,18 +83,8 @@ public class WindowMinecoloniesBuildTool extends WindowBuildTool
         }
         else
         {
-            Minecraft.getInstance().tell(new WindowBuildDecoration(msg, Settings.instance.getPosition(), structureName, Settings.instance.getWallExtents())::open);
+            Minecraft.getInstance().tell(new WindowBuildDecoration(msg, Settings.instance.getPosition(), structureName, blueprint -> Settings.instance.getPlacement())::open);
         }
-    }
-
-    @Override
-    public boolean isWallModeAvailable()
-    {
-        if (!super.isWallModeAvailable()) return false;
-        if (mc.player.isCreative()) return true;
-
-        // todo: check colony research
-        return true;
     }
 
     @Override
@@ -116,17 +103,14 @@ public class WindowMinecoloniesBuildTool extends WindowBuildTool
     public void paste(final StructureName name, final boolean complete)
     {
         final BlockPos offset = Settings.instance.getActiveStructure().getPrimaryBlockOffset();
-        ;
         final BlockState state = Settings.instance.getActiveStructure().getBlockState(offset);
 
         Network.getNetwork().sendToServer(new BuildToolPasteMessage(
           name.toString(),
           name.toString(),
           Settings.instance.getPosition(),
-          Settings.instance.getRotation(),
+          Settings.instance.getPlacement(),
           name.isHut(),
-          Settings.instance.getMirror(),
-          Settings.instance.getWallExtents(),
           complete,
           state));
     }

--- a/src/main/java/com/minecolonies/coremod/client/gui/WindowMinecoloniesBuildTool.java
+++ b/src/main/java/com/minecolonies/coremod/client/gui/WindowMinecoloniesBuildTool.java
@@ -15,14 +15,13 @@ import com.minecolonies.coremod.items.ItemSupplyCampDeployer;
 import com.minecolonies.coremod.items.ItemSupplyChestDeployer;
 import com.minecolonies.coremod.network.messages.server.BuildToolPasteMessage;
 import com.minecolonies.coremod.network.messages.server.BuildToolPlaceMessage;
-import net.minecraft.network.chat.TranslatableComponent;
 import net.minecraft.resources.ResourceLocation;
-import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.screens.Screen;
+import net.minecraft.core.BlockPos;
 import net.minecraft.world.entity.player.Inventory;
 import net.minecraft.world.item.BlockItem;
-import net.minecraft.core.BlockPos;
+import net.minecraft.world.level.block.state.BlockState;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -78,6 +77,7 @@ public class WindowMinecoloniesBuildTool extends WindowBuildTool
           Settings.instance.getRotation(),
           structureName.isHut(),
           Settings.instance.getMirror(),
+          Settings.instance.getWallExtents(),
           state);
 
         if (structureName.isHut())
@@ -86,8 +86,18 @@ public class WindowMinecoloniesBuildTool extends WindowBuildTool
         }
         else
         {
-            Minecraft.getInstance().tell(new WindowBuildDecoration(msg, Settings.instance.getPosition(), structureName)::open);
+            Minecraft.getInstance().tell(new WindowBuildDecoration(msg, Settings.instance.getPosition(), structureName, Settings.instance.getWallExtents())::open);
         }
+    }
+
+    @Override
+    public boolean isWallModeAvailable()
+    {
+        if (!super.isWallModeAvailable()) return false;
+        if (mc.player.isCreative()) return true;
+
+        // todo: check colony research
+        return true;
     }
 
     @Override
@@ -116,6 +126,7 @@ public class WindowMinecoloniesBuildTool extends WindowBuildTool
           Settings.instance.getRotation(),
           name.isHut(),
           Settings.instance.getMirror(),
+          Settings.instance.getWallExtents(),
           complete,
           state));
     }

--- a/src/main/java/com/minecolonies/coremod/client/gui/WindowMinecoloniesBuildTool.java
+++ b/src/main/java/com/minecolonies/coremod/client/gui/WindowMinecoloniesBuildTool.java
@@ -180,4 +180,18 @@ public class WindowMinecoloniesBuildTool extends WindowBuildTool
           item -> item.getItem() instanceof BlockItem
                     && ((BlockItem) item.getItem()).getBlock() == IBuildingRegistry.getInstance().getValue(new ResourceLocation(Constants.MOD_ID, name)).getBuildingBlock());
     }
+
+    @Override
+    public boolean isWallModeAvailable()
+    {
+        if (super.isWallModeAvailable())
+        {
+            return true;
+        }
+
+        // for backwards compatibility, we enable this for any schematic in a /walls/ dir.
+        // this can eventually be removed once all schematics are tagged appropriately.
+        final String sname = Settings.instance.getStructureName();
+        return sname != null && sname.contains("/walls/");
+    }
 }

--- a/src/main/java/com/minecolonies/coremod/client/gui/WindowMinecoloniesShapeTool.java
+++ b/src/main/java/com/minecolonies/coremod/client/gui/WindowMinecoloniesShapeTool.java
@@ -2,6 +2,7 @@ package com.minecolonies.coremod.client.gui;
 
 import com.ldtteam.structurize.client.gui.WindowShapeTool;
 import com.ldtteam.structurize.helpers.Settings;
+import com.ldtteam.structurize.helpers.WallExtents;
 import com.ldtteam.structurize.management.StructureName;
 import com.minecolonies.coremod.network.messages.server.BuildToolPlaceMessage;
 import net.minecraft.client.Minecraft;
@@ -36,8 +37,9 @@ public class WindowMinecoloniesShapeTool extends WindowShapeTool
                 0,
                 false,
                 Mirror.NONE,
+                new WallExtents(),
                 Blocks.AIR.defaultBlockState());
 
-        Minecraft.getInstance().tell(new WindowBuildDecoration(msg, Settings.instance.getPosition(), sn)::open);
+        Minecraft.getInstance().tell(new WindowBuildDecoration(msg, Settings.instance.getPosition(), sn, new WallExtents())::open);
     }
 }

--- a/src/main/java/com/minecolonies/coremod/client/gui/WindowMinecoloniesShapeTool.java
+++ b/src/main/java/com/minecolonies/coremod/client/gui/WindowMinecoloniesShapeTool.java
@@ -2,13 +2,12 @@ package com.minecolonies.coremod.client.gui;
 
 import com.ldtteam.structurize.client.gui.WindowShapeTool;
 import com.ldtteam.structurize.helpers.Settings;
-import com.ldtteam.structurize.helpers.WallExtents;
 import com.ldtteam.structurize.management.StructureName;
+import com.ldtteam.structurize.util.PlacementSettings;
 import com.minecolonies.coremod.network.messages.server.BuildToolPlaceMessage;
 import net.minecraft.client.Minecraft;
 import net.minecraft.core.BlockPos;
 import net.minecraft.world.level.block.Blocks;
-import net.minecraft.world.level.block.Mirror;
 import org.jetbrains.annotations.Nullable;
 
 public class WindowMinecoloniesShapeTool extends WindowShapeTool
@@ -34,12 +33,10 @@ public class WindowMinecoloniesShapeTool extends WindowShapeTool
                 sn.toString(),
                 Settings.instance.getShape().toString(),
                 Settings.instance.getPosition(),
-                0,
+                new PlacementSettings(),
                 false,
-                Mirror.NONE,
-                new WallExtents(),
                 Blocks.AIR.defaultBlockState());
 
-        Minecraft.getInstance().tell(new WindowBuildDecoration(msg, Settings.instance.getPosition(), sn, new WallExtents())::open);
+        Minecraft.getInstance().tell(new WindowBuildDecoration(msg, Settings.instance.getPosition(), sn, bp -> new PlacementSettings())::open);
     }
 }

--- a/src/main/java/com/minecolonies/coremod/client/render/worldevent/ColonyPatrolPointRenderer.java
+++ b/src/main/java/com/minecolonies/coremod/client/render/worldevent/ColonyPatrolPointRenderer.java
@@ -3,6 +3,7 @@ package com.minecolonies.coremod.client.render.worldevent;
 import com.ldtteam.structurize.blueprints.v1.Blueprint;
 import com.ldtteam.structurize.client.StructureClientHandler;
 import com.ldtteam.structurize.helpers.Settings;
+import com.ldtteam.structurize.helpers.WallExtents;
 import com.ldtteam.structurize.util.PlacementSettings;
 import com.minecolonies.api.colony.IColonyManager;
 import com.minecolonies.api.colony.IColonyView;
@@ -52,7 +53,7 @@ public class ColonyPatrolPointRenderer
         if (partolPointTemplate == null)
         {
             final PlacementSettings settings = new PlacementSettings(Settings.instance.getMirror(),
-                BlockPosUtil.getRotationFromRotations(Settings.instance.getRotation()));
+                BlockPosUtil.getRotationFromRotations(Settings.instance.getRotation()), new WallExtents());
 
             partolPointTemplate = new LoadOnlyStructureHandler(ctx.clientLevel,
                 guardTowerView.getPosition(),

--- a/src/main/java/com/minecolonies/coremod/client/render/worldevent/ColonyWaypointRenderer.java
+++ b/src/main/java/com/minecolonies/coremod/client/render/worldevent/ColonyWaypointRenderer.java
@@ -3,6 +3,7 @@ package com.minecolonies.coremod.client.render.worldevent;
 import com.ldtteam.structurize.blueprints.v1.Blueprint;
 import com.ldtteam.structurize.client.StructureClientHandler;
 import com.ldtteam.structurize.helpers.Settings;
+import com.ldtteam.structurize.helpers.WallExtents;
 import com.ldtteam.structurize.util.PlacementSettings;
 import com.minecolonies.api.util.BlockPosUtil;
 import com.minecolonies.api.util.LoadOnlyStructureHandler;
@@ -31,7 +32,7 @@ public class ColonyWaypointRenderer
             if (wayPointTemplate == null)
             {
                 final PlacementSettings settings = new PlacementSettings(Settings.instance.getMirror(),
-                    BlockPosUtil.getRotationFromRotations(Settings.instance.getRotation()));
+                    BlockPosUtil.getRotationFromRotations(Settings.instance.getRotation()), new WallExtents());
 
                 wayPointTemplate = new LoadOnlyStructureHandler(ctx.clientLevel,
                     BlockPos.ZERO,

--- a/src/main/java/com/minecolonies/coremod/client/render/worldevent/NearColonyBuildingsRenderer.java
+++ b/src/main/java/com/minecolonies/coremod/client/render/worldevent/NearColonyBuildingsRenderer.java
@@ -6,6 +6,7 @@ import com.ldtteam.structurize.blocks.interfaces.IBlueprintDataProvider;
 import com.ldtteam.structurize.blueprints.v1.Blueprint;
 import com.ldtteam.structurize.client.StructureClientHandler;
 import com.ldtteam.structurize.helpers.Settings;
+import com.ldtteam.structurize.helpers.WallExtents;
 import com.ldtteam.structurize.items.ModItems;
 import com.ldtteam.structurize.management.StructureName;
 import com.ldtteam.structurize.management.Structures;
@@ -16,13 +17,9 @@ import com.ldtteam.structurize.util.WorldRenderMacros;
 import com.minecolonies.api.MinecoloniesAPIProxy;
 import com.minecolonies.api.colony.buildings.ModBuildings;
 import com.minecolonies.api.colony.buildings.views.IBuildingView;
-import com.minecolonies.api.util.BlockPosUtil;
 import com.minecolonies.api.util.LoadOnlyStructureHandler;
-import com.minecolonies.coremod.colony.buildings.views.EmptyView;
 import com.minecolonies.coremod.colony.buildings.workerbuildings.PostBox;
-import com.minecolonies.coremod.colony.buildings.workerbuildings.Stash;
 import net.minecraft.core.BlockPos;
-import net.minecraft.world.level.block.Mirror;
 import net.minecraft.world.level.block.entity.BlockEntity;
 import net.minecraftforge.server.ServerLifecycleHooks;
 
@@ -165,8 +162,8 @@ public class NearColonyBuildingsRenderer
                 }
 
                 final Blueprint blueprint = wrapper.getBluePrint();
-                final Mirror mirror = buildingView.isMirrored() ? Mirror.FRONT_BACK : Mirror.NONE;
-                blueprint.rotateWithMirror(BlockPosUtil.getRotationFromRotations(buildingView.getRotation()), mirror, ctx.clientLevel);
+                final PlacementSettings settings = new PlacementSettings(buildingView.isMirrored(), buildingView.getRotation(), new WallExtents());
+                blueprint.rotateWithMirror(settings.getRotation(), settings.getMirror(), ctx.clientLevel);
 
                 final BlockPos primaryOffset = blueprint.getPrimaryBlockOffset();
                 final BlockPos boxStartPos = currentPosition.subtract(primaryOffset);

--- a/src/main/java/com/minecolonies/coremod/colony/buildings/AbstractBuilding.java
+++ b/src/main/java/com/minecolonies/coremod/colony/buildings/AbstractBuilding.java
@@ -957,9 +957,7 @@ public abstract class AbstractBuilding extends AbstractBuildingContainer
           = ColonyUtils.calculateCorners(this.getPosition(),
           colony.getWorld(),
           wrapper.getBluePrint(),
-          workOrder.getRotation(colony.getWorld()),
-          workOrder.isMirrored(),
-          workOrder.getWallExtents());
+          workOrder.getSettings());
         this.setCorners(corners.getA(), corners.getB());
     }
 

--- a/src/main/java/com/minecolonies/coremod/colony/buildings/AbstractBuilding.java
+++ b/src/main/java/com/minecolonies/coremod/colony/buildings/AbstractBuilding.java
@@ -958,7 +958,8 @@ public abstract class AbstractBuilding extends AbstractBuildingContainer
           colony.getWorld(),
           wrapper.getBluePrint(),
           workOrder.getRotation(colony.getWorld()),
-          workOrder.isMirrored());
+          workOrder.isMirrored(),
+          workOrder.getWallExtents());
         this.setCorners(corners.getA(), corners.getB());
     }
 

--- a/src/main/java/com/minecolonies/coremod/colony/buildings/workerbuildings/BuildingMiner.java
+++ b/src/main/java/com/minecolonies/coremod/colony/buildings/workerbuildings/BuildingMiner.java
@@ -1,46 +1,41 @@
 package com.minecolonies.coremod.colony.buildings.workerbuildings;
 
-import com.ldtteam.blockui.views.BOWindow;
+import com.ldtteam.structurize.helpers.WallExtents;
 import com.ldtteam.structurize.management.Structures;
 import com.ldtteam.structurize.util.PlacementSettings;
 import com.minecolonies.api.colony.ICitizenData;
 import com.minecolonies.api.colony.IColony;
-import com.minecolonies.api.colony.IColonyView;
 import com.minecolonies.api.colony.buildings.modules.settings.ISettingKey;
 import com.minecolonies.api.colony.jobs.ModJobs;
-import com.minecolonies.api.tileentities.AbstractTileEntityColonyBuilding;
 import com.minecolonies.api.util.BlockPosUtil;
 import com.minecolonies.api.util.ItemStackUtils;
 import com.minecolonies.api.util.LoadOnlyStructureHandler;
 import com.minecolonies.api.util.constant.Constants;
 import com.minecolonies.api.util.constant.ToolType;
-import com.minecolonies.coremod.client.gui.huts.WindowHutWorkerModulePlaceholder;
 import com.minecolonies.coremod.colony.buildings.AbstractBuilding;
 import com.minecolonies.coremod.colony.buildings.AbstractBuildingStructureBuilder;
-import com.minecolonies.coremod.colony.buildings.modules.BuildingResourcesModule;
 import com.minecolonies.coremod.colony.buildings.modules.QuarryModule;
 import com.minecolonies.coremod.colony.buildings.modules.WorkerBuildingModule;
 import com.minecolonies.coremod.colony.buildings.modules.settings.BlockSetting;
 import com.minecolonies.coremod.colony.buildings.modules.settings.IntSetting;
 import com.minecolonies.coremod.colony.buildings.modules.settings.SettingKey;
-import com.minecolonies.coremod.colony.buildings.modules.settings.StringSetting;
-import com.minecolonies.coremod.colony.buildings.utils.BuildingBuilderResource;
-import com.minecolonies.coremod.colony.buildings.views.AbstractBuildingBuilderView;
 import com.minecolonies.coremod.colony.jobs.JobMiner;
 import com.minecolonies.coremod.colony.workorders.WorkOrderBuildMiner;
 import com.minecolonies.coremod.entity.ai.citizen.miner.Node;
+import com.minecolonies.coremod.util.BuildingUtils;
 import net.minecraft.core.BlockPos;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.resources.ResourceLocation;
-import net.minecraft.tags.ItemTags;
 import net.minecraft.util.Tuple;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.Blocks;
 import org.jetbrains.annotations.NotNull;
 
-import java.util.*;
-import java.util.function.Predicate;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
 
 import static com.minecolonies.api.util.constant.BuildingConstants.*;
 import static com.minecolonies.api.util.constant.Constants.STACKSIZE;
@@ -298,7 +293,8 @@ public class BuildingMiner extends AbstractBuildingStructureBuilder
 
         if (requiredName != null &&  (job == null || job.getWorkOrder() == null))
         {
-            final WorkOrderBuildMiner wo = new WorkOrderBuildMiner(requiredName, requiredName, rotateCount, structurePos, false, buildingMiner.getPosition());
+            final PlacementSettings settings = new PlacementSettings(false, rotateCount, new WallExtents());
+            final WorkOrderBuildMiner wo = new WorkOrderBuildMiner(requiredName, requiredName, structurePos, settings, buildingMiner.getPosition());
             wo.setClaimedBy(buildingMiner.getPosition());
             buildingMiner.getColony().getWorkManager().addWorkOrder(wo, false);
             if (job != null)

--- a/src/main/java/com/minecolonies/coremod/colony/colonyEvents/raidEvents/pirateEvent/ShipBasedRaiderUtils.java
+++ b/src/main/java/com/minecolonies/coremod/colony/colonyEvents/raidEvents/pirateEvent/ShipBasedRaiderUtils.java
@@ -2,6 +2,7 @@ package com.minecolonies.coremod.colony.colonyEvents.raidEvents.pirateEvent;
 
 import com.google.common.collect.Lists;
 import com.ldtteam.structurize.blueprints.v1.Blueprint;
+import com.ldtteam.structurize.helpers.WallExtents;
 import com.ldtteam.structurize.management.Structures;
 import com.ldtteam.structurize.util.PlacementSettings;
 import com.minecolonies.api.colony.IColony;
@@ -76,7 +77,7 @@ public final class ShipBasedRaiderUtils
           structure = new CreativeRaiderStructureHandler(world,
           targetSpawnPoint,
           Structures.SCHEMATICS_PREFIX + SHIP_FOLDER + shipSize,
-          new PlacementSettings(Mirror.NONE, BlockPosUtil.getRotationFromRotations(shipRotation)),
+          new PlacementSettings(Mirror.NONE, BlockPosUtil.getRotationFromRotations(shipRotation), new WallExtents()),
           true,
           event,
           colony.getID());

--- a/src/main/java/com/minecolonies/coremod/colony/managers/EventStructureManager.java
+++ b/src/main/java/com/minecolonies/coremod/colony/managers/EventStructureManager.java
@@ -3,6 +3,7 @@ package com.minecolonies.coremod.colony.managers;
 import com.ldtteam.structurize.Structurize;
 import com.ldtteam.structurize.blueprints.v1.Blueprint;
 import com.ldtteam.structurize.blueprints.v1.BlueprintTagUtils;
+import com.ldtteam.structurize.helpers.WallExtents;
 import com.ldtteam.structurize.items.ItemScanTool;
 import com.ldtteam.structurize.management.StructureName;
 import com.ldtteam.structurize.management.Structures;
@@ -142,6 +143,7 @@ public class EventStructureManager implements IEventStructureManager
                     entry.getKey(),
                     Rotation.NONE,
                     Mirror.NONE,
+                    new WallExtents(),
                     true, null) == null)
                 {
                     fileName = new StructureName("cache", "backup", Structures.SCHEMATICS_PREFIX + STRUCTURE_BACKUP_FOLDER).toString() + oldBackupPath;
@@ -150,6 +152,7 @@ public class EventStructureManager implements IEventStructureManager
                             entry.getKey(),
                             Rotation.NONE,
                             Mirror.NONE,
+                            new WallExtents(),
                             true, null);
                 }
 

--- a/src/main/java/com/minecolonies/coremod/colony/managers/EventStructureManager.java
+++ b/src/main/java/com/minecolonies/coremod/colony/managers/EventStructureManager.java
@@ -7,6 +7,7 @@ import com.ldtteam.structurize.helpers.WallExtents;
 import com.ldtteam.structurize.items.ItemScanTool;
 import com.ldtteam.structurize.management.StructureName;
 import com.ldtteam.structurize.management.Structures;
+import com.ldtteam.structurize.util.PlacementSettings;
 import com.minecolonies.api.colony.IColony;
 import com.minecolonies.api.colony.colonyEvents.IColonyRaidEvent;
 import com.minecolonies.api.colony.managers.interfaces.IEventStructureManager;
@@ -14,14 +15,12 @@ import com.minecolonies.api.util.BlockPosUtil;
 import com.minecolonies.api.util.CreativeBuildingStructureHandler;
 import com.minecolonies.api.util.Log;
 import com.minecolonies.coremod.util.CreativeRaiderStructureHandler;
-import net.minecraft.nbt.CompoundTag;
-import net.minecraft.nbt.Tag;
-import net.minecraft.nbt.ListTag;
-import net.minecraft.world.level.block.Mirror;
-import net.minecraft.world.level.block.Rotation;
 import net.minecraft.core.BlockPos;
+import net.minecraft.nbt.CompoundTag;
+import net.minecraft.nbt.ListTag;
+import net.minecraft.nbt.Tag;
 import net.minecraft.world.level.Level;
-
+import net.minecraft.world.level.block.Mirror;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.HashMap;
@@ -112,11 +111,11 @@ public class EventStructureManager implements IEventStructureManager
         }
         backupSchematics.put(anchor, eventID);
 
+        final PlacementSettings settings = new PlacementSettings(mirror, BlockPosUtil.getRotationFromRotations(rotations), new WallExtents());
         CreativeRaiderStructureHandler.loadAndPlaceStructureWithRotation(world,
           schematicPath,
           spawnPos,
-          BlockPosUtil.getRotationFromRotations(rotations),
-          mirror,
+          settings,
           true, colony.getID(), (IColonyRaidEvent) eventManager.getEventByID(eventID), null);
 
         return true;
@@ -141,18 +140,14 @@ public class EventStructureManager implements IEventStructureManager
                 if(CreativeBuildingStructureHandler.loadAndPlaceStructureWithRotation(colony.getWorld(),
                     fileName,
                     entry.getKey(),
-                    Rotation.NONE,
-                    Mirror.NONE,
-                    new WallExtents(),
+                    new PlacementSettings(),
                     true, null) == null)
                 {
                     fileName = new StructureName("cache", "backup", Structures.SCHEMATICS_PREFIX + STRUCTURE_BACKUP_FOLDER).toString() + oldBackupPath;
                     CreativeBuildingStructureHandler.loadAndPlaceStructureWithRotation(colony.getWorld(),
                             fileName,
                             entry.getKey(),
-                            Rotation.NONE,
-                            Mirror.NONE,
-                            new WallExtents(),
+                            new PlacementSettings(),
                             true, null);
                 }
 

--- a/src/main/java/com/minecolonies/coremod/colony/workorders/WorkManager.java
+++ b/src/main/java/com/minecolonies/coremod/colony/workorders/WorkManager.java
@@ -309,9 +309,7 @@ public class WorkManager implements IWorkManager
           = ColonyUtils.calculateCorners(order.getSchematicLocation(),
           world,
           new LoadOnlyStructureHandler(world, order.getSchematicLocation(), order.getStructureName(), new PlacementSettings(), true).getBluePrint(),
-          order.getRotation(world),
-          order.isMirrored(),
-          order.getWallExtents());
+          order.getSettings());
 
         Set<ChunkPos> chunks = new HashSet<>();
         final int minX = Math.min(corners.getA().getX(), corners.getB().getX()) + 1;

--- a/src/main/java/com/minecolonies/coremod/colony/workorders/WorkManager.java
+++ b/src/main/java/com/minecolonies/coremod/colony/workorders/WorkManager.java
@@ -310,7 +310,8 @@ public class WorkManager implements IWorkManager
           world,
           new LoadOnlyStructureHandler(world, order.getSchematicLocation(), order.getStructureName(), new PlacementSettings(), true).getBluePrint(),
           order.getRotation(world),
-          order.isMirrored());
+          order.isMirrored(),
+          order.getWallExtents());
 
         Set<ChunkPos> chunks = new HashSet<>();
         final int minX = Math.min(corners.getA().getX(), corners.getB().getX()) + 1;

--- a/src/main/java/com/minecolonies/coremod/colony/workorders/WorkOrderBuild.java
+++ b/src/main/java/com/minecolonies/coremod/colony/workorders/WorkOrderBuild.java
@@ -1,8 +1,10 @@
 package com.minecolonies.coremod.colony.workorders;
 
+import com.ldtteam.structurize.helpers.WallExtents;
 import com.ldtteam.structurize.management.StructureName;
 import com.ldtteam.structurize.management.Structures;
 import com.ldtteam.structurize.util.LanguageHandler;
+import com.ldtteam.structurize.util.PlacementSettings;
 import com.minecolonies.api.colony.ICitizenData;
 import com.minecolonies.api.colony.IColony;
 import com.minecolonies.api.colony.buildings.IBuilding;
@@ -11,11 +13,10 @@ import com.minecolonies.api.tileentities.AbstractTileEntityColonyBuilding;
 import com.minecolonies.coremod.colony.Colony;
 import com.minecolonies.coremod.colony.buildings.workerbuildings.BuildingBuilder;
 import com.minecolonies.coremod.entity.ai.citizen.builder.ConstructionTapeHelper;
+import net.minecraft.core.BlockPos;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.network.FriendlyByteBuf;
 import net.minecraft.world.level.block.entity.BlockEntity;
-import net.minecraft.core.BlockPos;
-import net.minecraft.world.level.Level;
 import org.jetbrains.annotations.NotNull;
 
 /**
@@ -76,8 +77,10 @@ public class WorkOrderBuild extends WorkOrderBuildDecoration
         {
             this.upgradeName = building.getSchematicName() + level;
         }
-        this.buildingRotation = building.getRotation();
-        this.isBuildingMirrored = building.getTileEntity() == null ? building.isMirrored() : building.getTileEntity().isMirrored();
+        this.settings = new PlacementSettings(
+                building.getTileEntity() == null ? building.isMirrored() : building.getTileEntity().isMirrored(),
+                building.getRotation(),
+                new WallExtents());
         this.cleared = level > 1;
 
         //normalize the structureName
@@ -234,12 +237,6 @@ public class WorkOrderBuild extends WorkOrderBuildDecoration
         }
 
         return displayName;
-    }
-
-    @Override
-    public int getRotation(final Level world)
-    {
-        return buildingRotation;
     }
 
     @Override

--- a/src/main/java/com/minecolonies/coremod/colony/workorders/WorkOrderBuildDecoration.java
+++ b/src/main/java/com/minecolonies/coremod/colony/workorders/WorkOrderBuildDecoration.java
@@ -1,5 +1,6 @@
 package com.minecolonies.coremod.colony.workorders;
 
+import com.ldtteam.structurize.helpers.WallExtents;
 import com.ldtteam.structurize.management.StructureName;
 import com.ldtteam.structurize.util.LanguageHandler;
 import com.minecolonies.api.advancements.AdvancementTriggers;
@@ -38,6 +39,7 @@ public class WorkOrderBuildDecoration extends AbstractWorkOrder
 
     protected boolean isBuildingMirrored;
     protected int     buildingRotation;
+    protected WallExtents wall;
     protected String  structureName;
     protected boolean cleared;
     protected String  workOrderName;
@@ -62,8 +64,11 @@ public class WorkOrderBuildDecoration extends AbstractWorkOrder
      * @param rotation      The number of times the decoration was rotated.
      * @param location      The location where the decoration should be built.
      * @param mirror        Is the decoration mirrored?
+     * @param wall          The wall extents
      */
-    public WorkOrderBuildDecoration(final String structureName, final String workOrderName, final int rotation, final BlockPos location, final boolean mirror)
+    public WorkOrderBuildDecoration(final String structureName, final String workOrderName,
+                                    final int rotation, final BlockPos location, final boolean mirror,
+                                    final WallExtents wall)
     {
         super();
         //normalise structure name
@@ -74,6 +79,7 @@ public class WorkOrderBuildDecoration extends AbstractWorkOrder
         this.buildingLocation = location;
         this.cleared = false;
         this.isBuildingMirrored = mirror;
+        this.wall = wall;
         this.requested = false;
     }
 
@@ -111,6 +117,7 @@ public class WorkOrderBuildDecoration extends AbstractWorkOrder
         buildingRotation = compound.getInt(TAG_BUILDING_ROTATION);
         requested = compound.getBoolean(TAG_IS_REQUESTED);
         isBuildingMirrored = compound.getBoolean(TAG_IS_MIRRORED);
+        wall.load(compound);
         amountOfRes = compound.getInt(TAG_AMOUNT_OF_RES);
         levelUp = compound.getBoolean(TAG_LEVEL);
     }
@@ -140,6 +147,7 @@ public class WorkOrderBuildDecoration extends AbstractWorkOrder
         compound.putInt(TAG_BUILDING_ROTATION, buildingRotation);
         compound.putBoolean(TAG_IS_REQUESTED, requested);
         compound.putBoolean(TAG_IS_MIRRORED, isBuildingMirrored);
+        wall.save(compound);
         compound.putInt(TAG_AMOUNT_OF_RES, amountOfRes);
         compound.putBoolean(TAG_LEVEL, levelUp);
     }
@@ -321,6 +329,13 @@ public class WorkOrderBuildDecoration extends AbstractWorkOrder
     {
         return isBuildingMirrored;
     }
+
+    /**
+     * Gets the wall extents (if any).
+     *
+     * @return the wall extents
+     */
+    public WallExtents getWallExtents() { return wall; }
 
     /**
      * Amount of resources this building requires.

--- a/src/main/java/com/minecolonies/coremod/colony/workorders/WorkOrderBuildMiner.java
+++ b/src/main/java/com/minecolonies/coremod/colony/workorders/WorkOrderBuildMiner.java
@@ -1,12 +1,12 @@
 package com.minecolonies.coremod.colony.workorders;
 
-import com.ldtteam.structurize.helpers.WallExtents;
+import com.ldtteam.structurize.util.PlacementSettings;
 import com.minecolonies.api.colony.ICitizenData;
 import com.minecolonies.api.colony.IColony;
 import com.minecolonies.api.colony.workorders.IWorkManager;
 import com.minecolonies.api.util.BlockPosUtil;
-import net.minecraft.nbt.CompoundTag;
 import net.minecraft.core.BlockPos;
+import net.minecraft.nbt.CompoundTag;
 import org.jetbrains.annotations.NotNull;
 
 import static com.minecolonies.api.util.constant.NbtTagConstants.TAG_POS;
@@ -34,20 +34,18 @@ public class WorkOrderBuildMiner extends WorkOrderBuildDecoration
      *
      * @param structureName The name of the mine.
      * @param workOrderName The user friendly name of the mine.
-     * @param rotation      The number of times the mine was rotated.
      * @param location      The location where the mine should be built.
-     * @param mirror        Is the mine mirrored?
+     * @param settings      The placement settings.
      * @param minerBuilding The id of the building of the miner.
      */
     public WorkOrderBuildMiner(
       final String structureName,
       final String workOrderName,
-      final int rotation,
       final BlockPos location,
-      final boolean mirror,
+      final PlacementSettings settings,
       final BlockPos minerBuilding)
     {
-        super(structureName, workOrderName, rotation, location, mirror, new WallExtents());
+        super(structureName, workOrderName, location, settings);
         this.minerBuilding = minerBuilding;
     }
 

--- a/src/main/java/com/minecolonies/coremod/colony/workorders/WorkOrderBuildMiner.java
+++ b/src/main/java/com/minecolonies/coremod/colony/workorders/WorkOrderBuildMiner.java
@@ -1,5 +1,6 @@
 package com.minecolonies.coremod.colony.workorders;
 
+import com.ldtteam.structurize.helpers.WallExtents;
 import com.minecolonies.api.colony.ICitizenData;
 import com.minecolonies.api.colony.IColony;
 import com.minecolonies.api.colony.workorders.IWorkManager;
@@ -46,7 +47,7 @@ public class WorkOrderBuildMiner extends WorkOrderBuildDecoration
       final boolean mirror,
       final BlockPos minerBuilding)
     {
-        super(structureName, workOrderName, rotation, location, mirror);
+        super(structureName, workOrderName, rotation, location, mirror, new WallExtents());
         this.minerBuilding = minerBuilding;
     }
 

--- a/src/main/java/com/minecolonies/coremod/entity/ai/basic/AbstractEntityAIStructure.java
+++ b/src/main/java/com/minecolonies/coremod/entity/ai/basic/AbstractEntityAIStructure.java
@@ -3,6 +3,8 @@ package com.minecolonies.coremod.entity.ai.basic;
 import com.google.common.collect.ImmutableList;
 import com.ldtteam.structurize.blueprints.v1.Blueprint;
 import com.ldtteam.structurize.blocks.schematic.BlockFluidSubstitution;
+import com.ldtteam.structurize.blueprints.v1.BlueprintUtil;
+import com.ldtteam.structurize.helpers.WallExtents;
 import com.ldtteam.structurize.placement.BlockPlacementResult;
 import com.ldtteam.structurize.placement.StructurePhasePlacementResult;
 import com.ldtteam.structurize.placement.StructurePlacer;
@@ -548,9 +550,10 @@ public abstract class AbstractEntityAIStructure<J extends AbstractJobStructure<?
      * @param rotateTimes number of times to rotateWithMirror it.
      * @param position    the position to set it.
      * @param isMirrored  is the structure mirroed?
+     * @param wall        the wall extents.
      * @param removal     if removal step.
      */
-    public void loadStructure(@NotNull final String name, final int rotateTimes, final BlockPos position, final boolean isMirrored, final boolean removal)
+    public void loadStructure(@NotNull final String name, final int rotateTimes, final BlockPos position, final boolean isMirrored, final WallExtents wall, final boolean removal)
     {
         final BuildingStructureHandler<J, B> structure;
         IBuilding colonyBuilding = worker.getCitizenColonyHandler().getColony().getBuildingManager().getBuilding(position);
@@ -561,7 +564,7 @@ public abstract class AbstractEntityAIStructure<J extends AbstractJobStructure<?
             structure = new BuildingStructureHandler<>(world,
               position,
               name,
-              new PlacementSettings(isMirrored ? Mirror.FRONT_BACK : Mirror.NONE, BlockPosUtil.getRotationFromRotations(rotateTimes)),
+              new PlacementSettings(isMirrored ? Mirror.FRONT_BACK : Mirror.NONE, BlockPosUtil.getRotationFromRotations(rotateTimes), wall),
               this, new BuildingStructureHandler.Stage[] {REMOVE_WATER, REMOVE});
             getOwnBuilding().setTotalStages(2);
         }
@@ -571,7 +574,7 @@ public abstract class AbstractEntityAIStructure<J extends AbstractJobStructure<?
             structure = new BuildingStructureHandler<>(world,
               position,
               name,
-              new PlacementSettings(isMirrored ? Mirror.FRONT_BACK : Mirror.NONE, BlockPosUtil.getRotationFromRotations(rotateTimes)),
+              new PlacementSettings(isMirrored ? Mirror.FRONT_BACK : Mirror.NONE, BlockPosUtil.getRotationFromRotations(rotateTimes), wall),
               this, new BuildingStructureHandler.Stage[] {BUILD_SOLID, CLEAR_WATER, CLEAR_NON_SOLIDS, DECORATE, SPAWN});
             getOwnBuilding().setTotalStages(5);
         }
@@ -580,7 +583,7 @@ public abstract class AbstractEntityAIStructure<J extends AbstractJobStructure<?
             structure = new BuildingStructureHandler<>(world,
               position,
               name,
-              new PlacementSettings(isMirrored ? Mirror.FRONT_BACK : Mirror.NONE, BlockPosUtil.getRotationFromRotations(rotateTimes)),
+              new PlacementSettings(isMirrored ? Mirror.FRONT_BACK : Mirror.NONE, BlockPosUtil.getRotationFromRotations(rotateTimes), wall),
               this, new BuildingStructureHandler.Stage[] {CLEAR, BUILD_SOLID, CLEAR_WATER, CLEAR_NON_SOLIDS, DECORATE, SPAWN});
             getOwnBuilding().setTotalStages(6);
         }
@@ -592,8 +595,11 @@ public abstract class AbstractEntityAIStructure<J extends AbstractJobStructure<?
             return;
         }
 
-        job.setBlueprint(structure.getBluePrint());
-        job.getBlueprint().rotateWithMirror(BlockPosUtil.getRotationFromRotations(rotateTimes), isMirrored ? Mirror.FRONT_BACK : Mirror.NONE, world);
+        Blueprint blueprint = structure.getBluePrint();
+        blueprint.rotateWithMirror(BlockPosUtil.getRotationFromRotations(rotateTimes), isMirrored ? Mirror.FRONT_BACK : Mirror.NONE, world);
+        blueprint = BlueprintUtil.createWall(blueprint, wall);
+        structure.setBlueprint(blueprint);
+        job.setBlueprint(blueprint);
         setStructurePlacer(structure);
 
         if (getProgressPos() != null)

--- a/src/main/java/com/minecolonies/coremod/entity/ai/basic/AbstractEntityAIStructure.java
+++ b/src/main/java/com/minecolonies/coremod/entity/ai/basic/AbstractEntityAIStructure.java
@@ -1,10 +1,9 @@
 package com.minecolonies.coremod.entity.ai.basic;
 
 import com.google.common.collect.ImmutableList;
-import com.ldtteam.structurize.blueprints.v1.Blueprint;
 import com.ldtteam.structurize.blocks.schematic.BlockFluidSubstitution;
+import com.ldtteam.structurize.blueprints.v1.Blueprint;
 import com.ldtteam.structurize.blueprints.v1.BlueprintUtil;
-import com.ldtteam.structurize.helpers.WallExtents;
 import com.ldtteam.structurize.placement.BlockPlacementResult;
 import com.ldtteam.structurize.placement.StructurePhasePlacementResult;
 import com.ldtteam.structurize.placement.StructurePlacer;
@@ -36,19 +35,18 @@ import com.minecolonies.coremod.colony.buildings.utils.BuildingBuilderResource;
 import com.minecolonies.coremod.colony.jobs.AbstractJobStructure;
 import com.minecolonies.coremod.entity.ai.util.BuildingStructureHandler;
 import com.minecolonies.coremod.tileentities.TileEntityDecorationController;
-import net.minecraft.world.level.block.AirBlock;
-import net.minecraft.world.level.block.Block;
-import net.minecraft.world.level.block.state.BlockState;
-import net.minecraft.world.level.block.Blocks;
-import net.minecraft.world.item.BlockItem;
-import net.minecraft.world.item.ItemStack;
-import net.minecraft.tags.BlockTags;
-import net.minecraft.world.level.block.entity.BlockEntity;
-import net.minecraft.world.InteractionHand;
-import net.minecraft.world.level.block.Mirror;
-import net.minecraft.world.phys.AABB;
 import net.minecraft.core.BlockPos;
 import net.minecraft.network.chat.TranslatableComponent;
+import net.minecraft.tags.BlockTags;
+import net.minecraft.world.InteractionHand;
+import net.minecraft.world.item.BlockItem;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.level.block.AirBlock;
+import net.minecraft.world.level.block.Block;
+import net.minecraft.world.level.block.Blocks;
+import net.minecraft.world.level.block.entity.BlockEntity;
+import net.minecraft.world.level.block.state.BlockState;
+import net.minecraft.world.phys.AABB;
 import net.minecraftforge.common.util.TriPredicate;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -547,13 +545,11 @@ public abstract class AbstractEntityAIStructure<J extends AbstractJobStructure<?
      * Loads the structure given the name, rotation and position.
      *
      * @param name        the name to retrieve  it.
-     * @param rotateTimes number of times to rotateWithMirror it.
      * @param position    the position to set it.
-     * @param isMirrored  is the structure mirroed?
-     * @param wall        the wall extents.
+     * @param settings    the placement settings.
      * @param removal     if removal step.
      */
-    public void loadStructure(@NotNull final String name, final int rotateTimes, final BlockPos position, final boolean isMirrored, final WallExtents wall, final boolean removal)
+    public void loadStructure(@NotNull final String name, final BlockPos position, final PlacementSettings settings, final boolean removal)
     {
         final BuildingStructureHandler<J, B> structure;
         IBuilding colonyBuilding = worker.getCitizenColonyHandler().getColony().getBuildingManager().getBuilding(position);
@@ -564,7 +560,7 @@ public abstract class AbstractEntityAIStructure<J extends AbstractJobStructure<?
             structure = new BuildingStructureHandler<>(world,
               position,
               name,
-              new PlacementSettings(isMirrored ? Mirror.FRONT_BACK : Mirror.NONE, BlockPosUtil.getRotationFromRotations(rotateTimes), wall),
+              settings,
               this, new BuildingStructureHandler.Stage[] {REMOVE_WATER, REMOVE});
             getOwnBuilding().setTotalStages(2);
         }
@@ -574,7 +570,7 @@ public abstract class AbstractEntityAIStructure<J extends AbstractJobStructure<?
             structure = new BuildingStructureHandler<>(world,
               position,
               name,
-              new PlacementSettings(isMirrored ? Mirror.FRONT_BACK : Mirror.NONE, BlockPosUtil.getRotationFromRotations(rotateTimes), wall),
+              settings,
               this, new BuildingStructureHandler.Stage[] {BUILD_SOLID, CLEAR_WATER, CLEAR_NON_SOLIDS, DECORATE, SPAWN});
             getOwnBuilding().setTotalStages(5);
         }
@@ -583,7 +579,7 @@ public abstract class AbstractEntityAIStructure<J extends AbstractJobStructure<?
             structure = new BuildingStructureHandler<>(world,
               position,
               name,
-              new PlacementSettings(isMirrored ? Mirror.FRONT_BACK : Mirror.NONE, BlockPosUtil.getRotationFromRotations(rotateTimes), wall),
+              settings,
               this, new BuildingStructureHandler.Stage[] {CLEAR, BUILD_SOLID, CLEAR_WATER, CLEAR_NON_SOLIDS, DECORATE, SPAWN});
             getOwnBuilding().setTotalStages(6);
         }
@@ -596,8 +592,8 @@ public abstract class AbstractEntityAIStructure<J extends AbstractJobStructure<?
         }
 
         Blueprint blueprint = structure.getBluePrint();
-        blueprint.rotateWithMirror(BlockPosUtil.getRotationFromRotations(rotateTimes), isMirrored ? Mirror.FRONT_BACK : Mirror.NONE, world);
-        blueprint = BlueprintUtil.createWall(blueprint, wall);
+        blueprint.rotateWithMirror(settings.getRotation(), settings.getMirror(), world);
+        blueprint = BlueprintUtil.createWall(blueprint, settings.getWallExtents());
         structure.setBlueprint(blueprint);
         job.setBlueprint(blueprint);
         setStructurePlacer(structure);

--- a/src/main/java/com/minecolonies/coremod/entity/ai/basic/AbstractEntityAIStructureWithWorkOrder.java
+++ b/src/main/java/com/minecolonies/coremod/entity/ai/basic/AbstractEntityAIStructureWithWorkOrder.java
@@ -163,10 +163,9 @@ public abstract class AbstractEntityAIStructureWithWorkOrder<J extends AbstractJ
             return;
         }
 
-        final int tempRotation = workOrder.getRotation(world);
         final boolean removal = workOrder instanceof WorkOrderBuildRemoval;
 
-        loadStructure(workOrder.getStructureName(), tempRotation, pos, workOrder.isMirrored(), workOrder.getWallExtents(), removal);
+        loadStructure(workOrder.getStructureName(), pos, workOrder.getSettings(), removal);
         workOrder.setCleared(false);
         workOrder.setRequested(removal);
     }

--- a/src/main/java/com/minecolonies/coremod/entity/ai/basic/AbstractEntityAIStructureWithWorkOrder.java
+++ b/src/main/java/com/minecolonies/coremod/entity/ai/basic/AbstractEntityAIStructureWithWorkOrder.java
@@ -166,7 +166,7 @@ public abstract class AbstractEntityAIStructureWithWorkOrder<J extends AbstractJ
         final int tempRotation = workOrder.getRotation(world);
         final boolean removal = workOrder instanceof WorkOrderBuildRemoval;
 
-        loadStructure(workOrder.getStructureName(), tempRotation, pos, workOrder.isMirrored(), removal);
+        loadStructure(workOrder.getStructureName(), tempRotation, pos, workOrder.isMirrored(), workOrder.getWallExtents(), removal);
         workOrder.setCleared(false);
         workOrder.setRequested(removal);
     }
@@ -199,6 +199,7 @@ public abstract class AbstractEntityAIStructureWithWorkOrder<J extends AbstractJ
         StructurePhasePlacementResult result;
         final WorkerLoadOnlyStructureHandler structure =
           new WorkerLoadOnlyStructureHandler(world, structurePlacer.getB().getWorldPos(), structurePlacer.getB().getBluePrint(), new PlacementSettings(), true, this);
+        //structure.setBlueprint(BlueprintUtil.createWall(structure.getBluePrint(), job.getWorkOrder().getWallExtents()));
 
         if (job.getWorkOrder().getIteratorType().isEmpty() && getOwnBuilding().hasModule(ISettingsModule.class) && getOwnBuilding().getSetting(BuildingBuilder.BUILDING_MODE) != null)
         {

--- a/src/main/java/com/minecolonies/coremod/entity/ai/citizen/builder/ConstructionTapeHelper.java
+++ b/src/main/java/com/minecolonies/coremod/entity/ai/citizen/builder/ConstructionTapeHelper.java
@@ -45,7 +45,8 @@ public final class ConstructionTapeHelper
           world,
           new LoadOnlyStructureHandler(world, workOrder.getSchematicLocation(), workOrder.getStructureName(), new PlacementSettings(), true).getBluePrint(),
           workOrder.getRotation(world),
-          workOrder.isMirrored());
+          workOrder.isMirrored(),
+          workOrder.getWallExtents());
         placeConstructionTape(corners, world);
     }
 
@@ -155,7 +156,7 @@ public final class ConstructionTapeHelper
         if (structure.hasBluePrint())
         {
             final Tuple<BlockPos, BlockPos> corners = ColonyUtils.calculateCorners(workOrder.getSchematicLocation(), world,
-              structure.getBluePrint(), workOrder.getRotation(world), workOrder.isMirrored());
+              structure.getBluePrint(), workOrder.getRotation(world), workOrder.isMirrored(), workOrder.getWallExtents());
             removeConstructionTape(corners, world);
         }
     }

--- a/src/main/java/com/minecolonies/coremod/entity/ai/citizen/builder/ConstructionTapeHelper.java
+++ b/src/main/java/com/minecolonies/coremod/entity/ai/citizen/builder/ConstructionTapeHelper.java
@@ -44,9 +44,7 @@ public final class ConstructionTapeHelper
           = ColonyUtils.calculateCorners(workOrder.getSchematicLocation(),
           world,
           new LoadOnlyStructureHandler(world, workOrder.getSchematicLocation(), workOrder.getStructureName(), new PlacementSettings(), true).getBluePrint(),
-          workOrder.getRotation(world),
-          workOrder.isMirrored(),
-          workOrder.getWallExtents());
+          workOrder.getSettings());
         placeConstructionTape(corners, world);
     }
 
@@ -156,7 +154,7 @@ public final class ConstructionTapeHelper
         if (structure.hasBluePrint())
         {
             final Tuple<BlockPos, BlockPos> corners = ColonyUtils.calculateCorners(workOrder.getSchematicLocation(), world,
-              structure.getBluePrint(), workOrder.getRotation(world), workOrder.isMirrored(), workOrder.getWallExtents());
+              structure.getBluePrint(), workOrder.getSettings());
             removeConstructionTape(corners, world);
         }
     }

--- a/src/main/java/com/minecolonies/coremod/entity/ai/citizen/miner/EntityAIQuarrier.java
+++ b/src/main/java/com/minecolonies/coremod/entity/ai/citizen/miner/EntityAIQuarrier.java
@@ -1,5 +1,6 @@
 package com.minecolonies.coremod.entity.ai.citizen.miner;
 
+import com.ldtteam.structurize.helpers.WallExtents;
 import com.ldtteam.structurize.management.Structures;
 import com.ldtteam.structurize.placement.BlockPlacementResult;
 import com.ldtteam.structurize.placement.StructurePhasePlacementResult;
@@ -33,7 +34,6 @@ import net.minecraft.world.item.Items;
 import net.minecraft.world.level.block.AirBlock;
 import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.Blocks;
-import net.minecraft.world.level.block.Mirror;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.material.FluidState;
 import net.minecraft.world.level.material.Fluids;
@@ -44,7 +44,8 @@ import static com.minecolonies.api.entity.ai.statemachine.states.AIWorkerState.*
 import static com.minecolonies.api.research.util.ResearchConstants.BLOCK_PLACE_SPEED;
 import static com.minecolonies.api.util.constant.CitizenConstants.PROGRESS_MULTIPLIER;
 import static com.minecolonies.api.util.constant.Constants.TICKS_SECOND;
-import static com.minecolonies.api.util.constant.TranslationConstants.*;
+import static com.minecolonies.api.util.constant.TranslationConstants.QUARRY_MINER_FINISHED_QUARRY;
+import static com.minecolonies.api.util.constant.TranslationConstants.QUARRY_MINER_NO_QUARRY;
 import static com.minecolonies.coremod.colony.buildings.workerbuildings.BuildingMiner.FILL_BLOCK;
 import static com.minecolonies.coremod.entity.ai.basic.AbstractEntityAIStructure.ItemCheckResult.RECALC;
 import static com.minecolonies.coremod.entity.ai.util.BuildingStructureHandler.Stage.*;
@@ -130,7 +131,7 @@ public class EntityAIQuarrier extends AbstractEntityAIStructureWithWorkOrder<Job
             }
 
             final String name = Structures.SCHEMATICS_PREFIX + "/" + quarry.getStyle() + "/" + quarry.getSchematicName() + "shaft1";
-            final WorkOrderBuildMiner wo = new WorkOrderBuildMiner(name, name, quarry.getRotation(), quarry.getPosition().below(2), false, getOwnBuilding().getPosition());
+            final WorkOrderBuildMiner wo = new WorkOrderBuildMiner(name, name, quarry.getPosition().below(2), new PlacementSettings(false, quarry.getRotation(), new WallExtents()), getOwnBuilding().getPosition());
             getOwnBuilding().getColony().getWorkManager().addWorkOrder(wo, false);
             job.setWorkOrder(wo);
         }
@@ -139,14 +140,14 @@ public class EntityAIQuarrier extends AbstractEntityAIStructureWithWorkOrder<Job
     }
 
     @Override
-    public void loadStructure(@NotNull final String name, final int rotateTimes, final BlockPos position, final boolean isMirrored, final boolean removal)
+    public void loadStructure(@NotNull final String name, final BlockPos position, final PlacementSettings settings, final boolean removal)
     {
         final BuildingStructureHandler<JobQuarrier, BuildingMiner> structure;
 
         structure = new BuildingStructureHandler<>(world,
           position,
               name,
-              new PlacementSettings(isMirrored ? Mirror.FRONT_BACK : Mirror.NONE, BlockPosUtil.getRotationFromRotations(rotateTimes)),
+              settings,
               this, new BuildingStructureHandler.Stage[] {BUILD_SOLID, DECORATE, CLEAR});
             getOwnBuilding().setTotalStages(3);
 
@@ -159,7 +160,7 @@ public class EntityAIQuarrier extends AbstractEntityAIStructureWithWorkOrder<Job
         }
 
         job.setBlueprint(structure.getBluePrint());
-        job.getBlueprint().rotateWithMirror(BlockPosUtil.getRotationFromRotations(rotateTimes), isMirrored ? Mirror.FRONT_BACK : Mirror.NONE, world);
+        job.getBlueprint().rotateWithMirror(settings.getRotation(), settings.getMirror(), world);
         setStructurePlacer(structure);
 
         if (getProgressPos() != null)

--- a/src/main/java/com/minecolonies/coremod/network/messages/server/AbstractBuildRequestMessage.java
+++ b/src/main/java/com/minecolonies/coremod/network/messages/server/AbstractBuildRequestMessage.java
@@ -1,0 +1,45 @@
+package com.minecolonies.coremod.network.messages.server;
+
+import com.minecolonies.api.network.IMessage;
+import net.minecraft.core.BlockPos;
+import net.minecraft.network.FriendlyByteBuf;
+import net.minecraftforge.fml.LogicalSide;
+import net.minecraftforge.network.NetworkEvent;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+/**
+ * An abstract request for a builder to build something
+ */
+public abstract class AbstractBuildRequestMessage implements IMessage
+{
+    /** The builder who should build this, or ZERO to not specify one yet */
+    public BlockPos builder = BlockPos.ZERO;
+
+    /** The anchor position of the build request */
+    protected BlockPos pos;
+
+    @Override
+    public void toBytes(@NotNull FriendlyByteBuf buf)
+    {
+        buf.writeBlockPos(pos);
+        buf.writeBlockPos(builder);
+    }
+
+    @Override
+    public void fromBytes(@NotNull FriendlyByteBuf buf)
+    {
+        pos = buf.readBlockPos();
+        builder = buf.readBlockPos();
+    }
+
+    @Nullable
+    @Override
+    public LogicalSide getExecutionSide()
+    {
+        return LogicalSide.SERVER;
+    }
+
+    @Override
+    public abstract void onExecute(@NotNull NetworkEvent.Context ctxIn, boolean isLogicalServer);
+}

--- a/src/main/java/com/minecolonies/coremod/network/messages/server/BuildToolPasteMessage.java
+++ b/src/main/java/com/minecolonies/coremod/network/messages/server/BuildToolPasteMessage.java
@@ -1,5 +1,6 @@
 package com.minecolonies.coremod.network.messages.server;
 
+import com.ldtteam.structurize.helpers.WallExtents;
 import com.ldtteam.structurize.management.StructureName;
 import com.ldtteam.structurize.management.Structures;
 import com.ldtteam.structurize.placement.StructurePlacementUtils;
@@ -59,6 +60,7 @@ public class BuildToolPasteMessage implements IMessage
     private BlockPos pos;
     private boolean  isHut;
     private boolean  mirror;
+    private WallExtents wall;
 
     /**
      * Empty constructor used when registering the
@@ -81,10 +83,11 @@ public class BuildToolPasteMessage implements IMessage
      * @param state         the state.
      */
     public BuildToolPasteMessage(
-      final String structureName,
-      final String workOrderName, final BlockPos pos,
-      final int rotation, final boolean isHut,
-      final Mirror mirror, final boolean complete, final BlockState state)
+            final String structureName,
+            final String workOrderName, final BlockPos pos,
+            final int rotation, final boolean isHut,
+            final Mirror mirror, final WallExtents wall,
+            final boolean complete, final BlockState state)
     {
         super();
         this.structureName = structureName;
@@ -93,6 +96,7 @@ public class BuildToolPasteMessage implements IMessage
         this.rotation = rotation;
         this.isHut = isHut;
         this.mirror = mirror == Mirror.FRONT_BACK;
+        this.wall = wall;
         this.complete = complete;
         this.state = state;
     }
@@ -115,6 +119,8 @@ public class BuildToolPasteMessage implements IMessage
         isHut = buf.readBoolean();
 
         mirror = buf.readBoolean();
+
+        wall = WallExtents.deserialize(buf);
 
         complete = buf.readBoolean();
 
@@ -141,6 +147,8 @@ public class BuildToolPasteMessage implements IMessage
         buf.writeBoolean(isHut);
 
         buf.writeBoolean(mirror);
+
+        wall.serialize(buf);
 
         buf.writeBoolean(complete);
 
@@ -171,7 +179,7 @@ public class BuildToolPasteMessage implements IMessage
             {
                 handleHut(CompatibilityUtils.getWorldFromEntity(player), player, sn, rotation, pos, mirror, state, complete);
                 CreativeBuildingStructureHandler.loadAndPlaceStructureWithRotation(player.level, structureName,
-                  pos, BlockPosUtil.getRotationFromRotations(rotation), mirror ? Mirror.FRONT_BACK : Mirror.NONE, !complete, player);
+                  pos, BlockPosUtil.getRotationFromRotations(rotation), mirror ? Mirror.FRONT_BACK : Mirror.NONE, new WallExtents(), !complete, player);
 
                 @Nullable final IBuilding building = IColonyManager.getInstance().getBuilding(CompatibilityUtils.getWorldFromEntity(player), pos);
                 if (building != null)
@@ -183,7 +191,7 @@ public class BuildToolPasteMessage implements IMessage
             else
             {
                 StructurePlacementUtils.loadAndPlaceStructureWithRotation(ctxIn.getSender().level, structureName,
-                  pos, BlockPosUtil.getRotationFromRotations(rotation), mirror ? Mirror.FRONT_BACK : Mirror.NONE, !complete, ctxIn.getSender());
+                  pos, BlockPosUtil.getRotationFromRotations(rotation), mirror ? Mirror.FRONT_BACK : Mirror.NONE, wall, !complete, ctxIn.getSender());
             }
         }
         else if (structureName.contains("supply"))
@@ -223,7 +231,7 @@ public class BuildToolPasteMessage implements IMessage
                 }
 
                 CreativeBuildingStructureHandler.loadAndPlaceStructureWithRotation(player.level, structureName,
-                  pos, BlockPosUtil.getRotationFromRotations(rotation), mirror ? Mirror.FRONT_BACK : Mirror.NONE, !complete, player);
+                  pos, BlockPosUtil.getRotationFromRotations(rotation), mirror ? Mirror.FRONT_BACK : Mirror.NONE, new WallExtents(), !complete, player);
             }
             else
             {

--- a/src/main/java/com/minecolonies/coremod/network/messages/server/DecorationBuildRequestMessage.java
+++ b/src/main/java/com/minecolonies/coremod/network/messages/server/DecorationBuildRequestMessage.java
@@ -169,7 +169,8 @@ public class DecorationBuildRequestMessage implements IMessage
               name + level,
               difference,
               pos,
-              state.getValue(BlockDecorationController.MIRROR));
+              state.getValue(BlockDecorationController.MIRROR),
+              ((TileEntityDecorationController) entity).getWallExtents());
 
             if (level != ((TileEntityDecorationController) entity).getTier())
             {

--- a/src/main/java/com/minecolonies/coremod/tileentities/TileEntityDecorationController.java
+++ b/src/main/java/com/minecolonies/coremod/tileentities/TileEntityDecorationController.java
@@ -1,17 +1,21 @@
 package com.minecolonies.coremod.tileentities;
 
 import com.ldtteam.structurize.blocks.interfaces.IBlueprintDataProvider;
+import com.ldtteam.structurize.blueprints.v1.Blueprint;
 import com.ldtteam.structurize.helpers.WallExtents;
+import com.ldtteam.structurize.util.PlacementSettings;
 import com.minecolonies.api.tileentities.MinecoloniesTileEntities;
+import com.minecolonies.api.util.BlockPosUtil;
 import com.minecolonies.api.util.WorldUtil;
-import net.minecraft.world.level.block.state.BlockState;
+import com.minecolonies.coremod.blocks.BlockDecorationController;
+import net.minecraft.core.BlockPos;
+import net.minecraft.core.Direction;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.network.Connection;
 import net.minecraft.network.protocol.game.ClientboundBlockEntityDataPacket;
-import net.minecraft.world.level.block.entity.BlockEntity;
-import net.minecraft.core.Direction;
 import net.minecraft.util.Tuple;
-import net.minecraft.core.BlockPos;
+import net.minecraft.world.level.block.entity.BlockEntity;
+import net.minecraft.world.level.block.state.BlockState;
 import org.jetbrains.annotations.NotNull;
 
 import javax.annotation.Nullable;
@@ -272,5 +276,23 @@ public class TileEntityDecorationController extends BlockEntity implements IBlue
     public BlockPos getTilePos()
     {
         return worldPosition;
+    }
+
+    /**
+     * Recalculate the original placement settings for this structure.
+     *
+     * @param blueprint the structure
+     * @return the settings
+     */
+    @NotNull
+    public PlacementSettings calculatePlacementSettings(@Nullable final Blueprint blueprint)
+    {
+        final int difference = BlockPosUtil.calculateExistingRotation(blueprint,
+                getBlockState(), BlockDecorationController.class, BlockDecorationController.FACING);
+
+        return new PlacementSettings(
+                getBlockState().getValue(BlockDecorationController.MIRROR),
+                difference,
+                getWallExtents());
     }
 }

--- a/src/main/java/com/minecolonies/coremod/tileentities/TileEntityDecorationController.java
+++ b/src/main/java/com/minecolonies/coremod/tileentities/TileEntityDecorationController.java
@@ -1,6 +1,7 @@
 package com.minecolonies.coremod.tileentities;
 
 import com.ldtteam.structurize.blocks.interfaces.IBlueprintDataProvider;
+import com.ldtteam.structurize.helpers.WallExtents;
 import com.minecolonies.api.tileentities.MinecoloniesTileEntities;
 import com.minecolonies.api.util.WorldUtil;
 import net.minecraft.world.level.block.state.BlockState;
@@ -53,6 +54,11 @@ public class TileEntityDecorationController extends BlockEntity implements IBlue
      */
     private BlockPos corner1 = BlockPos.ZERO;
     private BlockPos corner2 = BlockPos.ZERO;
+
+    /**
+     * Wall extents
+     */
+    private WallExtents wall = new WallExtents();
 
     /**
      * Map of block positions relative to TE pos and string tags
@@ -187,6 +193,18 @@ public class TileEntityDecorationController extends BlockEntity implements IBlue
     {
         corner1 = pos1;
         corner2 = pos2;
+    }
+
+    @Override
+    public WallExtents getWallExtents()
+    {
+        return wall;
+    }
+
+    @Override
+    public void setWallExtents(final WallExtents extents)
+    {
+        wall = extents;
     }
 
     @Override

--- a/src/main/java/com/minecolonies/coremod/util/BuildingUtils.java
+++ b/src/main/java/com/minecolonies/coremod/util/BuildingUtils.java
@@ -1,10 +1,18 @@
 package com.minecolonies.coremod.util;
 
+import com.ldtteam.structurize.blueprints.v1.Blueprint;
 import com.minecolonies.api.blocks.AbstractBlockHut;
 import com.minecolonies.api.util.InventoryUtils;
+import com.minecolonies.api.util.Log;
 import net.minecraft.world.entity.player.Inventory;
 import net.minecraft.world.item.BlockItem;
 import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.level.block.Block;
+import net.minecraft.world.level.block.state.BlockState;
+import net.minecraft.world.level.block.state.properties.DirectionProperty;
+import org.jetbrains.annotations.NotNull;
+
+import javax.annotation.Nullable;
 
 public final class BuildingUtils
 {
@@ -39,4 +47,5 @@ public final class BuildingUtils
         }
         return ItemStack.EMPTY;
     }
+
 }

--- a/src/main/java/com/minecolonies/coremod/util/ColonyUtils.java
+++ b/src/main/java/com/minecolonies/coremod/util/ColonyUtils.java
@@ -1,6 +1,8 @@
 package com.minecolonies.coremod.util;
 
 import com.ldtteam.structurize.blueprints.v1.Blueprint;
+import com.ldtteam.structurize.blueprints.v1.BlueprintUtil;
+import com.ldtteam.structurize.helpers.WallExtents;
 import com.minecolonies.api.util.BlockPosUtil;
 import net.minecraft.world.level.block.Mirror;
 import net.minecraft.util.Tuple;
@@ -30,14 +32,16 @@ public final class ColonyUtils
      * @param blueprint  the structureWrapper.
      * @param rotation   the rotation.
      * @param isMirrored if its mirrored.
+     * @param wall       the wall extents.
      * @return a tuple with the required corners.
      */
     public static Tuple<BlockPos, BlockPos> calculateCorners(
-      final BlockPos pos,
-      final Level world,
-      final Blueprint blueprint,
-      final int rotation,
-      final boolean isMirrored)
+            final BlockPos pos,
+            final Level world,
+            Blueprint blueprint,
+            final int rotation,
+            final boolean isMirrored,
+            final WallExtents wall)
     {
         if (blueprint == null)
         {
@@ -45,6 +49,8 @@ public final class ColonyUtils
         }
 
         blueprint.rotateWithMirror(BlockPosUtil.getRotationFromRotations(rotation), isMirrored ? Mirror.FRONT_BACK : Mirror.NONE, world);
+        blueprint = BlueprintUtil.createWall(blueprint, wall);
+
         final BlockPos zeroPos = pos.subtract(blueprint.getPrimaryBlockOffset());
 
         final BlockPos pos1 = new BlockPos(zeroPos.getX(), zeroPos.getY(), zeroPos.getZ());

--- a/src/main/java/com/minecolonies/coremod/util/ColonyUtils.java
+++ b/src/main/java/com/minecolonies/coremod/util/ColonyUtils.java
@@ -2,11 +2,9 @@ package com.minecolonies.coremod.util;
 
 import com.ldtteam.structurize.blueprints.v1.Blueprint;
 import com.ldtteam.structurize.blueprints.v1.BlueprintUtil;
-import com.ldtteam.structurize.helpers.WallExtents;
-import com.minecolonies.api.util.BlockPosUtil;
-import net.minecraft.world.level.block.Mirror;
-import net.minecraft.util.Tuple;
+import com.ldtteam.structurize.util.PlacementSettings;
 import net.minecraft.core.BlockPos;
+import net.minecraft.util.Tuple;
 import net.minecraft.world.level.Level;
 
 /**
@@ -30,26 +28,22 @@ public final class ColonyUtils
      * @param pos        the central position.
      * @param world      the world.
      * @param blueprint  the structureWrapper.
-     * @param rotation   the rotation.
-     * @param isMirrored if its mirrored.
-     * @param wall       the wall extents.
+     * @param settings   the placement settings.
      * @return a tuple with the required corners.
      */
     public static Tuple<BlockPos, BlockPos> calculateCorners(
             final BlockPos pos,
             final Level world,
             Blueprint blueprint,
-            final int rotation,
-            final boolean isMirrored,
-            final WallExtents wall)
+            final PlacementSettings settings)
     {
         if (blueprint == null)
         {
             return new Tuple<>(pos, pos);
         }
 
-        blueprint.rotateWithMirror(BlockPosUtil.getRotationFromRotations(rotation), isMirrored ? Mirror.FRONT_BACK : Mirror.NONE, world);
-        blueprint = BlueprintUtil.createWall(blueprint, wall);
+        blueprint.rotateWithMirror(settings.getRotation(), settings.getMirror(), world);
+        blueprint = BlueprintUtil.createWall(blueprint, settings.getWallExtents());
 
         final BlockPos zeroPos = pos.subtract(blueprint.getPrimaryBlockOffset());
 

--- a/src/main/java/com/minecolonies/coremod/util/CreativeRaiderStructureHandler.java
+++ b/src/main/java/com/minecolonies/coremod/util/CreativeRaiderStructureHandler.java
@@ -3,6 +3,7 @@ package com.minecolonies.coremod.util;
 import com.ldtteam.structurize.api.util.Log;
 import com.ldtteam.structurize.blocks.interfaces.IBlueprintDataProvider;
 import com.ldtteam.structurize.blueprints.v1.Blueprint;
+import com.ldtteam.structurize.helpers.WallExtents;
 import com.ldtteam.structurize.management.Manager;
 import com.ldtteam.structurize.placement.StructurePlacer;
 import com.ldtteam.structurize.placement.structure.CreativeStructureHandler;
@@ -146,7 +147,7 @@ public final class CreativeRaiderStructureHandler extends CreativeStructureHandl
         try
         {
             @NotNull final IStructureHandler structure =
-              new CreativeRaiderStructureHandler(worldObj, pos, name, new PlacementSettings(mirror, rotation), fancyPlacement, event, colonyId);
+              new CreativeRaiderStructureHandler(worldObj, pos, name, new PlacementSettings(mirror, rotation, new WallExtents()), fancyPlacement, event, colonyId);
             if (structure.hasBluePrint())
             {
                 @NotNull final StructurePlacer instantPlacer = new StructurePlacer(structure);

--- a/src/main/java/com/minecolonies/coremod/util/CreativeRaiderStructureHandler.java
+++ b/src/main/java/com/minecolonies/coremod/util/CreativeRaiderStructureHandler.java
@@ -3,7 +3,6 @@ package com.minecolonies.coremod.util;
 import com.ldtteam.structurize.api.util.Log;
 import com.ldtteam.structurize.blocks.interfaces.IBlueprintDataProvider;
 import com.ldtteam.structurize.blueprints.v1.Blueprint;
-import com.ldtteam.structurize.helpers.WallExtents;
 import com.ldtteam.structurize.management.Manager;
 import com.ldtteam.structurize.placement.StructurePlacer;
 import com.ldtteam.structurize.placement.structure.CreativeStructureHandler;
@@ -13,15 +12,13 @@ import com.ldtteam.structurize.util.PlacementSettings;
 import com.ldtteam.structurize.util.TickedWorldOperation;
 import com.minecolonies.api.colony.colonyEvents.IColonyRaidEvent;
 import com.minecolonies.coremod.colony.colonyEvents.raidEvents.pirateEvent.ShipBasedRaiderUtils;
-import net.minecraft.world.level.block.Blocks;
+import net.minecraft.core.BlockPos;
+import net.minecraft.nbt.CompoundTag;
 import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.world.item.ItemStack;
-import net.minecraft.nbt.CompoundTag;
-import net.minecraft.world.level.block.entity.BlockEntity;
-import net.minecraft.world.level.block.Mirror;
-import net.minecraft.world.level.block.Rotation;
-import net.minecraft.core.BlockPos;
 import net.minecraft.world.level.Level;
+import net.minecraft.world.level.block.Blocks;
+import net.minecraft.world.level.block.entity.BlockEntity;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -129,8 +126,7 @@ public final class CreativeRaiderStructureHandler extends CreativeStructureHandl
      * @param worldObj       the world to load it in
      * @param name           the structures name
      * @param pos            coordinates
-     * @param rotation       the rotation.
-     * @param mirror         the mirror used.
+     * @param settings       the placement settings.
      * @param fancyPlacement if fancy or complete.
      * @param colonyId       the colony id.
      * @param event          the raid event.
@@ -139,15 +135,14 @@ public final class CreativeRaiderStructureHandler extends CreativeStructureHandl
      */
     public static Blueprint loadAndPlaceStructureWithRotation(
       final Level worldObj, @NotNull final String name,
-      @NotNull final BlockPos pos, final Rotation rotation,
-      @NotNull final Mirror mirror,
+      @NotNull final BlockPos pos, final PlacementSettings settings,
       final boolean fancyPlacement, final int colonyId, final IColonyRaidEvent event,
       @Nullable final ServerPlayer player)
     {
         try
         {
             @NotNull final IStructureHandler structure =
-              new CreativeRaiderStructureHandler(worldObj, pos, name, new PlacementSettings(mirror, rotation, new WallExtents()), fancyPlacement, event, colonyId);
+              new CreativeRaiderStructureHandler(worldObj, pos, name, settings, fancyPlacement, event, colonyId);
             if (structure.hasBluePrint())
             {
                 @NotNull final StructurePlacer instantPlacer = new StructurePlacer(structure);

--- a/src/main/resources/assets/minecolonies/gui/windowdecorationcontroller.xml
+++ b/src/main/resources/assets/minecolonies/gui/windowdecorationcontroller.xml
@@ -1,13 +1,13 @@
 <window xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" pause="true"
         lightbox="true"
         xsi:noNamespaceSchemaLocation="file:../../../../../api/java/com/minecolonies/blockui/blockui.xsd">
-    <label id="nameLabel" size="50% 11" pos="50 40" color="white"
+    <label id="nameLabel" size="250 11" pos="50 40" color="white"
            label="$(com.minecolonies.coremod.gui.deco.name)"/>
-    <input id="name" size="150 18" pos="50 50" maxlength="100"/>
+    <input id="name" size="250 18" pos="50 50" maxlength="100"/>
 
-    <label id="levelLabel" size="50% 11" pos="250 40" color="white"
+    <label id="levelLabel" size="50 11" pos="350 40" color="white"
            label="$(com.minecolonies.coremod.gui.deco.level)"/>
-    <input id="level" size="150 18" pos="250 50" maxlength="5"/>
+    <input id="level" size="50 18" pos="350 50" maxlength="5"/>
 
     <buttonimage id="done" align="TOP_MIDDLE" size="129 17" pos="0 80"
                  source="minecolonies:textures/gui/builderhut/builder_button_medium_large.png"
@@ -24,4 +24,6 @@
     <buttonimage id="build" align="TOP_MIDDLE" size="129 17" pos="60 120"
                  source="minecolonies:textures/gui/builderhut/builder_button_medium_large.png"
                  label="$(com.minecolonies.coremod.gui.workerhuts.upgrade)" textcolor="black"/>
+
+    <label id="infotextwallmode" size="50% 11" pos="0 150" color="white" align="TOP_MIDDLE" textalign="TOP_MIDDLE"/>
 </window>

--- a/src/main/resources/assets/minecolonies/lang/manual_en_us.json
+++ b/src/main/resources/assets/minecolonies/lang/manual_en_us.json
@@ -1080,7 +1080,7 @@
   "com.minecolonies.coremod.gui.deco.name": "The name of the decoration:",
   "com.minecolonies.coremod.gui.deco.level": "Level:",
   "com.minecolonies.coremod.gui.deco.level.none": "This schematic is already at the highest level or not upgradeable!",
-  "com.minecolonies.coremod.gui.deco.wallmode": "Wall: x%d (%d -- %d)",
+  "com.minecolonies.coremod.gui.deco.wallmode": "Extended: x%d (%d -- %d)",
 
   "com.minecolonies.coremod.gui.placement.warning": "We suggest using the build tool to place this schematic. This will allow you to adjust the position.",
   "com.minecolonies.coremod.gui.placement.buildtool": "Use build tool",
@@ -2129,5 +2129,6 @@
 
   "com.minecolonies.schematics.roads": "Roads",
   "com.minecolonies.schematics.rails": "Rails",
+  "com.minecolonies.schematics.walls": "Walls",
   "com.minecolonies.schematics.fields": "Fields"
 }

--- a/src/main/resources/assets/minecolonies/lang/manual_en_us.json
+++ b/src/main/resources/assets/minecolonies/lang/manual_en_us.json
@@ -1078,8 +1078,9 @@
   "block.minecolonies.decorationcontroller": "Decoration Controller",
   "com.minecolonies.coremod.gui.deco.namescan": "Final file path and filename, no level:",
   "com.minecolonies.coremod.gui.deco.name": "The name of the decoration:",
-  "com.minecolonies.coremod.gui.deco.level": "The level of the decoration:",
+  "com.minecolonies.coremod.gui.deco.level": "Level:",
   "com.minecolonies.coremod.gui.deco.level.none": "This schematic is already at the highest level or not upgradeable!",
+  "com.minecolonies.coremod.gui.deco.wallmode": "Wall: x%d (%d -- %d)",
 
   "com.minecolonies.coremod.gui.placement.warning": "We suggest using the build tool to place this schematic. This will allow you to adjust the position.",
   "com.minecolonies.coremod.gui.placement.buildtool": "Use build tool",

--- a/src/main/resources/assets/minecolonies/lang/manual_en_us.json
+++ b/src/main/resources/assets/minecolonies/lang/manual_en_us.json
@@ -2125,5 +2125,9 @@
   "com.minecolonies.building.simplequarry": "Simple Quarry",
   "com.minecolonies.building.mediumquarry": "Medium Quarry",
   "com.minecolonies.building.largequarry": "Large Quarry",
-  "com.minecolonies.coremod.gui.quarry.desc": "To start the Quarry construct a Mine, hire a Quarrier and assign the Quarrier to the Quarry"
+  "com.minecolonies.coremod.gui.quarry.desc": "To start the Quarry construct a Mine, hire a Quarrier and assign the Quarrier to the Quarry",
+
+  "com.minecolonies.schematics.roads": "Roads",
+  "com.minecolonies.schematics.rails": "Rails",
+  "com.minecolonies.schematics.fields": "Fields"
 }


### PR DESCRIPTION
Depends on ldtteam/structurize#486

# Changes proposed in this pull request:
- fix translation string in decoration controller "cancel repair/upgrade"
- fix translation string in rally banner gui
- decoration controller repair/upgrade now shows you the list of expected materials and allow custom builder assignment, just like the initial deco build
- make work orders for decoration controller repair/upgrade have a short name instead of the full schematic path
- support for "~wall~ extendable mode" (decorations only) -- see linked Structurize PR for usage
  - an upgradable wall build only gets one decoration controller, which indicates that it's ~a wall~ extended in the gui
- support for PlacementSettings api changes
- adds top-level sections for Roads, Rail, Walls, and Fields (this removes them from the Decorations menu)
- all `/walls/` will automatically get the Extendable Mode UI.  other schematics (including roads/rails) can only use it if a tag is added (but walls should be updated to use the tag too, so eventually this backwards-compatibility check can be removed)

Review please

![image](https://user-images.githubusercontent.com/539951/153686303-1481ccf1-5edf-49c9-aafa-94ea1d8114da.png)
Now: ![image](https://user-images.githubusercontent.com/539951/154473993-87829253-31f9-4bbe-9517-8a654d14dfd3.png)

![image](https://user-images.githubusercontent.com/539951/153686312-fcdbe2c7-b078-4e8b-8bee-a436c2a24023.png)
![image](https://user-images.githubusercontent.com/539951/153686318-71e3f289-0cfa-4f79-b2f7-a4b6ce9222f4.png)
