### PR TITLE
Fix being able to select non builders hut using resource scroll

### DIFF
--- a/src/api/java/com/minecolonies/api/colony/buildings/registry/BuildingEntry.java
+++ b/src/api/java/com/minecolonies/api/colony/buildings/registry/BuildingEntry.java
@@ -153,6 +153,11 @@ public class BuildingEntry extends ForgeRegistryEntry<BuildingEntry>
         }
     }
 
+    public String getTranslationKey()
+    {
+        return "com." + getRegistryName().getNamespace() + ".building." + getRegistryName().getPath();
+    }
+
     private final Supplier<BiFunction<IColonyView, BlockPos, IBuildingView>> buildingViewProducer;
 
     public AbstractBlockHut<?> getBuildingBlock()

--- a/src/api/java/com/minecolonies/api/util/constant/TranslationConstants.java
+++ b/src/api/java/com/minecolonies/api/util/constant/TranslationConstants.java
@@ -130,11 +130,13 @@ public final class TranslationConstants
     @NonNls
     public static final String COM_MINECOLONIES_CLIPBOARD_COLONY_SET                                = "com.minecolonies.coremod.item.clipboard.registered";
     @NonNls
-    public static final String COM_MINECOLONIES_SCROLL_NEED_BUILDER                                 = "com.minecolonies.coremod.item.scroll.needcolony";
+    public static final String COM_MINECOLONIES_SCROLL_NO_COLONY                                    = "com.minecolonies.coremod.item.scroll.needcolony";
     @NonNls
-    public static final String COM_MINECOLONIES_SCROLL_BUILDER_SET                                  = "com.minecolonies.coremod.item.scroll.registered";
+    public static final String COM_MINECOLONIES_SCROLL_BUILDING_SET                                 = "com.minecolonies.coremod.item.scroll.registered";
     @NonNls
-    public static final String COM_MINECOLONIES_SCROLL_NO_BUILDER                                   = "com.minecolonies.coremod.item.scroll.no_builder";
+    public static final String COM_MINECOLONIES_SCROLL_WRONG_BUILDING                               = "com.minecolonies.coremod.item.scroll.wrong_building";
+    @NonNls
+    public static final String COM_MINECOLONIES_SCROLL_BUILDING_NO_WORKER                           = "com.minecolonies.coremod.item.scroll.no_builder";
     @NonNls
     public static final String COM_MINECOLONIES_BANNER_RALLY_GUARDS_SELECTED                        = "com.minecolonies.coremod.item.bannerrallyguards.selected";
     @NonNls

--- a/src/main/java/com/minecolonies/coremod/items/ItemResourceScroll.java
+++ b/src/main/java/com/minecolonies/coremod/items/ItemResourceScroll.java
@@ -8,9 +8,12 @@ import com.minecolonies.api.creativetab.ModCreativeTabs;
 import com.minecolonies.api.tileentities.AbstractTileEntityColonyBuilding;
 import com.minecolonies.api.tileentities.TileEntityColonyBuilding;
 import com.minecolonies.api.util.BlockPosUtil;
+import com.minecolonies.api.util.Log;
 import com.minecolonies.api.util.constant.TranslationConstants;
 import com.minecolonies.coremod.MineColonies;
 import com.minecolonies.coremod.colony.buildings.workerbuildings.BuildingBuilder;
+import net.minecraft.client.resources.I18n;
+import net.minecraft.client.resources.Language;
 import net.minecraft.client.util.ITooltipFlag;
 import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.item.Item;
@@ -29,6 +32,7 @@ import net.minecraft.util.text.TranslationTextComponent;
 import net.minecraft.world.World;
 import net.minecraftforge.api.distmarker.Dist;
 import net.minecraftforge.api.distmarker.OnlyIn;
+import org.apache.logging.log4j.Level;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -89,10 +93,13 @@ public class ItemResourceScroll extends AbstractItemMinecolonies
             {
                 if (!ctx.getLevel().isClientSide)
                 {
-                    LanguageHandler.sendPlayerMessage(ctx.getPlayer(),
+                    String buildingTypeKey = buildingEntity.getBuilding().getBuildingType().getTranslationKey();
+                    ITextComponent buildingTypeComponent = new TranslationTextComponent(buildingTypeKey);
+                    ITextComponent mainComponent = new TranslationTextComponent(
                             COM_MINECOLONIES_SCROLL_WRONG_BUILDING,
-                            buildingEntity.getBuildingName(), // TODO: Should be changed with a proper building display name, though this does not seem to be available
+                            buildingTypeComponent,
                             buildingEntity.getColony().getName());
+                    ctx.getPlayer().sendMessage(mainComponent, ctx.getPlayer().getUUID());
                 }
             }
         }

--- a/src/main/java/com/minecolonies/coremod/items/ItemResourceScroll.java
+++ b/src/main/java/com/minecolonies/coremod/items/ItemResourceScroll.java
@@ -37,6 +37,7 @@ import java.util.List;
 import static com.minecolonies.api.util.constant.Constants.STACKSIZE;
 import static com.minecolonies.api.util.constant.NbtTagConstants.TAG_BUILDER;
 import static com.minecolonies.api.util.constant.NbtTagConstants.TAG_COLONY_ID;
+import static com.minecolonies.api.util.constant.TranslationConstants.*;
 
 /**
  * Class describing the resource scroll item.
@@ -70,14 +71,24 @@ public class ItemResourceScroll extends AbstractItemMinecolonies
 
         if (entity instanceof TileEntityColonyBuilding)
         {
-            compound.putInt(TAG_COLONY_ID, ((AbstractTileEntityColonyBuilding) entity).getColonyId());
-            BlockPosUtil.write(compound, TAG_BUILDER, ((AbstractTileEntityColonyBuilding) entity).getPosition());
+            final AbstractTileEntityColonyBuilding buildingEntity = (AbstractTileEntityColonyBuilding) entity;
 
-            if (!ctx.getLevel().isClientSide)
-            {
-                LanguageHandler.sendPlayerMessage(ctx.getPlayer(),
-                  TranslationConstants.COM_MINECOLONIES_SCROLL_BUILDER_SET,
-                  ((AbstractTileEntityColonyBuilding) entity).getColony().getName());
+            if (buildingEntity.getBuilding() instanceof BuildingBuilder) {
+                compound.putInt(TAG_COLONY_ID, buildingEntity.getColonyId());
+                BlockPosUtil.write(compound, TAG_BUILDER, buildingEntity.getPosition());
+
+                if (!ctx.getLevel().isClientSide) {
+                    LanguageHandler.sendPlayerMessage(ctx.getPlayer(),
+                            COM_MINECOLONIES_SCROLL_BUILDING_SET,
+                            buildingEntity.getColony().getName());
+                }
+            } else {
+                if (!ctx.getLevel().isClientSide) {
+                    LanguageHandler.sendPlayerMessage(ctx.getPlayer(),
+                            COM_MINECOLONIES_SCROLL_WRONG_BUILDING,
+                            buildingEntity.getBuildingName(), // TODO: Should be changed with a proper building display name, though this does not seem to be available
+                            buildingEntity.getColony().getName());
+                }
             }
         }
         else if (ctx.getLevel().isClientSide)
@@ -136,7 +147,7 @@ public class ItemResourceScroll extends AbstractItemMinecolonies
                 String name = ((BuildingBuilder.View) buildingView).getWorkerName();
                 tooltip.add(name != null && !name.trim().isEmpty()
                   ? new StringTextComponent(TextFormatting.DARK_PURPLE + name)
-                  : new TranslationTextComponent(TranslationConstants.COM_MINECOLONIES_SCROLL_NO_BUILDER));
+                  : new TranslationTextComponent(COM_MINECOLONIES_SCROLL_BUILDING_NO_WORKER));
             }
         }
     }
@@ -171,7 +182,7 @@ public class ItemResourceScroll extends AbstractItemMinecolonies
         }
         else
         {
-            player.displayClientMessage(new TranslationTextComponent(TranslationConstants.COM_MINECOLONIES_SCROLL_NEED_BUILDER), true);
+            player.displayClientMessage(new TranslationTextComponent(TranslationConstants.COM_MINECOLONIES_SCROLL_NO_COLONY), true);
         }
     }
 }

--- a/src/main/java/com/minecolonies/coremod/items/ItemResourceScroll.java
+++ b/src/main/java/com/minecolonies/coremod/items/ItemResourceScroll.java
@@ -73,17 +73,22 @@ public class ItemResourceScroll extends AbstractItemMinecolonies
         {
             final AbstractTileEntityColonyBuilding buildingEntity = (AbstractTileEntityColonyBuilding) entity;
 
-            if (buildingEntity.getBuilding() instanceof BuildingBuilder) {
+            if (buildingEntity.getBuilding() instanceof BuildingBuilder)
+            {
                 compound.putInt(TAG_COLONY_ID, buildingEntity.getColonyId());
                 BlockPosUtil.write(compound, TAG_BUILDER, buildingEntity.getPosition());
 
-                if (!ctx.getLevel().isClientSide) {
+                if (!ctx.getLevel().isClientSide)
+                {
                     LanguageHandler.sendPlayerMessage(ctx.getPlayer(),
                             COM_MINECOLONIES_SCROLL_BUILDING_SET,
                             buildingEntity.getColony().getName());
                 }
-            } else {
-                if (!ctx.getLevel().isClientSide) {
+            }
+            else
+            {
+                if (!ctx.getLevel().isClientSide)
+                {
                     LanguageHandler.sendPlayerMessage(ctx.getPlayer(),
                             COM_MINECOLONIES_SCROLL_WRONG_BUILDING,
                             buildingEntity.getBuildingName(), // TODO: Should be changed with a proper building display name, though this does not seem to be available

--- a/src/main/resources/assets/minecolonies/lang/manual_en_us.json
+++ b/src/main/resources/assets/minecolonies/lang/manual_en_us.json
@@ -833,6 +833,7 @@
   "com.minecolonies.coremod.item.clipboard.registered": "Noting requests on the clipboard from %s.",
   "com.minecolonies.coremod.item.scroll.needcolony": "No Builder set (sneak + use the scroll on the Builder's Hut)",
   "com.minecolonies.coremod.item.scroll.registered": "Linked resources for Builder's Hut at %s.",
+  "com.minecolonies.coremod.item.scroll.wrong_building": "Cannot link resource scroll to %s at %s",
   "com.minecolonies.coremod.item.scroll.no_builder": "§oNo Builder",
   "com.minecolonies.coremod.buildings.warehouse": "Warehouse",
   "com.minecolonies.coremod.buildings.warehouse.name": "Warehouse",


### PR DESCRIPTION
Closes ldtteam/minecolonies-features#407
Closes #
Closes #

# Changes proposed in this pull request:
- Prevents players from linking a resource scroll to non builders hut buildings, change would include one new translation message to be added

Review please

(First PR, should I make multiple PR's to fix this identical issue on other versions or how does the process go?)