### PR TITLE
Refactor crafting modules to use crafting types

### DIFF
--- a/src/api/java/com/minecolonies/api/IMinecoloniesAPI.java
+++ b/src/api/java/com/minecolonies/api/IMinecoloniesAPI.java
@@ -15,6 +15,7 @@ import com.minecolonies.api.colony.jobs.registry.IJobDataManager;
 import com.minecolonies.api.colony.jobs.registry.JobEntry;
 import com.minecolonies.api.compatibility.IFurnaceRecipes;
 import com.minecolonies.api.configuration.Configuration;
+import com.minecolonies.api.crafting.registry.CraftingType;
 import com.minecolonies.api.crafting.registry.RecipeTypeEntry;
 import com.minecolonies.api.entity.ai.registry.IMobAIRegistry;
 import com.minecolonies.api.entity.pathfinding.registry.IPathNavigateRegistry;
@@ -72,4 +73,6 @@ public interface IMinecoloniesAPI
     IForgeRegistry<ColonyEventDescriptionTypeRegistryEntry> getColonyEventDescriptionRegistry();
 
     IForgeRegistry<RecipeTypeEntry> getRecipeTypeRegistry();
+
+    IForgeRegistry<CraftingType> getCraftingTypeRegistry();
 }

--- a/src/api/java/com/minecolonies/api/MinecoloniesAPIProxy.java
+++ b/src/api/java/com/minecolonies/api/MinecoloniesAPIProxy.java
@@ -15,6 +15,7 @@ import com.minecolonies.api.colony.jobs.registry.IJobDataManager;
 import com.minecolonies.api.colony.jobs.registry.JobEntry;
 import com.minecolonies.api.compatibility.IFurnaceRecipes;
 import com.minecolonies.api.configuration.Configuration;
+import com.minecolonies.api.crafting.registry.CraftingType;
 import com.minecolonies.api.crafting.registry.RecipeTypeEntry;
 import com.minecolonies.api.entity.ai.registry.IMobAIRegistry;
 import com.minecolonies.api.entity.pathfinding.registry.IPathNavigateRegistry;
@@ -161,5 +162,11 @@ public final class MinecoloniesAPIProxy implements IMinecoloniesAPI
     public IForgeRegistry<RecipeTypeEntry> getRecipeTypeRegistry()
     {
         return apiInstance.getRecipeTypeRegistry();
+    }
+
+    @Override
+    public IForgeRegistry<CraftingType> getCraftingTypeRegistry()
+    {
+        return apiInstance.getCraftingTypeRegistry();
     }
 }

--- a/src/api/java/com/minecolonies/api/colony/buildings/modules/ICraftingBuildingModule.java
+++ b/src/api/java/com/minecolonies/api/colony/buildings/modules/ICraftingBuildingModule.java
@@ -6,6 +6,7 @@ import com.minecolonies.api.colony.jobs.registry.JobEntry;
 import com.minecolonies.api.colony.requestsystem.token.IToken;
 import com.minecolonies.api.crafting.IGenericRecipe;
 import com.minecolonies.api.crafting.IRecipeStorage;
+import com.minecolonies.api.crafting.registry.CraftingType;
 import com.minecolonies.api.util.OptionalPredicate;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.ResourceLocation;
@@ -13,6 +14,7 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.List;
+import java.util.Set;
 import java.util.function.Predicate;
 
 /**
@@ -78,28 +80,20 @@ public interface ICraftingBuildingModule extends IBuildingModule
     String getCustomRecipeKey();
 
     /**
-     * Check if this building type can learn (or otherwise process)
-     * vanilla crafting recipes of some kind.
-     *
-     * @return True if so; false otherwise.
+     * Check if the worker can learn a certain type of recipe.
+     * @param type the type to check for.
+     * @return true if so.
      */
-    boolean canLearnCraftingRecipes();
+    default boolean canLearnRecipe(final CraftingType type)
+    {
+        return getSupportedRecipeTypes().contains(type);
+    }
 
     /**
-     * Check if this building type can learn (or otherwise process)
-     * vanilla smelting recipes of some kind.
-     *
-     * @return True if so; false otherwise.
+     * Get the supported recipe types.
+     * @return a set of types.
      */
-    boolean canLearnFurnaceRecipes();
-
-    /**
-     * Check if it is possible for this building type to learn
-     * recipes that will only fit in a 3x3 crafting grid.
-     *
-     * @return True if 3x3 recipes can be taught.
-     */
-    boolean canLearnLargeRecipes();
+    Set<CraftingType> getSupportedRecipeTypes();
 
     /**
      * Checks if this particular recipe is *possible* to be learned by
@@ -125,6 +119,12 @@ public interface ICraftingBuildingModule extends IBuildingModule
      */
     @NotNull
     OptionalPredicate<ItemStack> getIngredientValidator();
+
+    /**
+     * Check if the module should have a large limit for learnable recipes.
+     * @return true if so.
+     */
+    boolean canLearnManyRecipes();
 
     /**
      * Check if the module on the client side should be displayed.

--- a/src/api/java/com/minecolonies/api/colony/buildings/modules/ICraftingBuildingModule.java
+++ b/src/api/java/com/minecolonies/api/colony/buildings/modules/ICraftingBuildingModule.java
@@ -84,16 +84,16 @@ public interface ICraftingBuildingModule extends IBuildingModule
      * @param type the type to check for.
      * @return true if so.
      */
-    default boolean canLearnRecipe(final CraftingType type)
+    default boolean canLearn(final CraftingType type)
     {
-        return getSupportedRecipeTypes().contains(type);
+        return getSupportedCraftingTypes().contains(type);
     }
 
     /**
-     * Get the supported recipe types.
+     * Get the supported crafting types.
      * @return a set of types.
      */
-    Set<CraftingType> getSupportedRecipeTypes();
+    Set<CraftingType> getSupportedCraftingTypes();
 
     /**
      * Checks if this particular recipe is *possible* to be learned by

--- a/src/api/java/com/minecolonies/api/crafting/GenericRecipe.java
+++ b/src/api/java/com/minecolonies/api/crafting/GenericRecipe.java
@@ -10,11 +10,13 @@ import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.inventory.CraftingInventory;
 import net.minecraft.inventory.container.Container;
 import net.minecraft.inventory.container.ContainerType;
+import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
 import net.minecraft.item.crafting.FurnaceRecipe;
 import net.minecraft.item.crafting.ICraftingRecipe;
 import net.minecraft.item.crafting.IRecipe;
 import net.minecraft.item.crafting.Ingredient;
+import net.minecraft.util.NonNullList;
 import net.minecraft.util.ResourceLocation;
 import net.minecraft.util.text.ITextComponent;
 import net.minecraft.world.World;
@@ -34,9 +36,9 @@ public class GenericRecipe implements IGenericRecipe
     public static IGenericRecipe of(@Nullable final IRecipe<?> recipe, @Nullable final World world)
     {
         if (recipe == null) return null;
-        final List<List<ItemStack>> inputs = recipe.getIngredients().stream()
+        final List<List<ItemStack>> inputs = compactInputs(recipe.getIngredients().stream()
                 .map(ingredient -> Arrays.asList(ingredient.getItems()))
-                .collect(Collectors.toList());
+                .collect(Collectors.toList()));
         final int size;
         final Block intermediate;
         if (recipe instanceof FurnaceRecipe)
@@ -264,5 +266,104 @@ public class GenericRecipe implements IGenericRecipe
             }
         }
         return Collections.emptyList();
+    }
+
+    private static List<List<ItemStack>> compactInputs(final List<List<ItemStack>> inputs)
+    {
+        // FYI, this largely does the same job as RecipeStorage.calculateCleanedInput(), but we can't re-use
+        // that implementation as we need to operate on Ingredients, which can be a list of stacks.
+        final Map<IngredientStacks, IngredientStacks> ingredients = new HashMap<>();
+
+        for (final List<ItemStack> ingredient : inputs)
+        {
+            final IngredientStacks newIngredient = new IngredientStacks(ingredient);
+            // also ignore the build tool as an ingredient, since colony crafters don't require it.
+            //   (see RecipeStorage.calculateCleanedInput() for why)
+            if (!newIngredient.getStacks().isEmpty() && newIngredient.getStacks().get(0).getItem() == buildTool.get()) continue;
+
+            final IngredientStacks existing = ingredients.get(newIngredient);
+            if (existing == null)
+            {
+                ingredients.put(newIngredient, newIngredient);
+            }
+            else
+            {
+                existing.merge(newIngredient);
+            }
+        }
+
+        return ingredients.values().stream()
+                .sorted(Comparator.reverseOrder())
+                .map(IngredientStacks::getStacks)
+                .collect(Collectors.toCollection(NonNullList::create));
+    }
+
+    private static class IngredientStacks implements Comparable<IngredientStacks>
+    {
+        private final List<ItemStack> stacks;
+        private final Set<Item> items;
+
+        public IngredientStacks(final List<ItemStack> ingredient)
+        {
+            this.stacks = ingredient.stream()
+                    .filter(stack -> !stack.isEmpty())
+                    .map(ItemStack::copy)
+                    .collect(Collectors.toList());
+
+            this.items = this.stacks.stream()
+                    .map(ItemStack::getItem)
+                    .collect(Collectors.toSet());
+        }
+
+        @NotNull
+        public List<ItemStack> getStacks() { return this.stacks; }
+
+        public int getCount() { return this.stacks.isEmpty() ? 0 : this.stacks.get(0).getCount(); }
+
+        @Override
+        public boolean equals(Object o)
+        {
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
+            final IngredientStacks that = (IngredientStacks) o;
+            return this.items.equals(that.items);
+            // note that this does not compare the counts to maintain key-stability
+        }
+
+        @Override
+        public int hashCode()
+        {
+            return this.items.hashCode();
+        }
+
+        @Override
+        public int compareTo(@NotNull IngredientStacks o)
+        {
+            int diff = this.getCount() - o.getCount();
+            if (diff != 0) return diff;
+
+            diff = this.stacks.size() - o.stacks.size();
+            if (diff != 0) return diff;
+
+            return this.hashCode() - o.hashCode();
+        }
+
+        public void merge(@NotNull final IngredientStacks other)
+        {
+            // assumes equals(other)
+            for (int i = 0; i < this.stacks.size(); i++)
+            {
+                this.stacks.get(i).grow(other.stacks.get(i).getCount());
+            }
+        }
+
+        @Override
+        public String toString()
+        {
+            return "IngredientStacks{" +
+                    "stacks=" + stacks +
+                    ", items=" + items +
+                    '}';
+        }
     }
 }

--- a/src/api/java/com/minecolonies/api/crafting/ModCraftingTypes.java
+++ b/src/api/java/com/minecolonies/api/crafting/ModCraftingTypes.java
@@ -1,0 +1,24 @@
+package com.minecolonies.api.crafting;
+
+import com.minecolonies.api.crafting.registry.CraftingType;
+import net.minecraft.util.ResourceLocation;
+
+import static com.minecolonies.api.util.constant.Constants.MOD_ID;
+
+public class ModCraftingTypes
+{
+    public static final ResourceLocation SMALL_CRAFTING_ID = new ResourceLocation(MOD_ID, "smallcrafting");
+    public static final ResourceLocation LARGE_CRAFTING_ID = new ResourceLocation(MOD_ID, "largecrafting");
+    public static final ResourceLocation SMELTING_ID = new ResourceLocation(MOD_ID, "smelting");
+    public static final ResourceLocation BREWING_ID = new ResourceLocation(MOD_ID, "brewing");
+
+    public static CraftingType SMALL_CRAFTING;
+    public static CraftingType LARGE_CRAFTING;
+    public static CraftingType SMELTING;
+    public static CraftingType BREWING;
+
+    private ModCraftingTypes()
+    {
+        throw new IllegalStateException("Tried to initialize: ModCraftingTypes but this is a Utility class.");
+    }
+}

--- a/src/api/java/com/minecolonies/api/crafting/RecipeCraftingType.java
+++ b/src/api/java/com/minecolonies/api/crafting/RecipeCraftingType.java
@@ -1,0 +1,74 @@
+package com.minecolonies.api.crafting;
+
+import com.minecolonies.api.crafting.registry.CraftingType;
+import com.minecolonies.api.util.Log;
+import net.minecraft.inventory.IInventory;
+import net.minecraft.item.crafting.IRecipe;
+import net.minecraft.item.crafting.IRecipeType;
+import net.minecraft.item.crafting.RecipeManager;
+import net.minecraft.util.ResourceLocation;
+import net.minecraft.world.World;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.Predicate;
+
+/**
+ * A {@link CraftingType} for the vanilla {@link IRecipeType}
+ * @param <C> the crafting inventory type
+ * @param <T> the recipe type
+ */
+public class RecipeCraftingType<C extends IInventory, T extends IRecipe<C>> extends CraftingType
+{
+    private final IRecipeType<T> recipeType;
+    private final Predicate<IRecipe<C>> predicate;
+
+    /**
+     * Create a new instance
+     * @param id the crafting type id
+     * @param recipeType the vanilla recipe type
+     * @param predicate filter acceptable recipes, or null to accept all
+     */
+    public RecipeCraftingType(@NotNull final ResourceLocation id,
+                              @NotNull final IRecipeType<T> recipeType,
+                              @Nullable final Predicate<IRecipe<C>> predicate)
+    {
+        super(id);
+        this.recipeType = recipeType;
+        this.predicate = predicate;
+    }
+
+    @Override
+    @NotNull
+    public List<IGenericRecipe> findRecipes(@NotNull RecipeManager recipeManager,
+                                            @Nullable final World world)
+    {
+        final List<IGenericRecipe> recipes = new ArrayList<>();
+        for (final IRecipe<C> recipe : recipeManager.byType(recipeType).values())
+        {
+            if (predicate != null && !predicate.test(recipe)) continue;
+
+            tryAddingVanillaRecipe(recipes, recipe, world);
+        }
+        return recipes;
+    }
+
+    private static void tryAddingVanillaRecipe(@NotNull final List<IGenericRecipe> recipes,
+                                               @NotNull final IRecipe<?> recipe,
+                                               @Nullable final World world)
+    {
+        if (recipe.getResultItem().isEmpty()) return;     // invalid or special recipes
+        try
+        {
+            final IGenericRecipe genericRecipe = GenericRecipe.of(recipe, world);
+            if (genericRecipe == null || genericRecipe.getInputs().isEmpty()) return;
+            recipes.add(genericRecipe);
+        }
+        catch (final Exception ex)
+        {
+            Log.getLogger().warn("Error evaluating recipe " + recipe.getId() + "; ignoring.", ex);
+        }
+    }
+}

--- a/src/api/java/com/minecolonies/api/crafting/registry/CraftingType.java
+++ b/src/api/java/com/minecolonies/api/crafting/registry/CraftingType.java
@@ -1,0 +1,49 @@
+package com.minecolonies.api.crafting.registry;
+
+import com.minecolonies.api.crafting.IGenericRecipe;
+import net.minecraft.item.crafting.RecipeManager;
+import net.minecraft.util.ResourceLocation;
+import net.minecraft.world.World;
+import net.minecraftforge.registries.ForgeRegistryEntry;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * Class to represent the different types of crafting supported by MineColonies
+ */
+public abstract class CraftingType extends ForgeRegistryEntry<CraftingType>
+{
+    protected CraftingType(@NotNull final ResourceLocation id)
+    {
+        setRegistryName(id);
+    }
+
+    /**
+     * Find all teachable recipes supported by this particular crafting type
+     * @param recipeManager the vanilla recipe manager
+     * @param world the world (if available)
+     * @return the list of teachable recipes
+     */
+    @NotNull
+    public abstract List<IGenericRecipe> findRecipes(@NotNull final RecipeManager recipeManager,
+                                                     @Nullable final World world);
+
+    @Override
+    public boolean equals(Object obj)
+    {
+        if (obj instanceof CraftingType)
+        {
+            return Objects.equals(getRegistryName(), ((CraftingType) obj).getRegistryName());
+        }
+        return false;
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return getRegistryName().hashCode();
+    }
+}

--- a/src/main/java/com/minecolonies/apiimp/CommonMinecoloniesAPIImpl.java
+++ b/src/main/java/com/minecolonies/apiimp/CommonMinecoloniesAPIImpl.java
@@ -17,6 +17,7 @@ import com.minecolonies.api.colony.jobs.registry.IJobDataManager;
 import com.minecolonies.api.colony.jobs.registry.JobEntry;
 import com.minecolonies.api.compatibility.IFurnaceRecipes;
 import com.minecolonies.api.configuration.Configuration;
+import com.minecolonies.api.crafting.registry.CraftingType;
 import com.minecolonies.api.crafting.registry.RecipeTypeEntry;
 import com.minecolonies.api.entity.ai.registry.IMobAIRegistry;
 import com.minecolonies.api.entity.pathfinding.registry.IPathNavigateRegistry;
@@ -63,6 +64,7 @@ public class CommonMinecoloniesAPIImpl implements IMinecoloniesAPI
     private        IForgeRegistry<ResearchRequirementEntry>                researchRequirementRegistry;
     private        IForgeRegistry<ResearchEffectEntry>                     researchEffectRegistry;
     private        IForgeRegistry<RecipeTypeEntry>                         recipeTypeEntryRegistry;
+    private        IForgeRegistry<CraftingType>                            craftingTypeRegistry;
 
     @Override
     @NotNull
@@ -223,6 +225,11 @@ public class CommonMinecoloniesAPIImpl implements IMinecoloniesAPI
                 .disableSaving().allowModification().setType(ColonyEventDescriptionTypeRegistryEntry.class)
                 .setIDRange(0, Integer.MAX_VALUE - 1).create();
 
+        craftingTypeRegistry = new RegistryBuilder<CraftingType>()
+                .setName(new ResourceLocation(Constants.MOD_ID, "craftingtypes"))
+                .disableSaving().allowModification().setType(CraftingType.class)
+                .setIDRange(0, Integer.MAX_VALUE - 1).create();
+
         recipeTypeEntryRegistry = new RegistryBuilder<RecipeTypeEntry>()
                                     .setName(new ResourceLocation(Constants.MOD_ID, "recipetypeentries"))
                                     .setDefaultKey(new ResourceLocation(Constants.MOD_ID, "classic"))
@@ -258,6 +265,12 @@ public class CommonMinecoloniesAPIImpl implements IMinecoloniesAPI
     public IForgeRegistry<RecipeTypeEntry> getRecipeTypeRegistry()
     {
         return recipeTypeEntryRegistry;
+    }
+
+    @Override
+    public IForgeRegistry<CraftingType> getCraftingTypeRegistry()
+    {
+        return craftingTypeRegistry;
     }
 }
 

--- a/src/main/java/com/minecolonies/apiimp/initializer/ModCraftingTypesInitializer.java
+++ b/src/main/java/com/minecolonies/apiimp/initializer/ModCraftingTypesInitializer.java
@@ -1,0 +1,38 @@
+package com.minecolonies.apiimp.initializer;
+
+import com.minecolonies.api.crafting.ModCraftingTypes;
+import com.minecolonies.api.crafting.RecipeCraftingType;
+import com.minecolonies.api.crafting.registry.CraftingType;
+import com.minecolonies.coremod.recipes.BrewingCraftingType;
+import net.minecraft.item.crafting.IRecipeType;
+import net.minecraftforge.event.RegistryEvent;
+import net.minecraftforge.registries.IForgeRegistry;
+
+public final class ModCraftingTypesInitializer
+{
+    private ModCraftingTypesInitializer()
+    {
+        throw new IllegalStateException("Tried to initialize: ModCraftingTypesInitializer but this is a Utility class.");
+    }
+
+    public static void init(final RegistryEvent.Register<CraftingType> event)
+    {
+        final IForgeRegistry<CraftingType> reg = event.getRegistry();
+
+        ModCraftingTypes.SMALL_CRAFTING = new RecipeCraftingType<>(ModCraftingTypes.SMALL_CRAFTING_ID,
+                IRecipeType.CRAFTING, r -> r.canCraftInDimensions(2, 2));
+        reg.register(ModCraftingTypes.SMALL_CRAFTING);
+
+        ModCraftingTypes.LARGE_CRAFTING = new RecipeCraftingType<>(ModCraftingTypes.LARGE_CRAFTING_ID,
+                IRecipeType.CRAFTING, r -> r.canCraftInDimensions(3, 3)
+                    && !r.canCraftInDimensions(2, 2));
+        reg.register(ModCraftingTypes.LARGE_CRAFTING);
+
+        ModCraftingTypes.SMELTING = new RecipeCraftingType<>(ModCraftingTypes.SMELTING_ID,
+                IRecipeType.SMELTING, null);
+        reg.register(ModCraftingTypes.SMELTING);
+
+        ModCraftingTypes.BREWING = new BrewingCraftingType();
+        reg.register(ModCraftingTypes.BREWING);
+    }
+}

--- a/src/main/java/com/minecolonies/coremod/client/gui/containers/WindowCrafting.java
+++ b/src/main/java/com/minecolonies/coremod/client/gui/containers/WindowCrafting.java
@@ -107,7 +107,7 @@ public class WindowCrafting extends ContainerScreen<ContainerCrafting>
         super(container, playerInventory, iTextComponent);
         this.building = (AbstractBuildingView) IColonyManager.getInstance().getBuildingView(playerInventory.player.level.dimension(), container.getPos());
         this.module = building.getModuleViewMatching(CraftingModuleView.class, v -> v.getId().equals(container.getModuleId()));
-        completeCrafting = module.canLearnRecipe(ModCraftingTypes.LARGE_CRAFTING);
+        completeCrafting = module.canLearn(ModCraftingTypes.LARGE_CRAFTING);
     }
 
     @NotNull
@@ -125,14 +125,14 @@ public class WindowCrafting extends ContainerScreen<ContainerCrafting>
     protected void init()
     {
         super.init();
-        final String buttonDisplay = module.canLearnRecipe(ModCraftingTypes.SMALL_CRAFTING) ? I18n.get("gui.done") : LanguageHandler.format("com.minecolonies.coremod.gui.recipe.full");
+        final String buttonDisplay = module.canLearn(ModCraftingTypes.SMALL_CRAFTING) ? I18n.get("gui.done") : LanguageHandler.format("com.minecolonies.coremod.gui.recipe.full");
         /*
          * The button to click done after finishing the recipe.
          */
         final Button
           doneButton = new Button(leftPos + BUTTON_X_OFFSET, topPos + BUTTON_Y_POS, BUTTON_WIDTH, BUTTON_HEIGHT, new StringTextComponent(buttonDisplay), new WindowCrafting.OnButtonPress());
         this.addButton(doneButton);
-        if (!module.canLearnRecipe(ModCraftingTypes.SMALL_CRAFTING))
+        if (!module.canLearn(ModCraftingTypes.SMALL_CRAFTING))
         {
             doneButton.active = false;
         }
@@ -143,7 +143,7 @@ public class WindowCrafting extends ContainerScreen<ContainerCrafting>
         @Override
         public void onPress(final Button button)
         {
-            if (module.canLearnRecipe(ModCraftingTypes.SMALL_CRAFTING))
+            if (module.canLearn(ModCraftingTypes.SMALL_CRAFTING))
             {
                 final List<ItemStorage> input = new LinkedList<>();
 

--- a/src/main/java/com/minecolonies/coremod/client/gui/containers/WindowCrafting.java
+++ b/src/main/java/com/minecolonies/coremod/client/gui/containers/WindowCrafting.java
@@ -3,6 +3,7 @@ package com.minecolonies.coremod.client.gui.containers;
 import com.ldtteam.structurize.util.LanguageHandler;
 import com.minecolonies.api.colony.IColonyManager;
 import com.minecolonies.api.crafting.ItemStorage;
+import com.minecolonies.api.crafting.ModCraftingTypes;
 import com.minecolonies.api.inventory.container.ContainerCrafting;
 import com.minecolonies.api.util.ItemStackUtils;
 import com.minecolonies.api.util.constant.Constants;
@@ -106,7 +107,7 @@ public class WindowCrafting extends ContainerScreen<ContainerCrafting>
         super(container, playerInventory, iTextComponent);
         this.building = (AbstractBuildingView) IColonyManager.getInstance().getBuildingView(playerInventory.player.level.dimension(), container.getPos());
         this.module = building.getModuleViewMatching(CraftingModuleView.class, v -> v.getId().equals(container.getModuleId()));
-        completeCrafting = module.canLearnLargeRecipes();
+        completeCrafting = module.canLearnRecipe(ModCraftingTypes.LARGE_CRAFTING);
     }
 
     @NotNull
@@ -124,14 +125,14 @@ public class WindowCrafting extends ContainerScreen<ContainerCrafting>
     protected void init()
     {
         super.init();
-        final String buttonDisplay = module.canLearnCraftingRecipes() ? I18n.get("gui.done") : LanguageHandler.format("com.minecolonies.coremod.gui.recipe.full");
+        final String buttonDisplay = module.canLearnRecipe(ModCraftingTypes.SMALL_CRAFTING) ? I18n.get("gui.done") : LanguageHandler.format("com.minecolonies.coremod.gui.recipe.full");
         /*
          * The button to click done after finishing the recipe.
          */
         final Button
           doneButton = new Button(leftPos + BUTTON_X_OFFSET, topPos + BUTTON_Y_POS, BUTTON_WIDTH, BUTTON_HEIGHT, new StringTextComponent(buttonDisplay), new WindowCrafting.OnButtonPress());
         this.addButton(doneButton);
-        if (!module.canLearnCraftingRecipes())
+        if (!module.canLearnRecipe(ModCraftingTypes.SMALL_CRAFTING))
         {
             doneButton.active = false;
         }
@@ -142,7 +143,7 @@ public class WindowCrafting extends ContainerScreen<ContainerCrafting>
         @Override
         public void onPress(final Button button)
         {
-            if (module.canLearnCraftingRecipes())
+            if (module.canLearnRecipe(ModCraftingTypes.SMALL_CRAFTING))
             {
                 final List<ItemStorage> input = new LinkedList<>();
 

--- a/src/main/java/com/minecolonies/coremod/client/gui/containers/WindowFurnaceCrafting.java
+++ b/src/main/java/com/minecolonies/coremod/client/gui/containers/WindowFurnaceCrafting.java
@@ -94,13 +94,13 @@ public class WindowFurnaceCrafting extends ContainerScreen<ContainerCraftingFurn
     protected void init()
     {
         super.init();
-        final String buttonDisplay = module.canLearnRecipe(ModCraftingTypes.SMELTING) ? I18n.get("gui.done") : LanguageHandler.format("com.minecolonies.coremod.gui.recipe.full");
+        final String buttonDisplay = module.canLearn(ModCraftingTypes.SMELTING) ? I18n.get("gui.done") : LanguageHandler.format("com.minecolonies.coremod.gui.recipe.full");
         /*
          * The button to click done after finishing the recipe.
          */
         final Button doneButton = new Button(leftPos + BUTTON_X_OFFSET, topPos + BUTTON_Y_POS, BUTTON_WIDTH, BUTTON_HEIGHT, new StringTextComponent(buttonDisplay), new OnButtonPress());
         this.addButton(doneButton);
-        if (!module.canLearnRecipe(ModCraftingTypes.SMELTING))
+        if (!module.canLearn(ModCraftingTypes.SMELTING))
         {
             doneButton.active = false;
         }
@@ -111,7 +111,7 @@ public class WindowFurnaceCrafting extends ContainerScreen<ContainerCraftingFurn
         @Override
         public void onPress(@NotNull final Button button)
         {
-            if (module.canLearnRecipe(ModCraftingTypes.SMELTING))
+            if (module.canLearn(ModCraftingTypes.SMELTING))
             {
                 final List<ItemStorage> input = new ArrayList<>();
                 input.add(new ItemStorage(container.slots.get(0).getItem()));

--- a/src/main/java/com/minecolonies/coremod/client/gui/containers/WindowFurnaceCrafting.java
+++ b/src/main/java/com/minecolonies/coremod/client/gui/containers/WindowFurnaceCrafting.java
@@ -4,6 +4,7 @@ import com.google.common.collect.ImmutableList;
 import com.ldtteam.structurize.util.LanguageHandler;
 import com.minecolonies.api.colony.IColonyManager;
 import com.minecolonies.api.crafting.ItemStorage;
+import com.minecolonies.api.crafting.ModCraftingTypes;
 import com.minecolonies.api.inventory.container.ContainerCraftingFurnace;
 import com.minecolonies.api.util.ItemStackUtils;
 import com.minecolonies.api.util.constant.Constants;
@@ -93,13 +94,13 @@ public class WindowFurnaceCrafting extends ContainerScreen<ContainerCraftingFurn
     protected void init()
     {
         super.init();
-        final String buttonDisplay = module.canLearnFurnaceRecipes() ? I18n.get("gui.done") : LanguageHandler.format("com.minecolonies.coremod.gui.recipe.full");
+        final String buttonDisplay = module.canLearnRecipe(ModCraftingTypes.SMELTING) ? I18n.get("gui.done") : LanguageHandler.format("com.minecolonies.coremod.gui.recipe.full");
         /*
          * The button to click done after finishing the recipe.
          */
         final Button doneButton = new Button(leftPos + BUTTON_X_OFFSET, topPos + BUTTON_Y_POS, BUTTON_WIDTH, BUTTON_HEIGHT, new StringTextComponent(buttonDisplay), new OnButtonPress());
         this.addButton(doneButton);
-        if (!module.canLearnFurnaceRecipes())
+        if (!module.canLearnRecipe(ModCraftingTypes.SMELTING))
         {
             doneButton.active = false;
         }
@@ -110,7 +111,7 @@ public class WindowFurnaceCrafting extends ContainerScreen<ContainerCraftingFurn
         @Override
         public void onPress(@NotNull final Button button)
         {
-            if (module.canLearnFurnaceRecipes())
+            if (module.canLearnRecipe(ModCraftingTypes.SMELTING))
             {
                 final List<ItemStorage> input = new ArrayList<>();
                 input.add(new ItemStorage(container.slots.get(0).getItem()));

--- a/src/main/java/com/minecolonies/coremod/client/gui/modules/WindowListRecipes.java
+++ b/src/main/java/com/minecolonies/coremod/client/gui/modules/WindowListRecipes.java
@@ -192,7 +192,7 @@ public class WindowListRecipes extends AbstractModuleWindow
                 List<ItemStack> displayStacks = recipe.getRecipeType().getOutputDisplayStacks();
                 icon.setItem(displayStacks.get((lifeCount / LIFE_COUNT_DIVIDER) % (displayStacks.size())));
 
-                if (!module.canLearnCraftingRecipes() && !module.canLearnFurnaceRecipes())
+                if (!module.isRecipeAlterationAllowed())
                 {
                     final Button removeButton = rowPane.findPaneOfTypeByID(BUTTON_REMOVE, Button.class);
                     if (removeButton != null)

--- a/src/main/java/com/minecolonies/coremod/colony/buildings/modules/AbstractCraftingBuildingModule.java
+++ b/src/main/java/com/minecolonies/coremod/colony/buildings/modules/AbstractCraftingBuildingModule.java
@@ -1,5 +1,7 @@
 package com.minecolonies.coremod.colony.buildings.modules;
 
+import com.google.common.collect.ImmutableSet;
+import com.minecolonies.api.MinecoloniesAPIProxy;
 import com.minecolonies.api.colony.ICitizenData;
 import com.minecolonies.api.colony.IColony;
 import com.minecolonies.api.colony.IColonyManager;
@@ -16,6 +18,7 @@ import com.minecolonies.api.colony.requestsystem.requestable.crafting.PublicCraf
 import com.minecolonies.api.colony.requestsystem.resolver.IRequestResolver;
 import com.minecolonies.api.colony.requestsystem.token.IToken;
 import com.minecolonies.api.crafting.*;
+import com.minecolonies.api.crafting.registry.CraftingType;
 import com.minecolonies.api.entity.citizen.AbstractEntityCitizen;
 import com.minecolonies.api.items.ModTags;
 import com.minecolonies.api.util.*;
@@ -142,14 +145,10 @@ public abstract class AbstractCraftingBuildingModule extends AbstractBuildingMod
      */
     protected int getMaxRecipes()
     {
-        final double increase;
-        if(canLearnLargeRecipes() || canLearnFurnaceRecipes())
+        double increase = 1 + building.getColony().getResearchManager().getResearchEffects().getEffectStrength(RECIPES);
+        if (canLearnManyRecipes())
         {
-            increase = (1 + building.getColony().getResearchManager().getResearchEffects().getEffectStrength(RECIPES)) * EXTRA_RECIPE_MULTIPLIER;
-        }
-        else
-        {
-            increase = 1 + building.getColony().getResearchManager().getResearchEffects().getEffectStrength(RECIPES);
+            increase *= EXTRA_RECIPE_MULTIPLIER;
         }
         return (int) (Math.pow(2, building.getBuildingLevel()) * increase);
     }
@@ -258,9 +257,13 @@ public abstract class AbstractCraftingBuildingModule extends AbstractBuildingMod
         {
             buf.writeBoolean(false);
         }
-        buf.writeBoolean(this.canLearnCraftingRecipes());
-        buf.writeBoolean(this.canLearnFurnaceRecipes());
-        buf.writeBoolean(this.canLearnLargeRecipes());
+
+        final Set<CraftingType> craftingTypes = this.getSupportedRecipeTypes();
+        buf.writeVarInt(craftingTypes.size());
+        for (final CraftingType type : craftingTypes)
+        {
+            buf.writeRegistryIdUnsafe(MinecoloniesAPIProxy.getInstance().getCraftingTypeRegistry(), type);
+        }
 
         final List<IRecipeStorage> storages = new ArrayList<>();
         final List<IRecipeStorage> disabledStorages = new ArrayList<>();
@@ -887,6 +890,12 @@ public abstract class AbstractCraftingBuildingModule extends AbstractBuildingMod
         return stack -> Optional.empty();
     }
 
+    @Override
+    public boolean canLearnManyRecipes()
+    {
+        return true;
+    }
+
     /** This module is for standard crafters (3x3 by default) */
     public abstract static class Crafting extends AbstractCraftingBuildingModule
     {
@@ -901,18 +910,15 @@ public abstract class AbstractCraftingBuildingModule extends AbstractBuildingMod
         }
 
         @Override
-        public boolean canLearnCraftingRecipes() { return true; }
-
-        @Override
-        public boolean canLearnFurnaceRecipes() { return false; }
-
-        @Override
-        public boolean canLearnLargeRecipes() { return true; }
+        public Set<CraftingType> getSupportedRecipeTypes()
+        {
+            return ImmutableSet.of(ModCraftingTypes.SMALL_CRAFTING, ModCraftingTypes.LARGE_CRAFTING);
+        }
 
         @Override
         public boolean isRecipeCompatible(@NotNull final IGenericRecipe recipe)
         {
-            return canLearnCraftingRecipes() &&
+            return canLearnRecipe(ModCraftingTypes.SMALL_CRAFTING) &&
                     recipe.getIntermediate() == Blocks.AIR;
         }
 
@@ -941,18 +947,15 @@ public abstract class AbstractCraftingBuildingModule extends AbstractBuildingMod
         }
 
         @Override
-        public boolean canLearnCraftingRecipes() { return false; }
-
-        @Override
-        public boolean canLearnFurnaceRecipes() { return true; }
-
-        @Override
-        public boolean canLearnLargeRecipes() { return false; }
+        public Set<CraftingType> getSupportedRecipeTypes()
+        {
+            return ImmutableSet.of(ModCraftingTypes.SMELTING);
+        }
 
         @Override
         public boolean isRecipeCompatible(@NotNull final IGenericRecipe recipe)
         {
-            return canLearnFurnaceRecipes() &&
+            return canLearnRecipe(ModCraftingTypes.SMELTING) &&
                     recipe.getIntermediate() == Blocks.FURNACE;
         }
 
@@ -981,13 +984,10 @@ public abstract class AbstractCraftingBuildingModule extends AbstractBuildingMod
         }
 
         @Override
-        public boolean canLearnCraftingRecipes() { return false; }
-
-        @Override
-        public boolean canLearnFurnaceRecipes() { return false; }
-
-        @Override
-        public boolean canLearnLargeRecipes() { return false; }
+        public Set<CraftingType> getSupportedRecipeTypes()
+        {
+            return ImmutableSet.of();
+        }
 
         @Override
         public boolean isRecipeCompatible(@NotNull final IGenericRecipe recipe) { return false; }

--- a/src/main/java/com/minecolonies/coremod/colony/buildings/modules/AbstractCraftingBuildingModule.java
+++ b/src/main/java/com/minecolonies/coremod/colony/buildings/modules/AbstractCraftingBuildingModule.java
@@ -258,7 +258,7 @@ public abstract class AbstractCraftingBuildingModule extends AbstractBuildingMod
             buf.writeBoolean(false);
         }
 
-        final Set<CraftingType> craftingTypes = this.getSupportedRecipeTypes();
+        final Set<CraftingType> craftingTypes = this.getSupportedCraftingTypes();
         buf.writeVarInt(craftingTypes.size());
         for (final CraftingType type : craftingTypes)
         {
@@ -910,7 +910,7 @@ public abstract class AbstractCraftingBuildingModule extends AbstractBuildingMod
         }
 
         @Override
-        public Set<CraftingType> getSupportedRecipeTypes()
+        public Set<CraftingType> getSupportedCraftingTypes()
         {
             return ImmutableSet.of(ModCraftingTypes.SMALL_CRAFTING, ModCraftingTypes.LARGE_CRAFTING);
         }
@@ -918,7 +918,7 @@ public abstract class AbstractCraftingBuildingModule extends AbstractBuildingMod
         @Override
         public boolean isRecipeCompatible(@NotNull final IGenericRecipe recipe)
         {
-            return canLearnRecipe(ModCraftingTypes.SMALL_CRAFTING) &&
+            return canLearn(ModCraftingTypes.SMALL_CRAFTING) &&
                     recipe.getIntermediate() == Blocks.AIR;
         }
 
@@ -947,7 +947,7 @@ public abstract class AbstractCraftingBuildingModule extends AbstractBuildingMod
         }
 
         @Override
-        public Set<CraftingType> getSupportedRecipeTypes()
+        public Set<CraftingType> getSupportedCraftingTypes()
         {
             return ImmutableSet.of(ModCraftingTypes.SMELTING);
         }
@@ -955,7 +955,7 @@ public abstract class AbstractCraftingBuildingModule extends AbstractBuildingMod
         @Override
         public boolean isRecipeCompatible(@NotNull final IGenericRecipe recipe)
         {
-            return canLearnRecipe(ModCraftingTypes.SMELTING) &&
+            return canLearn(ModCraftingTypes.SMELTING) &&
                     recipe.getIntermediate() == Blocks.FURNACE;
         }
 
@@ -984,7 +984,7 @@ public abstract class AbstractCraftingBuildingModule extends AbstractBuildingMod
         }
 
         @Override
-        public Set<CraftingType> getSupportedRecipeTypes()
+        public Set<CraftingType> getSupportedCraftingTypes()
         {
             return ImmutableSet.of();
         }

--- a/src/main/java/com/minecolonies/coremod/colony/buildings/modules/SimpleCraftingModule.java
+++ b/src/main/java/com/minecolonies/coremod/colony/buildings/modules/SimpleCraftingModule.java
@@ -1,12 +1,16 @@
 package com.minecolonies.coremod.colony.buildings.modules;
 
+import com.google.common.collect.ImmutableSet;
 import com.minecolonies.api.colony.jobs.IJob;
 import com.minecolonies.api.colony.jobs.registry.JobEntry;
 import com.minecolonies.api.colony.requestsystem.resolver.IRequestResolver;
+import com.minecolonies.api.crafting.ModCraftingTypes;
+import com.minecolonies.api.crafting.registry.CraftingType;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.Collections;
 import java.util.List;
+import java.util.Set;
 
 /**
  * This module is used for the buildings that only support simple
@@ -40,8 +44,14 @@ public class SimpleCraftingModule extends AbstractCraftingBuildingModule.Craftin
     }
 
     @Override
-    public boolean canLearnLargeRecipes()
+    public boolean canLearnManyRecipes()
     {
         return false;
+    }
+
+    @Override
+    public Set<CraftingType> getSupportedRecipeTypes()
+    {
+        return ImmutableSet.of(ModCraftingTypes.SMALL_CRAFTING);
     }
 }

--- a/src/main/java/com/minecolonies/coremod/colony/buildings/modules/SimpleCraftingModule.java
+++ b/src/main/java/com/minecolonies/coremod/colony/buildings/modules/SimpleCraftingModule.java
@@ -50,7 +50,7 @@ public class SimpleCraftingModule extends AbstractCraftingBuildingModule.Craftin
     }
 
     @Override
-    public Set<CraftingType> getSupportedRecipeTypes()
+    public Set<CraftingType> getSupportedCraftingTypes()
     {
         return ImmutableSet.of(ModCraftingTypes.SMALL_CRAFTING);
     }

--- a/src/main/java/com/minecolonies/coremod/colony/buildings/moduleviews/CraftingModuleView.java
+++ b/src/main/java/com/minecolonies/coremod/colony/buildings/moduleviews/CraftingModuleView.java
@@ -141,16 +141,16 @@ public class CraftingModuleView extends AbstractBuildingModuleView
      * @param type the type to check for.
      * @return true if so.
      */
-    public boolean canLearnRecipe(final CraftingType type)
+    public boolean canLearn(final CraftingType type)
     {
-        return getSupportedRecipeTypes().contains(type);
+        return getSupportedCraftingTypes().contains(type);
     }
 
     /**
-     * Get the supported recipe types.
+     * Get the supported crafting types.
      * @return a set of types.
      */
-    public Set<CraftingType> getSupportedRecipeTypes()
+    public Set<CraftingType> getSupportedCraftingTypes()
     {
         return recipeTypeSet;
     }

--- a/src/main/java/com/minecolonies/coremod/colony/buildings/moduleviews/CraftingModuleView.java
+++ b/src/main/java/com/minecolonies/coremod/colony/buildings/moduleviews/CraftingModuleView.java
@@ -1,10 +1,12 @@
 package com.minecolonies.coremod.colony.buildings.moduleviews;
 
 import com.ldtteam.blockout.views.Window;
+import com.minecolonies.api.MinecoloniesAPIProxy;
 import com.minecolonies.api.colony.buildings.modules.AbstractBuildingModuleView;
 import com.minecolonies.api.colony.jobs.registry.JobEntry;
 import com.minecolonies.api.colony.requestsystem.StandardFactoryController;
 import com.minecolonies.api.crafting.IRecipeStorage;
+import com.minecolonies.api.crafting.registry.CraftingType;
 import com.minecolonies.api.util.constant.Constants;
 import com.minecolonies.coremod.Network;
 import com.minecolonies.coremod.client.gui.modules.WindowListRecipes;
@@ -20,7 +22,9 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
 /**
  * Client side representation of the crafting module.
@@ -40,9 +44,7 @@ public class CraftingModuleView extends AbstractBuildingModuleView
     /**
      * Different flags.
      */
-    private boolean canLearnCraftingRecipes;
-    private boolean canLearnFurnaceRecipes;
-    private boolean canLearnLargeRecipes;
+    private Set<CraftingType> recipeTypeSet = new HashSet<>();
 
     /**
      * The list of recipes the worker knows, correspond to a subset of the recipes in the colony.
@@ -76,9 +78,16 @@ public class CraftingModuleView extends AbstractBuildingModuleView
             this.jobEntry = null;
         }
 
-        this.canLearnCraftingRecipes = buf.readBoolean();
-        this.canLearnFurnaceRecipes = buf.readBoolean();
-        this.canLearnLargeRecipes = buf.readBoolean();
+        recipeTypeSet.clear();
+        final int size = buf.readVarInt();
+        for (int i = 0; i < size; ++i)
+        {
+            final CraftingType type = buf.readRegistryIdUnsafe(MinecoloniesAPIProxy.getInstance().getCraftingTypeRegistry());
+            if (type != null)
+            {
+                recipeTypeSet.add(type);
+            }
+        }
 
         recipes.clear();
         disabledRecipes.clear();
@@ -124,15 +133,27 @@ public class CraftingModuleView extends AbstractBuildingModuleView
      */
     public boolean isRecipeAlterationAllowed()
     {
-        return canLearnCraftingRecipes || canLearnFurnaceRecipes;
+        return !recipeTypeSet.isEmpty();
     }
 
-    /** True if this module can be taught crafting recipes. */
-    public boolean canLearnCraftingRecipes() { return this.canLearnCraftingRecipes; }
-    /** True if this module can be taught smelting recipes. */
-    public boolean canLearnFurnaceRecipes() { return this.canLearnFurnaceRecipes; }
-    /** True if this module can be taught 3x3 crafting recipes. */
-    public boolean canLearnLargeRecipes() { return this.canLearnLargeRecipes; }
+    /**
+     * Check if the worker can learn a certain type of recipe.
+     * @param type the type to check for.
+     * @return true if so.
+     */
+    public boolean canLearnRecipe(final CraftingType type)
+    {
+        return getSupportedRecipeTypes().contains(type);
+    }
+
+    /**
+     * Get the supported recipe types.
+     * @return a set of types.
+     */
+    public Set<CraftingType> getSupportedRecipeTypes()
+    {
+        return recipeTypeSet;
+    }
 
     /**
      * Unique id of the crafting module view.

--- a/src/main/java/com/minecolonies/coremod/colony/buildings/workerbuildings/BuildingBaker.java
+++ b/src/main/java/com/minecolonies/coremod/colony/buildings/workerbuildings/BuildingBaker.java
@@ -1,5 +1,6 @@
 package com.minecolonies.coremod.colony.buildings.workerbuildings;
 
+import com.google.common.collect.ImmutableSet;
 import com.minecolonies.api.colony.IColony;
 import com.minecolonies.api.colony.IColonyManager;
 import com.minecolonies.api.colony.jobs.registry.JobEntry;
@@ -7,6 +8,7 @@ import com.minecolonies.api.colony.requestsystem.token.IToken;
 import com.minecolonies.api.crafting.IGenericRecipe;
 import com.minecolonies.api.crafting.IRecipeStorage;
 import com.minecolonies.api.crafting.ItemStorage;
+import com.minecolonies.api.crafting.registry.CraftingType;
 import com.minecolonies.api.util.CraftingUtils;
 import com.minecolonies.api.util.OptionalPredicate;
 import com.minecolonies.coremod.colony.buildings.AbstractBuilding;
@@ -19,6 +21,7 @@ import org.jetbrains.annotations.NotNull;
 
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import java.util.function.Predicate;
 
 import static com.minecolonies.api.util.constant.TagConstants.CRAFTING_BAKER;
@@ -122,10 +125,11 @@ public class BuildingBaker extends AbstractBuilding
         }
 
         @Override
-        public boolean canLearnCraftingRecipes()
+        public Set<CraftingType> getSupportedRecipeTypes()
         {
-            if (building == null) return true;  // because it can learn at *some* level
-            return building.getBuildingLevel() >= 3;
+            return (building == null || building.getBuildingLevel() >= 3)
+                    ? super.getSupportedRecipeTypes()
+                    : ImmutableSet.of();
         }
 
         @Override
@@ -177,10 +181,11 @@ public class BuildingBaker extends AbstractBuilding
         }
 
         @Override
-        public boolean canLearnFurnaceRecipes()
+        public Set<CraftingType> getSupportedRecipeTypes()
         {
-            if (building == null) return true;  // because it can learn at *some* level
-            return building.getBuildingLevel() >= 3;
+            return (building == null || building.getBuildingLevel() >= 3)
+                    ? super.getSupportedRecipeTypes()
+                    : ImmutableSet.of();
         }
     }
 }

--- a/src/main/java/com/minecolonies/coremod/colony/buildings/workerbuildings/BuildingBaker.java
+++ b/src/main/java/com/minecolonies/coremod/colony/buildings/workerbuildings/BuildingBaker.java
@@ -125,10 +125,10 @@ public class BuildingBaker extends AbstractBuilding
         }
 
         @Override
-        public Set<CraftingType> getSupportedRecipeTypes()
+        public Set<CraftingType> getSupportedCraftingTypes()
         {
             return (building == null || building.getBuildingLevel() >= 3)
-                    ? super.getSupportedRecipeTypes()
+                    ? super.getSupportedCraftingTypes()
                     : ImmutableSet.of();
         }
 
@@ -181,10 +181,10 @@ public class BuildingBaker extends AbstractBuilding
         }
 
         @Override
-        public Set<CraftingType> getSupportedRecipeTypes()
+        public Set<CraftingType> getSupportedCraftingTypes()
         {
             return (building == null || building.getBuildingLevel() >= 3)
-                    ? super.getSupportedRecipeTypes()
+                    ? super.getSupportedCraftingTypes()
                     : ImmutableSet.of();
         }
     }

--- a/src/main/java/com/minecolonies/coremod/colony/buildings/workerbuildings/BuildingCook.java
+++ b/src/main/java/com/minecolonies/coremod/colony/buildings/workerbuildings/BuildingCook.java
@@ -1,5 +1,6 @@
 package com.minecolonies.coremod.colony.buildings.workerbuildings;
 
+import com.google.common.collect.ImmutableSet;
 import com.minecolonies.api.MinecoloniesAPIProxy;
 import com.minecolonies.api.colony.ICitizenData;
 import com.minecolonies.api.colony.IColony;
@@ -10,6 +11,7 @@ import com.minecolonies.api.crafting.GenericRecipe;
 import com.minecolonies.api.crafting.IGenericRecipe;
 import com.minecolonies.api.crafting.IRecipeStorage;
 import com.minecolonies.api.crafting.ItemStorage;
+import com.minecolonies.api.crafting.registry.CraftingType;
 import com.minecolonies.api.items.ModTags;
 import com.minecolonies.api.util.CraftingUtils;
 import com.minecolonies.api.util.ItemStackUtils;
@@ -310,10 +312,11 @@ public class BuildingCook extends AbstractBuilding
         }
 
         @Override
-        public boolean canLearnCraftingRecipes()
+        public Set<CraftingType> getSupportedRecipeTypes()
         {
-            if (building == null) return true;  // because it can learn at *some* level
-            return building.getBuildingLevel() >= 3;
+            return (building == null || building.getBuildingLevel() >= 3)
+                    ? super.getSupportedRecipeTypes()
+                    : ImmutableSet.of();
         }
 
         @Override

--- a/src/main/java/com/minecolonies/coremod/colony/buildings/workerbuildings/BuildingCook.java
+++ b/src/main/java/com/minecolonies/coremod/colony/buildings/workerbuildings/BuildingCook.java
@@ -312,10 +312,10 @@ public class BuildingCook extends AbstractBuilding
         }
 
         @Override
-        public Set<CraftingType> getSupportedRecipeTypes()
+        public Set<CraftingType> getSupportedCraftingTypes()
         {
             return (building == null || building.getBuildingLevel() >= 3)
-                    ? super.getSupportedRecipeTypes()
+                    ? super.getSupportedCraftingTypes()
                     : ImmutableSet.of();
         }
 

--- a/src/main/java/com/minecolonies/coremod/colony/crafting/GenericRecipeUtils.java
+++ b/src/main/java/com/minecolonies/coremod/colony/crafting/GenericRecipeUtils.java
@@ -7,23 +7,19 @@ import com.minecolonies.api.research.IGlobalResearch;
 import com.minecolonies.api.research.IGlobalResearchTree;
 import com.minecolonies.api.util.OptionalPredicate;
 import com.minecolonies.api.util.constant.TranslationConstants;
-import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
-import net.minecraft.item.crafting.IRecipe;
-import net.minecraft.item.crafting.Ingredient;
-import net.minecraft.util.NonNullList;
 import net.minecraft.util.ResourceLocation;
 import net.minecraft.util.text.ITextComponent;
 import net.minecraft.util.text.StringTextComponent;
 import net.minecraft.util.text.TranslationTextComponent;
-import net.minecraft.world.World;
 import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
 
-import java.util.*;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import java.util.Set;
 import java.util.stream.Collectors;
 
-import static com.ldtteam.structurize.items.ModItems.buildTool;
 import static com.minecolonies.api.util.constant.BuildingConstants.CONST_DEFAULT_MAX_BUILDING_LEVEL;
 
 /**
@@ -67,15 +63,6 @@ public final class GenericRecipeUtils
     {
         final List<ITextComponent> restrictions = calculateRestrictions(customRecipe);
         return Objects.requireNonNull(GenericRecipe.of(storage, restrictions, customRecipe.getMinBuildingLevel()));
-    }
-
-    @NotNull
-    public static IGenericRecipe create(@NotNull final IRecipe<?> recipe, @Nullable final World world)
-    {
-        final IGenericRecipe original = Objects.requireNonNull(GenericRecipe.of(recipe, world));
-        final List<List<ItemStack>> inputs = compact(recipe.getIngredients());
-        return new GenericRecipe(original.getRecipeId(), original.getPrimaryOutput(), original.getAdditionalOutputs(), inputs,
-                original.getGridSize(), original.getIntermediate(), original.getLootTable(), new ArrayList<>(), -1);
     }
 
     /**
@@ -150,106 +137,5 @@ public final class GenericRecipeUtils
 
         // otherwise it may be an effect with no research (perhaps disabled via datapack)
         return new StringTextComponent("???");
-    }
-
-    private static List<List<ItemStack>> compact(final NonNullList<Ingredient> inputs)
-    {
-        // FYI, this largely does the same job as RecipeStorage.calculateCleanedInput(), but we can't re-use
-        // that implementation as we need to operate on Ingredients, which can be a list of stacks.
-        final Map<IngredientStacks, IngredientStacks> ingredients = new HashMap<>();
-
-        for (final Ingredient ingredient : inputs)
-        {
-            if (ingredient == Ingredient.EMPTY) continue;
-
-            final IngredientStacks newIngredient = new IngredientStacks(ingredient);
-            // also ignore the build tool as an ingredient, since colony crafters don't require it.
-            //   (see RecipeStorage.calculateCleanedInput() for why)
-            if (!newIngredient.getStacks().isEmpty() && newIngredient.getStacks().get(0).getItem() == buildTool.get()) continue;
-
-            final IngredientStacks existing = ingredients.get(newIngredient);
-            if (existing == null)
-            {
-                ingredients.put(newIngredient, newIngredient);
-            }
-            else
-            {
-                existing.merge(newIngredient);
-            }
-        }
-
-        return ingredients.values().stream()
-                .sorted(Comparator.reverseOrder())
-                .map(IngredientStacks::getStacks)
-                .collect(Collectors.toCollection(NonNullList::create));
-    }
-
-    private static class IngredientStacks implements Comparable<IngredientStacks>
-    {
-        private final List<ItemStack> stacks;
-        private final Set<Item> items;
-
-        public IngredientStacks(final Ingredient ingredient)
-        {
-            this.stacks = Collections.unmodifiableList(Arrays.stream(ingredient.getItems())
-                    .filter(stack -> !stack.isEmpty())
-                    .map(ItemStack::copy)
-                    .collect(Collectors.toList()));
-
-            this.items = this.stacks.stream()
-                    .map(ItemStack::getItem)
-                    .collect(Collectors.toSet());
-        }
-
-        @NotNull
-        public List<ItemStack> getStacks() { return this.stacks; }
-
-        public int getCount() { return this.stacks.isEmpty() ? 0 : this.stacks.get(0).getCount(); }
-
-        @Override
-        public boolean equals(Object o)
-        {
-            if (this == o) return true;
-            if (o == null || getClass() != o.getClass()) return false;
-            final IngredientStacks that = (IngredientStacks) o;
-            return this.items.equals(that.items);
-            // note that this does not compare the counts to maintain key-stability
-        }
-
-        @Override
-        public int hashCode()
-        {
-            return this.items.hashCode();
-        }
-
-        @Override
-        public int compareTo(@NotNull IngredientStacks o)
-        {
-            int diff = this.getCount() - o.getCount();
-            if (diff != 0) return diff;
-
-            diff = this.stacks.size() - o.stacks.size();
-            if (diff != 0) return diff;
-
-            return this.hashCode() - o.hashCode();
-        }
-
-        public void merge(@NotNull final IngredientStacks other)
-        {
-            // assumes equals(other)
-            for (int i = 0; i < this.stacks.size(); i++)
-            {
-                this.stacks.get(i).grow(other.stacks.get(i).getCount());
-            }
-        }
-
-        @Override
-        public String toString()
-        {
-            return "IngredientStacks{" +
-                    "stacks=" + stacks +
-                    ", items=" + items +
-                    '}';
-        }
     }
 }

--- a/src/main/java/com/minecolonies/coremod/colony/crafting/RecipeAnalyzer.java
+++ b/src/main/java/com/minecolonies/coremod/colony/crafting/RecipeAnalyzer.java
@@ -57,7 +57,7 @@ public final class RecipeAnalyzer
         // all vanilla teachable recipes
         for (final Map.Entry<CraftingType, List<IGenericRecipe>> entry : vanilla.entrySet())
         {
-            if (crafting.canLearnRecipe(entry.getKey()))
+            if (crafting.canLearn(entry.getKey()))
             {
                 for (final IGenericRecipe recipe : entry.getValue())
                 {

--- a/src/main/java/com/minecolonies/coremod/colony/crafting/RecipeAnalyzer.java
+++ b/src/main/java/com/minecolonies/coremod/colony/crafting/RecipeAnalyzer.java
@@ -1,15 +1,12 @@
 package com.minecolonies.coremod.colony.crafting;
 
 import com.google.common.collect.ImmutableMap;
+import com.minecolonies.api.MinecoloniesAPIProxy;
 import com.minecolonies.api.colony.buildings.modules.ICraftingBuildingModule;
 import com.minecolonies.api.crafting.IGenericRecipe;
 import com.minecolonies.api.crafting.IRecipeStorage;
+import com.minecolonies.api.crafting.registry.CraftingType;
 import com.minecolonies.api.util.ItemStackUtils;
-import com.minecolonies.api.util.Log;
-import net.minecraft.inventory.CraftingInventory;
-import net.minecraft.inventory.IInventory;
-import net.minecraft.item.crafting.IRecipe;
-import net.minecraft.item.crafting.IRecipeType;
 import net.minecraft.item.crafting.RecipeManager;
 import net.minecraft.world.World;
 import org.jetbrains.annotations.NotNull;
@@ -30,46 +27,18 @@ public final class RecipeAnalyzer
      * @param recipeManager the vanilla recipe manager
      * @return the recipe map
      */
-    public static Map<IRecipeType<?>, List<IGenericRecipe>> buildVanillaRecipesMap(@NotNull final RecipeManager recipeManager,
-                                                                                   @Nullable final World world)
+    public static Map<CraftingType, List<IGenericRecipe>> buildVanillaRecipesMap(@NotNull final RecipeManager recipeManager,
+                                                                                 @Nullable final World world)
     {
-        final List<IGenericRecipe> craftingRecipes = new ArrayList<>();
-        for (final IRecipe<CraftingInventory> recipe : recipeManager.byType(IRecipeType.CRAFTING).values())
-        {
-            if (!recipe.canCraftInDimensions(3, 3)) continue;
+        final ImmutableMap.Builder<CraftingType, List<IGenericRecipe>> builder = ImmutableMap.builder();
 
-            tryAddingVanillaRecipe(craftingRecipes, recipe, world);
+        for (final CraftingType type : MinecoloniesAPIProxy.getInstance().getCraftingTypeRegistry().getValues())
+        {
+            final List<IGenericRecipe> recipes = type.findRecipes(recipeManager, world);
+            builder.put(type, recipes);
         }
 
-        final List<IGenericRecipe> smeltingRecipes = new ArrayList<>();
-        for (final IRecipe<IInventory> recipe : recipeManager.byType(IRecipeType.SMELTING).values())
-        {
-            tryAddingVanillaRecipe(smeltingRecipes, recipe, world);
-        }
-
-        return new ImmutableMap.Builder<IRecipeType<?>, List<IGenericRecipe>>()
-                .put(IRecipeType.CRAFTING, craftingRecipes)
-                .put(IRecipeType.SMELTING, smeltingRecipes)
-                .build();
-    }
-
-    private static void tryAddingVanillaRecipe(@NotNull final List<IGenericRecipe> recipes,
-                                               @NotNull final IRecipe<?> recipe,
-                                               @Nullable final World world)
-    {
-        if (recipe.getResultItem().isEmpty()) return;     // invalid or special recipes
-
-        try
-        {
-            final IGenericRecipe genericRecipe = GenericRecipeUtils.create(recipe, world);
-            if (genericRecipe.getInputs().isEmpty()) return;
-
-            recipes.add(genericRecipe);
-        }
-        catch (final Exception ex)
-        {
-            Log.getLogger().warn("Error evaluating recipe " + recipe.getId() + "; ignoring.", ex);
-        }
+        return builder.build();
     }
 
     /**
@@ -80,34 +49,24 @@ public final class RecipeAnalyzer
      * @return list of recipes
      */
     @NotNull
-    public static List<IGenericRecipe> findRecipes(@NotNull final Map<IRecipeType<?>, List<IGenericRecipe>> vanilla,
+    public static List<IGenericRecipe> findRecipes(@NotNull final Map<CraftingType, List<IGenericRecipe>> vanilla,
                                                    @NotNull final ICraftingBuildingModule crafting)
     {
         final List<IGenericRecipe> recipes = new ArrayList<>();
 
-        // vanilla shaped and shapeless crafting recipes
-        if (crafting.canLearnCraftingRecipes())
+        // all vanilla teachable recipes
+        for (final Map.Entry<CraftingType, List<IGenericRecipe>> entry : vanilla.entrySet())
         {
-            for (final IGenericRecipe recipe : vanilla.get(IRecipeType.CRAFTING))
+            if (crafting.canLearnRecipe(entry.getKey()))
             {
-                if (!crafting.canLearnLargeRecipes() && recipe.getGridSize() > 2) continue;
-
-                final IGenericRecipe safeRecipe = GenericRecipeUtils.filterInputs(recipe, crafting.getIngredientValidator());
-                if (!crafting.isRecipeCompatible(safeRecipe)) continue;
-
-                recipes.add(safeRecipe);
-            }
-        }
-
-        // vanilla furnace recipes (do we want to check smoking and blasting too?)
-        if (crafting.canLearnFurnaceRecipes())
-        {
-            for (final IGenericRecipe recipe : vanilla.get(IRecipeType.SMELTING))
-            {
-                final IGenericRecipe safeRecipe = GenericRecipeUtils.filterInputs(recipe, crafting.getIngredientValidator());
-                if (!crafting.isRecipeCompatible(safeRecipe)) continue;
-
-                recipes.add(safeRecipe);
+                for (final IGenericRecipe recipe : entry.getValue())
+                {
+                    final IGenericRecipe safeRecipe = GenericRecipeUtils.filterInputs(recipe, crafting.getIngredientValidator());
+                    if (crafting.isRecipeCompatible(safeRecipe))
+                    {
+                        recipes.add(safeRecipe);
+                    }
+                }
             }
         }
 

--- a/src/main/java/com/minecolonies/coremod/compatibility/CraftingTagAuditor.java
+++ b/src/main/java/com/minecolonies/coremod/compatibility/CraftingTagAuditor.java
@@ -8,13 +8,13 @@ import com.minecolonies.api.colony.buildings.registry.BuildingEntry;
 import com.minecolonies.api.compatibility.ICompatibilityManager;
 import com.minecolonies.api.crafting.IGenericRecipe;
 import com.minecolonies.api.crafting.ItemStorage;
+import com.minecolonies.api.crafting.registry.CraftingType;
 import com.minecolonies.api.util.Log;
 import com.minecolonies.coremod.colony.buildings.modules.SimpleCraftingModule;
 import com.minecolonies.coremod.colony.crafting.CustomRecipeManager;
 import com.minecolonies.coremod.colony.crafting.LootTableAnalyzer;
 import com.minecolonies.coremod.colony.crafting.RecipeAnalyzer;
 import net.minecraft.item.ItemStack;
-import net.minecraft.item.crafting.IRecipeType;
 import net.minecraft.server.MinecraftServer;
 import net.minecraft.util.ResourceLocation;
 import net.minecraft.world.storage.FolderName;
@@ -111,7 +111,7 @@ public class CraftingTagAuditor
                                       @NotNull final MinecraftServer server,
                                       @NotNull final CustomRecipeManager customRecipeManager) throws IOException
     {
-        final Map<IRecipeType<?>, List<IGenericRecipe>> vanillaRecipesMap =
+        final Map<CraftingType, List<IGenericRecipe>> vanillaRecipesMap =
                 RecipeAnalyzer.buildVanillaRecipesMap(server.getRecipeManager(), server.overworld());
         final List<ICraftingBuildingModule> crafters = getCraftingModules()
                 .stream()

--- a/src/main/java/com/minecolonies/coremod/compatibility/jei/GenericRecipeCategory.java
+++ b/src/main/java/com/minecolonies/coremod/compatibility/jei/GenericRecipeCategory.java
@@ -4,6 +4,7 @@ import com.minecolonies.api.colony.buildings.modules.ICraftingBuildingModule;
 import com.minecolonies.api.colony.buildings.registry.BuildingEntry;
 import com.minecolonies.api.colony.jobs.IJob;
 import com.minecolonies.api.crafting.IGenericRecipe;
+import com.minecolonies.api.crafting.registry.CraftingType;
 import com.minecolonies.api.util.constant.TranslationConstants;
 import com.minecolonies.coremod.colony.crafting.CustomRecipeManager;
 import com.minecolonies.coremod.colony.crafting.LootTableAnalyzer;
@@ -20,7 +21,6 @@ import net.minecraft.block.BlockState;
 import net.minecraft.block.Blocks;
 import net.minecraft.client.renderer.Rectangle2d;
 import net.minecraft.item.ItemStack;
-import net.minecraft.item.crafting.IRecipeType;
 import net.minecraft.util.ResourceLocation;
 import net.minecraft.util.text.ITextComponent;
 import net.minecraft.util.text.TranslationTextComponent;
@@ -301,7 +301,7 @@ public class GenericRecipeCategory extends JobBasedRecipeCategory<IGenericRecipe
     }
 
     @NotNull
-    public List<IGenericRecipe> findRecipes(@NotNull final Map<IRecipeType<?>, List<IGenericRecipe>> vanilla)
+    public List<IGenericRecipe> findRecipes(@NotNull final Map<CraftingType, List<IGenericRecipe>> vanilla)
     {
         final List<IGenericRecipe> recipes = RecipeAnalyzer.findRecipes(vanilla, this.crafting);
 

--- a/src/main/java/com/minecolonies/coremod/compatibility/jei/HerderRecipeCategory.java
+++ b/src/main/java/com/minecolonies/coremod/compatibility/jei/HerderRecipeCategory.java
@@ -3,6 +3,7 @@ package com.minecolonies.coremod.compatibility.jei;
 import com.minecolonies.api.colony.buildings.registry.BuildingEntry;
 import com.minecolonies.api.colony.jobs.IJob;
 import com.minecolonies.api.crafting.IGenericRecipe;
+import com.minecolonies.api.crafting.registry.CraftingType;
 import com.minecolonies.coremod.colony.buildings.modules.AnimalHerdingModule;
 import com.minecolonies.coremod.colony.crafting.LootTableAnalyzer;
 import com.mojang.blaze3d.matrix.MatrixStack;
@@ -16,7 +17,6 @@ import net.minecraft.client.Minecraft;
 import net.minecraft.entity.EntityType;
 import net.minecraft.entity.LivingEntity;
 import net.minecraft.item.ItemStack;
-import net.minecraft.item.crafting.IRecipeType;
 import net.minecraft.util.ResourceLocation;
 import net.minecraft.util.text.ITextComponent;
 import net.minecraftforge.api.distmarker.Dist;
@@ -143,7 +143,7 @@ public class HerderRecipeCategory extends JobBasedRecipeCategory<HerderRecipeCat
 
     @NotNull
     @Override
-    public Collection<?> findRecipes(@NotNull final Map<IRecipeType<?>, List<IGenericRecipe>> vanilla)
+    public Collection<?> findRecipes(@NotNull final Map<CraftingType, List<IGenericRecipe>> vanilla)
     {
         final List<ItemStack> breedingItems = this.herding.getBreedingItems();
 

--- a/src/main/java/com/minecolonies/coremod/compatibility/jei/JEIPlugin.java
+++ b/src/main/java/com/minecolonies/coremod/compatibility/jei/JEIPlugin.java
@@ -9,6 +9,7 @@ import com.minecolonies.api.colony.jobs.IJob;
 import com.minecolonies.api.colony.jobs.ModJobs;
 import com.minecolonies.api.crafting.CompostRecipe;
 import com.minecolonies.api.crafting.IGenericRecipe;
+import com.minecolonies.api.crafting.registry.CraftingType;
 import com.minecolonies.api.util.Log;
 import com.minecolonies.api.util.constant.Constants;
 import com.minecolonies.api.util.constant.TranslationConstants;
@@ -30,7 +31,6 @@ import mezz.jei.api.registration.*;
 import mezz.jei.api.runtime.IJeiRuntime;
 import net.minecraft.client.Minecraft;
 import net.minecraft.item.ItemStack;
-import net.minecraft.item.crafting.IRecipeType;
 import net.minecraft.util.ResourceLocation;
 import net.minecraft.util.text.TranslationTextComponent;
 import net.minecraftforge.common.MinecraftForge;
@@ -163,7 +163,7 @@ public class JEIPlugin implements IModPlugin
         this.weakRuntime = new WeakReference<>(jeiRuntime);
     }
 
-    private void populateRecipes(@NotNull final Map<IRecipeType<?>, List<IGenericRecipe>> vanilla,
+    private void populateRecipes(@NotNull final Map<CraftingType, List<IGenericRecipe>> vanilla,
                                  @NotNull final BiConsumer<Collection<?>, ResourceLocation> registrar)
     {
         registrar.accept(CompostRecipeCategory.findRecipes(), CompostRecipe.ID);

--- a/src/main/java/com/minecolonies/coremod/compatibility/jei/JobBasedRecipeCategory.java
+++ b/src/main/java/com/minecolonies/coremod/compatibility/jei/JobBasedRecipeCategory.java
@@ -6,6 +6,7 @@ import com.google.common.cache.LoadingCache;
 import com.minecolonies.api.colony.buildings.registry.BuildingEntry;
 import com.minecolonies.api.colony.jobs.IJob;
 import com.minecolonies.api.crafting.IGenericRecipe;
+import com.minecolonies.api.crafting.registry.CraftingType;
 import com.minecolonies.api.entity.ModEntities;
 import com.minecolonies.api.util.constant.Constants;
 import com.minecolonies.api.util.constant.TranslationConstants;
@@ -24,7 +25,6 @@ import net.minecraft.client.gui.screen.Screen;
 import net.minecraft.client.renderer.Rectangle2d;
 import net.minecraft.client.resources.I18n;
 import net.minecraft.item.ItemStack;
-import net.minecraft.item.crafting.IRecipeType;
 import net.minecraft.util.ResourceLocation;
 import net.minecraft.util.text.*;
 import org.jetbrains.annotations.NotNull;
@@ -143,7 +143,7 @@ public abstract class JobBasedRecipeCategory<T> implements IRecipeCategory<T>
         return this.icon;
     }
 
-    public Collection<?> findRecipes(@NotNull final Map<IRecipeType<?>, List<IGenericRecipe>> vanilla)
+    public Collection<?> findRecipes(@NotNull final Map<CraftingType, List<IGenericRecipe>> vanilla)
     {
         return Collections.emptyList();
     }

--- a/src/main/java/com/minecolonies/coremod/compatibility/jei/transfer/CraftingGuiHandler.java
+++ b/src/main/java/com/minecolonies/coremod/compatibility/jei/transfer/CraftingGuiHandler.java
@@ -1,5 +1,6 @@
 package com.minecolonies.coremod.compatibility.jei.transfer;
 
+import com.minecolonies.api.crafting.ModCraftingTypes;
 import com.minecolonies.coremod.Network;
 import com.minecolonies.coremod.client.gui.containers.WindowCrafting;
 import com.minecolonies.coremod.colony.buildings.moduleviews.CraftingModuleView;
@@ -49,7 +50,7 @@ public class CraftingGuiHandler extends AbstractTeachingGuiHandler<WindowCraftin
     @Override
     protected boolean isSupportedCraftingModule(@NotNull final CraftingModuleView moduleView)
     {
-        return moduleView.canLearnCraftingRecipes();
+        return moduleView.canLearnRecipe(ModCraftingTypes.SMALL_CRAFTING);
     }
 
     @Override

--- a/src/main/java/com/minecolonies/coremod/compatibility/jei/transfer/CraftingGuiHandler.java
+++ b/src/main/java/com/minecolonies/coremod/compatibility/jei/transfer/CraftingGuiHandler.java
@@ -50,7 +50,7 @@ public class CraftingGuiHandler extends AbstractTeachingGuiHandler<WindowCraftin
     @Override
     protected boolean isSupportedCraftingModule(@NotNull final CraftingModuleView moduleView)
     {
-        return moduleView.canLearnRecipe(ModCraftingTypes.SMALL_CRAFTING);
+        return moduleView.canLearn(ModCraftingTypes.SMALL_CRAFTING);
     }
 
     @Override

--- a/src/main/java/com/minecolonies/coremod/compatibility/jei/transfer/FurnaceCraftingGuiHandler.java
+++ b/src/main/java/com/minecolonies/coremod/compatibility/jei/transfer/FurnaceCraftingGuiHandler.java
@@ -49,7 +49,7 @@ public class FurnaceCraftingGuiHandler extends AbstractTeachingGuiHandler<Window
     @Override
     protected boolean isSupportedCraftingModule(@NotNull final CraftingModuleView moduleView)
     {
-        return moduleView.canLearnRecipe(ModCraftingTypes.SMELTING);
+        return moduleView.canLearn(ModCraftingTypes.SMELTING);
     }
 
     @Override

--- a/src/main/java/com/minecolonies/coremod/compatibility/jei/transfer/FurnaceCraftingGuiHandler.java
+++ b/src/main/java/com/minecolonies/coremod/compatibility/jei/transfer/FurnaceCraftingGuiHandler.java
@@ -1,5 +1,6 @@
 package com.minecolonies.coremod.compatibility.jei.transfer;
 
+import com.minecolonies.api.crafting.ModCraftingTypes;
 import com.minecolonies.coremod.Network;
 import com.minecolonies.coremod.client.gui.containers.WindowFurnaceCrafting;
 import com.minecolonies.coremod.colony.buildings.moduleviews.CraftingModuleView;
@@ -48,7 +49,7 @@ public class FurnaceCraftingGuiHandler extends AbstractTeachingGuiHandler<Window
     @Override
     protected boolean isSupportedCraftingModule(@NotNull final CraftingModuleView moduleView)
     {
-        return moduleView.canLearnFurnaceRecipes();
+        return moduleView.canLearnRecipe(ModCraftingTypes.SMELTING);
     }
 
     @Override

--- a/src/main/java/com/minecolonies/coremod/network/messages/server/colony/building/OpenCraftingGUIMessage.java
+++ b/src/main/java/com/minecolonies/coremod/network/messages/server/colony/building/OpenCraftingGUIMessage.java
@@ -2,6 +2,7 @@ package com.minecolonies.coremod.network.messages.server.colony.building;
 
 import com.minecolonies.api.colony.IColony;
 import com.minecolonies.api.colony.buildings.IBuilding;
+import com.minecolonies.api.crafting.ModCraftingTypes;
 import com.minecolonies.api.inventory.container.ContainerCrafting;
 import com.minecolonies.api.inventory.container.ContainerCraftingFurnace;
 import com.minecolonies.coremod.colony.buildings.modules.AbstractCraftingBuildingModule;
@@ -70,7 +71,7 @@ public class OpenCraftingGUIMessage extends AbstractBuildingServerMessage<IBuild
         }
 
         final AbstractCraftingBuildingModule module = building.getModuleMatching(AbstractCraftingBuildingModule.class, m -> m.getId().equals(id));
-        if (module.canLearnFurnaceRecipes())
+        if (module.canLearnRecipe(ModCraftingTypes.SMELTING))
         {
             NetworkHooks.openGui(player, new INamedContainerProvider()
             {
@@ -104,9 +105,9 @@ public class OpenCraftingGUIMessage extends AbstractBuildingServerMessage<IBuild
                 @Override
                 public Container createMenu(final int id, @NotNull final PlayerInventory inv, @NotNull final PlayerEntity player)
                 {
-                    return new ContainerCrafting(id, inv, module.canLearnLargeRecipes(), building.getID(), module.getId());
+                    return new ContainerCrafting(id, inv, module.canLearnRecipe(ModCraftingTypes.LARGE_CRAFTING), building.getID(), module.getId());
                 }
-            }, buffer -> new PacketBuffer(buffer.writeBoolean(module.canLearnLargeRecipes())).writeBlockPos(building.getID()).writeUtf(module.getId()));
+            }, buffer -> new PacketBuffer(buffer.writeBoolean(module.canLearnRecipe(ModCraftingTypes.LARGE_CRAFTING))).writeBlockPos(building.getID()).writeUtf(module.getId()));
         }
     }
 }

--- a/src/main/java/com/minecolonies/coremod/network/messages/server/colony/building/OpenCraftingGUIMessage.java
+++ b/src/main/java/com/minecolonies/coremod/network/messages/server/colony/building/OpenCraftingGUIMessage.java
@@ -71,7 +71,7 @@ public class OpenCraftingGUIMessage extends AbstractBuildingServerMessage<IBuild
         }
 
         final AbstractCraftingBuildingModule module = building.getModuleMatching(AbstractCraftingBuildingModule.class, m -> m.getId().equals(id));
-        if (module.canLearnRecipe(ModCraftingTypes.SMELTING))
+        if (module.canLearn(ModCraftingTypes.SMELTING))
         {
             NetworkHooks.openGui(player, new INamedContainerProvider()
             {
@@ -105,9 +105,9 @@ public class OpenCraftingGUIMessage extends AbstractBuildingServerMessage<IBuild
                 @Override
                 public Container createMenu(final int id, @NotNull final PlayerInventory inv, @NotNull final PlayerEntity player)
                 {
-                    return new ContainerCrafting(id, inv, module.canLearnRecipe(ModCraftingTypes.LARGE_CRAFTING), building.getID(), module.getId());
+                    return new ContainerCrafting(id, inv, module.canLearn(ModCraftingTypes.LARGE_CRAFTING), building.getID(), module.getId());
                 }
-            }, buffer -> new PacketBuffer(buffer.writeBoolean(module.canLearnRecipe(ModCraftingTypes.LARGE_CRAFTING))).writeBlockPos(building.getID()).writeUtf(module.getId()));
+            }, buffer -> new PacketBuffer(buffer.writeBoolean(module.canLearn(ModCraftingTypes.LARGE_CRAFTING))).writeBlockPos(building.getID()).writeUtf(module.getId()));
         }
     }
 }

--- a/src/main/java/com/minecolonies/coremod/proxy/CommonProxy.java
+++ b/src/main/java/com/minecolonies/coremod/proxy/CommonProxy.java
@@ -11,6 +11,7 @@ import com.minecolonies.api.colony.interactionhandling.registry.InteractionRespo
 import com.minecolonies.api.colony.jobs.registry.JobEntry;
 import com.minecolonies.api.crafting.CompostRecipe;
 import com.minecolonies.api.crafting.CountedIngredient;
+import com.minecolonies.api.crafting.registry.CraftingType;
 import com.minecolonies.api.crafting.registry.RecipeTypeEntry;
 import com.minecolonies.api.research.effects.registry.ResearchEffectEntry;
 import com.minecolonies.api.research.registry.ResearchRequirementEntry;
@@ -153,6 +154,12 @@ public abstract class CommonProxy implements IProxy
     public static void registerRecipeTypes(final RegistryEvent.Register<RecipeTypeEntry> event)
     {
         ModRecipeTypesInitializer.init(event);
+    }
+
+    @SubscribeEvent
+    public static void registerCraftingTypes(final RegistryEvent.Register<CraftingType> event)
+    {
+        ModCraftingTypesInitializer.init(event);
     }
 
     @SubscribeEvent

--- a/src/main/java/com/minecolonies/coremod/recipes/BrewingCraftingType.java
+++ b/src/main/java/com/minecolonies/coremod/recipes/BrewingCraftingType.java
@@ -1,15 +1,25 @@
 package com.minecolonies.coremod.recipes;
 
+import com.minecolonies.api.MinecoloniesAPIProxy;
+import com.minecolonies.api.compatibility.ICompatibilityManager;
+import com.minecolonies.api.crafting.GenericRecipe;
 import com.minecolonies.api.crafting.IGenericRecipe;
 import com.minecolonies.api.crafting.ModCraftingTypes;
 import com.minecolonies.api.crafting.registry.CraftingType;
+import net.minecraft.block.Blocks;
+import net.minecraft.item.ItemStack;
 import net.minecraft.item.crafting.RecipeManager;
 import net.minecraft.world.World;
+import net.minecraftforge.common.brewing.BrewingRecipeRegistry;
+import net.minecraftforge.common.brewing.IBrewingRecipe;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
+import java.util.stream.Collectors;
 
 /**
  * A crafting type for brewing recipes
@@ -25,7 +35,38 @@ public class BrewingCraftingType extends CraftingType
     @NotNull
     public List<IGenericRecipe> findRecipes(@NotNull RecipeManager recipeManager, @Nullable World world)
     {
-        // TODO: enumerate vanilla brewing recipes
-        return new ArrayList<>();
+        final List<IGenericRecipe> recipes = new ArrayList<>();
+        final ICompatibilityManager compatibilityManager = MinecoloniesAPIProxy.getInstance().getColonyManager().getCompatibilityManager();
+
+        for (final IBrewingRecipe recipe : BrewingRecipeRegistry.getRecipes())
+        {
+            final List<ItemStack> inputs = compatibilityManager.getListOfAllItems().stream()
+                    .filter(recipe::isInput)
+                    .collect(Collectors.toList());
+            final List<ItemStack> ingredients = compatibilityManager.getListOfAllItems().stream()
+                    .filter(recipe::isIngredient)
+                    .collect(Collectors.toList());
+
+            for (final ItemStack input : inputs)
+            {
+                for (final ItemStack ingredient : ingredients)
+                {
+                    final ItemStack output = recipe.getOutput(input, ingredient);
+                    if (!output.isEmpty())
+                    {
+                        final ItemStack actualInput = input.copy();
+                        actualInput.setCount(3);
+                        final ItemStack actualOutput = output.copy();
+                        actualOutput.setCount(3);
+
+                        recipes.add(new GenericRecipe(null, actualOutput, Collections.emptyList(),
+                                Arrays.asList(Collections.singletonList(actualInput), Collections.singletonList(ingredient)),
+                                4, Blocks.BREWING_STAND, null, Collections.emptyList(), -1));
+                    }
+                }
+            }
+        }
+
+        return recipes;
     }
 }

--- a/src/main/java/com/minecolonies/coremod/recipes/BrewingCraftingType.java
+++ b/src/main/java/com/minecolonies/coremod/recipes/BrewingCraftingType.java
@@ -1,0 +1,31 @@
+package com.minecolonies.coremod.recipes;
+
+import com.minecolonies.api.crafting.IGenericRecipe;
+import com.minecolonies.api.crafting.ModCraftingTypes;
+import com.minecolonies.api.crafting.registry.CraftingType;
+import net.minecraft.item.crafting.RecipeManager;
+import net.minecraft.world.World;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * A crafting type for brewing recipes
+ */
+public class BrewingCraftingType extends CraftingType
+{
+    public BrewingCraftingType()
+    {
+        super(ModCraftingTypes.BREWING_ID);
+    }
+
+    @Override
+    @NotNull
+    public List<IGenericRecipe> findRecipes(@NotNull RecipeManager recipeManager, @Nullable World world)
+    {
+        // TODO: enumerate vanilla brewing recipes
+        return new ArrayList<>();
+    }
+}


### PR DESCRIPTION
# Changes proposed in this pull request:
- Adds a registry for CraftingTypes (to allow future expansion via addons)
- Refactors crafting modules, recipe auditor, and JEI to use CraftingTypes
- Includes `CraftingType.BREWING` in anticipation of #8286

Review please

This extracts and expands on common ideas between #8286 and #8282 and is intended to be merged before those, so that they can be updated to use this method instead of their own.

I've also added recipe enumeration for brewing recipes; in theory, as soon as #8286 is updated to have a crafting module for `CraftingTypes.BREWING` then it should automatically get recipe auditing and JEI support as well, but I haven't tested this.

There is possibly some other almost-common logic that could be moved to CraftingType -- perhaps some of the logic to decide what recipe GUI to show?