### PR TITLE
Raider fixes

### DIFF
--- a/src/api/java/com/minecolonies/api/entity/pathfinding/PathingStuckHandler.java
+++ b/src/api/java/com/minecolonies/api/entity/pathfinding/PathingStuckHandler.java
@@ -1,19 +1,18 @@
 package com.minecolonies.api.entity.pathfinding;
 
 import com.minecolonies.api.entity.ai.citizen.builder.IBuilderUndestroyable;
-import com.minecolonies.api.items.ModTags;
 import com.minecolonies.api.util.BlockPosUtil;
-import net.minecraft.world.level.block.Block;
-import net.minecraft.world.level.block.state.BlockState;
-import net.minecraft.world.level.block.Blocks;
-import net.minecraft.world.level.block.LadderBlock;
-import net.minecraft.world.entity.Mob;
-import net.minecraft.world.level.pathfinder.Node;
+import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
 import net.minecraft.world.damagesource.EntityDamageSource;
-import net.minecraft.core.BlockPos;
-import net.minecraft.world.phys.Vec3;
+import net.minecraft.world.entity.Mob;
 import net.minecraft.world.level.Level;
+import net.minecraft.world.level.block.Block;
+import net.minecraft.world.level.block.Blocks;
+import net.minecraft.world.level.block.LadderBlock;
+import net.minecraft.world.level.block.state.BlockState;
+import net.minecraft.world.level.pathfinder.Node;
+import net.minecraft.world.phys.Vec3;
 
 import java.util.Arrays;
 import java.util.List;
@@ -285,7 +284,7 @@ public class PathingStuckHandler implements IStuckHandler
         if (stuckLevel == 0)
         {
             stuckLevel++;
-            delayToNextUnstuckAction = 200;
+            delayToNextUnstuckAction = 100;
             navigator.stop();
             return;
         }
@@ -295,9 +294,18 @@ public class PathingStuckHandler implements IStuckHandler
         {
             stuckLevel++;
             delayToNextUnstuckAction = 300;
+
+            if (navigator.getPath() != null)
+            {
+                moveAwayStartPos = navigator.getPath().getNodePos(navigator.getPath().getNextNodeIndex());
+            }
+            else
+            {
+                moveAwayStartPos = navigator.getOurEntity().blockPosition().above();
+            }
+
             navigator.stop();
             navigator.moveAwayFromXYZ(navigator.getOurEntity().blockPosition(), 10, 1.0f, false);
-            moveAwayStartPos = navigator.getOurEntity().blockPosition();
             return;
         }
 
@@ -322,6 +330,10 @@ public class PathingStuckHandler implements IStuckHandler
             {
                 delayToNextUnstuckAction = 100;
                 placeLeaves(navigator);
+            }
+            else if (canPlaceLadders || canBuildLeafBridges)
+            {
+                return;
             }
         }
 
@@ -445,7 +457,7 @@ public class PathingStuckHandler implements IStuckHandler
         final Level world = navigator.getOurEntity().level;
         final Mob entity = navigator.getOurEntity();
 
-        final Direction badFacing = BlockPosUtil.getFacing(new BlockPos(entity.position()), navigator.getDesiredPos());
+        final Direction badFacing = BlockPosUtil.getFacing(new BlockPos(entity.position()), navigator.getDesiredPos()).getOpposite();
 
         for (final Direction dir : HORIZONTAL_DIRS)
         {
@@ -454,11 +466,31 @@ public class PathingStuckHandler implements IStuckHandler
                 continue;
             }
 
-            if (world.isEmptyBlock(new BlockPos(entity.position()).below().relative(dir)))
+            for (int i = 1; i <= (dir == badFacing.getOpposite() ? 3 : 1); i++)
             {
-                world.setBlockAndUpdate(new BlockPos(entity.position()).below().relative(dir), Blocks.ACACIA_LEAVES.defaultBlockState());
+                if (!tryPlaceLeaveOnPos(world, new BlockPos(entity.position()).below().relative(dir, i)))
+                {
+                    break;
+                }
             }
         }
+    }
+
+    /**
+     * Places a leave block in the world
+     *
+     * @param world
+     * @param pos
+     * @return
+     */
+    private boolean tryPlaceLeaveOnPos(final Level world, final BlockPos pos)
+    {
+        if (world.isEmptyBlock(pos))
+        {
+            world.setBlockAndUpdate(pos, Blocks.ACACIA_LEAVES.defaultBlockState());
+            return true;
+        }
+        return false;
     }
 
     /**

--- a/src/main/java/com/minecolonies/coremod/colony/colonyEvents/raidEvents/AbstractShipRaidEvent.java
+++ b/src/main/java/com/minecolonies/coremod/colony/colonyEvents/raidEvents/AbstractShipRaidEvent.java
@@ -39,7 +39,6 @@ import net.minecraft.world.level.block.Mirror;
 import net.minecraft.world.level.block.entity.BlockEntity;
 import net.minecraft.world.level.block.entity.SpawnerBlockEntity;
 import net.minecraft.world.level.pathfinder.Path;
-
 import org.jetbrains.annotations.NotNull;
 
 import java.util.*;
@@ -179,7 +178,7 @@ public abstract class AbstractShipRaidEvent implements IColonyRaidEvent, IColony
             true);
         structure.getBluePrint().rotateWithMirror(BlockPosUtil.getRotationFromRotations(shipRotation), Mirror.NONE, colony.getWorld());
 
-        if (spawnPathResult.isDone())
+        if (spawnPathResult != null && spawnPathResult.isDone())
         {
             final Path path = spawnPathResult.getPath();
             if (path != null && path.canReach())

--- a/src/main/java/com/minecolonies/coremod/colony/colonyEvents/raidEvents/HordeRaidEvent.java
+++ b/src/main/java/com/minecolonies/coremod/colony/colonyEvents/raidEvents/HordeRaidEvent.java
@@ -17,24 +17,24 @@ import com.minecolonies.api.util.constant.NbtTagConstants;
 import com.minecolonies.coremod.colony.colonyEvents.raidEvents.barbarianEvent.Horde;
 import com.minecolonies.coremod.colony.colonyEvents.raidEvents.pirateEvent.ShipBasedRaiderUtils;
 import com.minecolonies.coremod.network.messages.client.PlayAudioMessage;
-import net.minecraft.world.level.block.Blocks;
+import net.minecraft.core.BlockPos;
+import net.minecraft.nbt.CompoundTag;
+import net.minecraft.nbt.ListTag;
+import net.minecraft.nbt.Tag;
+import net.minecraft.network.chat.MutableComponent;
+import net.minecraft.network.chat.TextComponent;
+import net.minecraft.server.level.ServerBossEvent;
+import net.minecraft.server.level.ServerPlayer;
+import net.minecraft.sounds.SoundSource;
+import net.minecraft.world.BossEvent;
+import net.minecraft.world.effect.MobEffectInstance;
+import net.minecraft.world.effect.MobEffects;
 import net.minecraft.world.entity.Entity;
 import net.minecraft.world.entity.EntityType;
 import net.minecraft.world.entity.LivingEntity;
 import net.minecraft.world.entity.player.Player;
-import net.minecraft.server.level.ServerPlayer;
-import net.minecraft.nbt.CompoundTag;
-import net.minecraft.nbt.Tag;
-import net.minecraft.nbt.ListTag;
+import net.minecraft.world.level.block.Blocks;
 import net.minecraft.world.level.pathfinder.Path;
-import net.minecraft.world.effect.MobEffectInstance;
-import net.minecraft.world.effect.MobEffects;
-import net.minecraft.sounds.SoundSource;
-import net.minecraft.core.BlockPos;
-import net.minecraft.network.chat.MutableComponent;
-import net.minecraft.network.chat.TextComponent;
-import net.minecraft.world.BossEvent;
-import net.minecraft.server.level.ServerBossEvent;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.*;
@@ -317,7 +317,7 @@ public abstract class HordeRaidEvent implements IColonyRaidEvent, IColonyCampFir
     @Override
     public void onStart()
     {
-        if (spawnPathResult.isDone())
+        if (spawnPathResult != null && spawnPathResult.isDone())
         {
             final Path path = spawnPathResult.getPath();
             if (path != null && path.canReach())

--- a/src/main/java/com/minecolonies/coremod/colony/managers/RaidManager.java
+++ b/src/main/java/com/minecolonies/coremod/colony/managers/RaidManager.java
@@ -466,22 +466,22 @@ public class RaidManager implements IRaiderManager
             return null;
         }
 
-        spawnPos = BlockPosUtil.findAround(colony.getWorld(),
+        BlockPos worldSpawnPos = BlockPosUtil.findAround(colony.getWorld(),
           BlockPosUtil.getFloor(spawnPos, colony.getWorld()),
           3,
           30,
           SOLID_AIR_POS_SELECTOR);
 
-        if (spawnPos == null && MineColonies.getConfig().getServer().skyRaiders.get())
+        if (worldSpawnPos == null && MineColonies.getConfig().getServer().skyRaiders.get())
         {
-            spawnPos = BlockPosUtil.findAround(colony.getWorld(),
+            worldSpawnPos = BlockPosUtil.findAround(colony.getWorld(),
               BlockPosUtil.getFloor(spawnPos, colony.getWorld()),
               10,
               15,
               DOUBLE_AIR_POS_SELECTOR);
         }
 
-        return spawnPos;
+        return worldSpawnPos;
     }
 
     /**
@@ -496,35 +496,28 @@ public class RaidManager implements IRaiderManager
       final BlockPos advancePos)
     {
         BlockPos spawnPos = new BlockPos(start);
-        BlockPos tempPos = new BlockPos(spawnPos);
+        Vec3 tempPos = new Vec3(spawnPos.getX(), spawnPos.getY(), spawnPos.getZ());
         final Collection<IBuilding> buildings = colony.getBuildingManager().getBuildings().values();
 
-        final int xDiff = start.getX() - advancePos.getX();
-        final int zDiff = start.getZ() - advancePos.getZ();
+        final int xDiff = Math.abs(start.getX() - advancePos.getX());
+        final int zDiff = Math.abs(start.getZ() - advancePos.getZ());
 
-        Vec3 rates = new Vec3(1, 1, 1);
-
-        if (xDiff > zDiff)
-        {
-            rates = new Vec3((xDiff) / ((double) zDiff), 1, start.getZ() < advancePos.getZ() ? 1 : -1);
-        }
-        else
-        {
-            rates = new Vec3(start.getX() < advancePos.getX() ? 1 : -1, 1, (zDiff) / ((double) xDiff));
-        }
+        Vec3 xzRatio = new Vec3(xDiff * (start.getX() < advancePos.getX() ? 1 : -1), 0, zDiff * (start.getZ() < advancePos.getZ() ? 1 : -1));
+        // Reduce ratio to 3 chunks a step
+        xzRatio = xzRatio.normalize().scale(3);
 
         int validChunkCount = 0;
         for (int i = 0; i < 10; i++)
         {
-            if (WorldUtil.isEntityBlockLoaded(colony.getWorld(), tempPos))
+            if (WorldUtil.isEntityBlockLoaded(colony.getWorld(), new BlockPos(tempPos)))
             {
-                tempPos = tempPos.offset(16 * rates.x, 0, 16 * rates.z);
+                tempPos = tempPos.add(16 * xzRatio.x, 0, 16 * xzRatio.z);
 
-                if (WorldUtil.isEntityBlockLoaded(colony.getWorld(), tempPos))
+                if (WorldUtil.isEntityBlockLoaded(colony.getWorld(), new BlockPos(tempPos)))
                 {
-                    if (isValidSpawnPoint(buildings, tempPos))
+                    if (isValidSpawnPoint(buildings, new BlockPos(tempPos)))
                     {
-                        spawnPos = tempPos;
+                        spawnPos = new BlockPos(tempPos);
                         validChunkCount++;
                         if (validChunkCount > 5)
                         {

--- a/src/main/java/com/minecolonies/coremod/entity/pathfinding/pathjobs/AbstractPathJob.java
+++ b/src/main/java/com/minecolonies/coremod/entity/pathfinding/pathjobs/AbstractPathJob.java
@@ -2,7 +2,6 @@ package com.minecolonies.coremod.entity.pathfinding.pathjobs;
 
 import com.ldtteam.domumornamentum.block.decorative.FloatingCarpetBlock;
 import com.ldtteam.domumornamentum.block.decorative.PanelBlock;
-import com.ldtteam.domumornamentum.block.vanilla.TrapdoorBlock;
 import com.minecolonies.api.blocks.decorative.AbstractBlockMinecoloniesConstructionTape;
 import com.minecolonies.api.blocks.huts.AbstractBlockMinecoloniesDefault;
 import com.minecolonies.api.entity.pathfinding.AbstractAdvancedPathNavigate;
@@ -10,7 +9,6 @@ import com.minecolonies.api.entity.pathfinding.PathResult;
 import com.minecolonies.api.entity.pathfinding.PathingOptions;
 import com.minecolonies.api.entity.pathfinding.SurfaceType;
 import com.minecolonies.api.util.BlockPosUtil;
-import com.minecolonies.api.util.CompatibilityUtils;
 import com.minecolonies.api.util.Log;
 import com.minecolonies.coremod.MineColonies;
 import com.minecolonies.coremod.Network;
@@ -21,25 +19,26 @@ import com.minecolonies.coremod.entity.pathfinding.PathPointExtended;
 import com.minecolonies.coremod.network.messages.client.SyncPathMessage;
 import com.minecolonies.coremod.network.messages.client.SyncPathReachedMessage;
 import com.minecolonies.coremod.util.WorkerUtil;
+import net.minecraft.core.BlockPos;
+import net.minecraft.core.Direction;
+import net.minecraft.core.Vec3i;
 import net.minecraft.server.level.ServerPlayer;
+import net.minecraft.util.Mth;
+import net.minecraft.world.entity.LivingEntity;
 import net.minecraft.world.entity.Mob;
 import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.level.Level;
+import net.minecraft.world.level.LevelReader;
 import net.minecraft.world.level.block.*;
+import net.minecraft.world.level.block.state.BlockState;
+import net.minecraft.world.level.block.state.properties.BlockStateProperties;
+import net.minecraft.world.level.block.state.properties.Half;
 import net.minecraft.world.level.material.Material;
-import net.minecraft.world.entity.LivingEntity;
 import net.minecraft.world.level.pathfinder.BlockPathTypes;
 import net.minecraft.world.level.pathfinder.Node;
 import net.minecraft.world.level.pathfinder.Path;
-import net.minecraft.world.level.block.state.properties.BlockStateProperties;
-import net.minecraft.world.level.block.state.properties.Half;
-import net.minecraft.core.Direction;
 import net.minecraft.world.phys.AABB;
-import net.minecraft.core.BlockPos;
-import net.minecraft.util.Mth;
 import net.minecraft.world.phys.shapes.VoxelShape;
-import net.minecraft.core.Vec3i;
-import net.minecraft.world.level.LevelReader;
-import net.minecraft.world.level.Level;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -48,8 +47,6 @@ import java.util.*;
 import java.util.concurrent.Callable;
 
 import static com.minecolonies.api.util.constant.PathingConstants.*;
-
-import net.minecraft.world.level.block.state.BlockState;
 
 /**
  * Abstract class for Jobs that run in the multithreaded path finder.
@@ -1069,7 +1066,8 @@ public abstract class AbstractPathJob implements Callable<Path>
         {
             node.setLadder();
         }
-        else if (isSwimming)
+
+        if (isSwimming)
         {
             node.setSwimming();
         }
@@ -1160,8 +1158,8 @@ public abstract class AbstractPathJob implements Callable<Path>
     {
         final boolean canDrop = parent != null && !parent.isLadder();
         //  Nothing to stand on
-        if (!canDrop || isSwimming || ((parent.pos.getX() != pos.getX() || parent.pos.getZ() != pos.getZ()) && isPassable(parent.pos.below(), false, parent)
-                                         && SurfaceType.getSurfaceType(world, world.getBlockState(parent.pos.below()), parent.pos.below()) == SurfaceType.DROPABLE))
+        if (!canDrop || ((parent.pos.getX() != pos.getX() || parent.pos.getZ() != pos.getZ()) && isPassable(parent.pos.below(), false, parent)
+                           && SurfaceType.getSurfaceType(world, world.getBlockState(parent.pos.below()), parent.pos.below()) == SurfaceType.DROPABLE))
         {
             return -100;
         }


### PR DESCRIPTION
Closes #8130

# Changes proposed in this pull request:
- Fix sky raiders not spawning
- Improved unstuck handling, leaves are now trying to place in the right direction
- Fix raid spawn location calculation always ending up in the same areas, now can spawn in a circle around the colony as intended
- Fix pathing nodes not saving the swimming flag correctly, when it is a ladder node, causing ladders onto of water to path into the water below.

Review please
