### PR TITLE
Fix JEI init crash

### DIFF
--- a/src/main/java/com/minecolonies/coremod/recipes/ArchitectsCutterCraftingType.java
+++ b/src/main/java/com/minecolonies/coremod/recipes/ArchitectsCutterCraftingType.java
@@ -8,8 +8,6 @@ import com.minecolonies.api.crafting.GenericRecipe;
 import com.minecolonies.api.crafting.IGenericRecipe;
 import com.minecolonies.api.crafting.ModCraftingTypes;
 import com.minecolonies.api.crafting.RecipeCraftingType;
-import net.minecraft.core.Holder;
-import net.minecraft.core.Registry;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.world.Container;
 import net.minecraft.world.item.ItemStack;
@@ -26,7 +24,6 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Random;
 import java.util.stream.Collectors;
-import java.util.stream.StreamSupport;
 
 public class ArchitectsCutterCraftingType extends RecipeCraftingType<Container, ArchitectsCutterRecipe>
 {
@@ -51,8 +48,8 @@ public class ArchitectsCutterCraftingType extends RecipeCraftingType<Container, 
             final List<List<ItemStack>> inputs = new ArrayList<>();
             for (final IMateriallyTexturedBlockComponent component : materiallyTexturedBlock.getComponents())
             {
-
-                final List<Block> blocks = StreamSupport.stream(Registry.BLOCK.getTagOrEmpty(component.getValidSkins()).spliterator(), false).map(Holder::value).toList();
+                final List<Block> blocks = ForgeRegistries.BLOCKS.tags().getTag(component.getValidSkins()).stream()
+                        .collect(Collectors.toCollection(ArrayList::new));
                 Collections.shuffle(blocks, rnd);
                 inputs.add(blocks.stream().map(ItemStack::new).collect(Collectors.toList()));
             }


### PR DESCRIPTION
Closes #8333

# Changes proposed in this pull request:
- Fixes the JEI plugin not starting in 1.18.2 due to porting edit.

Review please

This only affects 1.18.2.  The key change is just to ensure it creates an `ArrayList` instead of leaving it to the whims of the stream (the bug was that it happened to choose an immutable list); but I also changed the method used to populate the list since this seems tidier.