### PR TITLE
Basic lectern placement

### DIFF
--- a/src/main/java/com/minecolonies/coremod/placementhandlers/LecternPlacementHandler.java
+++ b/src/main/java/com/minecolonies/coremod/placementhandlers/LecternPlacementHandler.java
@@ -1,0 +1,86 @@
+package com.minecolonies.coremod.placementhandlers;
+
+import com.ldtteam.structurize.placement.handlers.placement.IPlacementHandler;
+import com.ldtteam.structurize.placement.handlers.placement.PlacementHandlers;
+import com.ldtteam.structurize.util.BlockUtils;
+import net.minecraft.block.BlockState;
+import net.minecraft.block.LecternBlock;
+import net.minecraft.item.ItemStack;
+import net.minecraft.item.Items;
+import net.minecraft.nbt.CompoundNBT;
+import net.minecraft.tileentity.LecternTileEntity;
+import net.minecraft.tileentity.TileEntity;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.world.World;
+import net.minecraftforge.common.util.Constants;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class LecternPlacementHandler implements IPlacementHandler
+{
+    @Override
+    public boolean canHandle(@NotNull final World world,
+                             @NotNull final BlockPos pos,
+                             @NotNull final BlockState blockState)
+    {
+        return blockState.getBlock() instanceof LecternBlock;
+    }
+
+    @Override
+    public List<ItemStack> getRequiredItems(@NotNull final World world,
+                                            @NotNull final BlockPos pos,
+                                            @NotNull final BlockState blockState,
+                                            @Nullable final CompoundNBT tileEntityData,
+                                            final boolean complete)
+    {
+        final List<ItemStack> itemList = new ArrayList<>();
+        itemList.add(BlockUtils.getItemStackFromBlockState(blockState));
+
+        final LecternTileEntity lectern = getLectern(blockState, tileEntityData);
+        if (lectern != null && lectern.hasBook())
+        {
+            itemList.add(new ItemStack(Items.BOOK));
+        }
+
+        return itemList;
+    }
+
+    @Override
+    public ActionProcessingResult handle(@NotNull final World world,
+                                         @NotNull final BlockPos pos,
+                                         @NotNull final BlockState blockState,
+                                         @Nullable CompoundNBT tileEntityData,
+                                         final boolean complete,
+                                         final BlockPos centerPos)
+    {
+        if (!world.setBlock(pos, blockState, Constants.BlockFlags.DEFAULT))
+        {
+            return ActionProcessingResult.DENY;
+        }
+
+        if (tileEntityData != null)
+        {
+            PlacementHandlers.handleTileEntityPlacement(tileEntityData, world, pos);
+        }
+
+        return ActionProcessingResult.SUCCESS;
+    }
+
+    @Nullable
+    private static LecternTileEntity getLectern(@NotNull final BlockState blockState,
+                                                @Nullable final CompoundNBT tileEntityData)
+    {
+        if (tileEntityData != null)
+        {
+            final TileEntity tileEntity = TileEntity.loadStatic(blockState, tileEntityData);
+            if (tileEntity instanceof LecternTileEntity)
+            {
+                return (LecternTileEntity) tileEntity;
+            }
+        }
+        return null;
+    }
+}

--- a/src/main/java/com/minecolonies/coremod/placementhandlers/PlacementHandlerInitializer.java
+++ b/src/main/java/com/minecolonies/coremod/placementhandlers/PlacementHandlerInitializer.java
@@ -29,5 +29,6 @@ public final class PlacementHandlerInitializer
         PlacementHandlers.add(new WayPointBlockPlacementHandler());
         PlacementHandlers.add(new GatePlacementHandler());
         PlacementHandlers.add(new NetherrackPlacementHandler());
+        PlacementHandlers.add(new LecternPlacementHandler());
     }
 }


### PR DESCRIPTION
# Changes proposed in this pull request:
- Makes it so that building a lectern that contains a book (of any kind) costs a blank book rather than being free.

Review please

The intent is to make it more practical to include written guide books inside schematics.  For best results:
1. Write your content in a Book & Quill (don't sign it)
2. In creative mode, place the Book & Quill on a lectern (anywhere)
3. Right-click on the lectern and Take Book
4. This will have duplicated your book.  Put one copy in a safe place outside the schematic for future editing.
5. Right-click and sign the other book, giving it a suitable title.
6. Put the signed book on a lectern within the scan region, and scan.

(This procedure works without this PR too -- but then it doesn't cost a book to build.)

The cost is a plain book rather than a Book & Quill mostly to avoid accidentally stealing and deleting a player's in-progress books, or refusing to accept a book that might have been touched even slightly (depending how the NBT matching is set).  Even though this is a bit cheaper than it "should" be, it's still a bit better than free.

I did originally have some other features in here, but I ended up removing them:
* I wanted to make it so that if the builder deconstructs a lectern, it would drop the plain book again (to avoid duping whichever book was on the lectern in the schematic).  However this is a bit too dangerous if the builder breaks any other lectern (e.g. one player-placed) as it would destroy their book.  Also, it's still possible to dupe the book via taking it and then Repair, so this doesn't really gain much.  (And books can be copied in survival anyway, albeit not usually quite that easily.)  There also doesn't seem to be any particular good hooks to alter the drops in the existing code -- it's doable, but a bit too ugly.
* I originally had it so you'd scan it with an unsigned book, and then if you placed it in fancy mode the book would be auto-signed and if you placed it in placeholder mode then it would remain unsigned (and in fact even if you originally placed a signed book it would de-sign the book when pasted in placeholder mode).  The idea was to make it easier to keep the book editable when rescanning the schematic, and provide a way to "recover" the editable book if you messed up and only had a signed copy.  However the creative duplication trick above seemed sufficiently simple (albeit not quite as foolproof, since you need to keep an item safe outside the schematic itself), and there are other mods around for editing signed books if you're desperate.