### PR TITLE
Fixed issues with planter AI and resource scroll

### DIFF
--- a/src/main/java/com/minecolonies/coremod/colony/buildings/modules/BuildingResourcesModule.java
+++ b/src/main/java/com/minecolonies/coremod/colony/buildings/modules/BuildingResourcesModule.java
@@ -22,6 +22,7 @@ import com.minecolonies.coremod.entity.ai.util.BuildingStructureHandler;
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.CompoundNBT;
 import net.minecraft.network.PacketBuffer;
+import net.minecraft.util.text.StringTextComponent;
 import net.minecraftforge.items.CapabilityItemHandler;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -91,18 +92,18 @@ public class BuildingResourcesModule extends AbstractBuildingModule implements I
         if (data != null && data.getJob() instanceof AbstractJobStructure)
         {
             final AbstractJobStructure<?, ?> structureBuilderJob = (AbstractJobStructure<?, ?>) data.getJob();
-            final IWorkOrder workOrderDecoration = structureBuilderJob.getWorkOrder();
-            if (workOrderDecoration != null)
+            final IWorkOrder workOrder = structureBuilderJob.getWorkOrder();
+            if (workOrder != null)
             {
-                buf.writeUtf(workOrderDecoration.getDisplayName().getContents());
-                buf.writeDouble(workOrderDecoration.getAmountOfResources() == 0 ? 0 : qty / workOrderDecoration.getAmountOfResources());
+                buf.writeComponent(workOrder.getDisplayName());
+                buf.writeDouble(workOrder.getAmountOfResources() == 0 ? 0 : qty / workOrder.getAmountOfResources());
                 buf.writeInt(totalStages);
                 buf.writeInt(currentStage);
                 return;
             }
         }
 
-        buf.writeUtf("");
+        buf.writeComponent(new StringTextComponent(""));
         buf.writeDouble(0.0);
         buf.writeInt(0);
         buf.writeInt(0);

--- a/src/main/java/com/minecolonies/coremod/colony/buildings/moduleviews/BuildingResourcesModuleView.java
+++ b/src/main/java/com/minecolonies/coremod/colony/buildings/moduleviews/BuildingResourcesModuleView.java
@@ -7,6 +7,7 @@ import com.minecolonies.coremod.client.gui.modules.WindowBuilderResModule;
 import com.minecolonies.coremod.colony.buildings.utils.BuildingBuilderResource;
 import net.minecraft.item.ItemStack;
 import net.minecraft.network.PacketBuffer;
+import net.minecraft.util.text.ITextComponent;
 import net.minecraftforge.api.distmarker.Dist;
 import net.minecraftforge.api.distmarker.OnlyIn;
 import org.jetbrains.annotations.NotNull;
@@ -25,7 +26,7 @@ public class BuildingResourcesModuleView extends AbstractBuildingModuleView
     /**
      * The building he is working on.
      */
-    private String constructionName;
+    private ITextComponent constructionName;
 
     /**
      * Building progress.
@@ -55,7 +56,7 @@ public class BuildingResourcesModuleView extends AbstractBuildingModuleView
             resources.put(key, resource);
         }
 
-        constructionName = buf.readUtf(32767);
+        constructionName = buf.readComponent();
         progress = buf.readDouble();
         totalStages = buf.readInt();
         finishedStages = buf.readInt();
@@ -66,7 +67,7 @@ public class BuildingResourcesModuleView extends AbstractBuildingModuleView
      *
      * @return a string describing it.
      */
-    public String getConstructionName()
+    public ITextComponent getConstructionName()
     {
         return constructionName;
     }


### PR DESCRIPTION
Closes #8257 
Closes #8258 

# Changes proposed in this pull request:
- Upon unknown causes the plantation reports there's no soil positions, cause of this is unknown but for protection there's a safeguard around the random call so the range is always 0..1
- Planter did not properly check inventory during the planting cycle, this caused him to walk around aimlessly not planting anything.
- Resource scroll properly displays the building name it's working on again!

Review please
