### PR TITLE
Another attempt on fixing 8103

### DIFF
--- a/src/api/java/com/minecolonies/api/colony/jobs/IJob.java
+++ b/src/api/java/com/minecolonies/api/colony/jobs/IJob.java
@@ -277,4 +277,16 @@ public interface IJob<AI extends Goal> extends INBTSerializable<CompoundTag>
      * @param jobEntry the job entry belonging to it.
      */
     void setRegistryEntry(JobEntry jobEntry);
+
+    /**
+     * Whether the given stack should be dumped by the worker,
+     * regardless of the items the building currently needs.
+     *
+     * @param stack The stack to base the decision on.
+     * @return true if the stack should be dumped in the building regardless.
+     */
+    default boolean shouldDumpAnyway(ItemStack stack)
+    {
+        return false;
+    }
 }

--- a/src/main/java/com/minecolonies/coremod/colony/jobs/JobCookAssistant.java
+++ b/src/main/java/com/minecolonies/coremod/colony/jobs/JobCookAssistant.java
@@ -6,6 +6,7 @@ import com.minecolonies.api.colony.ICitizenData;
 import com.minecolonies.api.colony.jobs.ModJobs;
 import com.minecolonies.api.colony.jobs.registry.JobEntry;
 import com.minecolonies.coremod.entity.ai.citizen.cook.EntityAIWorkCookAssistant;
+import net.minecraft.world.item.ItemStack;
 import org.jetbrains.annotations.NotNull;
 
 /**
@@ -40,5 +41,21 @@ public class JobCookAssistant extends AbstractJobCrafter<EntityAIWorkCookAssista
     public EntityAIWorkCookAssistant generateAI()
     {
         return new EntityAIWorkCookAssistant(this);
+    }
+
+    /**
+     * Whether the given stack should be dumped by the worker,
+     * regardless of the items the building currently needs.
+     *
+     * @param stack The stack to base the decision on.
+     * @return true if the stack should be dumped in the building regardless.
+     */
+    @Override
+    public boolean shouldDumpAnyway(ItemStack stack) {
+        // The assistant cook should dump everything, and not keep food or fuel in their inventory,
+        // which is what the restaurant dictates to its workers.
+        // They may incorrectly keep food in their inventory what they just crafted otherwise,
+        // which messes up the crafting request
+        return true;
     }
 }

--- a/src/main/java/com/minecolonies/coremod/colony/jobs/JobCookAssistant.java
+++ b/src/main/java/com/minecolonies/coremod/colony/jobs/JobCookAssistant.java
@@ -51,7 +51,8 @@ public class JobCookAssistant extends AbstractJobCrafter<EntityAIWorkCookAssista
      * @return true if the stack should be dumped in the building regardless.
      */
     @Override
-    public boolean shouldDumpAnyway(ItemStack stack) {
+    public boolean shouldDumpAnyway(ItemStack stack)
+    {
         // The assistant cook should dump everything, and not keep food or fuel in their inventory,
         // which is what the restaurant dictates to its workers.
         // They may incorrectly keep food in their inventory what they just crafted otherwise,

--- a/src/main/java/com/minecolonies/coremod/entity/ai/basic/AbstractEntityAIBasic.java
+++ b/src/main/java/com/minecolonies/coremod/entity/ai/basic/AbstractEntityAIBasic.java
@@ -1134,7 +1134,12 @@ public abstract class AbstractEntityAIBasic<J extends AbstractJob<?, J>, B exten
         }
 
         boolean dumpAnyway = false;
-        if (slotAt + MIN_OPEN_SLOTS * 2 >= totalSize)
+
+        if (job.shouldDumpAnyway(stackToDump))
+        {
+            dumpAnyway = true;
+        }
+        else if (slotAt + MIN_OPEN_SLOTS * 2 >= totalSize)
         {
             final long openSlots = InventoryUtils.openSlotCount(worker.getInventoryCitizen());
             if (openSlots < MIN_OPEN_SLOTS * 2)


### PR DESCRIPTION
Closes #8103 
Closes #
Closes #

# Changes proposed in this pull request:
- Make the assistant cook dump everything
- In this attempt, the job is queried to find out whether the item should be dumped in the building before the building is queried to find out whether the citizen should dump the item or not. This should comply with the commentary given in #8165
- The added method is made in a way that future jobs could decide to dump some types of items regardless. This is currently not needed yet for the assistant cook.

Review please
