### PR TITLE
Make build mode setting respect current Structurize setting before researched

### DIFF
--- a/src/api/java/com/minecolonies/api/colony/buildings/IBuilding.java
+++ b/src/api/java/com/minecolonies/api/colony/buildings/IBuilding.java
@@ -510,9 +510,18 @@ public interface IBuilding extends IBuildingContainer, IRequestResolverProvider,
      * Get setting for key. Utility function.
      * @param key the key.
      * @param <T> the key type.
-     * @return the optional wrapping the value.
+     * @return the setting.
      */
     <T extends ISetting> T getSetting(@NotNull final ISettingKey<T> key);
+
+    /**
+     * Get setting for key. Utility function.
+     * @param key the key.
+     * @param <T> the key type.
+     * @return the optional wrapping the value.
+     */
+    @NotNull
+    <T extends ISetting> Optional<T> getOptionalSetting(@NotNull final ISettingKey<T> key);
 
     /**
      * Check if the assigned citizens are allowed to eat the following stack.

--- a/src/api/java/com/minecolonies/api/colony/buildings/modules/AbstractBuildingModule.java
+++ b/src/api/java/com/minecolonies/api/colony/buildings/modules/AbstractBuildingModule.java
@@ -40,6 +40,12 @@ public abstract class AbstractBuildingModule implements IBuildingModule
     }
 
     @Override
+    public IBuilding getBuilding()
+    {
+        return this.building;
+    }
+
+    @Override
     public IBuildingModule setBuilding(final IBuilding building)
     {
         this.building = building;

--- a/src/api/java/com/minecolonies/api/colony/buildings/modules/IBuildingModule.java
+++ b/src/api/java/com/minecolonies/api/colony/buildings/modules/IBuildingModule.java
@@ -9,6 +9,12 @@ import com.minecolonies.api.util.IHasDirty;
 public interface IBuildingModule extends IHasDirty
 {
     /**
+     * Get the building of the module.
+     * @return the building.
+     */
+    IBuilding getBuilding();
+
+    /**
      * Set the building of the module.
      * @param building the building to set.
      * @return the module itself.

--- a/src/api/java/com/minecolonies/api/colony/buildings/modules/ISettingsModule.java
+++ b/src/api/java/com/minecolonies/api/colony/buildings/modules/ISettingsModule.java
@@ -3,6 +3,9 @@ package com.minecolonies.api.colony.buildings.modules;
 import com.minecolonies.api.colony.buildings.modules.settings.ISetting;
 import com.minecolonies.api.colony.buildings.modules.settings.ISettingKey;
 import net.minecraft.entity.player.ServerPlayerEntity;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.Optional;
 
 /**
  * Settings module interface.
@@ -24,6 +27,15 @@ public interface ISettingsModule extends IBuildingModule
      * @return the setting.
      */
     <T extends ISetting> T getSetting(final ISettingKey<T> key);
+
+    /**
+     * Get a specific setting.
+     * @param key the key of the setting.
+     * @param <T> the type of setting.
+     * @return the setting, if it exists and is active.
+     */
+    @NotNull
+    <T extends ISetting> Optional<T> getOptionalSetting(final ISettingKey<T> key);
 
     /**
      * Update a given settings value.

--- a/src/api/java/com/minecolonies/api/colony/buildings/modules/settings/ISetting.java
+++ b/src/api/java/com/minecolonies/api/colony/buildings/modules/settings/ISetting.java
@@ -3,6 +3,7 @@ package com.minecolonies.api.colony.buildings.modules.settings;
 import com.ldtteam.blockout.Pane;
 import com.ldtteam.blockout.views.Window;
 import com.minecolonies.api.colony.buildings.IBuilding;
+import com.minecolonies.api.colony.buildings.modules.ISettingsModule;
 import com.minecolonies.api.colony.buildings.views.IBuildingView;
 import net.minecraft.entity.player.ServerPlayerEntity;
 
@@ -45,10 +46,19 @@ public interface ISetting
     void trigger();
 
     /**
-     * Check if this setting is visible.
+     * Check if this setting is effective (provided {@link ISettingsModule#getOptionalSetting(ISettingKey)} is used).
+     * @return true by default
+     */
+    default boolean isActive(ISettingsModule module)
+    {
+        return true;
+    }
+
+    /**
+     * Check if this setting is visible in the GUI.
      * @return true by default.
      */
-    default boolean isActive(ISettingsModuleView modle)
+    default boolean isActive(ISettingsModuleView module)
     {
         return true;
     }

--- a/src/main/java/com/minecolonies/coremod/colony/buildings/AbstractBuilding.java
+++ b/src/main/java/com/minecolonies/coremod/colony/buildings/AbstractBuilding.java
@@ -1120,6 +1120,14 @@ public abstract class AbstractBuilding extends AbstractBuildingContainer
         return getFirstModuleOccurance(ISettingsModule.class).getSetting(key);
     }
 
+    @Override
+    @NotNull
+    public <T extends ISetting> Optional<T> getOptionalSetting(@NotNull final ISettingKey<T> key)
+    {
+        return getFirstOptionalModuleOccurance(ISettingsModule.class)
+                .flatMap(module -> module.getOptionalSetting(key));
+    }
+
     /**
      * Get the right module for the recipe.
      * @param token the recipe trying to be fulfilled.

--- a/src/main/java/com/minecolonies/coremod/colony/buildings/modules/SettingsModule.java
+++ b/src/main/java/com/minecolonies/coremod/colony/buildings/modules/SettingsModule.java
@@ -14,9 +14,11 @@ import net.minecraft.nbt.ListNBT;
 import net.minecraft.network.PacketBuffer;
 import net.minecraft.util.ResourceLocation;
 import net.minecraftforge.common.util.Constants;
+import org.jetbrains.annotations.NotNull;
 
 import java.util.LinkedHashMap;
 import java.util.Map;
+import java.util.Optional;
 
 /**
  * Module containing all settings.
@@ -32,6 +34,14 @@ public class SettingsModule extends AbstractBuildingModule implements IPersisten
     public <T extends ISetting> T getSetting(final ISettingKey<T> key)
     {
         return (T) settings.getOrDefault(key, null);
+    }
+
+    @Override
+    @NotNull
+    public <T extends ISetting> Optional<T> getOptionalSetting(final ISettingKey<T> key)
+    {
+        final T setting = getSetting(key);
+        return setting == null || !setting.isActive(this) ? Optional.empty() : Optional.of(setting);
     }
 
     @Override

--- a/src/main/java/com/minecolonies/coremod/colony/buildings/modules/settings/BuilderModeSetting.java
+++ b/src/main/java/com/minecolonies/coremod/colony/buildings/modules/settings/BuilderModeSetting.java
@@ -2,7 +2,11 @@ package com.minecolonies.coremod.colony.buildings.modules.settings;
 
 import com.ldtteam.structurize.Structurize;
 import com.ldtteam.structurize.placement.StructureIterators;
+import com.minecolonies.api.colony.buildings.IBuilding;
+import com.minecolonies.api.colony.buildings.modules.ISettingsModule;
 import com.minecolonies.api.colony.buildings.modules.settings.ISettingsModuleView;
+import com.minecolonies.coremod.colony.buildings.workerbuildings.BuildingBuilder;
+import org.jetbrains.annotations.NotNull;
 
 import java.util.List;
 
@@ -34,8 +38,22 @@ public class BuilderModeSetting extends StringSetting
     }
 
     @Override
+    public boolean isActive(final ISettingsModule module)
+    {
+        return module.getBuilding().getColony().getResearchManager().getResearchEffects().getEffectStrength(BUILDER_MODE) > 0;
+    }
+
+    @Override
     public boolean isActive(final ISettingsModuleView module)
     {
         return module.getColony().getResearchManager().getResearchEffects().getEffectStrength(BUILDER_MODE) > 0;
+    }
+
+    @NotNull
+    public static String getActualValue(@NotNull final IBuilding building)
+    {
+        return building.getOptionalSetting(BuildingBuilder.BUILDING_MODE)
+                .map(StringSetting::getValue)
+                .orElse(Structurize.getConfig().getServer().iteratorType.get());
     }
 }

--- a/src/main/java/com/minecolonies/coremod/colony/buildings/modules/settings/CrafterRecipeSetting.java
+++ b/src/main/java/com/minecolonies/coremod/colony/buildings/modules/settings/CrafterRecipeSetting.java
@@ -1,6 +1,8 @@
 package com.minecolonies.coremod.colony.buildings.modules.settings;
 
+import com.minecolonies.api.colony.buildings.modules.ISettingsModule;
 import com.minecolonies.api.colony.buildings.modules.settings.ISettingsModuleView;
+
 import java.util.List;
 
 import static com.minecolonies.api.research.util.ResearchConstants.RECIPE_MODE;
@@ -32,6 +34,12 @@ public class CrafterRecipeSetting extends StringSettingWithDesc
     public CrafterRecipeSetting(final List<String> settings, final int currentIndex)
     {
         super(settings, currentIndex);
+    }
+
+    @Override
+    public boolean isActive(final ISettingsModule module)
+    {
+        return module.getBuilding().getColony().getResearchManager().getResearchEffects().getEffectStrength(RECIPE_MODE) > 0;
     }
 
     @Override

--- a/src/main/java/com/minecolonies/coremod/colony/buildings/modules/settings/DynamicTreesSetting.java
+++ b/src/main/java/com/minecolonies/coremod/colony/buildings/modules/settings/DynamicTreesSetting.java
@@ -1,5 +1,6 @@
 package com.minecolonies.coremod.colony.buildings.modules.settings;
 
+import com.minecolonies.api.colony.buildings.modules.ISettingsModule;
 import com.minecolonies.api.colony.buildings.modules.settings.ISettingsModuleView;
 import com.minecolonies.coremod.MineColonies;
 import net.minecraftforge.fml.ModList;
@@ -22,6 +23,12 @@ public class DynamicTreesSetting extends IntSetting
     public DynamicTreesSetting(int value, int defaultValue)
     {
         super(value, defaultValue);
+    }
+
+    @Override
+    public boolean isActive(final ISettingsModule module)
+    {
+        return ModList.get().isLoaded("dynamictrees");
     }
 
     /**

--- a/src/main/java/com/minecolonies/coremod/entity/ai/basic/AbstractEntityAIStructureWithWorkOrder.java
+++ b/src/main/java/com/minecolonies/coremod/entity/ai/basic/AbstractEntityAIStructureWithWorkOrder.java
@@ -6,7 +6,6 @@ import com.ldtteam.structurize.placement.StructurePhasePlacementResult;
 import com.ldtteam.structurize.placement.StructurePlacer;
 import com.ldtteam.structurize.util.PlacementSettings;
 import com.minecolonies.api.colony.buildings.IBuilding;
-import com.minecolonies.api.colony.buildings.modules.ISettingsModule;
 import com.minecolonies.api.crafting.ItemStorage;
 import com.minecolonies.api.entity.ai.statemachine.states.IAIState;
 import com.minecolonies.api.tileentities.AbstractTileEntityColonyBuilding;
@@ -16,8 +15,8 @@ import com.minecolonies.api.util.Tuple;
 import com.minecolonies.api.util.WorldUtil;
 import com.minecolonies.api.util.constant.Constants;
 import com.minecolonies.coremod.colony.buildings.AbstractBuildingStructureBuilder;
+import com.minecolonies.coremod.colony.buildings.modules.settings.BuilderModeSetting;
 import com.minecolonies.coremod.colony.buildings.utils.BuildingBuilderResource;
-import com.minecolonies.coremod.colony.buildings.workerbuildings.BuildingBuilder;
 import com.minecolonies.coremod.colony.colonyEvents.buildingEvents.BuildingBuiltEvent;
 import com.minecolonies.coremod.colony.colonyEvents.buildingEvents.BuildingDeconstructedEvent;
 import com.minecolonies.coremod.colony.colonyEvents.buildingEvents.BuildingUpgradedEvent;
@@ -200,9 +199,10 @@ public abstract class AbstractEntityAIStructureWithWorkOrder<J extends AbstractJ
         final WorkerLoadOnlyStructureHandler structure =
           new WorkerLoadOnlyStructureHandler(world, structurePlacer.getB().getWorldPos(), structurePlacer.getB().getBluePrint(), new PlacementSettings(), true, this);
 
-        if (job.getWorkOrder().getIteratorType().isEmpty() && getOwnBuilding().hasModule(ISettingsModule.class) && getOwnBuilding().getSetting(BuildingBuilder.BUILDING_MODE) != null)
+        if (job.getWorkOrder().getIteratorType().isEmpty())
         {
-            job.getWorkOrder().setIteratorType(getOwnBuilding().getSetting(BuildingBuilder.BUILDING_MODE).getValue());
+            final String mode = BuilderModeSetting.getActualValue(getOwnBuilding());
+            job.getWorkOrder().setIteratorType(mode);
         }
 
         final StructurePlacer placer = new StructurePlacer(structure, job.getWorkOrder().getIteratorType());

--- a/src/main/java/com/minecolonies/coremod/entity/ai/citizen/builder/EntityAIStructureBuilder.java
+++ b/src/main/java/com/minecolonies/coremod/entity/ai/citizen/builder/EntityAIStructureBuilder.java
@@ -3,15 +3,20 @@ package com.minecolonies.coremod.entity.ai.citizen.builder;
 import com.ldtteam.structurize.placement.StructurePlacer;
 import com.ldtteam.structurize.util.BlockUtils;
 import com.minecolonies.api.colony.buildings.IBuilding;
-import com.minecolonies.api.colony.buildings.modules.ISettingsModule;
 import com.minecolonies.api.colony.workorders.IWorkOrder;
 import com.minecolonies.api.entity.ai.statemachine.AITarget;
 import com.minecolonies.api.entity.ai.statemachine.states.IAIState;
-import com.minecolonies.api.util.*;
+import com.minecolonies.api.util.BlockPosUtil;
+import com.minecolonies.api.util.Tuple;
+import com.minecolonies.api.util.WorldUtil;
 import com.minecolonies.coremod.MineColonies;
+import com.minecolonies.coremod.colony.buildings.modules.settings.BuilderModeSetting;
 import com.minecolonies.coremod.colony.buildings.workerbuildings.BuildingBuilder;
 import com.minecolonies.coremod.colony.jobs.JobBuilder;
-import com.minecolonies.coremod.colony.workorders.*;
+import com.minecolonies.coremod.colony.workorders.WorkOrderBuild;
+import com.minecolonies.coremod.colony.workorders.WorkOrderBuildBuilding;
+import com.minecolonies.coremod.colony.workorders.WorkOrderBuildDecoration;
+import com.minecolonies.coremod.colony.workorders.WorkOrderBuildRemoval;
 import com.minecolonies.coremod.entity.ai.basic.AbstractEntityAIStructureWithWorkOrder;
 import com.minecolonies.coremod.entity.ai.util.BuildingStructureHandler;
 import net.minecraft.block.Block;
@@ -22,10 +27,7 @@ import net.minecraft.util.math.BlockPos;
 import org.jetbrains.annotations.NotNull;
 
 import static com.minecolonies.api.entity.ai.statemachine.states.AIWorkerState.*;
-import static com.minecolonies.api.util.constant.TranslationConstants.COM_MINECOLONIES_COREMOD_ENTITY_BUILDER_BUILDCOMPLETE;
-import static com.minecolonies.api.util.constant.TranslationConstants.COM_MINECOLONIES_COREMOD_ENTITY_BUILDER_BUILDCOMPLETE_MANUAL;
-import static com.minecolonies.api.util.constant.TranslationConstants.COM_MINECOLONIES_COREMOD_ENTITY_BUILDER_DECOCOMPLETE;
-import static com.minecolonies.api.util.constant.TranslationConstants.COM_MINECOLONIES_COREMOD_ENTITY_BUILDER_DECOCOMPLETE_MANUAL;
+import static com.minecolonies.api.util.constant.TranslationConstants.*;
 
 /**
  * AI class for the builder. Manages building and repairing buildings.
@@ -141,10 +143,12 @@ public class EntityAIStructureBuilder extends AbstractEntityAIStructureWithWorkO
     @Override
     public void setStructurePlacer(final BuildingStructureHandler<JobBuilder, BuildingBuilder> structure)
     {
-        if (job.getWorkOrder().getIteratorType().isEmpty() && getOwnBuilding().hasModule(ISettingsModule.class) && getOwnBuilding().getSetting(BuildingBuilder.BUILDING_MODE) != null)
+        if (job.getWorkOrder().getIteratorType().isEmpty())
         {
-            job.getWorkOrder().setIteratorType(getOwnBuilding().getSetting(BuildingBuilder.BUILDING_MODE).getValue());
+            final String mode = BuilderModeSetting.getActualValue(getOwnBuilding());
+            job.getWorkOrder().setIteratorType(mode);
         }
+
         structurePlacer = new Tuple<>(new StructurePlacer(structure, job.getWorkOrder().getIteratorType()), structure);
     }
 


### PR DESCRIPTION
# Changes proposed in this pull request:
- Before researching Builder Modes, uses the current Structurize config interator, not whatever (invisible) setting is saved in the builder hut.

Review please

As before, the current Structurize setting gets saved in the builder hut as of the moment when it is first built, regardless of whether the research is unlocked or not.  (So when the research is unlocked, the iterator may change, if the config was edited after the hut was first built.)

Also as before, work orders save the iterator when building begins, and so will ignore further changes after this unless the order is cancelled and restarted.

This introduces `building.getOptionalSetting`, which should be the preferred way to access building settings (and most, if not all, existing usages should probably switch to it, rather than accessing the module directly and/or using the non-optional variant).  Currently however this PR does not change any existing usages other than to fix this specific issue.