### PR TITLE
Fix/request name

### DIFF
--- a/src/api/java/com/minecolonies/api/colony/buildings/IBuilding.java
+++ b/src/api/java/com/minecolonies/api/colony/buildings/IBuilding.java
@@ -78,9 +78,10 @@ public interface IBuilding extends IBuildingContainer, IRequestResolverProvider,
      * @param clazz the class of the module.
      * @param modulePredicate the predicate to match.
      * @param <T> the module type.
-     * @return the first matching module (could be null).
+     * @return the first matching module.
+     * @throws IllegalArgumentException if your condition does not match any modules
      */
-    @Nullable
+    @NotNull
     <T extends IBuildingModule> T getModuleMatching(Class<T> clazz, Predicate<? super T> modulePredicate);
 
     /**

--- a/src/api/java/com/minecolonies/api/colony/buildings/IBuilding.java
+++ b/src/api/java/com/minecolonies/api/colony/buildings/IBuilding.java
@@ -77,10 +77,10 @@ public interface IBuilding extends IBuildingContainer, IRequestResolverProvider,
      * Get a module matching a certain predicate.
      * @param clazz the class of the module.
      * @param modulePredicate the predicate to match.
-     * @param <T> the optional type.
-     * @return optional of the matching predicate (could be empty).
+     * @param <T> the module type.
+     * @return the first matching module (could be null).
      */
-    @NotNull
+    @Nullable
     <T extends IBuildingModule> T getModuleMatching(Class<T> clazz, Predicate<? super T> modulePredicate);
 
     /**

--- a/src/main/java/com/minecolonies/coremod/colony/buildings/AbstractBuilding.java
+++ b/src/main/java/com/minecolonies/coremod/colony/buildings/AbstractBuilding.java
@@ -210,7 +210,7 @@ public abstract class AbstractBuilding extends AbstractBuildingContainer
         return Optional.empty();
     }
 
-    @Nullable
+    @NotNull
     @Override
     public <T extends IBuildingModule> T getModuleMatching(final Class<T> clazz, final Predicate<? super T> modulePredicate)
     {
@@ -221,7 +221,7 @@ public abstract class AbstractBuilding extends AbstractBuildingContainer
                 return (T) module;
             }
         }
-        return null;
+        throw new IllegalArgumentException("no matching module");
     }
 
     @NotNull

--- a/src/main/java/com/minecolonies/coremod/colony/buildings/AbstractBuilding.java
+++ b/src/main/java/com/minecolonies/coremod/colony/buildings/AbstractBuilding.java
@@ -210,7 +210,7 @@ public abstract class AbstractBuilding extends AbstractBuildingContainer
         return Optional.empty();
     }
 
-    @NotNull
+    @Nullable
     @Override
     public <T extends IBuildingModule> T getModuleMatching(final Class<T> clazz, final Predicate<? super T> modulePredicate)
     {
@@ -1944,12 +1944,12 @@ public abstract class AbstractBuilding extends AbstractBuildingContainer
     @Override
     public IFormattableTextComponent getRequesterDisplayName(@NotNull final IRequestManager manager, @NotNull final IRequest<?> request)
     {
-        final int citizenId = getCitizensByRequest().get(request.getId());
-        if (!getCitizensByRequest().containsKey(citizenId))
+        if (!getCitizensByRequest().containsKey(request.getId()))
         {
             return new StringTextComponent("<UNKNOWN>");
         }
 
+        final int citizenId = getCitizensByRequest().get(request.getId());
         final ICitizenData citizenData = colony.getCitizenManager().getCivilian(citizenId);
         if (citizenData.getJob() == null)
         {

--- a/src/main/java/com/minecolonies/coremod/colony/requestsystem/resolvers/PublicWorkerCraftingProductionResolver.java
+++ b/src/main/java/com/minecolonies/coremod/colony/requestsystem/resolvers/PublicWorkerCraftingProductionResolver.java
@@ -3,6 +3,7 @@ package com.minecolonies.coremod.colony.requestsystem.resolvers;
 import com.google.common.collect.Lists;
 import com.minecolonies.api.colony.ICitizenData;
 import com.minecolonies.api.colony.IColony;
+import com.minecolonies.api.colony.buildings.IBuilding;
 import com.minecolonies.api.colony.buildings.views.IBuildingView;
 import com.minecolonies.api.colony.jobs.registry.JobEntry;
 import com.minecolonies.api.colony.requestsystem.location.ILocation;
@@ -15,6 +16,7 @@ import com.minecolonies.api.colony.requestsystem.token.IToken;
 import com.minecolonies.coremod.colony.Colony;
 import com.minecolonies.coremod.colony.buildings.AbstractBuilding;
 import com.minecolonies.coremod.colony.buildings.modules.CraftingWorkerBuildingModule;
+import com.minecolonies.coremod.colony.buildings.modules.WorkerBuildingModule;
 import com.minecolonies.coremod.colony.buildings.moduleviews.WorkerBuildingModuleView;
 import com.minecolonies.coremod.colony.jobs.AbstractJobCrafter;
 import com.minecolonies.coremod.colony.requestsystem.resolvers.core.AbstractCraftingProductionResolver;
@@ -138,6 +140,11 @@ public class PublicWorkerCraftingProductionResolver extends AbstractCraftingProd
         {
             final IBuildingView bwv = (IBuildingView) requester;
             return new TranslationTextComponent(bwv.getModuleViewMatching(WorkerBuildingModuleView.class, m -> m.getJobEntry() == getJobEntry()).getJobDisplayName());
+        }
+        if (requester instanceof IBuilding)
+        {
+            final IBuilding building = (IBuilding) requester;
+            return new TranslationTextComponent(building.getModuleMatching(WorkerBuildingModule.class, m -> m.getJobEntry() == getJobEntry()).getJobDisplayName());
         }
         return super.getRequesterDisplayName(manager, request);
     }

--- a/src/main/java/com/minecolonies/coremod/colony/requestsystem/resolvers/PublicWorkerCraftingRequestResolver.java
+++ b/src/main/java/com/minecolonies/coremod/colony/requestsystem/resolvers/PublicWorkerCraftingRequestResolver.java
@@ -1,5 +1,6 @@
 package com.minecolonies.coremod.colony.requestsystem.resolvers;
 
+import com.minecolonies.api.colony.buildings.IBuilding;
 import com.minecolonies.api.colony.buildings.modules.ICraftingBuildingModule;
 import com.minecolonies.api.colony.buildings.views.IBuildingView;
 import com.minecolonies.api.colony.jobs.registry.JobEntry;
@@ -13,7 +14,6 @@ import com.minecolonies.api.colony.requestsystem.requester.IRequester;
 import com.minecolonies.api.colony.requestsystem.token.IToken;
 import com.minecolonies.coremod.colony.buildings.AbstractBuilding;
 import com.minecolonies.coremod.colony.buildings.moduleviews.CraftingModuleView;
-import com.minecolonies.coremod.colony.buildings.moduleviews.WorkerBuildingModuleView;
 import com.minecolonies.coremod.colony.requestsystem.resolvers.core.AbstractCraftingRequestResolver;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.text.IFormattableTextComponent;
@@ -86,6 +86,14 @@ public class PublicWorkerCraftingRequestResolver extends AbstractCraftingRequest
             if (moduleView != null)
             {
                 return new TranslationTextComponent(moduleView.getJobEntry().getTranslationKey());
+            }
+        }
+        if (requester instanceof IBuilding)
+        {
+            final ICraftingBuildingModule module = ((IBuilding) requester).getModuleMatching(ICraftingBuildingModule.class, m -> m.getCraftingJob() != null &&  m.getCraftingJob().getJobRegistryEntry() == getJobEntry());
+            if (module != null)
+            {
+                return new TranslationTextComponent(module.getCraftingJob().getJobRegistryEntry().getTranslationKey());
             }
         }
         return super.getRequesterDisplayName(manager, request);

--- a/src/main/java/com/minecolonies/coremod/colony/requestsystem/resolvers/PublicWorkerCraftingRequestResolver.java
+++ b/src/main/java/com/minecolonies/coremod/colony/requestsystem/resolvers/PublicWorkerCraftingRequestResolver.java
@@ -92,10 +92,7 @@ public class PublicWorkerCraftingRequestResolver extends AbstractCraftingRequest
         if (requester instanceof IBuilding)
         {
             final WorkerBuildingModule module = ((IBuilding) requester).getModuleMatching(WorkerBuildingModule.class, m -> m.getJobEntry() == getJobEntry());
-            if (module != null)
-            {
-                return new TranslationTextComponent(module.getJobEntry().getTranslationKey());
-            }
+            return new TranslationTextComponent(module.getJobEntry().getTranslationKey());
         }
         return super.getRequesterDisplayName(manager, request);
     }

--- a/src/main/java/com/minecolonies/coremod/colony/requestsystem/resolvers/PublicWorkerCraftingRequestResolver.java
+++ b/src/main/java/com/minecolonies/coremod/colony/requestsystem/resolvers/PublicWorkerCraftingRequestResolver.java
@@ -13,7 +13,8 @@ import com.minecolonies.api.colony.requestsystem.requestable.crafting.PublicCraf
 import com.minecolonies.api.colony.requestsystem.requester.IRequester;
 import com.minecolonies.api.colony.requestsystem.token.IToken;
 import com.minecolonies.coremod.colony.buildings.AbstractBuilding;
-import com.minecolonies.coremod.colony.buildings.moduleviews.CraftingModuleView;
+import com.minecolonies.coremod.colony.buildings.modules.WorkerBuildingModule;
+import com.minecolonies.coremod.colony.buildings.moduleviews.WorkerBuildingModuleView;
 import com.minecolonies.coremod.colony.requestsystem.resolvers.core.AbstractCraftingRequestResolver;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.text.IFormattableTextComponent;
@@ -82,7 +83,7 @@ public class PublicWorkerCraftingRequestResolver extends AbstractCraftingRequest
         final IRequester requester = manager.getColony().getRequesterBuildingForPosition(getLocation().getInDimensionLocation());
         if (requester instanceof IBuildingView)
         {
-            final CraftingModuleView moduleView = ((IBuildingView) requester).getModuleViewMatching(CraftingModuleView.class, m -> m.getJobEntry() == getJobEntry());
+            final WorkerBuildingModuleView moduleView = ((IBuildingView) requester).getModuleViewMatching(WorkerBuildingModuleView.class, m -> m.getJobEntry() == getJobEntry());
             if (moduleView != null)
             {
                 return new TranslationTextComponent(moduleView.getJobEntry().getTranslationKey());
@@ -90,10 +91,10 @@ public class PublicWorkerCraftingRequestResolver extends AbstractCraftingRequest
         }
         if (requester instanceof IBuilding)
         {
-            final ICraftingBuildingModule module = ((IBuilding) requester).getModuleMatching(ICraftingBuildingModule.class, m -> m.getCraftingJob() != null &&  m.getCraftingJob().getJobRegistryEntry() == getJobEntry());
+            final WorkerBuildingModule module = ((IBuilding) requester).getModuleMatching(WorkerBuildingModule.class, m -> m.getJobEntry() == getJobEntry());
             if (module != null)
             {
-                return new TranslationTextComponent(module.getCraftingJob().getJobRegistryEntry().getTranslationKey());
+                return new TranslationTextComponent(module.getJobEntry().getTranslationKey());
             }
         }
         return super.getRequesterDisplayName(manager, request);


### PR DESCRIPTION
# Changes proposed in this pull request:
- Fixes `@NotNullable` method that returns null, plus associated javadoc
- Allows request `getRequesterDisplayName` to work again if called server-side
- Fixes NPE if calling `building.getRequesterDisplayName` with invalid request (e.g. one owned by a module rather than the building itself).

Review please

Most of these are not things directly run into in MineColonies code itself, they were encountered by trying to use the API from my mod.

The building/requestresolver code still strikes me as a bit weird.  I followed the pattern of the existing code but I do wonder whether it would be better to make the requestresolver just call the building, and have the building be responsible for checking its modules if it doesn't know about the request itself.  It seems a bit weird for external code to be reaching directly into modules.