### PR TITLE
Fix Compost Barrel logic to not void excess when extracting compost

### DIFF
--- a/src/main/java/com/minecolonies/coremod/blocks/BlockBarrel.java
+++ b/src/main/java/com/minecolonies/coremod/blocks/BlockBarrel.java
@@ -82,7 +82,7 @@ public class BlockBarrel extends AbstractBlockBarrel<BlockBarrel> implements Ent
         final BlockEntity te = worldIn.getBlockEntity(pos);
         if (te instanceof TileEntityBarrel && !worldIn.isClientSide)
         {
-            ((TileEntityBarrel) te).useBarrel(player, itemstack);
+            ((TileEntityBarrel) te).useBarrel(player, itemstack, ray.getDirection());
             ((TileEntityBarrel) te).updateBlock(worldIn);
         }
 

--- a/src/main/java/com/minecolonies/coremod/tileentities/TileEntityBarrel.java
+++ b/src/main/java/com/minecolonies/coremod/tileentities/TileEntityBarrel.java
@@ -113,20 +113,6 @@ public class TileEntityBarrel extends AbstractTileEntityBarrel implements ITicka
     /**
      * Method called when a player uses the block. Takes the needed items from the player.
      *
-     * @deprecated Use side-sensitive version
-     * @param playerIn  the player
-     * @param itemstack the itemStack on the hand of the player
-     * @return if the barrel took any item
-     */
-    @Deprecated
-    public boolean useBarrel(final Player playerIn, final ItemStack itemstack)
-    {
-        return useBarrel(playerIn, itemstack, null);
-    }
-
-    /**
-     * Method called when a player uses the block. Takes the needed items from the player.
-     *
      * @param playerIn  the player
      * @param itemstack the itemStack on the hand of the player
      * @param hitFace   the side of the barrel the player hit.

--- a/src/main/java/com/minecolonies/coremod/tileentities/TileEntityBarrel.java
+++ b/src/main/java/com/minecolonies/coremod/tileentities/TileEntityBarrel.java
@@ -10,6 +10,13 @@ import com.minecolonies.api.tileentities.ITickable;
 import com.minecolonies.api.tileentities.MinecoloniesTileEntities;
 import com.minecolonies.api.util.ItemStackUtils;
 import com.minecolonies.api.util.WorldUtil;
+import net.minecraft.core.Direction;
+import net.minecraft.sounds.SoundEvent;
+import net.minecraft.sounds.SoundEvents;
+import net.minecraft.sounds.SoundSource;
+import net.minecraft.world.entity.EntityType;
+import net.minecraft.world.entity.MobSpawnType;
+import net.minecraft.world.entity.item.ItemEntity;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.item.ItemStack;
@@ -106,15 +113,44 @@ public class TileEntityBarrel extends AbstractTileEntityBarrel implements ITicka
     /**
      * Method called when a player uses the block. Takes the needed items from the player.
      *
+     * @deprecated Use side-sensitive version
      * @param playerIn  the player
      * @param itemstack the itemStack on the hand of the player
      * @return if the barrel took any item
      */
+    @Deprecated
     public boolean useBarrel(final Player playerIn, final ItemStack itemstack)
+    {
+        return useBarrel(playerIn, itemstack, null);
+    }
+
+    /**
+     * Method called when a player uses the block. Takes the needed items from the player.
+     *
+     * @param playerIn  the player
+     * @param itemstack the itemStack on the hand of the player
+     * @param hitFace   the side of the barrel the player hit.
+     *                  Passing null when composting is complete will insert resulting compost directly into inventory, spawning overflow as an ItemEntity
+     * @return if the barrel took any item
+     */
+    public boolean useBarrel(final Player playerIn, final ItemStack itemstack, @Nullable Direction hitFace)
     {
         if (done)
         {
-            playerIn.getInventory().add(new ItemStack(ModItems.compost, 6));
+            ItemStack compostStack = new ItemStack(ModItems.compost, 6);
+            if (hitFace != null) // Spawn all as ItemEntity
+            {
+                playerIn.level.addFreshEntity(new ItemEntity(playerIn.level, worldPosition.getX() + 0.5, worldPosition.getY() + 1.75, worldPosition.getZ() + 0.5, compostStack, hitFace.getStepX() / 5f, hitFace.getStepY() / 5f + 0.2f, hitFace.getStepZ() / 5f));
+                this.level.playSound(null, worldPosition, SoundEvents.ITEM_FRAME_REMOVE_ITEM, SoundSource.BLOCKS, 1, 1);
+            }
+            else // Insert directly into inventory, spawning overflow as ItemEntity
+            {
+                if(!playerIn.getInventory().add(compostStack))
+                {
+                    playerIn.level.addFreshEntity(new ItemEntity(playerIn.level, worldPosition.getX() + 0.5, worldPosition.getY() + 1.75, worldPosition.getZ() + 0.5, compostStack, 0, 0.2f, 0));
+                }
+                this.level.playSound(null, worldPosition, SoundEvents.ITEM_FRAME_REMOVE_ITEM, SoundSource.BLOCKS, 1, 1);
+            }
             done = false;
             return true;
         }


### PR DESCRIPTION
# Changes proposed in this pull request:
- Fix Compost Barrel logic to not void excess when extracting compost
- Also changed the method of dispensing finished compost:
  - If a side is given (the clicked side of the barrel), finished compost is spawned as an item entity moving in the direction of the indicated side.
  - If null side is given, fixed old logic is invoked inserting results directly into the player's inventory with overflow being spawned on top of the barrel with no velocity.

Review please
