### PR TITLE
Add copper ore to the default lucky ore list

### DIFF
--- a/src/api/java/com/minecolonies/api/configuration/ServerConfiguration.java
+++ b/src/api/java/com/minecolonies/api/configuration/ServerConfiguration.java
@@ -455,6 +455,7 @@ public class ServerConfiguration extends AbstractConfiguration
         luckyOres = defineList(builder, "luckyores",
           Arrays.asList
                   ("minecraft:coal_ore!64",
+                    "minecraft:copper_ore!48",
                     "minecraft:iron_ore!32",
                     "minecraft:gold_ore!16",
                     "minecraft:redstone_ore!8",


### PR DESCRIPTION
It's a little more common than iron to make up for the fact that you only get ore, not raw copper.

# Changes proposed in this pull request:
- Add copper ore to the default lucky ore list with a weight of 48

Review please
