### PR TITLE
Better request handling

### DIFF
--- a/src/api/java/com/minecolonies/api/colony/requestsystem/resolver/IRequestResolver.java
+++ b/src/api/java/com/minecolonies/api/colony/requestsystem/resolver/IRequestResolver.java
@@ -118,6 +118,16 @@ public interface IRequestResolver<R extends IRequestable> extends IRequester
     }
 
     /**
+     * Check how suitable this resolver is for the request.
+     * @param request the request to check.
+     * @return the suitability metric (an int for easy comparison).
+     */
+    default int getSuitabilityMetric(@NotNull final IRequest<? extends R> request)
+    {
+        return 0;
+    }
+
+    /**
      * The priority of this resolver. The higher the priority the earlier this resolver is called.
      *
      * @return The priority of this resolver.

--- a/src/main/java/com/minecolonies/apiimp/initializer/ModBuildingsInitializer.java
+++ b/src/main/java/com/minecolonies/apiimp/initializer/ModBuildingsInitializer.java
@@ -171,7 +171,7 @@ public final class ModBuildingsInitializer
                               .setBuildingProducer(BuildingCook::new)
                               .setBuildingViewProducer(() -> EmptyView::new)
                               .setRegistryName(new ResourceLocation(Constants.MOD_ID, ModBuildings.COOK_ID))
-                              .addBuildingModuleProducer(() -> new WorkerBuildingModule(ModJobs.cook, Skill.Adaptability, Skill.Knowledge, true, (b) -> 1), () -> WorkerBuildingModuleView::new)
+                              .addBuildingModuleProducer(() -> new NoPrivateCrafterWorkerModule(ModJobs.cook, Skill.Adaptability, Skill.Knowledge, true, (b) -> 1), () -> WorkerBuildingModuleView::new)
                               .addBuildingModuleProducer(() -> new CraftingWorkerBuildingModule(ModJobs.cookassistant, Skill.Creativity, Skill.Knowledge, false, (b) -> b.getBuildingLevel() >= 3 ? 1 : 0, Skill.Knowledge, Skill.Creativity), () -> WorkerBuildingModuleView::new)
                               .addBuildingModuleProducer(() -> new BuildingCook.CraftingModule(ModJobs.cookassistant), () -> CraftingModuleView::new)
                               .addBuildingModuleProducer(() -> new BuildingCook.SmeltingModule(ModJobs.cookassistant), () -> CraftingModuleView::new)

--- a/src/main/java/com/minecolonies/coremod/colony/buildings/modules/NoPrivateCrafterWorkerModule.java
+++ b/src/main/java/com/minecolonies/coremod/colony/buildings/modules/NoPrivateCrafterWorkerModule.java
@@ -1,0 +1,36 @@
+package com.minecolonies.coremod.colony.buildings.modules;
+
+import com.google.common.collect.ImmutableList;
+import com.minecolonies.api.colony.buildings.IBuilding;
+import com.minecolonies.api.colony.buildings.IBuildingWorkerModule;
+import com.minecolonies.api.colony.buildings.modules.*;
+import com.minecolonies.api.colony.jobs.registry.JobEntry;
+import com.minecolonies.api.colony.requestsystem.resolver.IRequestResolver;
+import com.minecolonies.api.entity.citizen.Skill;
+import com.minecolonies.api.util.constant.TypeConstants;
+import com.minecolonies.coremod.colony.requestsystem.resolvers.BuildingRequestResolver;
+
+import java.util.List;
+import java.util.function.Function;
+
+/**
+ * The worker module for citizen where they are assigned to if they work at it.
+ */
+public class NoPrivateCrafterWorkerModule extends WorkerBuildingModule implements IAssignsJob, IBuildingEventsModule, ITickingModule, IPersistentModule, IBuildingWorkerModule, ICreatesResolversModule
+{
+    public NoPrivateCrafterWorkerModule(
+      final JobEntry entry,
+      final Skill primary,
+      final Skill secondary,
+      final boolean canWorkingDuringRain,
+      final Function<IBuilding, Integer> sizeLimit)
+    {
+        super(entry, primary, secondary, canWorkingDuringRain, sizeLimit);
+    }
+
+    @Override
+    public List<IRequestResolver<?>> createResolvers()
+    {
+        return ImmutableList.of(new BuildingRequestResolver(building.getRequester().getLocation(), building.getColony().getRequestManager().getFactoryController().getNewInstance(TypeConstants.ITOKEN)));
+    }
+}

--- a/src/main/java/com/minecolonies/coremod/colony/requestsystem/management/handlers/RequestHandler.java
+++ b/src/main/java/com/minecolonies/coremod/colony/requestsystem/management/handlers/RequestHandler.java
@@ -190,7 +190,7 @@ public class RequestHandler implements IRequestHandler
             }
             else
             {
-                return resolve(request, previousResolver, resolverTokenBlackList, attemptResult);
+                break;
             }
         }
 

--- a/src/main/java/com/minecolonies/coremod/colony/requestsystem/management/handlers/RequestHandler.java
+++ b/src/main/java/com/minecolonies/coremod/colony/requestsystem/management/handlers/RequestHandler.java
@@ -145,6 +145,9 @@ public class RequestHandler implements IRequestHandler
                                                                .thenComparingInt((IRequestResolver<?> r) -> typeIndexList.indexOf(r.getRequestType())))
                                                      .collect(Collectors.toCollection(LinkedHashSet::new));
 
+        IRequestResolver previousResolver = null;
+        int previousMetric = Integer.MAX_VALUE;
+        @Nullable List<IToken<?>> attemptResult = null;
         for (@SuppressWarnings(RAWTYPES) final IRequestResolver resolver : resolvers)
         {
             //Skip when the resolver is in the blacklist.
@@ -159,54 +162,92 @@ public class RequestHandler implements IRequestHandler
                 continue;
             }
 
-            @Nullable final List<IToken<?>> attemptResult = resolver.attemptResolveRequest(new WrappedBlacklistAssignmentRequestManager(manager, resolverTokenBlackList), request);
-
-            //Skip if attempt failed (aka attemptResult == null)
-            if (attemptResult == null)
+            if (previousResolver == null)
             {
+                //Skip if attempt failed (aka attemptResult == null)
+                attemptResult = resolver.attemptResolveRequest(new WrappedBlacklistAssignmentRequestManager(manager, resolverTokenBlackList), request);
+                if (attemptResult != null)
+                {
+                    previousResolver = resolver;
+                    previousMetric = resolver.getSuitabilityMetric(request);
+                }
                 continue;
             }
 
-            //Successfully found a resolver. Registering
-            manager.getLogger().debug("Finished resolver assignment search for request: " + request + " successfully");
-
-            manager.getResolverHandler().addRequestToResolver(resolver, request);
-            //TODO: Change this false to simulation.
-            resolver.onRequestAssigned(manager, request, false);
-
-            for (final IToken<?> childRequestToken :
-              attemptResult)
+            if (previousResolver.getClass().equals(resolver.getClass()))
             {
-                final IRequest<?> childRequest = manager.getRequestHandler().getRequest(childRequestToken);
-
-                childRequest.setParent(request.getId());
-                request.addChild(childRequest.getId());
-            }
-
-            for (final IToken<?> childRequestToken :
-              attemptResult)
-            {
-                final IRequest<?> childRequest = manager.getRequestHandler().getRequest(childRequestToken);
-
-                if (!isAssigned(childRequestToken))
+                final int currentResolverMetric = resolver.getSuitabilityMetric(request);
+                if (currentResolverMetric < previousMetric)
                 {
-                    assignRequest(childRequest, resolverTokenBlackList);
+                    @Nullable List<IToken<?>> tempAttemptResolveRequest = resolver.attemptResolveRequest(new WrappedBlacklistAssignmentRequestManager(manager, resolverTokenBlackList), request);
+                    if (tempAttemptResolveRequest != null)
+                    {
+                        previousResolver = resolver;
+                        previousMetric = resolver.getSuitabilityMetric(request);
+                        attemptResult = tempAttemptResolveRequest;
+                    }
                 }
             }
-
-            if (request.getState().ordinal() < RequestState.IN_PROGRESS.ordinal())
+            else
             {
-                request.setState(new WrappedStaticStateRequestManager(manager), RequestState.IN_PROGRESS);
-                if (!request.hasChildren())
-                {
-                    resolveRequest(request);
-                }
+                return resolve(request, previousResolver, resolverTokenBlackList, attemptResult);
             }
+        }
 
-            return resolver.getId();
+        if (previousResolver != null)
+        {
+            return resolve(request, previousResolver, resolverTokenBlackList, attemptResult);
         }
 
         return null;
+    }
+
+    /**
+     * Attempt to resolve a given request with a set resolver.
+     * @param request the request to fulfill.
+     * @param resolver the resolver to use.
+     * @param resolverTokenBlackList the black list.
+     * @return the resolver token.
+     */
+    private IToken<?> resolve(final IRequest<?> request, final IRequestResolver resolver, final Collection<IToken<?>> resolverTokenBlackList, @Nullable final List<IToken<?>> attemptResult)
+    {
+        //Successfully found a resolver. Registering
+        manager.getLogger().debug("Finished resolver assignment search for request: " + request + " successfully");
+
+        manager.getResolverHandler().addRequestToResolver(resolver, request);
+        //TODO: Change this false to simulation.
+        resolver.onRequestAssigned(manager, request, false);
+
+        for (final IToken<?> childRequestToken :
+          attemptResult)
+        {
+            final IRequest<?> childRequest = manager.getRequestHandler().getRequest(childRequestToken);
+
+            childRequest.setParent(request.getId());
+            request.addChild(childRequest.getId());
+        }
+
+        for (final IToken<?> childRequestToken :
+          attemptResult)
+        {
+            final IRequest<?> childRequest = manager.getRequestHandler().getRequest(childRequestToken);
+
+            if (!isAssigned(childRequestToken))
+            {
+                assignRequest(childRequest, resolverTokenBlackList);
+            }
+        }
+
+        if (request.getState().ordinal() < RequestState.IN_PROGRESS.ordinal())
+        {
+            request.setState(new WrappedStaticStateRequestManager(manager), RequestState.IN_PROGRESS);
+            if (!request.hasChildren())
+            {
+                resolveRequest(request);
+            }
+        }
+
+        return resolver.getId();
     }
 
     /**

--- a/src/main/java/com/minecolonies/coremod/colony/requestsystem/management/handlers/UpdateHandler.java
+++ b/src/main/java/com/minecolonies/coremod/colony/requestsystem/management/handlers/UpdateHandler.java
@@ -17,7 +17,8 @@ public class UpdateHandler implements IUpdateHandler
     @VisibleForTesting
     private static final List<IUpdateStep> UPDATE_STEPS = Lists.newArrayList(
       new InitialUpdate(),
-      new ResetRSToStoreJobInResolvers()
+      new ResetRSToStoreJobInResolvers(),
+      new ResetRSToUpdateRestaurantResolver()
     );
 
     private final IStandardRequestManager manager;

--- a/src/main/java/com/minecolonies/coremod/colony/requestsystem/management/handlers/update/implementation/ResetRSToUpdateRestaurantResolver.java
+++ b/src/main/java/com/minecolonies/coremod/colony/requestsystem/management/handlers/update/implementation/ResetRSToUpdateRestaurantResolver.java
@@ -1,0 +1,27 @@
+package com.minecolonies.coremod.colony.requestsystem.management.handlers.update.implementation;
+
+import com.minecolonies.api.colony.requestsystem.management.update.UpdateType;
+import com.minecolonies.coremod.colony.requestsystem.management.IStandardRequestManager;
+import com.minecolonies.coremod.colony.requestsystem.management.handlers.update.IUpdateStep;
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * Update fix to restaurant.
+ */
+public class ResetRSToUpdateRestaurantResolver implements IUpdateStep
+{
+    @Override
+    public int updatesToVersion()
+    {
+        return 14;
+    }
+
+    @Override
+    public void update(@NotNull final UpdateType type, @NotNull final IStandardRequestManager manager)
+    {
+        if (type == UpdateType.DATA_LOAD)
+        {
+            manager.reset();
+        }
+    }
+}

--- a/src/main/java/com/minecolonies/coremod/colony/requestsystem/resolvers/DeliveryRequestResolver.java
+++ b/src/main/java/com/minecolonies/coremod/colony/requestsystem/resolvers/DeliveryRequestResolver.java
@@ -25,8 +25,8 @@ public class DeliveryRequestResolver extends DeliverymenRequestResolver<Delivery
     @Override
     public boolean canResolveRequest(@NotNull final IRequestManager manager, final IRequest<? extends Delivery> requestToCheck)
     {
-        final IWareHouse wareHouse = manager.getColony().getBuildingManager().getClosestWarehouseInColony(requestToCheck.getRequest().getStart().getInDimensionLocation());
-        if (wareHouse == null || !wareHouse.getID().equals(getLocation().getInDimensionLocation()))
+        final IWareHouse wareHouse = manager.getColony().getBuildingManager().getBuilding(getLocation().getInDimensionLocation(), IWareHouse.class);
+        if (wareHouse == null)
         {
             return false;
         }

--- a/src/main/java/com/minecolonies/coremod/colony/requestsystem/resolvers/DeliverymenRequestResolver.java
+++ b/src/main/java/com/minecolonies/coremod/colony/requestsystem/resolvers/DeliverymenRequestResolver.java
@@ -9,6 +9,7 @@ import com.minecolonies.api.colony.requestsystem.manager.IRequestManager;
 import com.minecolonies.api.colony.requestsystem.request.IRequest;
 import com.minecolonies.api.colony.requestsystem.requestable.IRequestable;
 import com.minecolonies.api.colony.requestsystem.token.IToken;
+import com.minecolonies.api.util.BlockPosUtil;
 import com.minecolonies.api.util.Log;
 import com.minecolonies.api.util.Tuple;
 import com.minecolonies.api.util.constant.TranslationConstants;
@@ -76,6 +77,12 @@ public abstract class DeliverymenRequestResolver<R extends IRequestable> extends
         }
 
         return citizenList;
+    }
+
+    @Override
+    public int getSuitabilityMetric(@NotNull final IRequest<? extends R> request)
+    {
+        return (int) BlockPosUtil.getDistance(request.getRequester().getLocation().getInDimensionLocation(), getLocation().getInDimensionLocation());
     }
 
     @Nullable

--- a/src/main/java/com/minecolonies/coremod/colony/requestsystem/resolvers/PickupRequestResolver.java
+++ b/src/main/java/com/minecolonies/coremod/colony/requestsystem/resolvers/PickupRequestResolver.java
@@ -1,6 +1,7 @@
 package com.minecolonies.coremod.colony.requestsystem.resolvers;
 
 import com.google.common.reflect.TypeToken;
+import com.minecolonies.api.colony.buildings.IBuilding;
 import com.minecolonies.api.colony.buildings.workerbuildings.IWareHouse;
 import com.minecolonies.api.colony.requestsystem.location.ILocation;
 import com.minecolonies.api.colony.requestsystem.manager.IRequestManager;
@@ -8,6 +9,7 @@ import com.minecolonies.api.colony.requestsystem.request.IRequest;
 import com.minecolonies.api.colony.requestsystem.requestable.deliveryman.Pickup;
 import com.minecolonies.api.colony.requestsystem.token.IToken;
 import com.minecolonies.api.util.constant.TypeConstants;
+import com.minecolonies.coremod.colony.buildings.workerbuildings.BuildingWareHouse;
 import org.jetbrains.annotations.NotNull;
 
 /**
@@ -31,8 +33,8 @@ public class PickupRequestResolver extends DeliverymenRequestResolver<Pickup>
     @Override
     public boolean canResolveRequest(@NotNull final IRequestManager manager, final IRequest<? extends Pickup> requestToCheck)
     {
-        final IWareHouse wareHouse = manager.getColony().getBuildingManager().getClosestWarehouseInColony(requestToCheck.getRequester().getLocation().getInDimensionLocation());
-        if (wareHouse == null || !wareHouse.getID().equals(getLocation().getInDimensionLocation()))
+        final IWareHouse wareHouse = manager.getColony().getBuildingManager().getBuilding(getLocation().getInDimensionLocation(), IWareHouse.class);
+        if (wareHouse == null)
         {
             return false;
         }

--- a/src/main/java/com/minecolonies/coremod/colony/requestsystem/resolvers/core/AbstractCraftingRequestResolver.java
+++ b/src/main/java/com/minecolonies/coremod/colony/requestsystem/resolvers/core/AbstractCraftingRequestResolver.java
@@ -16,6 +16,7 @@ import com.minecolonies.api.colony.requestsystem.token.IToken;
 import com.minecolonies.api.crafting.IRecipeStorage;
 import com.minecolonies.api.crafting.ItemStorage;
 import com.minecolonies.api.research.effects.AbstractResearchEffect;
+import com.minecolonies.api.util.BlockPosUtil;
 import com.minecolonies.api.util.ItemStackUtils;
 import com.minecolonies.coremod.colony.buildings.AbstractBuilding;
 import com.minecolonies.coremod.colony.buildings.modules.CraftingWorkerBuildingModule;
@@ -97,6 +98,12 @@ public abstract class AbstractCraftingRequestResolver extends AbstractRequestRes
     public void onRequestedRequestComplete(@NotNull final IRequestManager manager, @NotNull final IRequest<?> request)
     {
         //Noop
+    }
+
+    @Override
+    public int getSuitabilityMetric(@NotNull IRequest<? extends IDeliverable> request)
+    {
+        return (int) BlockPosUtil.getDistance(request.getRequester().getLocation().getInDimensionLocation(), getLocation().getInDimensionLocation());
     }
 
     @Override

--- a/src/main/java/com/minecolonies/coremod/colony/requestsystem/resolvers/core/AbstractRequestResolver.java
+++ b/src/main/java/com/minecolonies/coremod/colony/requestsystem/resolvers/core/AbstractRequestResolver.java
@@ -42,6 +42,12 @@ public abstract class AbstractRequestResolver<R extends IRequestable> implements
         return location;
     }
 
+    @Override
+    public int getSuitabilityMetric(@NotNull final IRequest<? extends R> request)
+    {
+        return 0;
+    }
+
     @NotNull
     @Override
     public MutableComponent getRequesterDisplayName(@NotNull final IRequestManager manager, @NotNull final IRequest<?> request)


### PR DESCRIPTION
Closes #8245
Closes #8231
Closes #

# Changes proposed in this pull request:
- This PR introduces resolver suitability. Resolvers can return a metric of how suited they are for the task.
- This could be distance-based but also based on how long the list is.
- It goes through the list of resolvers and for all resovlers of the same type it compares suitability.
- Removes private crafting resolver from cook, only assistant can craft

Review please
