### PR TITLE
Make archery prefer "work" tag to decide standing locations

### DIFF
--- a/src/main/java/com/minecolonies/coremod/colony/buildings/AbstractBuildingContainer.java
+++ b/src/main/java/com/minecolonies/coremod/colony/buildings/AbstractBuildingContainer.java
@@ -194,7 +194,8 @@ public abstract class AbstractBuildingContainer extends AbstractSchematicProvide
     @Nullable
     protected BlockPos getFirstLocationFromTag(@NotNull final String tagName)
     {
-        return getLocationsFromTag(tagName).stream().findFirst().orElse(null);
+        final List<BlockPos> locations = getLocationsFromTag(tagName);
+        return locations.isEmpty() ? null : locations.get(0);
     }
 
     /**

--- a/src/main/java/com/minecolonies/coremod/colony/buildings/AbstractBuildingContainer.java
+++ b/src/main/java/com/minecolonies/coremod/colony/buildings/AbstractBuildingContainer.java
@@ -28,10 +28,7 @@ import org.jetbrains.annotations.NotNull;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 import java.util.function.Predicate;
 
 import static com.minecolonies.api.colony.requestsystem.requestable.deliveryman.AbstractDeliverymanRequestable.getMaxBuildingPriority;
@@ -194,20 +191,25 @@ public abstract class AbstractBuildingContainer extends AbstractSchematicProvide
      * @param tagName the name of the tag to query
      * @return the BlockPos, or null if not found
      */
-    protected BlockPos getFirstLocationFromTag(String tagName)
+    @Nullable
+    protected BlockPos getFirstLocationFromTag(@NotNull final String tagName)
     {
-        if (tileEntity != null && !tileEntity.getPositionedTags().isEmpty())
+        return getLocationsFromTag(tagName).stream().findFirst().orElse(null);
+    }
+
+    /**
+     * Gets the list of tags, and finds all locations registered there.
+     * @param tagName the name of the tag to query
+     * @return all the matching BlockPos, or an empty list if not found
+     */
+    @NotNull
+    protected List<BlockPos> getLocationsFromTag(@NotNull final String tagName)
+    {
+        if (tileEntity != null)
         {
-            for (final Map.Entry<BlockPos, List<String>> entry : tileEntity.getPositionedTags().entrySet())
-            {
-                if(entry.getValue().contains(tagName))
-                {
-                    //Tagged block for a portal location should be one of the obsidian block at the bottom of the opening
-                    return getPosition().offset(entry.getKey());
-                }
-            }
+            return new ArrayList<>(tileEntity.getWorldTagNamePosMap().getOrDefault(tagName, Collections.emptySet()));
         }
-        return null;
+        return Collections.emptyList();
     }
 
     @Override

--- a/src/main/java/com/minecolonies/coremod/colony/buildings/workerbuildings/BuildingArchery.java
+++ b/src/main/java/com/minecolonies/coremod/colony/buildings/workerbuildings/BuildingArchery.java
@@ -109,6 +109,11 @@ public class BuildingArchery extends AbstractBuilding
      */
     public BlockPos getRandomShootingStandPosition(final Random random)
     {
+        final List<BlockPos> tagged = getLocationsFromTag(TAG_WORK);
+        if (!tagged.isEmpty())
+        {
+            return tagged.get(random.nextInt(tagged.size()));
+        }
         if (!shootingStands.isEmpty())
         {
             return shootingStands.get(random.nextInt(shootingStands.size()));

--- a/src/main/java/com/minecolonies/coremod/colony/buildings/workerbuildings/BuildingCook.java
+++ b/src/main/java/com/minecolonies/coremod/colony/buildings/workerbuildings/BuildingCook.java
@@ -1,6 +1,5 @@
 package com.minecolonies.coremod.colony.buildings.workerbuildings;
 
-import com.ldtteam.structurize.blocks.interfaces.IBlueprintDataProvider;
 import com.minecolonies.api.MinecoloniesAPIProxy;
 import com.minecolonies.api.colony.ICitizenData;
 import com.minecolonies.api.colony.IColony;
@@ -123,19 +122,8 @@ public class BuildingCook extends AbstractBuilding
             return;
         }
 
-        final IBlueprintDataProvider te = getTileEntity();
-        if (te != null)
-        {
-            initTags = true;
-            sitPositions = new ArrayList<>();
-            for (final Map.Entry<BlockPos, List<String>> entry : te.getWorldTagPosMap().entrySet())
-            {
-                if (entry.getValue().contains(TAG_SITTING))
-                {
-                    sitPositions.add(entry.getKey());
-                }
-            }
-        }
+        sitPositions = getLocationsFromTag(TAG_SITTING);
+        initTags = !sitPositions.isEmpty();
     }
 
     @Override


### PR DESCRIPTION
# Changes proposed in this pull request:
- Allows glowstone to be used decoratively in tagged buildings
- Falls back on using glowstone block list if no tags

Review please

Also updates the cook to use the new convenience method.  Didn't update the other tag queries because they check for more than one tag per building, so using the convenience method would be a very slight perf regression from redundant recalcs (but probably nobody cares).