### PR TITLE
Feature/domum paper

### DIFF
--- a/src/api/java/com/minecolonies/api/IMinecoloniesAPI.java
+++ b/src/api/java/com/minecolonies/api/IMinecoloniesAPI.java
@@ -15,6 +15,7 @@ import com.minecolonies.api.colony.jobs.registry.IJobDataManager;
 import com.minecolonies.api.colony.jobs.registry.JobEntry;
 import com.minecolonies.api.compatibility.IFurnaceRecipes;
 import com.minecolonies.api.configuration.Configuration;
+import com.minecolonies.api.crafting.registry.CraftingType;
 import com.minecolonies.api.crafting.registry.RecipeTypeEntry;
 import com.minecolonies.api.entity.ai.registry.IMobAIRegistry;
 import com.minecolonies.api.entity.pathfinding.registry.IPathNavigateRegistry;
@@ -72,4 +73,6 @@ public interface IMinecoloniesAPI
     IForgeRegistry<ColonyEventDescriptionTypeRegistryEntry> getColonyEventDescriptionRegistry();
 
     IForgeRegistry<RecipeTypeEntry> getRecipeTypeRegistry();
+
+    IForgeRegistry<CraftingType> getCraftingTypeRegistry();
 }

--- a/src/api/java/com/minecolonies/api/MinecoloniesAPIProxy.java
+++ b/src/api/java/com/minecolonies/api/MinecoloniesAPIProxy.java
@@ -15,6 +15,7 @@ import com.minecolonies.api.colony.jobs.registry.IJobDataManager;
 import com.minecolonies.api.colony.jobs.registry.JobEntry;
 import com.minecolonies.api.compatibility.IFurnaceRecipes;
 import com.minecolonies.api.configuration.Configuration;
+import com.minecolonies.api.crafting.registry.CraftingType;
 import com.minecolonies.api.crafting.registry.RecipeTypeEntry;
 import com.minecolonies.api.entity.ai.registry.IMobAIRegistry;
 import com.minecolonies.api.entity.pathfinding.registry.IPathNavigateRegistry;
@@ -161,5 +162,11 @@ public final class MinecoloniesAPIProxy implements IMinecoloniesAPI
     public IForgeRegistry<RecipeTypeEntry> getRecipeTypeRegistry()
     {
         return apiInstance.getRecipeTypeRegistry();
+    }
+
+    @Override
+    public IForgeRegistry<CraftingType> getCraftingTypeRegistry()
+    {
+        return apiInstance.getCraftingTypeRegistry();
     }
 }

--- a/src/api/java/com/minecolonies/api/colony/buildings/modules/ICraftingBuildingModule.java
+++ b/src/api/java/com/minecolonies/api/colony/buildings/modules/ICraftingBuildingModule.java
@@ -9,9 +9,9 @@ import com.minecolonies.api.crafting.IRecipeStorage;
 import com.minecolonies.api.entity.citizen.AbstractEntityCitizen;
 import com.minecolonies.api.crafting.registry.CraftingType;
 import com.minecolonies.api.util.OptionalPredicate;
-
-import net.minecraft.world.item.ItemStack;
 import net.minecraft.resources.ResourceLocation;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.crafting.RecipeType;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 

--- a/src/api/java/com/minecolonies/api/colony/buildings/modules/ICraftingBuildingModule.java
+++ b/src/api/java/com/minecolonies/api/colony/buildings/modules/ICraftingBuildingModule.java
@@ -7,6 +7,7 @@ import com.minecolonies.api.colony.requestsystem.token.IToken;
 import com.minecolonies.api.crafting.IGenericRecipe;
 import com.minecolonies.api.crafting.IRecipeStorage;
 import com.minecolonies.api.entity.citizen.AbstractEntityCitizen;
+import com.minecolonies.api.crafting.registry.CraftingType;
 import com.minecolonies.api.util.OptionalPredicate;
 
 import net.minecraft.world.item.ItemStack;
@@ -15,6 +16,7 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.List;
+import java.util.Set;
 import java.util.function.Predicate;
 
 /**
@@ -80,28 +82,20 @@ public interface ICraftingBuildingModule extends IBuildingModule
     String getCustomRecipeKey();
 
     /**
-     * Check if this building type can learn (or otherwise process)
-     * vanilla crafting recipes of some kind.
-     *
-     * @return True if so; false otherwise.
+     * Check if the worker can learn a certain type of recipe.
+     * @param type the type to check for.
+     * @return true if so.
      */
-    boolean canLearnCraftingRecipes();
+    default boolean canLearn(final CraftingType type)
+    {
+        return getSupportedCraftingTypes().contains(type);
+    }
 
     /**
-     * Check if this building type can learn (or otherwise process)
-     * vanilla smelting recipes of some kind.
-     *
-     * @return True if so; false otherwise.
+     * Get the supported crafting types.
+     * @return a set of types.
      */
-    boolean canLearnFurnaceRecipes();
-
-    /**
-     * Check if it is possible for this building type to learn
-     * recipes that will only fit in a 3x3 crafting grid.
-     *
-     * @return True if 3x3 recipes can be taught.
-     */
-    boolean canLearnLargeRecipes();
+    Set<CraftingType> getSupportedCraftingTypes();
 
     /**
      * Checks if this particular recipe is *possible* to be learned by
@@ -127,6 +121,12 @@ public interface ICraftingBuildingModule extends IBuildingModule
      */
     @NotNull
     OptionalPredicate<ItemStack> getIngredientValidator();
+
+    /**
+     * Check if the module should have a large limit for learnable recipes.
+     * @return true if so.
+     */
+    boolean canLearnManyRecipes();
 
     /**
      * Check if the module on the client side should be displayed.

--- a/src/api/java/com/minecolonies/api/crafting/GenericRecipe.java
+++ b/src/api/java/com/minecolonies/api/crafting/GenericRecipe.java
@@ -10,6 +10,7 @@ import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.inventory.AbstractContainerMenu;
 import net.minecraft.world.inventory.CraftingContainer;
 import net.minecraft.world.inventory.MenuType;
+import net.minecraft.world.item.Item;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.crafting.CraftingRecipe;
 import net.minecraft.world.item.crafting.Ingredient;
@@ -34,9 +35,9 @@ public class GenericRecipe implements IGenericRecipe
     public static IGenericRecipe of(@Nullable final Recipe<?> recipe, @Nullable final Level world)
     {
         if (recipe == null) return null;
-        final List<List<ItemStack>> inputs = recipe.getIngredients().stream()
+        final List<List<ItemStack>> inputs = compactInputs(recipe.getIngredients().stream()
                 .map(ingredient -> Arrays.asList(ingredient.getItems()))
-                .collect(Collectors.toList());
+                .collect(Collectors.toList()));
         final int size;
         final Block intermediate;
         if (recipe instanceof SmeltingRecipe)
@@ -264,5 +265,104 @@ public class GenericRecipe implements IGenericRecipe
             }
         }
         return Collections.emptyList();
+    }
+
+    private static List<List<ItemStack>> compactInputs(final List<List<ItemStack>> inputs)
+    {
+        // FYI, this largely does the same job as RecipeStorage.calculateCleanedInput(), but we can't re-use
+        // that implementation as we need to operate on Ingredients, which can be a list of stacks.
+        final Map<IngredientStacks, IngredientStacks> ingredients = new HashMap<>();
+
+        for (final List<ItemStack> ingredient : inputs)
+        {
+            final IngredientStacks newIngredient = new IngredientStacks(ingredient);
+            // also ignore the build tool as an ingredient, since colony crafters don't require it.
+            //   (see RecipeStorage.calculateCleanedInput() for why)
+            if (!newIngredient.getStacks().isEmpty() && newIngredient.getStacks().get(0).getItem() == buildTool.get()) continue;
+
+            final IngredientStacks existing = ingredients.get(newIngredient);
+            if (existing == null)
+            {
+                ingredients.put(newIngredient, newIngredient);
+            }
+            else
+            {
+                existing.merge(newIngredient);
+            }
+        }
+
+        return ingredients.values().stream()
+                .sorted(Comparator.reverseOrder())
+                .map(IngredientStacks::getStacks)
+                .collect(Collectors.toList());
+    }
+
+    private static class IngredientStacks implements Comparable<IngredientStacks>
+    {
+        private final List<ItemStack> stacks;
+        private final Set<Item> items;
+
+        public IngredientStacks(final List<ItemStack> ingredient)
+        {
+            this.stacks = ingredient.stream()
+                    .filter(stack -> !stack.isEmpty())
+                    .map(ItemStack::copy)
+                    .collect(Collectors.toList());
+
+            this.items = this.stacks.stream()
+                    .map(ItemStack::getItem)
+                    .collect(Collectors.toSet());
+        }
+
+        @NotNull
+        public List<ItemStack> getStacks() { return this.stacks; }
+
+        public int getCount() { return this.stacks.isEmpty() ? 0 : this.stacks.get(0).getCount(); }
+
+        @Override
+        public boolean equals(Object o)
+        {
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
+            final IngredientStacks that = (IngredientStacks) o;
+            return this.items.equals(that.items);
+            // note that this does not compare the counts to maintain key-stability
+        }
+
+        @Override
+        public int hashCode()
+        {
+            return this.items.hashCode();
+        }
+
+        @Override
+        public int compareTo(@NotNull IngredientStacks o)
+        {
+            int diff = this.getCount() - o.getCount();
+            if (diff != 0) return diff;
+
+            diff = this.stacks.size() - o.stacks.size();
+            if (diff != 0) return diff;
+
+            return this.hashCode() - o.hashCode();
+        }
+
+        public void merge(@NotNull final IngredientStacks other)
+        {
+            // assumes equals(other)
+            for (int i = 0; i < this.stacks.size(); i++)
+            {
+                this.stacks.get(i).grow(other.stacks.get(i).getCount());
+            }
+        }
+
+        @Override
+        public String toString()
+        {
+            return "IngredientStacks{" +
+                    "stacks=" + stacks +
+                    ", items=" + items +
+                    '}';
+        }
     }
 }

--- a/src/api/java/com/minecolonies/api/crafting/GenericRecipe.java
+++ b/src/api/java/com/minecolonies/api/crafting/GenericRecipe.java
@@ -35,6 +35,7 @@ public class GenericRecipe implements IGenericRecipe
     public static IGenericRecipe of(@Nullable final Recipe<?> recipe, @Nullable final Level world)
     {
         if (recipe == null) return null;
+
         final List<List<ItemStack>> inputs = compactInputs(recipe.getIngredients().stream()
                 .map(ingredient -> Arrays.asList(ingredient.getItems()))
                 .collect(Collectors.toList()));

--- a/src/api/java/com/minecolonies/api/crafting/ModCraftingTypes.java
+++ b/src/api/java/com/minecolonies/api/crafting/ModCraftingTypes.java
@@ -1,0 +1,24 @@
+package com.minecolonies.api.crafting;
+
+import com.minecolonies.api.crafting.registry.CraftingType;
+import net.minecraft.resources.ResourceLocation;
+
+import static com.minecolonies.api.util.constant.Constants.MOD_ID;
+
+public class ModCraftingTypes
+{
+    public static final ResourceLocation SMALL_CRAFTING_ID = new ResourceLocation(MOD_ID, "smallcrafting");
+    public static final ResourceLocation LARGE_CRAFTING_ID = new ResourceLocation(MOD_ID, "largecrafting");
+    public static final ResourceLocation SMELTING_ID = new ResourceLocation(MOD_ID, "smelting");
+    public static final ResourceLocation BREWING_ID = new ResourceLocation(MOD_ID, "brewing");
+
+    public static CraftingType SMALL_CRAFTING;
+    public static CraftingType LARGE_CRAFTING;
+    public static CraftingType SMELTING;
+    public static CraftingType BREWING;
+
+    private ModCraftingTypes()
+    {
+        throw new IllegalStateException("Tried to initialize: ModCraftingTypes but this is a Utility class.");
+    }
+}

--- a/src/api/java/com/minecolonies/api/crafting/ModCraftingTypes.java
+++ b/src/api/java/com/minecolonies/api/crafting/ModCraftingTypes.java
@@ -11,11 +11,13 @@ public class ModCraftingTypes
     public static final ResourceLocation LARGE_CRAFTING_ID = new ResourceLocation(MOD_ID, "largecrafting");
     public static final ResourceLocation SMELTING_ID = new ResourceLocation(MOD_ID, "smelting");
     public static final ResourceLocation BREWING_ID = new ResourceLocation(MOD_ID, "brewing");
+    public static final ResourceLocation ARCHITECTS_CUTTER_ID = new ResourceLocation("domum_ornamentum", "architects_cutter");
 
     public static CraftingType SMALL_CRAFTING;
     public static CraftingType LARGE_CRAFTING;
     public static CraftingType SMELTING;
     public static CraftingType BREWING;
+    public static CraftingType ARCHITECTS_CUTTER;
 
     private ModCraftingTypes()
     {

--- a/src/api/java/com/minecolonies/api/crafting/RecipeCraftingType.java
+++ b/src/api/java/com/minecolonies/api/crafting/RecipeCraftingType.java
@@ -1,0 +1,74 @@
+package com.minecolonies.api.crafting;
+
+import com.minecolonies.api.crafting.registry.CraftingType;
+import com.minecolonies.api.util.Log;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.world.Container;
+import net.minecraft.world.item.crafting.Recipe;
+import net.minecraft.world.item.crafting.RecipeManager;
+import net.minecraft.world.item.crafting.RecipeType;
+import net.minecraft.world.level.Level;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.Predicate;
+
+/**
+ * A {@link CraftingType} for the vanilla {@link RecipeType}
+ * @param <C> the crafting inventory type
+ * @param <T> the recipe type
+ */
+public class RecipeCraftingType<C extends Container, T extends Recipe<C>> extends CraftingType
+{
+    private final RecipeType<T> recipeType;
+    private final Predicate<Recipe<C>> predicate;
+
+    /**
+     * Create a new instance
+     * @param id the crafting type id
+     * @param recipeType the vanilla recipe type
+     * @param predicate filter acceptable recipes, or null to accept all
+     */
+    public RecipeCraftingType(@NotNull final ResourceLocation id,
+                              @NotNull final RecipeType<T> recipeType,
+                              @Nullable final Predicate<Recipe<C>> predicate)
+    {
+        super(id);
+        this.recipeType = recipeType;
+        this.predicate = predicate;
+    }
+
+    @Override
+    @NotNull
+    public List<IGenericRecipe> findRecipes(@NotNull RecipeManager recipeManager,
+                                            @Nullable final Level world)
+    {
+        final List<IGenericRecipe> recipes = new ArrayList<>();
+        for (final Recipe<C> recipe : recipeManager.byType(recipeType).values())
+        {
+            if (predicate != null && !predicate.test(recipe)) continue;
+
+            tryAddingVanillaRecipe(recipes, recipe, world);
+        }
+        return recipes;
+    }
+
+    private static void tryAddingVanillaRecipe(@NotNull final List<IGenericRecipe> recipes,
+                                               @NotNull final Recipe<?> recipe,
+                                               @Nullable final Level world)
+    {
+        if (recipe.getResultItem().isEmpty()) return;     // invalid or special recipes
+        try
+        {
+            final IGenericRecipe genericRecipe = GenericRecipe.of(recipe, world);
+            if (genericRecipe == null || genericRecipe.getInputs().isEmpty()) return;
+            recipes.add(genericRecipe);
+        }
+        catch (final Exception ex)
+        {
+            Log.getLogger().warn("Error evaluating recipe " + recipe.getId() + "; ignoring.", ex);
+        }
+    }
+}

--- a/src/api/java/com/minecolonies/api/crafting/RecipeCraftingType.java
+++ b/src/api/java/com/minecolonies/api/crafting/RecipeCraftingType.java
@@ -23,7 +23,7 @@ import java.util.function.Predicate;
 public class RecipeCraftingType<C extends Container, T extends Recipe<C>> extends CraftingType
 {
     private final RecipeType<T> recipeType;
-    private final Predicate<Recipe<C>> predicate;
+    private final Predicate<T> predicate;
 
     /**
      * Create a new instance
@@ -33,7 +33,7 @@ public class RecipeCraftingType<C extends Container, T extends Recipe<C>> extend
      */
     public RecipeCraftingType(@NotNull final ResourceLocation id,
                               @NotNull final RecipeType<T> recipeType,
-                              @Nullable final Predicate<Recipe<C>> predicate)
+                              @Nullable final Predicate<T> predicate)
     {
         super(id);
         this.recipeType = recipeType;
@@ -46,7 +46,7 @@ public class RecipeCraftingType<C extends Container, T extends Recipe<C>> extend
                                             @Nullable final Level world)
     {
         final List<IGenericRecipe> recipes = new ArrayList<>();
-        for (final Recipe<C> recipe : recipeManager.byType(recipeType).values())
+        for (final T recipe : recipeManager.getAllRecipesFor(recipeType))
         {
             if (predicate != null && !predicate.test(recipe)) continue;
 

--- a/src/api/java/com/minecolonies/api/crafting/registry/CraftingType.java
+++ b/src/api/java/com/minecolonies/api/crafting/registry/CraftingType.java
@@ -1,0 +1,49 @@
+package com.minecolonies.api.crafting.registry;
+
+import com.minecolonies.api.crafting.IGenericRecipe;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.world.item.crafting.RecipeManager;
+import net.minecraft.world.level.Level;
+import net.minecraftforge.registries.ForgeRegistryEntry;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * Class to represent the different types of crafting supported by MineColonies
+ */
+public abstract class CraftingType extends ForgeRegistryEntry<CraftingType>
+{
+    protected CraftingType(@NotNull final ResourceLocation id)
+    {
+        setRegistryName(id);
+    }
+
+    /**
+     * Find all teachable recipes supported by this particular crafting type
+     * @param recipeManager the vanilla recipe manager
+     * @param world the world (if available)
+     * @return the list of teachable recipes
+     */
+    @NotNull
+    public abstract List<IGenericRecipe> findRecipes(@NotNull final RecipeManager recipeManager,
+                                                     @Nullable final Level world);
+
+    @Override
+    public boolean equals(Object obj)
+    {
+        if (obj instanceof CraftingType)
+        {
+            return Objects.equals(getRegistryName(), ((CraftingType) obj).getRegistryName());
+        }
+        return false;
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return getRegistryName().hashCode();
+    }
+}

--- a/src/api/java/com/minecolonies/api/entity/pathfinding/PathingStuckHandler.java
+++ b/src/api/java/com/minecolonies/api/entity/pathfinding/PathingStuckHandler.java
@@ -1,6 +1,7 @@
 package com.minecolonies.api.entity.pathfinding;
 
 import com.minecolonies.api.entity.ai.citizen.builder.IBuilderUndestroyable;
+import com.minecolonies.api.items.ModTags;
 import com.minecolonies.api.util.BlockPosUtil;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;

--- a/src/datagen/generated/minecolonies/data/minecolonies/tags/blocks/validspawnblocks.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/tags/blocks/validspawnblocks.json
@@ -3,6 +3,7 @@
   "values": [
     "#minecraft:buttons",
     "#minecraft:rails",
+    "#minecraft:carpets",
     "minecraft:air",
     "minecraft:cave_air",
     "minecraft:snow",

--- a/src/datagen/generated/minecolonies/data/minecolonies/tags/items/plantation_ingredient.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/tags/items/plantation_ingredient.json
@@ -1,6 +1,8 @@
 {
   "replace": false,
   "values": [
-    "minecraft:bamboo"
+    "minecraft:bamboo",
+    "domum_ornamentum:paper_extra",
+    "domum_ornamentum:white_paper_extra"
   ]
 }

--- a/src/datagen/generated/minecolonies/data/minecolonies/tags/items/plantation_product.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/tags/items/plantation_product.json
@@ -4,6 +4,8 @@
     "minecraft:book",
     "minecraft:paper",
     "minecraft:sugar",
-    "minecraft:writable_book"
+    "minecraft:writable_book",
+    "domum_ornamentum:paper_extra",
+    "domum_ornamentum:white_paper_extra"
   ]
 }

--- a/src/datagen/generated/minecolonies/data/minecolonies/tags/items/stonemason_product_excluded.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/tags/items/stonemason_product_excluded.json
@@ -5,6 +5,8 @@
     "#minecraft:wooden_slabs",
     "#minecraft:wooden_stairs",
     "minecraft:lectern",
-    "minecraft:piston"
+    "minecraft:piston",
+    "domum_ornamentum:paper_extra",
+    "domum_ornamentum:white_paper_extra"
   ]
 }

--- a/src/main/java/com/minecolonies/apiimp/CommonMinecoloniesAPIImpl.java
+++ b/src/main/java/com/minecolonies/apiimp/CommonMinecoloniesAPIImpl.java
@@ -17,6 +17,7 @@ import com.minecolonies.api.colony.jobs.registry.IJobDataManager;
 import com.minecolonies.api.colony.jobs.registry.JobEntry;
 import com.minecolonies.api.compatibility.IFurnaceRecipes;
 import com.minecolonies.api.configuration.Configuration;
+import com.minecolonies.api.crafting.registry.CraftingType;
 import com.minecolonies.api.crafting.registry.RecipeTypeEntry;
 import com.minecolonies.api.entity.ai.registry.IMobAIRegistry;
 import com.minecolonies.api.entity.pathfinding.registry.IPathNavigateRegistry;
@@ -63,6 +64,7 @@ public class CommonMinecoloniesAPIImpl implements IMinecoloniesAPI
     private        IForgeRegistry<ResearchRequirementEntry>                researchRequirementRegistry;
     private        IForgeRegistry<ResearchEffectEntry>                     researchEffectRegistry;
     private        IForgeRegistry<RecipeTypeEntry>                         recipeTypeEntryRegistry;
+    private        IForgeRegistry<CraftingType>                            craftingTypeRegistry;
 
     @Override
     @NotNull
@@ -223,6 +225,11 @@ public class CommonMinecoloniesAPIImpl implements IMinecoloniesAPI
                 .disableSaving().allowModification().setType(ColonyEventDescriptionTypeRegistryEntry.class)
                 .setIDRange(0, Integer.MAX_VALUE - 1).create();
 
+        craftingTypeRegistry = new RegistryBuilder<CraftingType>()
+                .setName(new ResourceLocation(Constants.MOD_ID, "craftingtypes"))
+                .disableSaving().allowModification().setType(CraftingType.class)
+                .setIDRange(0, Integer.MAX_VALUE - 1).create();
+
         recipeTypeEntryRegistry = new RegistryBuilder<RecipeTypeEntry>()
                                     .setName(new ResourceLocation(Constants.MOD_ID, "recipetypeentries"))
                                     .setDefaultKey(new ResourceLocation(Constants.MOD_ID, "classic"))
@@ -258,6 +265,12 @@ public class CommonMinecoloniesAPIImpl implements IMinecoloniesAPI
     public IForgeRegistry<RecipeTypeEntry> getRecipeTypeRegistry()
     {
         return recipeTypeEntryRegistry;
+    }
+
+    @Override
+    public IForgeRegistry<CraftingType> getCraftingTypeRegistry()
+    {
+        return craftingTypeRegistry;
     }
 }
 

--- a/src/main/java/com/minecolonies/apiimp/initializer/ModCraftingTypesInitializer.java
+++ b/src/main/java/com/minecolonies/apiimp/initializer/ModCraftingTypesInitializer.java
@@ -1,0 +1,38 @@
+package com.minecolonies.apiimp.initializer;
+
+import com.minecolonies.api.crafting.ModCraftingTypes;
+import com.minecolonies.api.crafting.RecipeCraftingType;
+import com.minecolonies.api.crafting.registry.CraftingType;
+import com.minecolonies.coremod.recipes.BrewingCraftingType;
+import net.minecraft.world.item.crafting.RecipeType;
+import net.minecraftforge.event.RegistryEvent;
+import net.minecraftforge.registries.IForgeRegistry;
+
+public final class ModCraftingTypesInitializer
+{
+    private ModCraftingTypesInitializer()
+    {
+        throw new IllegalStateException("Tried to initialize: ModCraftingTypesInitializer but this is a Utility class.");
+    }
+
+    public static void init(final RegistryEvent.Register<CraftingType> event)
+    {
+        final IForgeRegistry<CraftingType> reg = event.getRegistry();
+
+        ModCraftingTypes.SMALL_CRAFTING = new RecipeCraftingType<>(ModCraftingTypes.SMALL_CRAFTING_ID,
+                RecipeType.CRAFTING, r -> r.canCraftInDimensions(2, 2));
+        reg.register(ModCraftingTypes.SMALL_CRAFTING);
+
+        ModCraftingTypes.LARGE_CRAFTING = new RecipeCraftingType<>(ModCraftingTypes.LARGE_CRAFTING_ID,
+                RecipeType.CRAFTING, r -> r.canCraftInDimensions(3, 3)
+                    && !r.canCraftInDimensions(2, 2));
+        reg.register(ModCraftingTypes.LARGE_CRAFTING);
+
+        ModCraftingTypes.SMELTING = new RecipeCraftingType<>(ModCraftingTypes.SMELTING_ID,
+                RecipeType.SMELTING, null);
+        reg.register(ModCraftingTypes.SMELTING);
+
+        ModCraftingTypes.BREWING = new BrewingCraftingType();
+        reg.register(ModCraftingTypes.BREWING);
+    }
+}

--- a/src/main/java/com/minecolonies/apiimp/initializer/ModCraftingTypesInitializer.java
+++ b/src/main/java/com/minecolonies/apiimp/initializer/ModCraftingTypesInitializer.java
@@ -3,6 +3,7 @@ package com.minecolonies.apiimp.initializer;
 import com.minecolonies.api.crafting.ModCraftingTypes;
 import com.minecolonies.api.crafting.RecipeCraftingType;
 import com.minecolonies.api.crafting.registry.CraftingType;
+import com.minecolonies.coremod.recipes.ArchitectsCutterCraftingType;
 import com.minecolonies.coremod.recipes.BrewingCraftingType;
 import net.minecraft.world.item.crafting.RecipeType;
 import net.minecraftforge.event.RegistryEvent;
@@ -34,5 +35,8 @@ public final class ModCraftingTypesInitializer
 
         ModCraftingTypes.BREWING = new BrewingCraftingType();
         reg.register(ModCraftingTypes.BREWING);
+
+        ModCraftingTypes.ARCHITECTS_CUTTER = new ArchitectsCutterCraftingType();
+        reg.register(ModCraftingTypes.ARCHITECTS_CUTTER);
     }
 }

--- a/src/main/java/com/minecolonies/coremod/client/gui/containers/WindowCrafting.java
+++ b/src/main/java/com/minecolonies/coremod/client/gui/containers/WindowCrafting.java
@@ -1,6 +1,5 @@
 package com.minecolonies.coremod.client.gui.containers;
 
-import com.ldtteam.structurize.util.LanguageHandler;
 import com.minecolonies.api.colony.IColonyManager;
 import com.minecolonies.api.crafting.ItemStorage;
 import com.minecolonies.api.crafting.ModCraftingTypes;
@@ -11,18 +10,19 @@ import com.minecolonies.coremod.Network;
 import com.minecolonies.coremod.colony.buildings.moduleviews.CraftingModuleView;
 import com.minecolonies.coremod.colony.buildings.views.AbstractBuildingView;
 import com.minecolonies.coremod.network.messages.server.colony.building.worker.AddRemoveRecipeMessage;
-import com.mojang.blaze3d.vertex.PoseStack;
 import com.mojang.blaze3d.systems.RenderSystem;
-import net.minecraft.client.gui.screens.inventory.AbstractContainerScreen;
+import com.mojang.blaze3d.vertex.PoseStack;
 import net.minecraft.client.gui.components.Button;
+import net.minecraft.client.gui.screens.inventory.AbstractContainerScreen;
 import net.minecraft.client.renderer.GameRenderer;
 import net.minecraft.client.resources.language.I18n;
-import net.minecraft.network.chat.TranslatableComponent;
-import net.minecraft.world.entity.player.Inventory;
-import net.minecraft.world.item.ItemStack;
-import net.minecraft.resources.ResourceLocation;
 import net.minecraft.network.chat.Component;
 import net.minecraft.network.chat.TextComponent;
+import net.minecraft.network.chat.TranslatableComponent;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.world.entity.player.Inventory;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.crafting.RecipeType;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.LinkedList;

--- a/src/main/java/com/minecolonies/coremod/client/gui/containers/WindowCrafting.java
+++ b/src/main/java/com/minecolonies/coremod/client/gui/containers/WindowCrafting.java
@@ -3,6 +3,7 @@ package com.minecolonies.coremod.client.gui.containers;
 import com.ldtteam.structurize.util.LanguageHandler;
 import com.minecolonies.api.colony.IColonyManager;
 import com.minecolonies.api.crafting.ItemStorage;
+import com.minecolonies.api.crafting.ModCraftingTypes;
 import com.minecolonies.api.inventory.container.ContainerCrafting;
 import com.minecolonies.api.util.ItemStackUtils;
 import com.minecolonies.api.util.constant.Constants;
@@ -108,7 +109,7 @@ public class WindowCrafting extends AbstractContainerScreen<ContainerCrafting>
         super(container, playerInventory, iTextComponent);
         this.building = (AbstractBuildingView) IColonyManager.getInstance().getBuildingView(playerInventory.player.level.dimension(), container.getPos());
         this.module = building.getModuleViewMatching(CraftingModuleView.class, v -> v.getId().equals(container.getModuleId()));
-        completeCrafting = module.canLearnLargeRecipes();
+        completeCrafting = module.canLearn(ModCraftingTypes.LARGE_CRAFTING);
     }
 
     @NotNull
@@ -126,14 +127,14 @@ public class WindowCrafting extends AbstractContainerScreen<ContainerCrafting>
     protected void init()
     {
         super.init();
-        final String buttonDisplay = module.canLearnCraftingRecipes() ? I18n.get("gui.done") : new TranslatableComponent("com.minecolonies.coremod.gui.recipe.full").getString();
+        final String buttonDisplay = module.canLearn(ModCraftingTypes.SMALL_CRAFTING) ? I18n.get("gui.done") : new TranslatableComponent("com.minecolonies.coremod.gui.recipe.full").getString();
         /*
          * The button to click done after finishing the recipe.
          */
         final Button
           doneButton = new Button(leftPos + BUTTON_X_OFFSET, topPos + BUTTON_Y_POS, BUTTON_WIDTH, BUTTON_HEIGHT, new TextComponent(buttonDisplay), new WindowCrafting.OnButtonPress());
         this.addRenderableWidget(doneButton);
-        if (!module.canLearnCraftingRecipes())
+        if (!module.canLearn(ModCraftingTypes.SMALL_CRAFTING))
         {
             doneButton.active = false;
         }
@@ -145,7 +146,7 @@ public class WindowCrafting extends AbstractContainerScreen<ContainerCrafting>
         @Override
         public void onPress(final Button button)
         {
-            if (module.canLearnCraftingRecipes())
+            if (module.canLearn(ModCraftingTypes.SMALL_CRAFTING))
             {
                 final List<ItemStorage> input = new LinkedList<>();
 

--- a/src/main/java/com/minecolonies/coremod/client/gui/containers/WindowFurnaceCrafting.java
+++ b/src/main/java/com/minecolonies/coremod/client/gui/containers/WindowFurnaceCrafting.java
@@ -4,6 +4,7 @@ import com.google.common.collect.ImmutableList;
 import com.ldtteam.structurize.util.LanguageHandler;
 import com.minecolonies.api.colony.IColonyManager;
 import com.minecolonies.api.crafting.ItemStorage;
+import com.minecolonies.api.crafting.ModCraftingTypes;
 import com.minecolonies.api.inventory.container.ContainerCraftingFurnace;
 import com.minecolonies.api.util.ItemStackUtils;
 import com.minecolonies.api.util.constant.Constants;
@@ -95,13 +96,13 @@ public class WindowFurnaceCrafting extends AbstractContainerScreen<ContainerCraf
     protected void init()
     {
         super.init();
-        final String buttonDisplay = module.canLearnFurnaceRecipes() ? I18n.get("gui.done") : new TranslatableComponent("com.minecolonies.coremod.gui.recipe.full").getString();
+        final String buttonDisplay = module.canLearn(ModCraftingTypes.SMELTING) ? I18n.get("gui.done") : new TranslatableComponent("com.minecolonies.coremod.gui.recipe.full").getString();
         /*
          * The button to click done after finishing the recipe.
          */
         final Button doneButton = new Button(leftPos + BUTTON_X_OFFSET, topPos + BUTTON_Y_POS, BUTTON_WIDTH, BUTTON_HEIGHT, new TextComponent(buttonDisplay), new OnButtonPress());
         this.addRenderableWidget(doneButton);
-        if (!module.canLearnFurnaceRecipes())
+        if (!module.canLearn(ModCraftingTypes.SMELTING))
         {
             doneButton.active = false;
         }
@@ -112,7 +113,7 @@ public class WindowFurnaceCrafting extends AbstractContainerScreen<ContainerCraf
         @Override
         public void onPress(@NotNull final Button button)
         {
-            if (module.canLearnFurnaceRecipes())
+            if (module.canLearn(ModCraftingTypes.SMELTING))
             {
                 final List<ItemStorage> input = new ArrayList<>();
                 input.add(new ItemStorage(container.slots.get(0).getItem()));

--- a/src/main/java/com/minecolonies/coremod/client/gui/containers/WindowFurnaceCrafting.java
+++ b/src/main/java/com/minecolonies/coremod/client/gui/containers/WindowFurnaceCrafting.java
@@ -1,7 +1,6 @@
 package com.minecolonies.coremod.client.gui.containers;
 
 import com.google.common.collect.ImmutableList;
-import com.ldtteam.structurize.util.LanguageHandler;
 import com.minecolonies.api.colony.IColonyManager;
 import com.minecolonies.api.crafting.ItemStorage;
 import com.minecolonies.api.crafting.ModCraftingTypes;
@@ -12,18 +11,19 @@ import com.minecolonies.coremod.Network;
 import com.minecolonies.coremod.colony.buildings.moduleviews.CraftingModuleView;
 import com.minecolonies.coremod.colony.buildings.views.AbstractBuildingView;
 import com.minecolonies.coremod.network.messages.server.colony.building.worker.AddRemoveRecipeMessage;
-import com.mojang.blaze3d.vertex.PoseStack;
 import com.mojang.blaze3d.systems.RenderSystem;
-import net.minecraft.client.gui.screens.inventory.AbstractContainerScreen;
+import com.mojang.blaze3d.vertex.PoseStack;
 import net.minecraft.client.gui.components.Button;
+import net.minecraft.client.gui.screens.inventory.AbstractContainerScreen;
 import net.minecraft.client.renderer.GameRenderer;
 import net.minecraft.client.resources.language.I18n;
-import net.minecraft.network.chat.TranslatableComponent;
-import net.minecraft.world.entity.player.Inventory;
-import net.minecraft.world.item.ItemStack;
-import net.minecraft.resources.ResourceLocation;
 import net.minecraft.network.chat.Component;
 import net.minecraft.network.chat.TextComponent;
+import net.minecraft.network.chat.TranslatableComponent;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.world.entity.player.Inventory;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.crafting.RecipeType;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.ArrayList;

--- a/src/main/java/com/minecolonies/coremod/client/gui/modules/WindowListRecipes.java
+++ b/src/main/java/com/minecolonies/coremod/client/gui/modules/WindowListRecipes.java
@@ -3,7 +3,6 @@ package com.minecolonies.coremod.client.gui.modules;
 import com.ldtteam.blockui.Pane;
 import com.ldtteam.blockui.controls.*;
 import com.ldtteam.blockui.views.ScrollingList;
-import com.ldtteam.structurize.util.LanguageHandler;
 import com.minecolonies.api.colony.buildings.views.IBuildingView;
 import com.minecolonies.api.crafting.IRecipeStorage;
 import com.minecolonies.api.crafting.ItemStorage;
@@ -15,7 +14,6 @@ import com.minecolonies.coremod.network.messages.server.colony.building.worker.A
 import com.minecolonies.coremod.network.messages.server.colony.building.worker.ChangeRecipePriorityMessage;
 import com.minecolonies.coremod.network.messages.server.colony.building.worker.ToggleRecipeMessage;
 import com.mojang.blaze3d.platform.InputConstants;
-import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.screens.Screen;
 import net.minecraft.network.chat.TranslatableComponent;
 import net.minecraft.world.item.ItemStack;

--- a/src/main/java/com/minecolonies/coremod/client/gui/modules/WindowListRecipes.java
+++ b/src/main/java/com/minecolonies/coremod/client/gui/modules/WindowListRecipes.java
@@ -187,7 +187,7 @@ public class WindowListRecipes extends AbstractModuleWindow
                 List<ItemStack> displayStacks = recipe.getRecipeType().getOutputDisplayStacks();
                 icon.setItem(displayStacks.get((lifeCount / LIFE_COUNT_DIVIDER) % (displayStacks.size())));
 
-                if (!module.canLearnCraftingRecipes() && !module.canLearnFurnaceRecipes())
+                if (!module.isRecipeAlterationAllowed())
                 {
                     final Button removeButton = rowPane.findPaneOfTypeByID(BUTTON_REMOVE, Button.class);
                     if (removeButton != null)

--- a/src/main/java/com/minecolonies/coremod/colony/buildings/modules/AbstractCraftingBuildingModule.java
+++ b/src/main/java/com/minecolonies/coremod/colony/buildings/modules/AbstractCraftingBuildingModule.java
@@ -1,6 +1,5 @@
 package com.minecolonies.coremod.colony.buildings.modules;
 
-import com.google.common.collect.ImmutableSet;
 import com.minecolonies.api.MinecoloniesAPIProxy;
 import com.minecolonies.api.colony.ICitizenData;
 import com.minecolonies.api.colony.IColony;
@@ -31,20 +30,19 @@ import com.minecolonies.coremod.colony.crafting.CustomRecipeManager;
 import com.minecolonies.coremod.colony.jobs.AbstractJobCrafter;
 import com.minecolonies.coremod.colony.requestsystem.resolvers.PublicWorkerCraftingProductionResolver;
 import com.minecolonies.coremod.colony.requestsystem.resolvers.PublicWorkerCraftingRequestResolver;
-import net.minecraft.nbt.Tag;
-import net.minecraft.world.level.block.Blocks;
-import net.minecraft.world.entity.player.Player;
-import net.minecraft.world.item.ItemStack;
-import net.minecraft.world.level.storage.loot.LootContext;
-import net.minecraft.world.level.storage.loot.parameters.LootContextParams;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.nbt.ListTag;
+import net.minecraft.nbt.Tag;
 import net.minecraft.network.FriendlyByteBuf;
-import net.minecraft.resources.ResourceLocation;
-import net.minecraft.util.Tuple;
 import net.minecraft.network.chat.TranslatableComponent;
+import net.minecraft.resources.ResourceLocation;
 import net.minecraft.server.level.ServerLevel;
-
+import net.minecraft.util.Tuple;
+import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.level.block.Blocks;
+import net.minecraft.world.level.storage.loot.LootContext;
+import net.minecraft.world.level.storage.loot.parameters.LootContextParams;
 import net.minecraftforge.items.IItemHandler;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -930,7 +928,7 @@ public abstract class AbstractCraftingBuildingModule extends AbstractBuildingMod
         @Override
         public Set<CraftingType> getSupportedCraftingTypes()
         {
-            return ImmutableSet.of(ModCraftingTypes.SMALL_CRAFTING, ModCraftingTypes.LARGE_CRAFTING);
+            return Set.of(ModCraftingTypes.SMALL_CRAFTING, ModCraftingTypes.LARGE_CRAFTING);
         }
 
         @Override
@@ -967,7 +965,7 @@ public abstract class AbstractCraftingBuildingModule extends AbstractBuildingMod
         @Override
         public Set<CraftingType> getSupportedCraftingTypes()
         {
-            return ImmutableSet.of(ModCraftingTypes.SMELTING);
+            return Set.of(ModCraftingTypes.SMELTING);
         }
 
         @Override
@@ -1004,7 +1002,7 @@ public abstract class AbstractCraftingBuildingModule extends AbstractBuildingMod
         @Override
         public Set<CraftingType> getSupportedCraftingTypes()
         {
-            return ImmutableSet.of();
+            return Set.of();
         }
 
         @Override

--- a/src/main/java/com/minecolonies/coremod/colony/buildings/modules/AbstractCraftingBuildingModule.java
+++ b/src/main/java/com/minecolonies/coremod/colony/buildings/modules/AbstractCraftingBuildingModule.java
@@ -1,5 +1,7 @@
 package com.minecolonies.coremod.colony.buildings.modules;
 
+import com.google.common.collect.ImmutableSet;
+import com.minecolonies.api.MinecoloniesAPIProxy;
 import com.minecolonies.api.colony.ICitizenData;
 import com.minecolonies.api.colony.IColony;
 import com.minecolonies.api.colony.IColonyManager;
@@ -16,6 +18,7 @@ import com.minecolonies.api.colony.requestsystem.requestable.crafting.PublicCraf
 import com.minecolonies.api.colony.requestsystem.resolver.IRequestResolver;
 import com.minecolonies.api.colony.requestsystem.token.IToken;
 import com.minecolonies.api.crafting.*;
+import com.minecolonies.api.crafting.registry.CraftingType;
 import com.minecolonies.api.entity.citizen.AbstractEntityCitizen;
 import com.minecolonies.api.items.ModTags;
 import com.minecolonies.api.util.*;
@@ -143,14 +146,10 @@ public abstract class AbstractCraftingBuildingModule extends AbstractBuildingMod
      */
     protected int getMaxRecipes()
     {
-        final double increase;
-        if(canLearnLargeRecipes() || canLearnFurnaceRecipes())
+        double increase = 1 + building.getColony().getResearchManager().getResearchEffects().getEffectStrength(RECIPES);
+        if (canLearnManyRecipes())
         {
-            increase = (1 + building.getColony().getResearchManager().getResearchEffects().getEffectStrength(RECIPES)) * EXTRA_RECIPE_MULTIPLIER;
-        }
-        else
-        {
-            increase = 1 + building.getColony().getResearchManager().getResearchEffects().getEffectStrength(RECIPES);
+            increase *= EXTRA_RECIPE_MULTIPLIER;
         }
         return (int) (Math.pow(2, building.getBuildingLevel()) * increase);
     }
@@ -259,9 +258,13 @@ public abstract class AbstractCraftingBuildingModule extends AbstractBuildingMod
         {
             buf.writeBoolean(false);
         }
-        buf.writeBoolean(this.canLearnCraftingRecipes());
-        buf.writeBoolean(this.canLearnFurnaceRecipes());
-        buf.writeBoolean(this.canLearnLargeRecipes());
+
+        final Set<CraftingType> craftingTypes = this.getSupportedCraftingTypes();
+        buf.writeVarInt(craftingTypes.size());
+        for (final CraftingType type : craftingTypes)
+        {
+            buf.writeRegistryIdUnsafe(MinecoloniesAPIProxy.getInstance().getCraftingTypeRegistry(), type);
+        }
 
         final List<IRecipeStorage> storages = new ArrayList<>();
         final List<IRecipeStorage> disabledStorages = new ArrayList<>();
@@ -905,6 +908,12 @@ public abstract class AbstractCraftingBuildingModule extends AbstractBuildingMod
         return stack -> Optional.empty();
     }
 
+    @Override
+    public boolean canLearnManyRecipes()
+    {
+        return true;
+    }
+
     /** This module is for standard crafters (3x3 by default) */
     public abstract static class Crafting extends AbstractCraftingBuildingModule
     {
@@ -919,18 +928,15 @@ public abstract class AbstractCraftingBuildingModule extends AbstractBuildingMod
         }
 
         @Override
-        public boolean canLearnCraftingRecipes() { return true; }
-
-        @Override
-        public boolean canLearnFurnaceRecipes() { return false; }
-
-        @Override
-        public boolean canLearnLargeRecipes() { return true; }
+        public Set<CraftingType> getSupportedCraftingTypes()
+        {
+            return ImmutableSet.of(ModCraftingTypes.SMALL_CRAFTING, ModCraftingTypes.LARGE_CRAFTING);
+        }
 
         @Override
         public boolean isRecipeCompatible(@NotNull final IGenericRecipe recipe)
         {
-            return canLearnCraftingRecipes() &&
+            return canLearn(ModCraftingTypes.SMALL_CRAFTING) &&
                     recipe.getIntermediate() == Blocks.AIR;
         }
 
@@ -959,18 +965,15 @@ public abstract class AbstractCraftingBuildingModule extends AbstractBuildingMod
         }
 
         @Override
-        public boolean canLearnCraftingRecipes() { return false; }
-
-        @Override
-        public boolean canLearnFurnaceRecipes() { return true; }
-
-        @Override
-        public boolean canLearnLargeRecipes() { return false; }
+        public Set<CraftingType> getSupportedCraftingTypes()
+        {
+            return ImmutableSet.of(ModCraftingTypes.SMELTING);
+        }
 
         @Override
         public boolean isRecipeCompatible(@NotNull final IGenericRecipe recipe)
         {
-            return canLearnFurnaceRecipes() &&
+            return canLearn(ModCraftingTypes.SMELTING) &&
                     recipe.getIntermediate() == Blocks.FURNACE;
         }
 
@@ -999,13 +1002,10 @@ public abstract class AbstractCraftingBuildingModule extends AbstractBuildingMod
         }
 
         @Override
-        public boolean canLearnCraftingRecipes() { return false; }
-
-        @Override
-        public boolean canLearnFurnaceRecipes() { return false; }
-
-        @Override
-        public boolean canLearnLargeRecipes() { return false; }
+        public Set<CraftingType> getSupportedCraftingTypes()
+        {
+            return ImmutableSet.of();
+        }
 
         @Override
         public boolean isRecipeCompatible(@NotNull final IGenericRecipe recipe) { return false; }

--- a/src/main/java/com/minecolonies/coremod/colony/buildings/modules/AbstractDOCraftingBuildingModule.java
+++ b/src/main/java/com/minecolonies/coremod/colony/buildings/modules/AbstractDOCraftingBuildingModule.java
@@ -1,0 +1,59 @@
+package com.minecolonies.coremod.colony.buildings.modules;
+
+import com.minecolonies.api.colony.jobs.registry.JobEntry;
+import com.minecolonies.api.crafting.IGenericRecipe;
+import com.minecolonies.api.crafting.ModCraftingTypes;
+import com.minecolonies.api.crafting.registry.CraftingType;
+import com.minecolonies.api.util.ItemStackUtils;
+import com.minecolonies.api.util.OptionalPredicate;
+import net.minecraft.world.item.ItemStack;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.List;
+import java.util.Set;
+
+/**
+ * An abstract crafting module for Domum Ornamentum cutter recipes
+ */
+public abstract class AbstractDOCraftingBuildingModule extends AbstractCraftingBuildingModule.Custom
+{
+    protected AbstractDOCraftingBuildingModule(@NotNull final JobEntry jobEntry)
+    {
+        super(jobEntry);
+    }
+
+    // ideally this should override getId() and return something DO-ish and not "custom" (which would also let a
+    // more appropriate icon be shown in the UI), but changing that now would break the existing saved recipes
+    // without a special upgrade...
+
+    @Override
+    public Set<CraftingType> getSupportedCraftingTypes()
+    {
+        return Set.of(ModCraftingTypes.ARCHITECTS_CUTTER);
+    }
+
+    @Override
+    public boolean isRecipeCompatible(final @NotNull IGenericRecipe recipe)
+    {
+        final OptionalPredicate<ItemStack> validator = getIngredientValidator();
+        final ItemStack stack = recipe.getPrimaryOutput();
+        if (stack.getItem().getRegistryName().getNamespace().equals("domum_ornamentum"))
+        {
+            for (final List<ItemStack> slot : recipe.getInputs())
+            {
+                // when teaching there should only be one stack in each slot; for JEI there may be more.
+                // any one compatible ingredient in any slot makes the whole recipe acceptable.
+                for (final ItemStack ingredientStack : slot)
+                {
+                    if (!ItemStackUtils.isEmpty(stack) && validator.test(ingredientStack).orElse(false))
+                    {
+                        return true;
+                    }
+                }
+            }
+        }
+        return false;
+    }
+
+    // override getIngredientValidator() to limit compatible ingredients
+}

--- a/src/main/java/com/minecolonies/coremod/colony/buildings/modules/SimpleCraftingModule.java
+++ b/src/main/java/com/minecolonies/coremod/colony/buildings/modules/SimpleCraftingModule.java
@@ -1,6 +1,5 @@
 package com.minecolonies.coremod.colony.buildings.modules;
 
-import com.google.common.collect.ImmutableSet;
 import com.minecolonies.api.colony.jobs.IJob;
 import com.minecolonies.api.colony.jobs.registry.JobEntry;
 import com.minecolonies.api.colony.requestsystem.resolver.IRequestResolver;
@@ -52,6 +51,6 @@ public class SimpleCraftingModule extends AbstractCraftingBuildingModule.Craftin
     @Override
     public Set<CraftingType> getSupportedCraftingTypes()
     {
-        return ImmutableSet.of(ModCraftingTypes.SMALL_CRAFTING);
+        return Set.of(ModCraftingTypes.SMALL_CRAFTING);
     }
 }

--- a/src/main/java/com/minecolonies/coremod/colony/buildings/modules/SimpleCraftingModule.java
+++ b/src/main/java/com/minecolonies/coremod/colony/buildings/modules/SimpleCraftingModule.java
@@ -1,12 +1,16 @@
 package com.minecolonies.coremod.colony.buildings.modules;
 
+import com.google.common.collect.ImmutableSet;
 import com.minecolonies.api.colony.jobs.IJob;
 import com.minecolonies.api.colony.jobs.registry.JobEntry;
 import com.minecolonies.api.colony.requestsystem.resolver.IRequestResolver;
+import com.minecolonies.api.crafting.ModCraftingTypes;
+import com.minecolonies.api.crafting.registry.CraftingType;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.Collections;
 import java.util.List;
+import java.util.Set;
 
 /**
  * This module is used for the buildings that only support simple
@@ -40,8 +44,14 @@ public class SimpleCraftingModule extends AbstractCraftingBuildingModule.Craftin
     }
 
     @Override
-    public boolean canLearnLargeRecipes()
+    public boolean canLearnManyRecipes()
     {
         return false;
+    }
+
+    @Override
+    public Set<CraftingType> getSupportedCraftingTypes()
+    {
+        return ImmutableSet.of(ModCraftingTypes.SMALL_CRAFTING);
     }
 }

--- a/src/main/java/com/minecolonies/coremod/colony/buildings/moduleviews/CraftingModuleView.java
+++ b/src/main/java/com/minecolonies/coremod/colony/buildings/moduleviews/CraftingModuleView.java
@@ -1,10 +1,12 @@
 package com.minecolonies.coremod.colony.buildings.moduleviews;
 
 import com.ldtteam.blockui.views.BOWindow;
+import com.minecolonies.api.MinecoloniesAPIProxy;
 import com.minecolonies.api.colony.buildings.modules.AbstractBuildingModuleView;
 import com.minecolonies.api.colony.jobs.registry.JobEntry;
 import com.minecolonies.api.colony.requestsystem.StandardFactoryController;
 import com.minecolonies.api.crafting.IRecipeStorage;
+import com.minecolonies.api.crafting.registry.CraftingType;
 import com.minecolonies.api.util.constant.Constants;
 import com.minecolonies.coremod.Network;
 import com.minecolonies.coremod.client.gui.modules.WindowListRecipes;
@@ -21,7 +23,9 @@ import org.jetbrains.annotations.Nullable;
 
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
 /**
  * Client side representation of the crafting module.
@@ -41,9 +45,7 @@ public class CraftingModuleView extends AbstractBuildingModuleView
     /**
      * Different flags.
      */
-    private boolean canLearnCraftingRecipes;
-    private boolean canLearnFurnaceRecipes;
-    private boolean canLearnLargeRecipes;
+    private Set<CraftingType> recipeTypeSet = new HashSet<>();
 
     /**
      * The list of recipes the worker knows, correspond to a subset of the recipes in the colony.
@@ -77,9 +79,16 @@ public class CraftingModuleView extends AbstractBuildingModuleView
             this.jobEntry = null;
         }
 
-        this.canLearnCraftingRecipes = buf.readBoolean();
-        this.canLearnFurnaceRecipes = buf.readBoolean();
-        this.canLearnLargeRecipes = buf.readBoolean();
+        recipeTypeSet.clear();
+        final int size = buf.readVarInt();
+        for (int i = 0; i < size; ++i)
+        {
+            final CraftingType type = buf.readRegistryIdUnsafe(MinecoloniesAPIProxy.getInstance().getCraftingTypeRegistry());
+            if (type != null)
+            {
+                recipeTypeSet.add(type);
+            }
+        }
 
         recipes.clear();
         disabledRecipes.clear();
@@ -125,15 +134,27 @@ public class CraftingModuleView extends AbstractBuildingModuleView
      */
     public boolean isRecipeAlterationAllowed()
     {
-        return canLearnCraftingRecipes || canLearnFurnaceRecipes;
+        return !recipeTypeSet.isEmpty();
     }
 
-    /** True if this module can be taught crafting recipes. */
-    public boolean canLearnCraftingRecipes() { return this.canLearnCraftingRecipes; }
-    /** True if this module can be taught smelting recipes. */
-    public boolean canLearnFurnaceRecipes() { return this.canLearnFurnaceRecipes; }
-    /** True if this module can be taught 3x3 crafting recipes. */
-    public boolean canLearnLargeRecipes() { return this.canLearnLargeRecipes; }
+    /**
+     * Check if the worker can learn a certain type of recipe.
+     * @param type the type to check for.
+     * @return true if so.
+     */
+    public boolean canLearn(final CraftingType type)
+    {
+        return getSupportedCraftingTypes().contains(type);
+    }
+
+    /**
+     * Get the supported crafting types.
+     * @return a set of types.
+     */
+    public Set<CraftingType> getSupportedCraftingTypes()
+    {
+        return recipeTypeSet;
+    }
 
     /**
      * Unique id of the crafting module view.

--- a/src/main/java/com/minecolonies/coremod/colony/buildings/moduleviews/CraftingModuleView.java
+++ b/src/main/java/com/minecolonies/coremod/colony/buildings/moduleviews/CraftingModuleView.java
@@ -14,15 +14,17 @@ import com.minecolonies.coremod.colony.buildings.views.AbstractBuildingView;
 import com.minecolonies.coremod.network.messages.server.colony.building.OpenCraftingGUIMessage;
 import net.minecraft.client.Minecraft;
 import net.minecraft.core.BlockPos;
+import net.minecraft.core.Registry;
 import net.minecraft.network.FriendlyByteBuf;
 import net.minecraft.world.MenuProvider;
+import net.minecraft.world.item.crafting.RecipeType;
 import net.minecraftforge.api.distmarker.Dist;
 import net.minecraftforge.api.distmarker.OnlyIn;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.ArrayList;
-import java.util.Collections;
+import java.util.HashSet;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;

--- a/src/main/java/com/minecolonies/coremod/colony/buildings/workerbuildings/BuildingBaker.java
+++ b/src/main/java/com/minecolonies/coremod/colony/buildings/workerbuildings/BuildingBaker.java
@@ -17,6 +17,7 @@ import net.minecraft.core.BlockPos;
 import net.minecraft.util.Tuple;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.Items;
+import net.minecraft.world.item.crafting.RecipeType;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.Map;

--- a/src/main/java/com/minecolonies/coremod/colony/buildings/workerbuildings/BuildingBaker.java
+++ b/src/main/java/com/minecolonies/coremod/colony/buildings/workerbuildings/BuildingBaker.java
@@ -1,5 +1,6 @@
 package com.minecolonies.coremod.colony.buildings.workerbuildings;
 
+import com.google.common.collect.ImmutableSet;
 import com.minecolonies.api.colony.IColony;
 import com.minecolonies.api.colony.IColonyManager;
 import com.minecolonies.api.colony.jobs.registry.JobEntry;
@@ -7,6 +8,7 @@ import com.minecolonies.api.colony.requestsystem.token.IToken;
 import com.minecolonies.api.crafting.IGenericRecipe;
 import com.minecolonies.api.crafting.IRecipeStorage;
 import com.minecolonies.api.crafting.ItemStorage;
+import com.minecolonies.api.crafting.registry.CraftingType;
 import com.minecolonies.api.util.CraftingUtils;
 import com.minecolonies.api.util.OptionalPredicate;
 import com.minecolonies.coremod.colony.buildings.AbstractBuilding;
@@ -19,6 +21,7 @@ import org.jetbrains.annotations.NotNull;
 
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import java.util.function.Predicate;
 
 import static com.minecolonies.api.util.constant.TagConstants.CRAFTING_BAKER;
@@ -122,10 +125,11 @@ public class BuildingBaker extends AbstractBuilding
         }
 
         @Override
-        public boolean canLearnCraftingRecipes()
+        public Set<CraftingType> getSupportedCraftingTypes()
         {
-            if (building == null) return true;  // because it can learn at *some* level
-            return building.getBuildingLevel() >= 3;
+            return (building == null || building.getBuildingLevel() >= 3)
+                    ? super.getSupportedCraftingTypes()
+                    : ImmutableSet.of();
         }
 
         @Override
@@ -177,10 +181,11 @@ public class BuildingBaker extends AbstractBuilding
         }
 
         @Override
-        public boolean canLearnFurnaceRecipes()
+        public Set<CraftingType> getSupportedCraftingTypes()
         {
-            if (building == null) return true;  // because it can learn at *some* level
-            return building.getBuildingLevel() >= 3;
+            return (building == null || building.getBuildingLevel() >= 3)
+                    ? super.getSupportedCraftingTypes()
+                    : ImmutableSet.of();
         }
     }
 }

--- a/src/main/java/com/minecolonies/coremod/colony/buildings/workerbuildings/BuildingCook.java
+++ b/src/main/java/com/minecolonies/coremod/colony/buildings/workerbuildings/BuildingCook.java
@@ -28,6 +28,7 @@ import net.minecraft.util.Tuple;
 import net.minecraft.world.item.Item;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.Items;
+import net.minecraft.world.item.crafting.RecipeType;
 import net.minecraftforge.items.IItemHandler;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;

--- a/src/main/java/com/minecolonies/coremod/colony/buildings/workerbuildings/BuildingCook.java
+++ b/src/main/java/com/minecolonies/coremod/colony/buildings/workerbuildings/BuildingCook.java
@@ -1,5 +1,6 @@
 package com.minecolonies.coremod.colony.buildings.workerbuildings;
 
+import com.google.common.collect.ImmutableSet;
 import com.minecolonies.api.MinecoloniesAPIProxy;
 import com.minecolonies.api.colony.ICitizenData;
 import com.minecolonies.api.colony.IColony;
@@ -10,6 +11,7 @@ import com.minecolonies.api.crafting.GenericRecipe;
 import com.minecolonies.api.crafting.IGenericRecipe;
 import com.minecolonies.api.crafting.IRecipeStorage;
 import com.minecolonies.api.crafting.ItemStorage;
+import com.minecolonies.api.crafting.registry.CraftingType;
 import com.minecolonies.api.items.ModTags;
 import com.minecolonies.api.util.CraftingUtils;
 import com.minecolonies.api.util.ItemStackUtils;
@@ -310,10 +312,11 @@ public class BuildingCook extends AbstractBuilding
         }
 
         @Override
-        public boolean canLearnCraftingRecipes()
+        public Set<CraftingType> getSupportedCraftingTypes()
         {
-            if (building == null) return true;  // because it can learn at *some* level
-            return building.getBuildingLevel() >= 3;
+            return (building == null || building.getBuildingLevel() >= 3)
+                    ? super.getSupportedCraftingTypes()
+                    : ImmutableSet.of();
         }
 
         @Override

--- a/src/main/java/com/minecolonies/coremod/colony/buildings/workerbuildings/BuildingFletcher.java
+++ b/src/main/java/com/minecolonies/coremod/colony/buildings/workerbuildings/BuildingFletcher.java
@@ -1,25 +1,19 @@
 package com.minecolonies.coremod.colony.buildings.workerbuildings;
 
-import com.ldtteam.domumornamentum.client.model.data.MaterialTextureData;
 import com.minecolonies.api.colony.IColony;
 import com.minecolonies.api.colony.jobs.registry.JobEntry;
 import com.minecolonies.api.crafting.IGenericRecipe;
-import com.minecolonies.api.crafting.ModCraftingTypes;
-import com.minecolonies.api.crafting.registry.CraftingType;
 import com.minecolonies.api.items.ModTags;
 import com.minecolonies.api.util.CraftingUtils;
-import com.minecolonies.api.util.ItemStackUtils;
 import com.minecolonies.api.util.OptionalPredicate;
 import com.minecolonies.coremod.colony.buildings.AbstractBuilding;
 import com.minecolonies.coremod.colony.buildings.modules.AbstractCraftingBuildingModule;
+import com.minecolonies.coremod.colony.buildings.modules.AbstractDOCraftingBuildingModule;
 import net.minecraft.core.BlockPos;
-import net.minecraft.nbt.CompoundTag;
 import net.minecraft.world.item.*;
-import net.minecraft.world.level.block.Block;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.Optional;
-import java.util.Set;
 
 import static com.minecolonies.api.util.constant.BuildingConstants.CONST_DEFAULT_MAX_BUILDING_LEVEL;
 import static com.minecolonies.api.util.constant.TagConstants.CRAFTING_FLETCHER;
@@ -93,9 +87,8 @@ public class BuildingFletcher extends AbstractBuilding
         }
     }
 
-    public static class DOCraftingModule extends AbstractCraftingBuildingModule.Custom
+    public static class DOCraftingModule extends AbstractDOCraftingBuildingModule
     {
-
         /**
          * Create a new module.
          *
@@ -107,29 +100,9 @@ public class BuildingFletcher extends AbstractBuilding
         }
 
         @Override
-        public boolean isRecipeCompatible(final @NotNull IGenericRecipe recipe)
+        public @NotNull OptionalPredicate<ItemStack> getIngredientValidator()
         {
-            final ItemStack stack = recipe.getPrimaryOutput().copy();
-            if (stack.getItem().getRegistryName().getNamespace().equals("domum_ornamentum"))
-            {
-                final CompoundTag dataNbt = stack.getOrCreateTagElement("textureData");
-                final MaterialTextureData textureData = MaterialTextureData.deserializeFromNBT(dataNbt);
-                for (final Block block : textureData.getTexturedComponents().values())
-                {
-                    final ItemStack ingredientStack = new ItemStack(block);
-                    if (!ItemStackUtils.isEmpty(ingredientStack) && ModTags.crafterIngredient.get(FLETCHER).contains(ingredientStack.getItem()))
-                    {
-                        return true;
-                    }
-                }
-            }
-            return false;
-        }
-
-        @Override
-        public Set<CraftingType> getSupportedCraftingTypes()
-        {
-            return Set.of(ModCraftingTypes.SMALL_CRAFTING, ModCraftingTypes.LARGE_CRAFTING);
+            return stack -> Optional.of(ModTags.crafterIngredient.get(FLETCHER).contains(stack.getItem()));
         }
     }
 }

--- a/src/main/java/com/minecolonies/coremod/colony/buildings/workerbuildings/BuildingFletcher.java
+++ b/src/main/java/com/minecolonies/coremod/colony/buildings/workerbuildings/BuildingFletcher.java
@@ -4,6 +4,8 @@ import com.ldtteam.domumornamentum.client.model.data.MaterialTextureData;
 import com.minecolonies.api.colony.IColony;
 import com.minecolonies.api.colony.jobs.registry.JobEntry;
 import com.minecolonies.api.crafting.IGenericRecipe;
+import com.minecolonies.api.crafting.ModCraftingTypes;
+import com.minecolonies.api.crafting.registry.CraftingType;
 import com.minecolonies.api.items.ModTags;
 import com.minecolonies.api.util.CraftingUtils;
 import com.minecolonies.api.util.ItemStackUtils;
@@ -17,6 +19,7 @@ import net.minecraft.world.level.block.Block;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.Optional;
+import java.util.Set;
 
 import static com.minecolonies.api.util.constant.BuildingConstants.CONST_DEFAULT_MAX_BUILDING_LEVEL;
 import static com.minecolonies.api.util.constant.TagConstants.CRAFTING_FLETCHER;
@@ -124,12 +127,9 @@ public class BuildingFletcher extends AbstractBuilding
         }
 
         @Override
-        public boolean canLearnCraftingRecipes() { return true; }
-
-        @Override
-        public boolean canLearnFurnaceRecipes() { return false; }
-
-        @Override
-        public boolean canLearnLargeRecipes() { return true; }
+        public Set<CraftingType> getSupportedCraftingTypes()
+        {
+            return Set.of(ModCraftingTypes.SMALL_CRAFTING, ModCraftingTypes.LARGE_CRAFTING);
+        }
     }
 }

--- a/src/main/java/com/minecolonies/coremod/colony/buildings/workerbuildings/BuildingGlassblower.java
+++ b/src/main/java/com/minecolonies/coremod/colony/buildings/workerbuildings/BuildingGlassblower.java
@@ -4,6 +4,8 @@ import com.ldtteam.domumornamentum.client.model.data.MaterialTextureData;
 import com.minecolonies.api.colony.IColony;
 import com.minecolonies.api.colony.jobs.registry.JobEntry;
 import com.minecolonies.api.crafting.IGenericRecipe;
+import com.minecolonies.api.crafting.ModCraftingTypes;
+import com.minecolonies.api.crafting.registry.CraftingType;
 import com.minecolonies.api.items.ModTags;
 import com.minecolonies.api.util.CraftingUtils;
 import com.minecolonies.api.util.ItemStackUtils;
@@ -15,6 +17,8 @@ import net.minecraft.nbt.CompoundTag;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.level.block.Block;
 import org.jetbrains.annotations.NotNull;
+
+import java.util.Set;
 
 import static com.minecolonies.api.util.constant.BuildingConstants.CONST_DEFAULT_MAX_BUILDING_LEVEL;
 import static com.minecolonies.api.util.constant.TagConstants.CRAFTING_GLASSBLOWER;
@@ -150,12 +154,9 @@ public class BuildingGlassblower extends AbstractBuilding
         }
 
         @Override
-        public boolean canLearnCraftingRecipes() { return true; }
-
-        @Override
-        public boolean canLearnFurnaceRecipes() { return false; }
-
-        @Override
-        public boolean canLearnLargeRecipes() { return true; }
+        public Set<CraftingType> getSupportedCraftingTypes()
+        {
+            return Set.of(ModCraftingTypes.SMALL_CRAFTING, ModCraftingTypes.LARGE_CRAFTING);
+        }
     }
 }

--- a/src/main/java/com/minecolonies/coremod/colony/buildings/workerbuildings/BuildingGlassblower.java
+++ b/src/main/java/com/minecolonies/coremod/colony/buildings/workerbuildings/BuildingGlassblower.java
@@ -1,24 +1,19 @@
 package com.minecolonies.coremod.colony.buildings.workerbuildings;
 
-import com.ldtteam.domumornamentum.client.model.data.MaterialTextureData;
 import com.minecolonies.api.colony.IColony;
 import com.minecolonies.api.colony.jobs.registry.JobEntry;
 import com.minecolonies.api.crafting.IGenericRecipe;
-import com.minecolonies.api.crafting.ModCraftingTypes;
-import com.minecolonies.api.crafting.registry.CraftingType;
 import com.minecolonies.api.items.ModTags;
 import com.minecolonies.api.util.CraftingUtils;
-import com.minecolonies.api.util.ItemStackUtils;
 import com.minecolonies.api.util.OptionalPredicate;
 import com.minecolonies.coremod.colony.buildings.AbstractBuilding;
 import com.minecolonies.coremod.colony.buildings.modules.AbstractCraftingBuildingModule;
+import com.minecolonies.coremod.colony.buildings.modules.AbstractDOCraftingBuildingModule;
 import net.minecraft.core.BlockPos;
-import net.minecraft.nbt.CompoundTag;
 import net.minecraft.world.item.ItemStack;
-import net.minecraft.world.level.block.Block;
 import org.jetbrains.annotations.NotNull;
 
-import java.util.Set;
+import java.util.Optional;
 
 import static com.minecolonies.api.util.constant.BuildingConstants.CONST_DEFAULT_MAX_BUILDING_LEVEL;
 import static com.minecolonies.api.util.constant.TagConstants.CRAFTING_GLASSBLOWER;
@@ -121,7 +116,7 @@ public class BuildingGlassblower extends AbstractBuilding
         }
     }
 
-    public static class DOCraftingModule extends AbstractCraftingBuildingModule.Custom
+    public static class DOCraftingModule extends AbstractDOCraftingBuildingModule
     {
         /**
          * Create a new module.
@@ -134,29 +129,9 @@ public class BuildingGlassblower extends AbstractBuilding
         }
 
         @Override
-        public boolean isRecipeCompatible(final @NotNull IGenericRecipe recipe)
+        public @NotNull OptionalPredicate<ItemStack> getIngredientValidator()
         {
-            final ItemStack stack = recipe.getPrimaryOutput().copy();
-            if (stack.getItem().getRegistryName().getNamespace().equals("domum_ornamentum"))
-            {
-                final CompoundTag dataNbt = stack.getOrCreateTagElement("textureData");
-                final MaterialTextureData textureData = MaterialTextureData.deserializeFromNBT(dataNbt);
-                for (final Block block : textureData.getTexturedComponents().values())
-                {
-                    final ItemStack ingredientStack = new ItemStack(block);
-                    if (!ItemStackUtils.isEmpty(ingredientStack) && ModTags.crafterIngredient.get(GLASS_BLOWER).contains(ingredientStack.getItem()))
-                    {
-                        return true;
-                    }
-                }
-            }
-            return false;
-        }
-
-        @Override
-        public Set<CraftingType> getSupportedCraftingTypes()
-        {
-            return Set.of(ModCraftingTypes.SMALL_CRAFTING, ModCraftingTypes.LARGE_CRAFTING);
+            return stack -> Optional.of(ModTags.crafterIngredient.get(GLASS_BLOWER).contains(stack.getItem()));
         }
     }
 }

--- a/src/main/java/com/minecolonies/coremod/colony/buildings/workerbuildings/BuildingMechanic.java
+++ b/src/main/java/com/minecolonies/coremod/colony/buildings/workerbuildings/BuildingMechanic.java
@@ -1,29 +1,23 @@
 package com.minecolonies.coremod.colony.buildings.workerbuildings;
 
-import com.ldtteam.domumornamentum.client.model.data.MaterialTextureData;
 import com.minecolonies.api.colony.IColony;
 import com.minecolonies.api.colony.jobs.registry.JobEntry;
 import com.minecolonies.api.crafting.IGenericRecipe;
-import com.minecolonies.api.crafting.ModCraftingTypes;
-import com.minecolonies.api.crafting.registry.CraftingType;
 import com.minecolonies.api.items.ModTags;
 import com.minecolonies.api.util.CraftingUtils;
-import com.minecolonies.api.util.ItemStackUtils;
 import com.minecolonies.api.util.OptionalPredicate;
 import com.minecolonies.coremod.colony.buildings.AbstractBuilding;
 import com.minecolonies.coremod.colony.buildings.modules.AbstractCraftingBuildingModule;
+import com.minecolonies.coremod.colony.buildings.modules.AbstractDOCraftingBuildingModule;
 import net.minecraft.core.BlockPos;
-import net.minecraft.nbt.CompoundTag;
 import net.minecraft.world.item.BlockItem;
 import net.minecraft.world.item.Item;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.MinecartItem;
-import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.HopperBlock;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.Optional;
-import java.util.Set;
 
 import static com.minecolonies.api.util.constant.BuildingConstants.CONST_DEFAULT_MAX_BUILDING_LEVEL;
 import static com.minecolonies.api.util.constant.TagConstants.CRAFTING_MECHANIC;
@@ -99,7 +93,7 @@ public class BuildingMechanic extends AbstractBuilding
         }
     }
 
-    public static class DOCraftingModule extends AbstractCraftingBuildingModule.Custom
+    public static class DOCraftingModule extends AbstractDOCraftingBuildingModule
     {
         /**
          * Create a new module.
@@ -112,33 +106,13 @@ public class BuildingMechanic extends AbstractBuilding
         }
 
         @Override
-        public boolean isRecipeCompatible(final @NotNull IGenericRecipe recipe)
+        public @NotNull OptionalPredicate<ItemStack> getIngredientValidator()
         {
-            final ItemStack stack = recipe.getPrimaryOutput().copy();
-            if (stack.getItem().getRegistryName().getNamespace().equals("domum_ornamentum"))
-            {
-                final CompoundTag dataNbt = stack.getOrCreateTagElement("textureData");
-                final MaterialTextureData textureData = MaterialTextureData.deserializeFromNBT(dataNbt);
-                for (final Block block : textureData.getTexturedComponents().values())
-                {
-                    final ItemStack ingredientStack = new ItemStack(block);
-                    if (!ItemStackUtils.isEmpty(ingredientStack)
-                          && !ModTags.crafterIngredient.get(BuildingFletcher.FLETCHER).contains(ingredientStack.getItem())
-                          && !ModTags.crafterIngredient.get(BuildingSawmill.SAWMILL).contains(ingredientStack.getItem())
-                          && !ModTags.crafterIngredient.get(BuildingStonemason.STONEMASON).contains(ingredientStack.getItem())
-                          && !ModTags.crafterIngredient.get(BuildingGlassblower.GLASS_BLOWER).contains(ingredientStack.getItem()))
-                    {
-                        return true;
-                    }
-                }
-            }
-            return false;
-        }
-
-        @Override
-        public Set<CraftingType> getSupportedCraftingTypes()
-        {
-            return Set.of(ModCraftingTypes.SMALL_CRAFTING, ModCraftingTypes.LARGE_CRAFTING);
+            return stack -> Optional.of(
+                       !ModTags.crafterIngredient.get(BuildingFletcher.FLETCHER).contains(stack.getItem())
+                    && !ModTags.crafterIngredient.get(BuildingSawmill.SAWMILL).contains(stack.getItem())
+                    && !ModTags.crafterIngredient.get(BuildingStonemason.STONEMASON).contains(stack.getItem())
+                    && !ModTags.crafterIngredient.get(BuildingGlassblower.GLASS_BLOWER).contains(stack.getItem()));
         }
     }
 }

--- a/src/main/java/com/minecolonies/coremod/colony/buildings/workerbuildings/BuildingMechanic.java
+++ b/src/main/java/com/minecolonies/coremod/colony/buildings/workerbuildings/BuildingMechanic.java
@@ -4,6 +4,8 @@ import com.ldtteam.domumornamentum.client.model.data.MaterialTextureData;
 import com.minecolonies.api.colony.IColony;
 import com.minecolonies.api.colony.jobs.registry.JobEntry;
 import com.minecolonies.api.crafting.IGenericRecipe;
+import com.minecolonies.api.crafting.ModCraftingTypes;
+import com.minecolonies.api.crafting.registry.CraftingType;
 import com.minecolonies.api.items.ModTags;
 import com.minecolonies.api.util.CraftingUtils;
 import com.minecolonies.api.util.ItemStackUtils;
@@ -21,6 +23,7 @@ import net.minecraft.world.level.block.HopperBlock;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.Optional;
+import java.util.Set;
 
 import static com.minecolonies.api.util.constant.BuildingConstants.CONST_DEFAULT_MAX_BUILDING_LEVEL;
 import static com.minecolonies.api.util.constant.TagConstants.CRAFTING_MECHANIC;
@@ -133,12 +136,9 @@ public class BuildingMechanic extends AbstractBuilding
         }
 
         @Override
-        public boolean canLearnCraftingRecipes() { return true; }
-
-        @Override
-        public boolean canLearnFurnaceRecipes() { return false; }
-
-        @Override
-        public boolean canLearnLargeRecipes() { return true; }
+        public Set<CraftingType> getSupportedCraftingTypes()
+        {
+            return Set.of(ModCraftingTypes.SMALL_CRAFTING, ModCraftingTypes.LARGE_CRAFTING);
+        }
     }
 }

--- a/src/main/java/com/minecolonies/coremod/colony/buildings/workerbuildings/BuildingSawmill.java
+++ b/src/main/java/com/minecolonies/coremod/colony/buildings/workerbuildings/BuildingSawmill.java
@@ -4,6 +4,8 @@ import com.ldtteam.domumornamentum.client.model.data.MaterialTextureData;
 import com.minecolonies.api.colony.IColony;
 import com.minecolonies.api.colony.jobs.registry.JobEntry;
 import com.minecolonies.api.crafting.IGenericRecipe;
+import com.minecolonies.api.crafting.ModCraftingTypes;
+import com.minecolonies.api.crafting.registry.CraftingType;
 import com.minecolonies.api.util.CraftingUtils;
 import com.minecolonies.api.util.ItemStackUtils;
 import com.minecolonies.api.util.OptionalPredicate;
@@ -19,6 +21,7 @@ import org.jetbrains.annotations.NotNull;
 
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 
 import static com.minecolonies.api.util.constant.BuildingConstants.CONST_DEFAULT_MAX_BUILDING_LEVEL;
 import static com.minecolonies.api.util.constant.TagConstants.CRAFTING_SAWMILL;
@@ -153,12 +156,9 @@ public class BuildingSawmill extends AbstractBuilding
         }
 
         @Override
-        public boolean canLearnCraftingRecipes() { return true; }
-
-        @Override
-        public boolean canLearnFurnaceRecipes() { return false; }
-
-        @Override
-        public boolean canLearnLargeRecipes() { return true; }
+        public Set<CraftingType> getSupportedCraftingTypes()
+        {
+            return Set.of(ModCraftingTypes.SMALL_CRAFTING, ModCraftingTypes.LARGE_CRAFTING);
+        }
     }
 }

--- a/src/main/java/com/minecolonies/coremod/colony/buildings/workerbuildings/BuildingSawmill.java
+++ b/src/main/java/com/minecolonies/coremod/colony/buildings/workerbuildings/BuildingSawmill.java
@@ -1,27 +1,22 @@
 package com.minecolonies.coremod.colony.buildings.workerbuildings;
 
-import com.ldtteam.domumornamentum.client.model.data.MaterialTextureData;
 import com.minecolonies.api.colony.IColony;
 import com.minecolonies.api.colony.jobs.registry.JobEntry;
 import com.minecolonies.api.crafting.IGenericRecipe;
-import com.minecolonies.api.crafting.ModCraftingTypes;
-import com.minecolonies.api.crafting.registry.CraftingType;
 import com.minecolonies.api.util.CraftingUtils;
 import com.minecolonies.api.util.ItemStackUtils;
 import com.minecolonies.api.util.OptionalPredicate;
 import com.minecolonies.coremod.colony.buildings.AbstractBuilding;
 import com.minecolonies.coremod.colony.buildings.modules.AbstractCraftingBuildingModule;
+import com.minecolonies.coremod.colony.buildings.modules.AbstractDOCraftingBuildingModule;
 import net.minecraft.core.BlockPos;
-import net.minecraft.nbt.CompoundTag;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.tags.ItemTags;
 import net.minecraft.world.item.ItemStack;
-import net.minecraft.world.level.block.Block;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.List;
 import java.util.Optional;
-import java.util.Set;
 
 import static com.minecolonies.api.util.constant.BuildingConstants.CONST_DEFAULT_MAX_BUILDING_LEVEL;
 import static com.minecolonies.api.util.constant.TagConstants.CRAFTING_SAWMILL;
@@ -123,7 +118,7 @@ public class BuildingSawmill extends AbstractBuilding
         }
     }
 
-    public static class DOCraftingModule extends AbstractCraftingBuildingModule.Custom
+    public static class DOCraftingModule extends AbstractDOCraftingBuildingModule
     {
         /**
          * Create a new module.
@@ -136,29 +131,9 @@ public class BuildingSawmill extends AbstractBuilding
         }
 
         @Override
-        public boolean isRecipeCompatible(final @NotNull IGenericRecipe recipe)
+        public @NotNull OptionalPredicate<ItemStack> getIngredientValidator()
         {
-            final ItemStack stack = recipe.getPrimaryOutput().copy();
-            if (stack.getItem().getRegistryName().getNamespace().equals("domum_ornamentum"))
-            {
-                final CompoundTag dataNbt = stack.getOrCreateTagElement("textureData");
-                final MaterialTextureData textureData = MaterialTextureData.deserializeFromNBT(dataNbt);
-                for (final Block block : textureData.getTexturedComponents().values())
-                {
-                    final ItemStack ingredientStack = new ItemStack(block);
-                    if (!ItemStackUtils.isEmpty(ingredientStack) && (ItemTags.PLANKS.contains(ingredientStack.getItem()) || ItemTags.LOGS.contains(ingredientStack.getItem())))
-                    {
-                        return true;
-                    }
-                }
-            }
-            return false;
-        }
-
-        @Override
-        public Set<CraftingType> getSupportedCraftingTypes()
-        {
-            return Set.of(ModCraftingTypes.SMALL_CRAFTING, ModCraftingTypes.LARGE_CRAFTING);
+            return stack -> Optional.of(ItemTags.PLANKS.contains(stack.getItem()) || ItemTags.LOGS.contains(stack.getItem()));
         }
     }
 }

--- a/src/main/java/com/minecolonies/coremod/colony/buildings/workerbuildings/BuildingStonemason.java
+++ b/src/main/java/com/minecolonies/coremod/colony/buildings/workerbuildings/BuildingStonemason.java
@@ -4,6 +4,8 @@ import com.ldtteam.domumornamentum.client.model.data.MaterialTextureData;
 import com.minecolonies.api.colony.IColony;
 import com.minecolonies.api.colony.jobs.registry.JobEntry;
 import com.minecolonies.api.crafting.IGenericRecipe;
+import com.minecolonies.api.crafting.ModCraftingTypes;
+import com.minecolonies.api.crafting.registry.CraftingType;
 import com.minecolonies.api.items.ModTags;
 import com.minecolonies.api.util.CraftingUtils;
 import com.minecolonies.api.util.ItemStackUtils;
@@ -15,6 +17,8 @@ import net.minecraft.nbt.CompoundTag;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.level.block.Block;
 import org.jetbrains.annotations.NotNull;
+
+import java.util.Set;
 
 import static com.minecolonies.api.util.constant.BuildingConstants.CONST_DEFAULT_MAX_BUILDING_LEVEL;
 import static com.minecolonies.api.util.constant.TagConstants.CRAFTING_STONEMASON;
@@ -114,12 +118,9 @@ public class BuildingStonemason extends AbstractBuilding
         }
 
         @Override
-        public boolean canLearnCraftingRecipes() { return true; }
-
-        @Override
-        public boolean canLearnFurnaceRecipes() { return false; }
-
-        @Override
-        public boolean canLearnLargeRecipes() { return true; }
+        public Set<CraftingType> getSupportedCraftingTypes()
+        {
+            return Set.of(ModCraftingTypes.SMALL_CRAFTING, ModCraftingTypes.LARGE_CRAFTING);
+        }
     }
 }

--- a/src/main/java/com/minecolonies/coremod/colony/buildings/workerbuildings/BuildingStonemason.java
+++ b/src/main/java/com/minecolonies/coremod/colony/buildings/workerbuildings/BuildingStonemason.java
@@ -1,24 +1,19 @@
 package com.minecolonies.coremod.colony.buildings.workerbuildings;
 
-import com.ldtteam.domumornamentum.client.model.data.MaterialTextureData;
 import com.minecolonies.api.colony.IColony;
 import com.minecolonies.api.colony.jobs.registry.JobEntry;
 import com.minecolonies.api.crafting.IGenericRecipe;
-import com.minecolonies.api.crafting.ModCraftingTypes;
-import com.minecolonies.api.crafting.registry.CraftingType;
 import com.minecolonies.api.items.ModTags;
 import com.minecolonies.api.util.CraftingUtils;
-import com.minecolonies.api.util.ItemStackUtils;
 import com.minecolonies.api.util.OptionalPredicate;
 import com.minecolonies.coremod.colony.buildings.AbstractBuilding;
 import com.minecolonies.coremod.colony.buildings.modules.AbstractCraftingBuildingModule;
+import com.minecolonies.coremod.colony.buildings.modules.AbstractDOCraftingBuildingModule;
 import net.minecraft.core.BlockPos;
-import net.minecraft.nbt.CompoundTag;
 import net.minecraft.world.item.ItemStack;
-import net.minecraft.world.level.block.Block;
 import org.jetbrains.annotations.NotNull;
 
-import java.util.Set;
+import java.util.Optional;
 
 import static com.minecolonies.api.util.constant.BuildingConstants.CONST_DEFAULT_MAX_BUILDING_LEVEL;
 import static com.minecolonies.api.util.constant.TagConstants.CRAFTING_STONEMASON;
@@ -85,7 +80,7 @@ public class BuildingStonemason extends AbstractBuilding
         }
     }
 
-    public static class DOCraftingModule extends AbstractCraftingBuildingModule.Custom
+    public static class DOCraftingModule extends AbstractDOCraftingBuildingModule
     {
         /**
          * Create a new module.
@@ -98,29 +93,9 @@ public class BuildingStonemason extends AbstractBuilding
         }
 
         @Override
-        public boolean isRecipeCompatible(final @NotNull IGenericRecipe recipe)
+        public @NotNull OptionalPredicate<ItemStack> getIngredientValidator()
         {
-            final ItemStack stack = recipe.getPrimaryOutput().copy();
-            if (stack.getItem().getRegistryName().getNamespace().equals("domum_ornamentum"))
-            {
-                final CompoundTag dataNbt = stack.getOrCreateTagElement("textureData");
-                final MaterialTextureData textureData = MaterialTextureData.deserializeFromNBT(dataNbt);
-                for (final Block block : textureData.getTexturedComponents().values())
-                {
-                    final ItemStack ingredientStack = new ItemStack(block);
-                    if (!ItemStackUtils.isEmpty(ingredientStack) && ModTags.crafterIngredient.get(STONEMASON).contains(ingredientStack.getItem()))
-                    {
-                        return true;
-                    }
-                }
-            }
-            return false;
-        }
-
-        @Override
-        public Set<CraftingType> getSupportedCraftingTypes()
-        {
-            return Set.of(ModCraftingTypes.SMALL_CRAFTING, ModCraftingTypes.LARGE_CRAFTING);
+            return stack -> Optional.of(ModTags.crafterIngredient.get(STONEMASON).contains(stack.getItem()));
         }
     }
 }

--- a/src/main/java/com/minecolonies/coremod/colony/crafting/GenericRecipeUtils.java
+++ b/src/main/java/com/minecolonies/coremod/colony/crafting/GenericRecipeUtils.java
@@ -18,12 +18,13 @@ import net.minecraft.world.item.crafting.Ingredient;
 import net.minecraft.world.item.crafting.Recipe;
 import net.minecraft.world.level.Level;
 import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
 
-import java.util.*;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import java.util.Set;
 import java.util.stream.Collectors;
 
-import static com.ldtteam.structurize.items.ModItems.buildTool;
 import static com.minecolonies.api.util.constant.BuildingConstants.CONST_DEFAULT_MAX_BUILDING_LEVEL;
 
 /**
@@ -67,15 +68,6 @@ public final class GenericRecipeUtils
     {
         final List<Component> restrictions = calculateRestrictions(customRecipe);
         return Objects.requireNonNull(GenericRecipe.of(storage, restrictions, customRecipe.getMinBuildingLevel()));
-    }
-
-    @NotNull
-    public static IGenericRecipe create(@NotNull final Recipe<?> recipe, @Nullable final Level world)
-    {
-        final IGenericRecipe original = Objects.requireNonNull(GenericRecipe.of(recipe, world));
-        final List<List<ItemStack>> inputs = compact(recipe.getIngredients());
-        return new GenericRecipe(original.getRecipeId(), original.getPrimaryOutput(), original.getAdditionalOutputs(), inputs,
-                original.getGridSize(), original.getIntermediate(), original.getLootTable(), new ArrayList<>(), -1);
     }
 
     /**
@@ -150,106 +142,5 @@ public final class GenericRecipeUtils
 
         // otherwise it may be an effect with no research (perhaps disabled via datapack)
         return new TextComponent("???");
-    }
-
-    private static List<List<ItemStack>> compact(final NonNullList<Ingredient> inputs)
-    {
-        // FYI, this largely does the same job as RecipeStorage.calculateCleanedInput(), but we can't re-use
-        // that implementation as we need to operate on Ingredients, which can be a list of stacks.
-        final Map<IngredientStacks, IngredientStacks> ingredients = new HashMap<>();
-
-        for (final Ingredient ingredient : inputs)
-        {
-            if (ingredient == Ingredient.EMPTY) continue;
-
-            final IngredientStacks newIngredient = new IngredientStacks(ingredient);
-            // also ignore the build tool as an ingredient, since colony crafters don't require it.
-            //   (see RecipeStorage.calculateCleanedInput() for why)
-            if (!newIngredient.getStacks().isEmpty() && newIngredient.getStacks().get(0).getItem() == buildTool.get()) continue;
-
-            final IngredientStacks existing = ingredients.get(newIngredient);
-            if (existing == null)
-            {
-                ingredients.put(newIngredient, newIngredient);
-            }
-            else
-            {
-                existing.merge(newIngredient);
-            }
-        }
-
-        return ingredients.values().stream()
-                .sorted(Comparator.reverseOrder())
-                .map(IngredientStacks::getStacks)
-                .collect(Collectors.toCollection(NonNullList::create));
-    }
-
-    private static class IngredientStacks implements Comparable<IngredientStacks>
-    {
-        private final List<ItemStack> stacks;
-        private final Set<Item> items;
-
-        public IngredientStacks(final Ingredient ingredient)
-        {
-            this.stacks = Collections.unmodifiableList(Arrays.stream(ingredient.getItems())
-                    .filter(stack -> !stack.isEmpty())
-                    .map(ItemStack::copy)
-                    .collect(Collectors.toList()));
-
-            this.items = this.stacks.stream()
-                    .map(ItemStack::getItem)
-                    .collect(Collectors.toSet());
-        }
-
-        @NotNull
-        public List<ItemStack> getStacks() { return this.stacks; }
-
-        public int getCount() { return this.stacks.isEmpty() ? 0 : this.stacks.get(0).getCount(); }
-
-        @Override
-        public boolean equals(Object o)
-        {
-            if (this == o) return true;
-            if (o == null || getClass() != o.getClass()) return false;
-            final IngredientStacks that = (IngredientStacks) o;
-            return this.items.equals(that.items);
-            // note that this does not compare the counts to maintain key-stability
-        }
-
-        @Override
-        public int hashCode()
-        {
-            return this.items.hashCode();
-        }
-
-        @Override
-        public int compareTo(@NotNull IngredientStacks o)
-        {
-            int diff = this.getCount() - o.getCount();
-            if (diff != 0) return diff;
-
-            diff = this.stacks.size() - o.stacks.size();
-            if (diff != 0) return diff;
-
-            return this.hashCode() - o.hashCode();
-        }
-
-        public void merge(@NotNull final IngredientStacks other)
-        {
-            // assumes equals(other)
-            for (int i = 0; i < this.stacks.size(); i++)
-            {
-                this.stacks.get(i).grow(other.stacks.get(i).getCount());
-            }
-        }
-
-        @Override
-        public String toString()
-        {
-            return "IngredientStacks{" +
-                    "stacks=" + stacks +
-                    ", items=" + items +
-                    '}';
-        }
     }
 }

--- a/src/main/java/com/minecolonies/coremod/colony/crafting/GenericRecipeUtils.java
+++ b/src/main/java/com/minecolonies/coremod/colony/crafting/GenericRecipeUtils.java
@@ -14,7 +14,6 @@ import net.minecraft.network.chat.TranslatableComponent;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.item.Item;
 import net.minecraft.world.item.ItemStack;
-import net.minecraft.world.item.crafting.Ingredient;
 import net.minecraft.world.item.crafting.Recipe;
 import net.minecraft.world.level.Level;
 import org.jetbrains.annotations.NotNull;

--- a/src/main/java/com/minecolonies/coremod/colony/crafting/LootTableAnalyzer.java
+++ b/src/main/java/com/minecolonies/coremod/colony/crafting/LootTableAnalyzer.java
@@ -12,13 +12,15 @@ import net.minecraft.network.FriendlyByteBuf;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.util.GsonHelper;
 import net.minecraft.util.Mth;
+import net.minecraft.util.Tuple;
 import net.minecraft.world.entity.EntityType;
 import net.minecraft.world.item.Item;
 import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.alchemy.Potion;
+import net.minecraft.world.item.alchemy.PotionUtils;
 import net.minecraft.world.item.enchantment.EnchantmentHelper;
 import net.minecraft.world.level.storage.loot.LootTable;
 import net.minecraft.world.level.storage.loot.LootTables;
-import net.minecraft.util.Tuple;
 import net.minecraftforge.registries.ForgeRegistries;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -193,6 +195,15 @@ public final class LootTableAnalyzer
                     {
                         float damage = 1.0F - processNumber(function.get("damage"), 0F);
                         stack.setDamageValue(Mth.floor(damage * stack.getMaxDamage()));
+                    }
+                    break;
+
+                case "minecraft:set_potion":
+                    final String id = GsonHelper.getAsString(function, "id");
+                    final Potion potion = ForgeRegistries.POTIONS.getValue(ResourceLocation.tryParse(id));
+                    if (potion != null)
+                    {
+                        PotionUtils.setPotion(stack, potion);
                     }
                     break;
 

--- a/src/main/java/com/minecolonies/coremod/colony/crafting/RecipeAnalyzer.java
+++ b/src/main/java/com/minecolonies/coremod/colony/crafting/RecipeAnalyzer.java
@@ -2,13 +2,13 @@ package com.minecolonies.coremod.colony.crafting;
 
 import com.google.common.collect.ImmutableMap;
 import com.minecolonies.api.MinecoloniesAPIProxy;
+import com.ldtteam.domumornamentum.recipe.ModRecipeTypes;
 import com.minecolonies.api.colony.buildings.modules.ICraftingBuildingModule;
 import com.minecolonies.api.crafting.IGenericRecipe;
 import com.minecolonies.api.crafting.IRecipeStorage;
 import com.minecolonies.api.crafting.registry.CraftingType;
 import com.minecolonies.api.util.ItemStackUtils;
 import net.minecraft.world.Container;
-import net.minecraft.world.inventory.CraftingContainer;
 import net.minecraft.world.item.crafting.Recipe;
 import net.minecraft.world.item.crafting.RecipeManager;
 import net.minecraft.world.item.crafting.RecipeType;
@@ -19,6 +19,7 @@ import org.jetbrains.annotations.Nullable;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.function.Predicate;
 
 /**
  * Utility helpers for analyzing the available recipes and determining which crafters are able to use them.
@@ -29,6 +30,7 @@ public final class RecipeAnalyzer
      * Build a map of all potentially learnable vanilla recipes, converted to {@link IGenericRecipe}.
      *
      * @param recipeManager the vanilla recipe manager
+     * @param world the world, if available (some recipes need it)
      * @return the recipe map
      */
     public static Map<CraftingType, List<IGenericRecipe>> buildVanillaRecipesMap(@NotNull final RecipeManager recipeManager,

--- a/src/main/java/com/minecolonies/coremod/colony/crafting/RecipeAnalyzer.java
+++ b/src/main/java/com/minecolonies/coremod/colony/crafting/RecipeAnalyzer.java
@@ -1,11 +1,12 @@
 package com.minecolonies.coremod.colony.crafting;
 
 import com.google.common.collect.ImmutableMap;
+import com.minecolonies.api.MinecoloniesAPIProxy;
 import com.minecolonies.api.colony.buildings.modules.ICraftingBuildingModule;
 import com.minecolonies.api.crafting.IGenericRecipe;
 import com.minecolonies.api.crafting.IRecipeStorage;
+import com.minecolonies.api.crafting.registry.CraftingType;
 import com.minecolonies.api.util.ItemStackUtils;
-import com.minecolonies.api.util.Log;
 import net.minecraft.world.Container;
 import net.minecraft.world.inventory.CraftingContainer;
 import net.minecraft.world.item.crafting.Recipe;
@@ -30,46 +31,18 @@ public final class RecipeAnalyzer
      * @param recipeManager the vanilla recipe manager
      * @return the recipe map
      */
-    public static Map<RecipeType<?>, List<IGenericRecipe>> buildVanillaRecipesMap(@NotNull final RecipeManager recipeManager,
-                                                                                  @Nullable final Level world)
+    public static Map<CraftingType, List<IGenericRecipe>> buildVanillaRecipesMap(@NotNull final RecipeManager recipeManager,
+                                                                                 @Nullable final Level world)
     {
-        final List<IGenericRecipe> craftingRecipes = new ArrayList<>();
-        for (final Recipe<CraftingContainer> recipe : recipeManager.byType(RecipeType.CRAFTING).values())
-        {
-            if (!recipe.canCraftInDimensions(3, 3)) continue;
+        final ImmutableMap.Builder<CraftingType, List<IGenericRecipe>> builder = ImmutableMap.builder();
 
-            tryAddingVanillaRecipe(craftingRecipes, recipe, world);
+        for (final CraftingType type : MinecoloniesAPIProxy.getInstance().getCraftingTypeRegistry().getValues())
+        {
+            final List<IGenericRecipe> recipes = type.findRecipes(recipeManager, world);
+            builder.put(type, recipes);
         }
 
-        final List<IGenericRecipe> smeltingRecipes = new ArrayList<>();
-        for (final Recipe<Container> recipe : recipeManager.byType(RecipeType.SMELTING).values())
-        {
-            tryAddingVanillaRecipe(smeltingRecipes, recipe, world);
-        }
-
-        return new ImmutableMap.Builder<RecipeType<?>, List<IGenericRecipe>>()
-                .put(RecipeType.CRAFTING, craftingRecipes)
-                .put(RecipeType.SMELTING, smeltingRecipes)
-                .build();
-    }
-
-    private static void tryAddingVanillaRecipe(@NotNull final List<IGenericRecipe> recipes,
-                                               @NotNull final Recipe<?> recipe,
-                                               @Nullable final Level world)
-    {
-        if (recipe.getResultItem().isEmpty()) return;     // invalid or special recipes
-
-        try
-        {
-            final IGenericRecipe genericRecipe = GenericRecipeUtils.create(recipe, world);
-            if (genericRecipe.getInputs().isEmpty()) return;
-
-            recipes.add(genericRecipe);
-        }
-        catch (final Exception ex)
-        {
-            Log.getLogger().warn("Error evaluating recipe " + recipe.getId() + "; ignoring.", ex);
-        }
+        return builder.build();
     }
 
     /**
@@ -80,34 +53,24 @@ public final class RecipeAnalyzer
      * @return list of recipes
      */
     @NotNull
-    public static List<IGenericRecipe> findRecipes(@NotNull final Map<RecipeType<?>, List<IGenericRecipe>> vanilla,
+    public static List<IGenericRecipe> findRecipes(@NotNull final Map<CraftingType, List<IGenericRecipe>> vanilla,
                                                    @NotNull final ICraftingBuildingModule crafting)
     {
         final List<IGenericRecipe> recipes = new ArrayList<>();
 
-        // vanilla shaped and shapeless crafting recipes
-        if (crafting.canLearnCraftingRecipes())
+        // all vanilla teachable recipes
+        for (final Map.Entry<CraftingType, List<IGenericRecipe>> entry : vanilla.entrySet())
         {
-            for (final IGenericRecipe recipe : vanilla.get(RecipeType.CRAFTING))
+            if (crafting.canLearn(entry.getKey()))
             {
-                if (!crafting.canLearnLargeRecipes() && recipe.getGridSize() > 2) continue;
-
-                final IGenericRecipe safeRecipe = GenericRecipeUtils.filterInputs(recipe, crafting.getIngredientValidator());
-                if (!crafting.isRecipeCompatible(safeRecipe)) continue;
-
-                recipes.add(safeRecipe);
-            }
-        }
-
-        // vanilla furnace recipes (do we want to check smoking and blasting too?)
-        if (crafting.canLearnFurnaceRecipes())
-        {
-            for (final IGenericRecipe recipe : vanilla.get(RecipeType.SMELTING))
-            {
-                final IGenericRecipe safeRecipe = GenericRecipeUtils.filterInputs(recipe, crafting.getIngredientValidator());
-                if (!crafting.isRecipeCompatible(safeRecipe)) continue;
-
-                recipes.add(safeRecipe);
+                for (final IGenericRecipe recipe : entry.getValue())
+                {
+                    final IGenericRecipe safeRecipe = GenericRecipeUtils.filterInputs(recipe, crafting.getIngredientValidator());
+                    if (crafting.isRecipeCompatible(safeRecipe))
+                    {
+                        recipes.add(safeRecipe);
+                    }
+                }
             }
         }
 

--- a/src/main/java/com/minecolonies/coremod/compatibility/CraftingTagAuditor.java
+++ b/src/main/java/com/minecolonies/coremod/compatibility/CraftingTagAuditor.java
@@ -8,6 +8,7 @@ import com.minecolonies.api.colony.buildings.registry.BuildingEntry;
 import com.minecolonies.api.compatibility.ICompatibilityManager;
 import com.minecolonies.api.crafting.IGenericRecipe;
 import com.minecolonies.api.crafting.ItemStorage;
+import com.minecolonies.api.crafting.registry.CraftingType;
 import com.minecolonies.api.util.Log;
 import com.minecolonies.coremod.colony.buildings.modules.SimpleCraftingModule;
 import com.minecolonies.coremod.colony.crafting.CustomRecipeManager;
@@ -111,7 +112,7 @@ public class CraftingTagAuditor
                                       @NotNull final MinecraftServer server,
                                       @NotNull final CustomRecipeManager customRecipeManager) throws IOException
     {
-        final Map<RecipeType<?>, List<IGenericRecipe>> vanillaRecipesMap =
+        final Map<CraftingType, List<IGenericRecipe>> vanillaRecipesMap =
                 RecipeAnalyzer.buildVanillaRecipesMap(server.getRecipeManager(), server.overworld());
         final List<ICraftingBuildingModule> crafters = getCraftingModules()
                 .stream()

--- a/src/main/java/com/minecolonies/coremod/compatibility/jei/GenericRecipeCategory.java
+++ b/src/main/java/com/minecolonies/coremod/compatibility/jei/GenericRecipeCategory.java
@@ -4,6 +4,7 @@ import com.minecolonies.api.colony.buildings.modules.ICraftingBuildingModule;
 import com.minecolonies.api.colony.buildings.registry.BuildingEntry;
 import com.minecolonies.api.colony.jobs.IJob;
 import com.minecolonies.api.crafting.IGenericRecipe;
+import com.minecolonies.api.crafting.registry.CraftingType;
 import com.minecolonies.api.util.constant.TranslationConstants;
 import com.minecolonies.coremod.colony.crafting.CustomRecipeManager;
 import com.minecolonies.coremod.colony.crafting.LootTableAnalyzer;
@@ -301,7 +302,7 @@ public class GenericRecipeCategory extends JobBasedRecipeCategory<IGenericRecipe
     }
 
     @NotNull
-    public List<IGenericRecipe> findRecipes(@NotNull final Map<RecipeType<?>, List<IGenericRecipe>> vanilla)
+    public List<IGenericRecipe> findRecipes(@NotNull final Map<CraftingType, List<IGenericRecipe>> vanilla)
     {
         final List<IGenericRecipe> recipes = RecipeAnalyzer.findRecipes(vanilla, this.crafting);
 

--- a/src/main/java/com/minecolonies/coremod/compatibility/jei/HerderRecipeCategory.java
+++ b/src/main/java/com/minecolonies/coremod/compatibility/jei/HerderRecipeCategory.java
@@ -3,6 +3,7 @@ package com.minecolonies.coremod.compatibility.jei;
 import com.minecolonies.api.colony.buildings.registry.BuildingEntry;
 import com.minecolonies.api.colony.jobs.IJob;
 import com.minecolonies.api.crafting.IGenericRecipe;
+import com.minecolonies.api.crafting.registry.CraftingType;
 import com.minecolonies.coremod.colony.buildings.modules.AnimalHerdingModule;
 import com.minecolonies.coremod.colony.crafting.LootTableAnalyzer;
 import com.mojang.blaze3d.vertex.PoseStack;
@@ -143,7 +144,7 @@ public class HerderRecipeCategory extends JobBasedRecipeCategory<HerderRecipeCat
 
     @NotNull
     @Override
-    public Collection<?> findRecipes(@NotNull final Map<RecipeType<?>, List<IGenericRecipe>> vanilla)
+    public Collection<?> findRecipes(@NotNull final Map<CraftingType, List<IGenericRecipe>> vanilla)
     {
         final List<ItemStack> breedingItems = this.herding.getBreedingItems();
 

--- a/src/main/java/com/minecolonies/coremod/compatibility/jei/JEIPlugin.java
+++ b/src/main/java/com/minecolonies/coremod/compatibility/jei/JEIPlugin.java
@@ -9,6 +9,7 @@ import com.minecolonies.api.colony.jobs.IJob;
 import com.minecolonies.api.colony.jobs.ModJobs;
 import com.minecolonies.api.crafting.CompostRecipe;
 import com.minecolonies.api.crafting.IGenericRecipe;
+import com.minecolonies.api.crafting.registry.CraftingType;
 import com.minecolonies.api.util.Log;
 import com.minecolonies.api.util.constant.Constants;
 import com.minecolonies.api.util.constant.TranslationConstants;
@@ -167,7 +168,7 @@ public class JEIPlugin implements IModPlugin
         this.weakRuntime = new WeakReference<>(jeiRuntime);
     }
 
-    private void populateRecipes(@NotNull final Map<RecipeType<?>, List<IGenericRecipe>> vanilla,
+    private void populateRecipes(@NotNull final Map<CraftingType, List<IGenericRecipe>> vanilla,
                                  @NotNull final BiConsumer<Collection<?>, ResourceLocation> registrar)
     {
         registrar.accept(CompostRecipeCategory.findRecipes(), CompostRecipe.ID);

--- a/src/main/java/com/minecolonies/coremod/compatibility/jei/JobBasedRecipeCategory.java
+++ b/src/main/java/com/minecolonies/coremod/compatibility/jei/JobBasedRecipeCategory.java
@@ -6,6 +6,7 @@ import com.google.common.cache.LoadingCache;
 import com.minecolonies.api.colony.buildings.registry.BuildingEntry;
 import com.minecolonies.api.colony.jobs.IJob;
 import com.minecolonies.api.crafting.IGenericRecipe;
+import com.minecolonies.api.crafting.registry.CraftingType;
 import com.minecolonies.api.entity.ModEntities;
 import com.minecolonies.api.util.constant.Constants;
 import com.minecolonies.api.util.constant.TranslationConstants;
@@ -144,7 +145,7 @@ public abstract class JobBasedRecipeCategory<T> implements IRecipeCategory<T>
         return this.icon;
     }
 
-    public Collection<?> findRecipes(@NotNull final Map<RecipeType<?>, List<IGenericRecipe>> vanilla)
+    public Collection<?> findRecipes(@NotNull final Map<CraftingType, List<IGenericRecipe>> vanilla)
     {
         return Collections.emptyList();
     }

--- a/src/main/java/com/minecolonies/coremod/compatibility/jei/transfer/CraftingGuiHandler.java
+++ b/src/main/java/com/minecolonies/coremod/compatibility/jei/transfer/CraftingGuiHandler.java
@@ -10,6 +10,7 @@ import mezz.jei.api.gui.handlers.IGuiClickableArea;
 import net.minecraft.world.inventory.CraftingContainer;
 import net.minecraft.world.inventory.Slot;
 import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.crafting.RecipeType;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.*;

--- a/src/main/java/com/minecolonies/coremod/compatibility/jei/transfer/CraftingGuiHandler.java
+++ b/src/main/java/com/minecolonies/coremod/compatibility/jei/transfer/CraftingGuiHandler.java
@@ -1,5 +1,6 @@
 package com.minecolonies.coremod.compatibility.jei.transfer;
 
+import com.minecolonies.api.crafting.ModCraftingTypes;
 import com.minecolonies.coremod.Network;
 import com.minecolonies.coremod.client.gui.containers.WindowCrafting;
 import com.minecolonies.coremod.colony.buildings.moduleviews.CraftingModuleView;
@@ -49,7 +50,7 @@ public class CraftingGuiHandler extends AbstractTeachingGuiHandler<WindowCraftin
     @Override
     protected boolean isSupportedCraftingModule(@NotNull final CraftingModuleView moduleView)
     {
-        return moduleView.canLearnCraftingRecipes();
+        return moduleView.canLearn(ModCraftingTypes.SMALL_CRAFTING);
     }
 
     @Override

--- a/src/main/java/com/minecolonies/coremod/compatibility/jei/transfer/FurnaceCraftingGuiHandler.java
+++ b/src/main/java/com/minecolonies/coremod/compatibility/jei/transfer/FurnaceCraftingGuiHandler.java
@@ -9,6 +9,7 @@ import com.minecolonies.coremod.network.messages.server.TransferRecipeCraftingTe
 import mezz.jei.api.gui.handlers.IGuiClickableArea;
 import net.minecraft.world.inventory.Slot;
 import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.crafting.RecipeType;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.*;

--- a/src/main/java/com/minecolonies/coremod/compatibility/jei/transfer/FurnaceCraftingGuiHandler.java
+++ b/src/main/java/com/minecolonies/coremod/compatibility/jei/transfer/FurnaceCraftingGuiHandler.java
@@ -1,5 +1,6 @@
 package com.minecolonies.coremod.compatibility.jei.transfer;
 
+import com.minecolonies.api.crafting.ModCraftingTypes;
 import com.minecolonies.coremod.Network;
 import com.minecolonies.coremod.client.gui.containers.WindowFurnaceCrafting;
 import com.minecolonies.coremod.colony.buildings.moduleviews.CraftingModuleView;
@@ -48,7 +49,7 @@ public class FurnaceCraftingGuiHandler extends AbstractTeachingGuiHandler<Window
     @Override
     protected boolean isSupportedCraftingModule(@NotNull final CraftingModuleView moduleView)
     {
-        return moduleView.canLearnFurnaceRecipes();
+        return moduleView.canLearn(ModCraftingTypes.SMELTING);
     }
 
     @Override

--- a/src/main/java/com/minecolonies/coremod/generation/defaults/DefaultItemTagsProvider.java
+++ b/src/main/java/com/minecolonies/coremod/generation/defaults/DefaultItemTagsProvider.java
@@ -1,5 +1,6 @@
 package com.minecolonies.coremod.generation.defaults;
 
+import com.ldtteam.domumornamentum.block.types.ExtraBlockType;
 import com.minecolonies.api.blocks.ModBlocks;
 import com.minecolonies.api.items.ModItems;
 import com.minecolonies.api.items.ModTags;
@@ -11,10 +12,15 @@ import net.minecraft.resources.ResourceLocation;
 import net.minecraft.tags.ItemTags;
 import net.minecraft.world.item.Item;
 import net.minecraft.world.item.Items;
+import net.minecraft.world.level.block.Block;
 import net.minecraftforge.common.Tags;
 import net.minecraftforge.common.data.ExistingFileHelper;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
+
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
 
 import static com.minecolonies.api.util.constant.Constants.MOD_ID;
 
@@ -152,6 +158,8 @@ public class DefaultItemTagsProvider extends ItemTagsProvider
                 .add(Items.RAW_IRON)
                 .add(Items.RAW_COPPER)
                 .add(Items.RAW_GOLD);
+
+        final Item[] paperExtras = getDomumExtra(ExtraBlockType.BASE_PAPER, ExtraBlockType.LIGHT_PAPER);
 
         tag(ModTags.crafterIngredient.get(TagConstants.CRAFTING_BAKER))
                 .addTag(Tags.Items.CROPS_WHEAT);
@@ -298,13 +306,15 @@ public class DefaultItemTagsProvider extends ItemTagsProvider
                 .add(Items.LEAD);
 
         tag(ModTags.crafterIngredient.get(TagConstants.CRAFTING_PLANTATION))
-                .add(Items.BAMBOO);
+                .add(Items.BAMBOO)
+                .add(paperExtras);
         tag(ModTags.crafterIngredientExclusions.get(TagConstants.CRAFTING_PLANTATION));
         tag(ModTags.crafterProduct.get(TagConstants.CRAFTING_PLANTATION))
                 .add(Items.BOOK)
                 .add(Items.PAPER)
                 .add(Items.SUGAR)
-                .add(Items.WRITABLE_BOOK);
+                .add(Items.WRITABLE_BOOK)
+                .add(paperExtras);
         tag(ModTags.crafterProductExclusions.get(TagConstants.CRAFTING_PLANTATION));
 
         tag(ModTags.crafterIngredient.get(TagConstants.CRAFTING_SAWMILL))
@@ -367,7 +377,8 @@ public class DefaultItemTagsProvider extends ItemTagsProvider
                 .addTag(ModTags.crafterProduct.get(TagConstants.CRAFTING_MECHANIC))
                 .addTag(ItemTags.WOODEN_SLABS)
                 .addTag(ItemTags.WOODEN_STAIRS)
-                .add(Items.LECTERN, Items.PISTON);
+                .add(Items.LECTERN, Items.PISTON)
+                .add(paperExtras);
 
         tag(ModTags.crafterIngredient.get(TagConstants.CRAFTING_STONE_SMELTERY))
                 .addTag(ModTags.crafterProduct.get(TagConstants.CRAFTING_STONEMASON));
@@ -425,5 +436,15 @@ public class DefaultItemTagsProvider extends ItemTagsProvider
                 .add(ModItems.rawPumpkinPie)
                 .add(ModItems.cakeBatter);
 
+    }
+
+    @NotNull
+    private static Item[] getDomumExtra(@NotNull final ExtraBlockType... types)
+    {
+        final Set<ExtraBlockType> typesSet = new HashSet<>(Arrays.asList(types));
+        return com.ldtteam.domumornamentum.block.ModBlocks.getInstance().getExtraTopBlocks().stream()
+                .filter(extra -> typesSet.contains(extra.getType()))
+                .map(Block::asItem)
+                .toArray(Item[]::new);
     }
 }

--- a/src/main/java/com/minecolonies/coremod/network/messages/server/colony/building/OpenCraftingGUIMessage.java
+++ b/src/main/java/com/minecolonies/coremod/network/messages/server/colony/building/OpenCraftingGUIMessage.java
@@ -2,6 +2,7 @@ package com.minecolonies.coremod.network.messages.server.colony.building;
 
 import com.minecolonies.api.colony.IColony;
 import com.minecolonies.api.colony.buildings.IBuilding;
+import com.minecolonies.api.crafting.ModCraftingTypes;
 import com.minecolonies.api.inventory.container.ContainerCrafting;
 import com.minecolonies.api.inventory.container.ContainerCraftingFurnace;
 import com.minecolonies.coremod.colony.buildings.modules.AbstractCraftingBuildingModule;
@@ -70,7 +71,7 @@ public class OpenCraftingGUIMessage extends AbstractBuildingServerMessage<IBuild
         }
 
         final AbstractCraftingBuildingModule module = building.getModuleMatching(AbstractCraftingBuildingModule.class, m -> m.getId().equals(id));
-        if (module.canLearnFurnaceRecipes())
+        if (module.canLearn(ModCraftingTypes.SMELTING))
         {
             NetworkHooks.openGui(player, new MenuProvider()
             {
@@ -104,9 +105,9 @@ public class OpenCraftingGUIMessage extends AbstractBuildingServerMessage<IBuild
                 @Override
                 public AbstractContainerMenu createMenu(final int id, @NotNull final Inventory inv, @NotNull final Player player)
                 {
-                    return new ContainerCrafting(id, inv, module.canLearnLargeRecipes(), building.getID(), module.getId());
+                    return new ContainerCrafting(id, inv, module.canLearn(ModCraftingTypes.LARGE_CRAFTING), building.getID(), module.getId());
                 }
-            }, buffer -> new FriendlyByteBuf(buffer.writeBoolean(module.canLearnLargeRecipes())).writeBlockPos(building.getID()).writeUtf(module.getId()));
+            }, buffer -> new FriendlyByteBuf(buffer.writeBoolean(module.canLearn(ModCraftingTypes.LARGE_CRAFTING))).writeBlockPos(building.getID()).writeUtf(module.getId()));
         }
     }
 }

--- a/src/main/java/com/minecolonies/coremod/network/messages/server/colony/building/OpenCraftingGUIMessage.java
+++ b/src/main/java/com/minecolonies/coremod/network/messages/server/colony/building/OpenCraftingGUIMessage.java
@@ -16,6 +16,7 @@ import net.minecraft.world.MenuProvider;
 import net.minecraft.network.FriendlyByteBuf;
 import net.minecraft.network.chat.Component;
 import net.minecraft.network.chat.TextComponent;
+import net.minecraft.world.item.crafting.RecipeType;
 import net.minecraftforge.network.NetworkEvent;
 import net.minecraftforge.network.NetworkHooks;
 import org.jetbrains.annotations.NotNull;

--- a/src/main/java/com/minecolonies/coremod/proxy/CommonProxy.java
+++ b/src/main/java/com/minecolonies/coremod/proxy/CommonProxy.java
@@ -11,6 +11,7 @@ import com.minecolonies.api.colony.interactionhandling.registry.InteractionRespo
 import com.minecolonies.api.colony.jobs.registry.JobEntry;
 import com.minecolonies.api.crafting.CompostRecipe;
 import com.minecolonies.api.crafting.CountedIngredient;
+import com.minecolonies.api.crafting.registry.CraftingType;
 import com.minecolonies.api.crafting.registry.RecipeTypeEntry;
 import com.minecolonies.api.research.effects.registry.ResearchEffectEntry;
 import com.minecolonies.api.research.registry.ResearchRequirementEntry;
@@ -153,6 +154,12 @@ public abstract class CommonProxy implements IProxy
     public static void registerRecipeTypes(final RegistryEvent.Register<RecipeTypeEntry> event)
     {
         ModRecipeTypesInitializer.init(event);
+    }
+
+    @SubscribeEvent
+    public static void registerCraftingTypes(final RegistryEvent.Register<CraftingType> event)
+    {
+        ModCraftingTypesInitializer.init(event);
     }
 
     @SubscribeEvent

--- a/src/main/java/com/minecolonies/coremod/recipes/ArchitectsCutterCraftingType.java
+++ b/src/main/java/com/minecolonies/coremod/recipes/ArchitectsCutterCraftingType.java
@@ -7,8 +7,9 @@ import com.ldtteam.domumornamentum.recipe.architectscutter.ArchitectsCutterRecip
 import com.minecolonies.api.crafting.GenericRecipe;
 import com.minecolonies.api.crafting.IGenericRecipe;
 import com.minecolonies.api.crafting.ModCraftingTypes;
-import com.minecolonies.api.crafting.registry.CraftingType;
+import com.minecolonies.api.crafting.RecipeCraftingType;
 import net.minecraft.nbt.CompoundTag;
+import net.minecraft.world.Container;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.crafting.RecipeManager;
 import net.minecraft.world.level.Level;
@@ -24,16 +25,17 @@ import java.util.List;
 import java.util.Random;
 import java.util.stream.Collectors;
 
-public class ArchitectsCutterCraftingType extends CraftingType
+public class ArchitectsCutterCraftingType extends RecipeCraftingType<Container, ArchitectsCutterRecipe>
 {
     public ArchitectsCutterCraftingType()
     {
-        super(ModCraftingTypes.ARCHITECTS_CUTTER_ID);
+        super(ModCraftingTypes.ARCHITECTS_CUTTER_ID, ModRecipeTypes.ARCHITECTS_CUTTER, null);
     }
 
     @Override
     public @NotNull List<IGenericRecipe> findRecipes(@NotNull RecipeManager recipeManager, @Nullable Level world)
     {
+        final Random rnd = world == null ? new Random() : world.getRandom();
         final List<IGenericRecipe> recipes = new ArrayList<>();
         for (final ArchitectsCutterRecipe recipe : recipeManager.getAllRecipesFor(ModRecipeTypes.ARCHITECTS_CUTTER))
         {
@@ -43,7 +45,6 @@ public class ArchitectsCutterCraftingType extends CraftingType
             if (!(generatedBlock instanceof final IMateriallyTexturedBlock materiallyTexturedBlock))
                 continue;
 
-            final Random rnd = world == null ? new Random() : world.getRandom();
             final List<List<ItemStack>> inputs = new ArrayList<>();
             for (final IMateriallyTexturedBlockComponent component : materiallyTexturedBlock.getComponents())
             {

--- a/src/main/java/com/minecolonies/coremod/recipes/ArchitectsCutterCraftingType.java
+++ b/src/main/java/com/minecolonies/coremod/recipes/ArchitectsCutterCraftingType.java
@@ -1,0 +1,71 @@
+package com.minecolonies.coremod.recipes;
+
+import com.ldtteam.domumornamentum.block.IMateriallyTexturedBlock;
+import com.ldtteam.domumornamentum.block.IMateriallyTexturedBlockComponent;
+import com.ldtteam.domumornamentum.recipe.ModRecipeTypes;
+import com.ldtteam.domumornamentum.recipe.architectscutter.ArchitectsCutterRecipe;
+import com.minecolonies.api.crafting.GenericRecipe;
+import com.minecolonies.api.crafting.IGenericRecipe;
+import com.minecolonies.api.crafting.ModCraftingTypes;
+import com.minecolonies.api.crafting.registry.CraftingType;
+import net.minecraft.nbt.CompoundTag;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.crafting.RecipeManager;
+import net.minecraft.world.level.Level;
+import net.minecraft.world.level.block.Block;
+import net.minecraft.world.level.block.Blocks;
+import net.minecraftforge.registries.ForgeRegistries;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Random;
+import java.util.stream.Collectors;
+
+public class ArchitectsCutterCraftingType extends CraftingType
+{
+    public ArchitectsCutterCraftingType()
+    {
+        super(ModCraftingTypes.ARCHITECTS_CUTTER_ID);
+    }
+
+    @Override
+    public @NotNull List<IGenericRecipe> findRecipes(@NotNull RecipeManager recipeManager, @Nullable Level world)
+    {
+        final List<IGenericRecipe> recipes = new ArrayList<>();
+        for (final ArchitectsCutterRecipe recipe : recipeManager.getAllRecipesFor(ModRecipeTypes.ARCHITECTS_CUTTER))
+        {
+            // cutter recipes don't implement getIngredients(), so we have to work around it
+            final Block generatedBlock = ForgeRegistries.BLOCKS.getValue(recipe.getBlockName());
+
+            if (!(generatedBlock instanceof final IMateriallyTexturedBlock materiallyTexturedBlock))
+                continue;
+
+            final Random rnd = world == null ? new Random() : world.getRandom();
+            final List<List<ItemStack>> inputs = new ArrayList<>();
+            for (final IMateriallyTexturedBlockComponent component : materiallyTexturedBlock.getComponents())
+            {
+                final List<Block> blocks = new ArrayList<>(component.getValidSkins().getValues());
+                Collections.shuffle(blocks, rnd);
+                inputs.add(blocks.stream().map(ItemStack::new).collect(Collectors.toList()));
+            }
+
+            final ItemStack output = recipe.getResultItem().copy();
+            output.setCount(Math.max(recipe.getCount(), inputs.size()));
+
+            // resultItem usually doesn't have textureData, but we need it to properly match the creative tab
+            if (!output.getOrCreateTag().contains("textureData"))
+            {
+                assert output.getTag() != null;
+                output.getTag().put("textureData", new CompoundTag());
+            }
+
+            recipes.add(new GenericRecipe(recipe.getId(), output, new ArrayList<>(),
+                    inputs, 3, Blocks.AIR, null, new ArrayList<>(), -1));
+        }
+
+        return recipes;
+    }
+}

--- a/src/main/java/com/minecolonies/coremod/recipes/BrewingCraftingType.java
+++ b/src/main/java/com/minecolonies/coremod/recipes/BrewingCraftingType.java
@@ -1,0 +1,72 @@
+package com.minecolonies.coremod.recipes;
+
+import com.minecolonies.api.MinecoloniesAPIProxy;
+import com.minecolonies.api.compatibility.ICompatibilityManager;
+import com.minecolonies.api.crafting.GenericRecipe;
+import com.minecolonies.api.crafting.IGenericRecipe;
+import com.minecolonies.api.crafting.ModCraftingTypes;
+import com.minecolonies.api.crafting.registry.CraftingType;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.crafting.RecipeManager;
+import net.minecraft.world.level.Level;
+import net.minecraft.world.level.block.Blocks;
+import net.minecraftforge.common.brewing.BrewingRecipeRegistry;
+import net.minecraftforge.common.brewing.IBrewingRecipe;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+
+/**
+ * A crafting type for brewing recipes
+ */
+public class BrewingCraftingType extends CraftingType
+{
+    public BrewingCraftingType()
+    {
+        super(ModCraftingTypes.BREWING_ID);
+    }
+
+    @Override
+    @NotNull
+    public List<IGenericRecipe> findRecipes(@NotNull RecipeManager recipeManager, @Nullable Level world)
+    {
+        final List<IGenericRecipe> recipes = new ArrayList<>();
+        final ICompatibilityManager compatibilityManager = MinecoloniesAPIProxy.getInstance().getColonyManager().getCompatibilityManager();
+
+        for (final IBrewingRecipe recipe : BrewingRecipeRegistry.getRecipes())
+        {
+            final List<ItemStack> inputs = compatibilityManager.getListOfAllItems().stream()
+                    .filter(recipe::isInput)
+                    .collect(Collectors.toList());
+            final List<ItemStack> ingredients = compatibilityManager.getListOfAllItems().stream()
+                    .filter(recipe::isIngredient)
+                    .collect(Collectors.toList());
+
+            for (final ItemStack input : inputs)
+            {
+                for (final ItemStack ingredient : ingredients)
+                {
+                    final ItemStack output = recipe.getOutput(input, ingredient);
+                    if (!output.isEmpty())
+                    {
+                        final ItemStack actualInput = input.copy();
+                        actualInput.setCount(3);
+                        final ItemStack actualOutput = output.copy();
+                        actualOutput.setCount(3);
+
+                        recipes.add(new GenericRecipe(null, actualOutput, Collections.emptyList(),
+                                Arrays.asList(Collections.singletonList(actualInput), Collections.singletonList(ingredient)),
+                                4, Blocks.BREWING_STAND, null, Collections.emptyList(), -1));
+                    }
+                }
+            }
+        }
+
+        return recipes;
+    }
+}


### PR DESCRIPTION
# Changes proposed in this pull request:
- `runData` added carpets to spawn blocks, apparently.
- Moves crafting of paper extra from stonemason to plantation.
    - Doesn't make the plantation responsible for DO-crafting paper wall or other DO blocks that include paper extra (since it's not currently a DO crafter), but that's a thing that could be done if we want to.
- Ports #8288 
- Makes DO crafting use a new crafting type.
    - There should be no actual change in behaviour from this.
- Adds recipe auditing for DO outputs and inputs.
- Since it shares code with the above, JEI will now also hint which blocks are acceptable for DO crafting at each crafter.

Review please

See [the spreadsheet](https://docs.google.com/spreadsheets/d/1fPdA5BDmnW3r2BXfRik8bmVt0nxwI3tOrrpc1vYXP_I/edit?usp=sharing):
- The "After" tab is before this PR
- The "WithDomum" tab is after this PR
- The "DomumInput" tab is a new visualisation of the acceptable input blocks.
    - For each output block type, it shows the possible input "skin" blocks and which crafter will accept them.
    - As before, only one of the input blocks needs to be acceptable to the crafter; the other blocks can be any valid skin, crafter-acceptable or not.