### PR TITLE
JM and Tinkers version checks weren't correct

### DIFF
--- a/src/main/resources/META-INF/mods.toml
+++ b/src/main/resources/META-INF/mods.toml
@@ -70,7 +70,7 @@ MineColonies is a colony simulator within Minecraft! There are numerous types of
 [[dependencies.minecolonies]]
     modId="tconstruct"
     mandatory=false
-    versionRange="[${project.minecraftVersion}-${project.tinkersConstructVersion},)"
+    versionRange="[${project.tinkersConstructVersion},)"
     ordering="NONE"
     side="BOTH"
 [[dependencies.minecolonies]]
@@ -88,6 +88,6 @@ MineColonies is a colony simulator within Minecraft! There are numerous types of
 [[dependencies.minecolonies]]
     modId="journeymap"
     mandatory=false
-    versionRange="[${project.minecraftVersion}-${project.jmapVersion},)"
+    versionRange="[${project.jmapVersion},)"
     ordering="NONE"
     side="BOTH"


### PR DESCRIPTION
# Changes proposed in this pull request:
- Makes 1.16 actually check for the right min versions of JourneyMap and Tinkers Construct

Review please

_shakes fist at inconsistent mod version naming conventions_

(This is already correct in 1.18.)