### PR TITLE
Add citizen direct item interactions

### DIFF
--- a/src/api/java/com/minecolonies/api/colony/jobs/IJob.java
+++ b/src/api/java/com/minecolonies/api/colony/jobs/IJob.java
@@ -5,20 +5,22 @@ import com.minecolonies.api.colony.IColony;
 import com.minecolonies.api.colony.jobs.registry.JobEntry;
 import com.minecolonies.api.colony.requestsystem.token.IToken;
 import com.minecolonies.api.entity.citizen.AbstractEntityCitizen;
+import net.minecraft.nbt.CompoundTag;
+import net.minecraft.network.FriendlyByteBuf;
 import net.minecraft.resources.ResourceLocation;
+import net.minecraft.world.damagesource.DamageSource;
 import net.minecraft.world.entity.ai.goal.Goal;
 import net.minecraft.world.entity.ai.goal.GoalSelector;
 import net.minecraft.world.item.ItemStack;
-import net.minecraft.nbt.CompoundTag;
-import net.minecraft.network.FriendlyByteBuf;
-import net.minecraft.world.damagesource.DamageSource;
 import net.minecraftforge.common.util.INBTSerializable;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.Set;
 
 import static com.minecolonies.api.util.constant.HappinessConstants.IDLE_AT_JOB_COMPLAINS_DAYS;
-import static com.minecolonies.api.util.constant.HappinessConstants.IDLE_AT_JOB_DEMANDS_DAYS;;
+import static com.minecolonies.api.util.constant.HappinessConstants.IDLE_AT_JOB_DEMANDS_DAYS;
+
+;
 
 public interface IJob<AI extends Goal> extends INBTSerializable<CompoundTag>
 {
@@ -274,7 +276,18 @@ public interface IJob<AI extends Goal> extends INBTSerializable<CompoundTag>
 
     /**
      * Set the registry entry of the job.
+     *
      * @param jobEntry the job entry belonging to it.
      */
     void setRegistryEntry(JobEntry jobEntry);
+
+    /**
+     * Whether the job is a guard
+     *
+     * @return
+     */
+    default boolean isGuard()
+    {
+        return false;
+    }
 }

--- a/src/api/java/com/minecolonies/api/colony/jobs/IJob.java
+++ b/src/api/java/com/minecolonies/api/colony/jobs/IJob.java
@@ -20,8 +20,6 @@ import java.util.Set;
 import static com.minecolonies.api.util.constant.HappinessConstants.IDLE_AT_JOB_COMPLAINS_DAYS;
 import static com.minecolonies.api.util.constant.HappinessConstants.IDLE_AT_JOB_DEMANDS_DAYS;
 
-;
-
 public interface IJob<AI extends Goal> extends INBTSerializable<CompoundTag>
 {
     /**

--- a/src/api/java/com/minecolonies/api/colony/workorders/IWorkManager.java
+++ b/src/api/java/com/minecolonies/api/colony/workorders/IWorkManager.java
@@ -2,8 +2,8 @@ package com.minecolonies.api.colony.workorders;
 
 import com.minecolonies.api.colony.ICitizenData;
 import com.minecolonies.api.colony.IColony;
-import net.minecraft.nbt.CompoundTag;
 import net.minecraft.core.BlockPos;
+import net.minecraft.nbt.CompoundTag;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -34,8 +34,7 @@ public interface IWorkManager
      * @param <W>  the type of work order to return.
      * @return the work order of the specified id, or null if it was not found or is of an incompatible type.
      */
-    @Nullable
-    <W extends IWorkOrder> W getWorkOrder(int id, @NotNull Class<W> type);
+    @Nullable <W extends IWorkOrder> W getWorkOrder(int id, @NotNull Class<W> type);
 
     /**
      * Get a work order of the specified id.
@@ -52,8 +51,7 @@ public interface IWorkManager
      * @param <W>  the type of work order to return.
      * @return an unclaimed work order of the given type, or null if no unclaimed work order of the type was found.
      */
-    @Nullable
-    <W extends IWorkOrder> W getUnassignedWorkOrder(@NotNull Class<W> type);
+    @Nullable <W extends IWorkOrder> W getUnassignedWorkOrder(@NotNull Class<W> type);
 
     /**
      * Get all work orders of a specified type.

--- a/src/api/java/com/minecolonies/api/entity/citizen/AbstractCivilianEntity.java
+++ b/src/api/java/com/minecolonies/api/entity/citizen/AbstractCivilianEntity.java
@@ -2,15 +2,20 @@ package com.minecolonies.api.entity.citizen;
 
 import com.minecolonies.api.colony.ICivilianData;
 import com.minecolonies.api.entity.pathfinding.IStuckHandlerEntity;
+import net.minecraft.server.level.ServerLevel;
+import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.world.entity.AgeableMob;
 import net.minecraft.world.entity.Entity;
 import net.minecraft.world.entity.EntityType;
 import net.minecraft.world.entity.npc.Npc;
+import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.level.Level;
-import net.minecraft.server.level.ServerLevel;
 import net.minecraftforge.common.util.ITeleporter;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
+
+import static com.minecolonies.api.sounds.EventType.INTERACTION;
+import static com.minecolonies.api.util.SoundUtils.playSoundAtCivilian;
 
 public abstract class AbstractCivilianEntity extends AgeableMob implements Npc, IStuckHandlerEntity
 {
@@ -31,6 +36,13 @@ public abstract class AbstractCivilianEntity extends AgeableMob implements Npc, 
      * @param data the data to set.
      */
     public abstract void setCivilianData(@Nullable ICivilianData data);
+
+    /**
+     * Setter for the citizen data.
+     *
+     * @return civilian data
+     */
+    public abstract ICivilianData getCivilianData();
 
     /**
      * Mark the citizen dirty to synch the data with the client.
@@ -65,6 +77,32 @@ public abstract class AbstractCivilianEntity extends AgeableMob implements Npc, 
     public void setCanBeStuck(final boolean canBeStuck)
     {
         this.canBeStuck = canBeStuck;
+    }
+
+    @Override
+    public void push(@NotNull final Entity entityIn)
+    {
+        if (entityIn instanceof ServerPlayer)
+        {
+            onPlayerCollide((Player) entityIn);
+        }
+        super.push(entityIn);
+    }
+
+    /**
+     * On player collision action
+     *
+     * @param player
+     */
+    public void onPlayerCollide(final Player player)
+    {
+        if (getNavigation().getPath() != null)
+        {
+            getNavigation().stop();
+            getLookControl().setLookAt(player);
+
+            playSoundAtCivilian(level, blockPosition(), INTERACTION, getCivilianData());
+        }
     }
 
     /**

--- a/src/api/java/com/minecolonies/api/entity/citizen/AbstractEntityCitizen.java
+++ b/src/api/java/com/minecolonies/api/entity/citizen/AbstractEntityCitizen.java
@@ -6,7 +6,6 @@ import com.minecolonies.api.client.render.modeltype.registry.IModelTypeRegistry;
 import com.minecolonies.api.colony.ICitizenData;
 import com.minecolonies.api.colony.ICitizenDataView;
 import com.minecolonies.api.colony.jobs.IJob;
-import com.minecolonies.api.colony.jobs.ModJobs;
 import com.minecolonies.api.colony.requestsystem.location.ILocation;
 import com.minecolonies.api.entity.MinecoloniesMinecart;
 import com.minecolonies.api.entity.ai.DesiredActivity;
@@ -368,8 +367,8 @@ public abstract class AbstractEntityCitizen extends AbstractCivilianEntity imple
     @Override
     public void onPlayerCollide(final Player player)
     {
-        final IJob job = getCitizenData().getJob();
-        if (job == null || job.getJobRegistryEntry() != ModJobs.archer && job.getJobRegistryEntry() != ModJobs.knight && job.getJobRegistryEntry() != ModJobs.druid)
+        final IJob<?> job = getCitizenData().getJob();
+        if (job == null || !job.isGuard())
         {
             super.onPlayerCollide(player);
         }

--- a/src/api/java/com/minecolonies/api/entity/citizen/AbstractEntityCitizen.java
+++ b/src/api/java/com/minecolonies/api/entity/citizen/AbstractEntityCitizen.java
@@ -5,6 +5,8 @@ import com.minecolonies.api.client.render.modeltype.ModModelTypes;
 import com.minecolonies.api.client.render.modeltype.registry.IModelTypeRegistry;
 import com.minecolonies.api.colony.ICitizenData;
 import com.minecolonies.api.colony.ICitizenDataView;
+import com.minecolonies.api.colony.jobs.IJob;
+import com.minecolonies.api.colony.jobs.ModJobs;
 import com.minecolonies.api.colony.requestsystem.location.ILocation;
 import com.minecolonies.api.entity.MinecoloniesMinecart;
 import com.minecolonies.api.entity.ai.DesiredActivity;
@@ -17,7 +19,6 @@ import com.minecolonies.api.inventory.InventoryCitizen;
 import com.minecolonies.api.sounds.EventType;
 import com.minecolonies.api.util.CompatibilityUtils;
 import com.minecolonies.api.util.ItemStackUtils;
-import com.minecolonies.api.util.Log;
 import com.minecolonies.api.util.SoundUtils;
 import com.mojang.datafixers.util.Pair;
 import net.minecraft.core.BlockPos;
@@ -134,14 +135,15 @@ public abstract class AbstractEntityCitizen extends AbstractCivilianEntity imple
 
     /**
      * Get the default attributes with their values.
+     *
      * @return the attribute modifier map.
      */
     public static AttributeSupplier.Builder getDefaultAttributes()
     {
         return LivingEntity.createLivingAttributes()
-                 .add(Attributes.MAX_HEALTH, BASE_MAX_HEALTH)
-                 .add(Attributes.MOVEMENT_SPEED, BASE_MOVEMENT_SPEED)
-                 .add(Attributes.FOLLOW_RANGE, BASE_PATHFINDING_RANGE);
+          .add(Attributes.MAX_HEALTH, BASE_MAX_HEALTH)
+          .add(Attributes.MOVEMENT_SPEED, BASE_MOVEMENT_SPEED)
+          .add(Attributes.FOLLOW_RANGE, BASE_PATHFINDING_RANGE);
     }
 
     public GoalSelector getTasks()
@@ -179,8 +181,9 @@ public abstract class AbstractEntityCitizen extends AbstractCivilianEntity imple
     }
 
     /**
-     * Calculate adjusted damage. 
+     * Calculate adjusted damage.
      * This doesn't actually damage armor, for non-player entities.
+     *
      * @param source
      * @param damage
      * @return
@@ -360,6 +363,21 @@ public abstract class AbstractEntityCitizen extends AbstractCivilianEntity imple
             return;
         }
         super.push(entityIn);
+    }
+
+    @Override
+    public void onPlayerCollide(final Player player)
+    {
+        final IJob job = getCitizenData().getJob();
+        if (job == null || job.getJobRegistryEntry() != ModJobs.archer && job.getJobRegistryEntry() != ModJobs.knight && job.getJobRegistryEntry() != ModJobs.druid)
+        {
+            super.onPlayerCollide(player);
+        }
+        else
+        {
+            // guards push the player out of their way
+            push(player);
+        }
     }
 
     @Override

--- a/src/api/java/com/minecolonies/api/util/BlockPosUtil.java
+++ b/src/api/java/com/minecolonies/api/util/BlockPosUtil.java
@@ -774,6 +774,11 @@ public final class BlockPosUtil
             return null;
         }
 
+        if (predicate.test(world, start))
+        {
+            return start;
+        }
+
         BlockPos temp;
         int y = 0;
         int y_offset = 1;

--- a/src/api/java/com/minecolonies/api/util/SoundUtils.java
+++ b/src/api/java/com/minecolonies/api/util/SoundUtils.java
@@ -1,14 +1,15 @@
 package com.minecolonies.api.util;
 
 import com.minecolonies.api.colony.ICitizenData;
+import com.minecolonies.api.colony.ICivilianData;
 import com.minecolonies.api.sounds.EventType;
-import net.minecraft.world.entity.player.Player;
-import net.minecraft.server.level.ServerPlayer;
+import net.minecraft.core.BlockPos;
 import net.minecraft.network.protocol.game.ClientboundSoundPacket;
-import net.minecraft.sounds.SoundSource;
+import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.sounds.SoundEvent;
 import net.minecraft.sounds.SoundEvents;
-import net.minecraft.core.BlockPos;
+import net.minecraft.sounds.SoundSource;
+import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.level.Level;
 import net.minecraftforge.event.world.NoteBlockEvent.Note;
 import org.jetbrains.annotations.NotNull;
@@ -238,6 +239,39 @@ public final class SoundUtils
         }
 
         final SoundEvent event = citizenData.isFemale() ? map.get(type).getB() : map.get(type).getA();
+
+        if (type.getChance() > rand.nextDouble() * ONE_HUNDRED)
+        {
+            worldIn.playSound(null,
+              position,
+              event,
+              SoundSource.NEUTRAL,
+              (float) VOLUME,
+              (float) PITCH);
+        }
+    }
+
+    /**
+     * Plays a sound with a certain chance at a certain position.
+     *
+     * @param worldIn      the world to play the sound in.
+     * @param position     position to play the sound at.
+     * @param type         sound to play.
+     * @param civilianData the citizen.
+     */
+    public static void playSoundAtCivilian(
+      @NotNull final Level worldIn,
+      @NotNull final BlockPos position,
+      @Nullable final EventType type,
+      @Nullable final ICivilianData civilianData)
+    {
+        if (civilianData == null)
+        {
+            return;
+        }
+
+        final Map<EventType, Tuple<SoundEvent, SoundEvent>> map = CITIZEN_SOUND_EVENTS.get(civilianData.isChild() ? "child" : "citizen");
+        final SoundEvent event = civilianData.isFemale() ? map.get(type).getB() : map.get(type).getA();
 
         if (type.getChance() > rand.nextDouble() * ONE_HUNDRED)
         {

--- a/src/main/java/com/minecolonies/coremod/colony/Colony.java
+++ b/src/main/java/com/minecolonies/coremod/colony/Colony.java
@@ -110,6 +110,11 @@ public class Colony implements IColony
     private Set<Long> pendingChunks = new HashSet<>();
 
     /**
+     * List of chunks pending for unloading, which have their tickets removed
+     */
+    private Set<Long> pendingToUnloadChunks = new HashSet<>();
+
+    /**
      * List of waypoints of the colony.
      */
     private final Map<BlockPos, BlockState> wayPoints = new HashMap<>();
@@ -467,11 +472,13 @@ public class Colony implements IColony
                 if (getPermissions().hasPermission(sub, Action.CAN_KEEP_COLONY_ACTIVE_WHILE_AWAY))
                 {
                     this.forceLoadTimer = CHUNK_UNLOAD_DELAY;
+                    pendingChunks.addAll(pendingToUnloadChunks);
                     for (final long pending : pendingChunks)
                     {
                         checkChunkAndRegisterTicket(pending, world.getChunk(ChunkPos.getX(pending), ChunkPos.getZ(pending)));
                     }
 
+                    pendingToUnloadChunks.clear();
                     pendingChunks.clear();
                     return;
                 }
@@ -490,6 +497,7 @@ public class Colony implements IColony
                         {
                             final ChunkPos pos = new ChunkPos(chunkX, chunkZ);
                             ((ServerChunkCache) world.getChunkSource()).removeRegionTicket(KEEP_LOADED_TYPE, pos, 2, pos);
+                            pendingToUnloadChunks.add(chunkPos);
                         }
                     }
                     ticketedChunks.clear();
@@ -1805,6 +1813,7 @@ public class Colony implements IColony
     public void removeLoadedChunk(final long chunkPos)
     {
         loadedChunks.remove(chunkPos);
+        pendingToUnloadChunks.remove(chunkPos);
     }
 
     @Override

--- a/src/main/java/com/minecolonies/coremod/colony/jobs/AbstractJobGuard.java
+++ b/src/main/java/com/minecolonies/coremod/colony/jobs/AbstractJobGuard.java
@@ -6,8 +6,8 @@ import com.minecolonies.api.entity.citizen.AbstractEntityCitizen;
 import com.minecolonies.coremod.MineColonies;
 import com.minecolonies.coremod.colony.buildings.AbstractBuildingGuards;
 import com.minecolonies.coremod.entity.ai.citizen.guard.AbstractEntityAIGuard;
-import net.minecraft.world.damagesource.DamageSource;
 import com.minecolonies.coremod.util.AttributeModifierUtils;
+import net.minecraft.world.damagesource.DamageSource;
 import net.minecraft.world.entity.ai.attributes.AttributeModifier;
 
 import static com.minecolonies.api.entity.ai.statemachine.states.AIWorkerState.GUARD_SLEEP;
@@ -47,6 +47,12 @@ public abstract class AbstractJobGuard<J extends AbstractJobGuard<J>> extends Ab
     public boolean allowsAvoidance()
     {
         return false;
+    }
+
+    @Override
+    public boolean isGuard()
+    {
+        return true;
     }
 
     /**

--- a/src/main/java/com/minecolonies/coremod/entity/SittingEntity.java
+++ b/src/main/java/com/minecolonies/coremod/entity/SittingEntity.java
@@ -28,6 +28,7 @@ public class SittingEntity extends Entity
      * The lifetime in ticks of the entity, auto-dismounts after.
      */
     int maxLifeTime = 100;
+    private BlockPos sittingpos = BlockPos.ZERO;
 
     public SittingEntity(final EntityType<?> type, final Level worldIn)
     {
@@ -142,14 +143,14 @@ public class SittingEntity extends Entity
     @Override
     public Vec3 getDismountLocationForPassenger(@NotNull final LivingEntity passenger)
     {
-        final BlockPos spawn = EntityUtils.getSpawnPoint(this.level, this.blockPosition());
+        final BlockPos start = sittingpos == BlockPos.ZERO ? blockPosition().above() : sittingpos;
+        final BlockPos spawn = EntityUtils.getSpawnPoint(this.level, start);
         if (spawn == null)
         {
             return super.getDismountLocationForPassenger(passenger);
         }
         return new Vec3(spawn.getX() + 0.5, spawn.getY() + 0.2, spawn.getZ() + 0.5);
     }
-
 
     /**
      * Sets the lifetime
@@ -159,6 +160,16 @@ public class SittingEntity extends Entity
     public void setMaxLifeTime(final int maxLifeTime)
     {
         this.maxLifeTime = maxLifeTime;
+    }
+
+    /**
+     * Sets the original block to sit "at" also used for standing up again.
+     *
+     * @param pos
+     */
+    public void setSittingPos(final BlockPos pos)
+    {
+        sittingpos = pos;
     }
 
     /**
@@ -198,6 +209,7 @@ public class SittingEntity extends Entity
 
         sittingEntity.setPos(pos.getX() + 0.5f, (pos.getY() + minY) - entity.getBbHeight() / 2, pos.getZ() + 0.5f);
         sittingEntity.setMaxLifeTime(maxLifeTime);
+        sittingEntity.setSittingPos(pos);
         entity.level.addFreshEntity(sittingEntity);
         entity.startRiding(sittingEntity);
         entity.getNavigation().stop();

--- a/src/main/java/com/minecolonies/coremod/entity/ai/citizen/school/EntityAIWorkPupil.java
+++ b/src/main/java/com/minecolonies/coremod/entity/ai/citizen/school/EntityAIWorkPupil.java
@@ -13,13 +13,13 @@ import com.minecolonies.coremod.entity.SittingEntity;
 import com.minecolonies.coremod.entity.ai.basic.AbstractEntityAIInteract;
 import com.minecolonies.coremod.entity.citizen.EntityCitizen;
 import com.minecolonies.coremod.network.messages.client.CircleParticleEffectMessage;
+import net.minecraft.core.BlockPos;
+import net.minecraft.core.particles.ParticleTypes;
+import net.minecraft.network.chat.TranslatableComponent;
 import net.minecraft.world.entity.EquipmentSlot;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.Items;
-import net.minecraft.core.particles.ParticleTypes;
 import net.minecraft.world.phys.AABB;
-import net.minecraft.core.BlockPos;
-import net.minecraft.network.chat.TranslatableComponent;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.function.Predicate;
@@ -141,7 +141,7 @@ public class EntityAIWorkPupil extends AbstractEntityAIInteract<JobPupil, Buildi
             return DECIDE;
         }
 
-        if (walkToBlock(studyPos))
+        if (walkToBlock(studyPos, 1))
         {
             return getState();
         }

--- a/src/main/java/com/minecolonies/coremod/entity/ai/minimal/EntityAICitizenWander.java
+++ b/src/main/java/com/minecolonies/coremod/entity/ai/minimal/EntityAICitizenWander.java
@@ -9,8 +9,8 @@ import com.minecolonies.api.entity.citizen.AbstractEntityCitizen;
 import com.minecolonies.api.entity.pathfinding.AbstractAdvancedPathNavigate;
 import com.minecolonies.api.tileentities.TileEntityColonyBuilding;
 import com.minecolonies.api.util.Log;
-import com.minecolonies.api.util.constant.Constants;
 import com.minecolonies.coremod.colony.buildings.workerbuildings.BuildingLibrary;
+import com.minecolonies.coremod.colony.jobs.AbstractJobGuard;
 import com.minecolonies.coremod.entity.SittingEntity;
 import com.minecolonies.coremod.entity.ai.citizen.student.EntityAIStudy;
 import net.minecraft.core.BlockPos;
@@ -223,7 +223,8 @@ public class EntityAICitizenWander extends Goal
         {
             return false;
         }
-        return citizen.getDesiredActivity() != DesiredActivity.SLEEP && citizen.getNavigation().isDone() && !citizen.isBaby();
+        return citizen.getDesiredActivity() != DesiredActivity.SLEEP && citizen.getNavigation().isDone() && !citizen.isBaby()
+                 && !(citizen.getCitizenData().getJob() instanceof AbstractJobGuard);
     }
 
     @Override

--- a/src/main/java/com/minecolonies/coremod/entity/citizen/EntityCitizen.java
+++ b/src/main/java/com/minecolonies/coremod/entity/citizen/EntityCitizen.java
@@ -444,19 +444,23 @@ public class EntityCitizen extends AbstractEntityCitizen implements IThreatTable
 
             if (!level.isClientSide())
             {
-                if (getRandom().nextInt(2) == 0)
+                if (getRandom().nextInt(3) == 0)
                 {
                     getCitizenDiseaseHandler().cure();
+                    playSound(SoundEvents.PLAYER_LEVELUP, 1.0f, (float) SoundUtils.getRandomPitch(getRandom()));
+                    Network.getNetwork()
+                      .sendToTrackingEntity(new VanillaParticleMessage(getX(), getY(), getZ(), ParticleTypes.HAPPY_VILLAGER),
+                        this);
                 }
-
-                playSound(SoundEvents.PLAYER_LEVELUP, 1.0f, (float) SoundUtils.getRandomPitch(getRandom()));
-                Network.getNetwork()
-                  .sendToTrackingEntity(new VanillaParticleMessage(getX(), getY(), getZ(), ParticleTypes.HAPPY_VILLAGER),
-                    this);
             }
 
             interactionCooldown = 20 * 60 * 5;
             return InteractionResult.CONSUME;
+        }
+
+        if (getCitizenDiseaseHandler().isSick())
+        {
+            return null;
         }
 
         if (ISFOOD.test(usedStack) && usedStack.getItem() != Items.GOLDEN_APPLE)

--- a/src/main/java/com/minecolonies/coremod/entity/citizen/EntityCitizen.java
+++ b/src/main/java/com/minecolonies/coremod/entity/citizen/EntityCitizen.java
@@ -439,7 +439,7 @@ public class EntityCitizen extends AbstractEntityCitizen implements IThreatTable
 
         if (usedStack.getItem() == Items.GOLDEN_APPLE && getCitizenDiseaseHandler().isSick())
         {
-            usedStack.setCount(usedStack.getCount() - 1);
+            usedStack.shrink(1);
             player.setItemInHand(hand, usedStack);
 
             if (!level.isClientSide())
@@ -478,7 +478,7 @@ public class EntityCitizen extends AbstractEntityCitizen implements IThreatTable
 
         if (usedStack.getItem() == Items.BOOK && isBaby())
         {
-            usedStack.setCount(usedStack.getCount() - 1);
+            usedStack.shrink(1);
             player.setItemInHand(hand, usedStack);
 
             if (!level.isClientSide())
@@ -492,7 +492,7 @@ public class EntityCitizen extends AbstractEntityCitizen implements IThreatTable
 
         if (usedStack.getItem() == Items.CACTUS)
         {
-            usedStack.setCount(usedStack.getCount() - 1);
+            usedStack.shrink(1);
             player.setItemInHand(hand, usedStack);
 
             if (!level.isClientSide())
@@ -508,7 +508,7 @@ public class EntityCitizen extends AbstractEntityCitizen implements IThreatTable
 
         if (usedStack.getItem() == Items.GLOWSTONE_DUST)
         {
-            usedStack.setCount(usedStack.getCount() - 1);
+            usedStack.shrink(1);
             player.setItemInHand(hand, usedStack);
 
             if (!level.isClientSide())
@@ -546,7 +546,7 @@ public class EntityCitizen extends AbstractEntityCitizen implements IThreatTable
     {
         if (usedStack.getDisplayName().getString().toLowerCase(Locale.ENGLISH).contains("cookie"))
         {
-            usedStack.setCount(usedStack.getCount() - 1);
+            usedStack.shrink(1);
             player.setItemInHand(hand, usedStack);
             interactionCooldown = 100;
 
@@ -595,7 +595,7 @@ public class EntityCitizen extends AbstractEntityCitizen implements IThreatTable
      */
     private void eatFoodInteraction(final ItemStack usedStack, final Player player, final InteractionHand hand)
     {
-        usedStack.setCount(usedStack.getCount() - 1);
+        usedStack.shrink(1);
         player.setItemInHand(hand, usedStack);
         interactionCooldown = 100;
 

--- a/src/main/java/com/minecolonies/coremod/entity/citizen/EntityCitizen.java
+++ b/src/main/java/com/minecolonies/coremod/entity/citizen/EntityCitizen.java
@@ -444,6 +444,11 @@ public class EntityCitizen extends AbstractEntityCitizen implements IThreatTable
 
             if (!level.isClientSide())
             {
+                if (getRandom().nextInt(2) == 0)
+                {
+                    getCitizenDiseaseHandler().cure();
+                }
+
                 playSound(SoundEvents.PLAYER_LEVELUP, 1.0f, (float) SoundUtils.getRandomPitch(getRandom()));
                 Network.getNetwork()
                   .sendToTrackingEntity(new VanillaParticleMessage(getX(), getY(), getZ(), ParticleTypes.HAPPY_VILLAGER),
@@ -490,6 +495,7 @@ public class EntityCitizen extends AbstractEntityCitizen implements IThreatTable
             {
                 player.sendMessage(new TranslatableComponent("com.minecolonies.coremod.interaction.ouch", getCitizenData().getName()), player.getUUID());
                 getNavigation().moveAwayFromLivingEntity(player, 5, 1);
+                setJumping(true);
             }
 
             interactionCooldown = 20 * 60 * 5;
@@ -542,6 +548,14 @@ public class EntityCitizen extends AbstractEntityCitizen implements IThreatTable
 
             if (!level.isClientSide())
             {
+                final double satIncrease = usedStack.getItem().getFoodProperties().getNutrition() * (1.0 + getCitizenColonyHandler().getColony()
+                  .getResearchManager()
+                  .getResearchEffects()
+                  .getEffectStrength(SATURATION));
+                citizenData.increaseSaturation(satIncrease / 2.0);
+
+                addEffect(new MobEffectInstance(MobEffects.MOVEMENT_SPEED, 300));
+
                 playSound(SoundEvents.GENERIC_EAT, 1.5f, (float) SoundUtils.getRandomPitch(getRandom()));
                 Network.getNetwork()
                   .sendToTrackingEntity(new ItemParticleEffectMessage(usedStack,

--- a/src/main/java/com/minecolonies/coremod/entity/citizen/citizenhandlers/CitizenSkillHandler.java
+++ b/src/main/java/com/minecolonies/coremod/entity/citizen/citizenhandlers/CitizenSkillHandler.java
@@ -177,10 +177,10 @@ public class CitizenSkillHandler implements ICitizenSkillHandler
 
         final IBuilding home = data.getHomeBuilding();
 
-        final double citizenHutLevel = home == null ? 1 : home.getBuildingLevel();
+        final double citizenHutLevel = home == null ? 0 : home.getBuildingLevel();
         final double citizenHutMaxLevel = home == null ? 5 : home.getMaxBuildingLevel();
 
-        if ((citizenHutLevel < citizenHutMaxLevel && citizenHutLevel * 10 <= level) || level >= MAX_CITIZEN_LEVEL)
+        if ((citizenHutLevel < citizenHutMaxLevel && (citizenHutLevel + 1) * 10 <= level) || level >= MAX_CITIZEN_LEVEL)
         {
             return;
         }

--- a/src/main/java/com/minecolonies/coremod/entity/citizen/citizenhandlers/CitizenSkillHandler.java
+++ b/src/main/java/com/minecolonies/coremod/entity/citizen/citizenhandlers/CitizenSkillHandler.java
@@ -7,13 +7,15 @@ import com.minecolonies.api.colony.buildings.IBuilding;
 import com.minecolonies.api.entity.citizen.AbstractEntityCitizen;
 import com.minecolonies.api.entity.citizen.Skill;
 import com.minecolonies.api.entity.citizen.citizenhandlers.ICitizenSkillHandler;
+import com.minecolonies.api.util.SoundUtils;
 import com.minecolonies.coremod.Network;
 import com.minecolonies.coremod.network.messages.client.VanillaParticleMessage;
 import com.minecolonies.coremod.util.ExperienceUtils;
+import net.minecraft.core.particles.ParticleTypes;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.nbt.ListTag;
-import net.minecraft.core.particles.ParticleTypes;
 import net.minecraft.nbt.Tag;
+import net.minecraft.sounds.SoundEvents;
 import net.minecraft.util.Tuple;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -30,11 +32,6 @@ import static com.minecolonies.api.util.constant.NbtTagConstants.*;
  */
 public class CitizenSkillHandler implements ICitizenSkillHandler
 {
-    /**
-     * Chance to level up intelligence.
-     */
-    private static final int CHANCE_TO_LEVEL = 50;
-
     /**
      * Skill map.
      */
@@ -180,7 +177,7 @@ public class CitizenSkillHandler implements ICitizenSkillHandler
 
         final IBuilding home = data.getHomeBuilding();
 
-        final double citizenHutLevel = home == null ? 0 : home.getBuildingLevel();
+        final double citizenHutLevel = home == null ? 1 : home.getBuildingLevel();
         final double citizenHutMaxLevel = home == null ? 5 : home.getMaxBuildingLevel();
 
         if ((citizenHutLevel < citizenHutMaxLevel && citizenHutLevel * 10 <= level) || level >= MAX_CITIZEN_LEVEL)
@@ -247,6 +244,7 @@ public class CitizenSkillHandler implements ICitizenSkillHandler
         if (data.getEntity().isPresent())
         {
             final AbstractEntityCitizen citizen = data.getEntity().get();
+            citizen.playSound(SoundEvents.PLAYER_LEVELUP, 1.0f, (float) SoundUtils.getRandomPitch(citizen.getRandom()));
             Network.getNetwork()
               .sendToTrackingEntity(new VanillaParticleMessage(citizen.getX(), citizen.getY(), citizen.getZ(), ParticleTypes.HAPPY_VILLAGER),
                 data.getEntity().get());

--- a/src/main/java/com/minecolonies/coremod/entity/citizen/citizenhandlers/CitizenSkillHandler.java
+++ b/src/main/java/com/minecolonies/coremod/entity/citizen/citizenhandlers/CitizenSkillHandler.java
@@ -25,6 +25,7 @@ import java.util.Map;
 import java.util.Random;
 
 import static com.minecolonies.api.util.constant.CitizenConstants.MAX_CITIZEN_LEVEL;
+import static com.minecolonies.api.util.constant.Constants.MAX_BUILDING_LEVEL;
 import static com.minecolonies.api.util.constant.NbtTagConstants.*;
 
 /**
@@ -178,9 +179,9 @@ public class CitizenSkillHandler implements ICitizenSkillHandler
         final IBuilding home = data.getHomeBuilding();
 
         final double citizenHutLevel = home == null ? 0 : home.getBuildingLevel();
-        final double citizenHutMaxLevel = home == null ? 5 : home.getMaxBuildingLevel();
+        final double citizenHutMaxLevel = home == null ? MAX_BUILDING_LEVEL : home.getMaxBuildingLevel();
 
-        if ((citizenHutLevel < citizenHutMaxLevel && (citizenHutLevel + 1) * 10 <= level) || level >= MAX_CITIZEN_LEVEL)
+        if (((citizenHutLevel < citizenHutMaxLevel || citizenHutMaxLevel < MAX_BUILDING_LEVEL) && (citizenHutLevel + 1) * 10 <= level) || level >= MAX_CITIZEN_LEVEL)
         {
             return;
         }

--- a/src/main/java/com/minecolonies/coremod/entity/pathfinding/MinecoloniesAdvancedPathNavigate.java
+++ b/src/main/java/com/minecolonies/coremod/entity/pathfinding/MinecoloniesAdvancedPathNavigate.java
@@ -400,7 +400,10 @@ public class MinecoloniesAdvancedPathNavigate extends AbstractAdvancedPathNaviga
                 }
                 else
                 {
-                    ourEntity.stopRiding();
+                    if (destination == null || mob.distanceToSqr(destination.getX(), destination.getY(), destination.getZ()) > 2)
+                    {
+                        ourEntity.stopRiding();
+                    }
                 }
             }
             else if ((Math.abs(pEx.x - mob.getX()) > 7 || Math.abs(pEx.z - mob.getZ()) > 7) && ourEntity.vehicle != null)

--- a/src/main/java/com/minecolonies/coremod/generation/defaults/DefaultBlockTagsProvider.java
+++ b/src/main/java/com/minecolonies/coremod/generation/defaults/DefaultBlockTagsProvider.java
@@ -158,6 +158,7 @@ public class DefaultBlockTagsProvider extends BlockTagsProvider
         tag(ModTags.validSpawn)
           .addTags(BlockTags.BUTTONS)
           .addTags(BlockTags.RAILS)
+          .addTags(BlockTags.CARPETS)
           .add(Blocks.AIR, Blocks.CAVE_AIR, Blocks.SNOW, Blocks.TALL_GRASS, Blocks.GRASS, Blocks.FERN, Blocks.TORCH);
     }
 }

--- a/src/main/resources/assets/minecolonies/lang/manual_en_us.json
+++ b/src/main/resources/assets/minecolonies/lang/manual_en_us.json
@@ -1661,6 +1661,10 @@
   "com.minecolonies.coremod.entity.citizen.raid": "Help! The colony is being raided. I am running for shelter.",
   "com.minecolonies.coremod.entity.citizen.sleeping": "zZzz... I want to sleep... Why are you bothering me?",
   "com.minecolonies.coremod.entity.citizen.mourning": "I'm still processing %ss death, I can't work today.",
+  "com.minecolonies.coremod.interaction.nocookie": "%s: I want cookie!",
+  "com.minecolonies.coremod.interaction.notnow": "%s: I can't do that right now",
+  "com.minecolonies.coremod.interaction.ouch": "%s: Oh is that for me... Ouch!",
+  "com.minecolonies.coremod.interaction.visitor.food": "%s: Tasty food? I guess I'll stay a bit longer here",
 
   "com.minecolonies.coremod.gui.townhall.happiness.homelessness": "Housing",
   "com.minecolonies.coremod.gui.townhall.happiness.unemployment": "Unemployment",


### PR DESCRIPTION
# Changes proposed in this pull request:
Added citizen interactions with certain items, e.g. right click food to feed or golden apple to cure sickness, using a book on a child gives it some intelligence xp.
Citizens now behave more responsive to players when they bump into one.
Position searches, including spawn point ones, now also consider the initial pos.
Improved standing up from sitting, the standing pos now depends on the originally targeted block for sitting.
Child pupils no longer teleport from far to their sitting position.
Fix guards doing wandering movement when they should not
Citizen levelup now plays the levelup sound.


Review please
