### PR TITLE
Better JEI support for alchemist

### DIFF
--- a/src/api/java/com/minecolonies/api/crafting/GenericRecipe.java
+++ b/src/api/java/com/minecolonies/api/crafting/GenericRecipe.java
@@ -195,18 +195,26 @@ public class GenericRecipe implements IGenericRecipe
     @Override
     public Optional<Boolean> matchesInput(@NotNull OptionalPredicate<ItemStack> predicate)
     {
+        Optional<Boolean> result = Optional.empty();
+
         for (final List<ItemStack> slot : this.inputs)
         {
             for (final ItemStack stack : slot)
             {
-                final Optional<Boolean> result = predicate.test(stack);
-                if (result.isPresent())
+                final Optional<Boolean> itemResult = predicate.test(stack);
+                if (itemResult.isPresent())
                 {
-                    return result;
+                    if (!itemResult.get())
+                    {
+                        // immediately fail on any predicate failure
+                        return itemResult;
+                    }
+                    // otherwise remember a pass but keep checking
+                    result = itemResult;
                 }
             }
         }
-        return Optional.empty();
+        return result;
     }
 
     @NotNull

--- a/src/api/java/com/minecolonies/api/crafting/IGenericRecipe.java
+++ b/src/api/java/com/minecolonies/api/crafting/IGenericRecipe.java
@@ -91,6 +91,8 @@ public interface IGenericRecipe
 
     /**
      * Checks whether the given predicate matches any input item of this recipe.
+     * Explicitly failing the predicate is considered more important -- if there's
+     * some inputs that pass and others that fail then this will return false.
      *
      * @param predicate The predicate to test.
      * @return True if any input (including alternates) matches the predicate;

--- a/src/api/java/com/minecolonies/api/inventory/container/ContainerCraftingBrewingstand.java
+++ b/src/api/java/com/minecolonies/api/inventory/container/ContainerCraftingBrewingstand.java
@@ -4,8 +4,6 @@ import com.minecolonies.api.inventory.ModContainers;
 import com.minecolonies.api.util.ItemStackUtils;
 import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.entity.player.PlayerInventory;
-import net.minecraft.inventory.Inventory;
-import net.minecraft.inventory.container.AbstractFurnaceContainer;
 import net.minecraft.inventory.container.ClickType;
 import net.minecraft.inventory.container.Container;
 import net.minecraft.inventory.container.Slot;
@@ -278,6 +276,18 @@ public class ContainerCraftingBrewingstand extends Container
     public void setInput(final ItemStack stack)
     {
         handleSlotClick(getSlot(0), stack);
+    }
+
+    /**
+     * Sets the container (input potion, intended mostly for crafting teaching).
+     *
+     * @param stack The container stack.
+     */
+    public void setContainer(final ItemStack stack)
+    {
+        handleSlotClick(getSlot(1), stack);
+        handleSlotClick(getSlot(2), stack);
+        handleSlotClick(getSlot(3), stack);
     }
 
     /**

--- a/src/datagen/generated/minecolonies/data/minecolonies/tags/items/blacksmith_product_excluded.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/tags/items/blacksmith_product_excluded.json
@@ -5,6 +5,7 @@
     "#minecolonies:mechanic_product",
     "#minecolonies:sawmill_product",
     "#minecolonies:stonemason_product",
-    "minecraft:firework_star"
+    "minecraft:firework_star",
+    "minecraft:glistering_melon_slice"
   ]
 }

--- a/src/datagen/generated/minecolonies/data/minecolonies/tags/items/farmer_product.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/tags/items/farmer_product.json
@@ -5,6 +5,8 @@
     "#forge:seeds",
     "minecolonies:composted_dirt",
     "minecraft:melon",
-    "minecraft:coarse_dirt"
+    "minecraft:coarse_dirt",
+    "minecraft:fermented_spider_eye",
+    "minecraft:glistering_melon_slice"
   ]
 }

--- a/src/main/java/com/minecolonies/coremod/colony/buildings/workerbuildings/BuildingAlchemist.java
+++ b/src/main/java/com/minecolonies/coremod/colony/buildings/workerbuildings/BuildingAlchemist.java
@@ -2,6 +2,7 @@ package com.minecolonies.coremod.colony.buildings.workerbuildings;
 
 import com.minecolonies.api.colony.IColony;
 import com.minecolonies.api.colony.jobs.registry.JobEntry;
+import com.minecolonies.api.crafting.GenericRecipe;
 import com.minecolonies.api.crafting.IGenericRecipe;
 import com.minecolonies.api.crafting.registry.CraftingType;
 import com.minecolonies.api.items.ModItems;
@@ -11,6 +12,7 @@ import com.minecolonies.coremod.colony.buildings.AbstractBuilding;
 import com.minecolonies.coremod.colony.buildings.modules.AbstractCraftingBuildingModule;
 import net.minecraft.block.Block;
 import net.minecraft.block.Blocks;
+import net.minecraft.item.ItemStack;
 import net.minecraft.item.Items;
 import net.minecraft.item.ShearsItem;
 import net.minecraft.nbt.CompoundNBT;
@@ -23,7 +25,10 @@ import net.minecraft.world.World;
 import net.minecraftforge.common.util.Constants;
 import org.jetbrains.annotations.NotNull;
 
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
 
 import static com.minecolonies.api.util.constant.BuildingConstants.CONST_DEFAULT_MAX_BUILDING_LEVEL;
 import static com.minecolonies.api.util.constant.NbtTagConstants.*;
@@ -262,6 +267,28 @@ public class BuildingAlchemist extends AbstractBuilding
         public Set<CraftingType> getSupportedCraftingTypes()
         {
             return Collections.emptySet();
+        }
+
+        @Override
+        public @NotNull List<IGenericRecipe> getAdditionalRecipesForDisplayPurposesOnly()
+        {
+            final List<IGenericRecipe> recipes = new ArrayList<>(super.getAdditionalRecipesForDisplayPurposesOnly());
+
+            // growing mistletoe
+            recipes.add(new GenericRecipe(null, new ItemStack(ModItems.mistletoe),
+                    Collections.emptyList(),
+                    Collections.singletonList(Collections.singletonList(new ItemStack(Items.SHEARS))),
+                    1, Blocks.OAK_LEAVES,
+                    null, Collections.emptyList(), -1));
+
+            // growing netherwart
+            recipes.add(new GenericRecipe(null, new ItemStack(Items.NETHER_WART, 4),
+                    Collections.emptyList(),
+                    Collections.singletonList(Collections.singletonList(new ItemStack(Items.NETHER_WART))),
+                    1, Blocks.SOUL_SAND,
+                    null, Collections.emptyList(), -1));
+
+            return recipes;
         }
     }
 }

--- a/src/main/java/com/minecolonies/coremod/colony/buildings/workerbuildings/BuildingAlchemist.java
+++ b/src/main/java/com/minecolonies/coremod/colony/buildings/workerbuildings/BuildingAlchemist.java
@@ -229,17 +229,6 @@ public class BuildingAlchemist extends AbstractBuilding
         {
             super(jobEntry);
         }
-
-        @Override
-        public boolean isRecipeCompatible(@NotNull final IGenericRecipe recipe)
-        {
-            if (!super.isRecipeCompatible(recipe))
-            {
-                return false;
-            }
-
-            return recipe.getPrimaryOutput().getItem() == Items.POTION;
-        }
     }
 
     public static class CraftingModule extends AbstractCraftingBuildingModule.Crafting

--- a/src/main/java/com/minecolonies/coremod/compatibility/CraftingTagAuditor.java
+++ b/src/main/java/com/minecolonies/coremod/compatibility/CraftingTagAuditor.java
@@ -86,6 +86,14 @@ public class CraftingTagAuditor
         void write(@NotNull BufferedWriter writer) throws IOException;
     }
 
+    private static List<ItemStack> getAllItems()
+    {
+        final ICompatibilityManager compatibility = IColonyManager.getInstance().getCompatibilityManager();
+        final List<ItemStack> items = new ArrayList<>(compatibility.getListOfAllItems());
+        items.sort(Comparator.comparing(stack -> stack.getItem().getRegistryName().toString()));
+        return items;
+    }
+
     private static void doTagAudit(@NotNull final BufferedWriter writer,
                                    @NotNull final MinecraftServer server) throws IOException
     {
@@ -93,8 +101,7 @@ public class CraftingTagAuditor
         writer.write(",tags...");
         writer.newLine();
 
-        final ICompatibilityManager compatibility = IColonyManager.getInstance().getCompatibilityManager();
-        for (final ItemStack item : compatibility.getListOfAllItems())
+        for (final ItemStack item : getAllItems())
         {
             writeItemData(writer, item);
 
@@ -143,8 +150,7 @@ public class CraftingTagAuditor
         }
         writer.newLine();
 
-        final ICompatibilityManager compatibility = IColonyManager.getInstance().getCompatibilityManager();
-        for (final ItemStack item : compatibility.getListOfAllItems())
+        for (final ItemStack item : getAllItems())
         {
             writeItemData(writer, item);
 

--- a/src/main/java/com/minecolonies/coremod/compatibility/jei/JEIPlugin.java
+++ b/src/main/java/com/minecolonies/coremod/compatibility/jei/JEIPlugin.java
@@ -16,10 +16,7 @@ import com.minecolonies.api.util.constant.TranslationConstants;
 import com.minecolonies.coremod.colony.buildings.modules.AnimalHerdingModule;
 import com.minecolonies.coremod.colony.crafting.CustomRecipesReloadedEvent;
 import com.minecolonies.coremod.colony.crafting.RecipeAnalyzer;
-import com.minecolonies.coremod.compatibility.jei.transfer.CraftingGuiHandler;
-import com.minecolonies.coremod.compatibility.jei.transfer.FurnaceCraftingGuiHandler;
-import com.minecolonies.coremod.compatibility.jei.transfer.PrivateCraftingTeachingTransferHandler;
-import com.minecolonies.coremod.compatibility.jei.transfer.PrivateSmeltingTeachingTransferHandler;
+import com.minecolonies.coremod.compatibility.jei.transfer.*;
 import mezz.jei.api.IModPlugin;
 import mezz.jei.api.constants.VanillaRecipeCategoryUid;
 import mezz.jei.api.constants.VanillaTypes;
@@ -148,6 +145,7 @@ public class JEIPlugin implements IModPlugin
     {
         registration.addRecipeTransferHandler(new PrivateCraftingTeachingTransferHandler(registration.getTransferHelper()), VanillaRecipeCategoryUid.CRAFTING);
         registration.addRecipeTransferHandler(new PrivateSmeltingTeachingTransferHandler(registration.getTransferHelper()), VanillaRecipeCategoryUid.FURNACE);
+        registration.addRecipeTransferHandler(new PrivateBrewingTeachingTransferHandler(registration.getTransferHelper()), VanillaRecipeCategoryUid.BREWING);
     }
 
     @Override
@@ -155,6 +153,7 @@ public class JEIPlugin implements IModPlugin
     {
         new CraftingGuiHandler(this.categories).register(registration);
         new FurnaceCraftingGuiHandler(this.categories).register(registration);
+        new BrewingCraftingGuiHandler(this.categories).register(registration);
     }
 
     @Override

--- a/src/main/java/com/minecolonies/coremod/compatibility/jei/transfer/BrewingCraftingGuiHandler.java
+++ b/src/main/java/com/minecolonies/coremod/compatibility/jei/transfer/BrewingCraftingGuiHandler.java
@@ -1,0 +1,82 @@
+package com.minecolonies.coremod.compatibility.jei.transfer;
+
+import com.minecolonies.api.crafting.ModCraftingTypes;
+import com.minecolonies.api.inventory.container.ContainerCraftingBrewingstand;
+import com.minecolonies.coremod.Network;
+import com.minecolonies.coremod.client.gui.containers.WindowBrewingstandCrafting;
+import com.minecolonies.coremod.colony.buildings.moduleviews.CraftingModuleView;
+import com.minecolonies.coremod.compatibility.jei.JobBasedRecipeCategory;
+import com.minecolonies.coremod.network.messages.server.TransferRecipeCraftingTeachingMessage;
+import mezz.jei.api.gui.handlers.IGuiClickableArea;
+import net.minecraft.inventory.container.Slot;
+import net.minecraft.item.ItemStack;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.*;
+
+/**
+ * Implements a "show recipes" button on the brewing teaching window, and allows you to drag
+ * individual ingredients directly from JEI to the teaching grid without using cheat mode.
+ */
+public class BrewingCraftingGuiHandler extends AbstractTeachingGuiHandler<WindowBrewingstandCrafting>
+{
+    public BrewingCraftingGuiHandler(@NotNull final List<JobBasedRecipeCategory<?>> categories)
+    {
+        super(categories);
+    }
+
+    @NotNull
+    @Override
+    protected Class<WindowBrewingstandCrafting> getWindowClass()
+    {
+        return WindowBrewingstandCrafting.class;
+    }
+
+    @NotNull
+    @Override
+    public Collection<IGuiClickableArea> getGuiClickableAreas(@NotNull final WindowBrewingstandCrafting containerScreen,
+                                                              final double mouseX,
+                                                              final double mouseY)
+    {
+        final List<IGuiClickableArea> areas = new ArrayList<>();
+        final JobBasedRecipeCategory<?> category = getRecipeCategory(containerScreen.getBuildingView());
+        if (category != null)
+        {
+            areas.add(IGuiClickableArea.createBasic(34, 15, 44, 34, category.getUid()));
+        }
+        return areas;
+    }
+
+    @Override
+    protected boolean isSupportedCraftingModule(@NotNull final CraftingModuleView moduleView)
+    {
+        return moduleView.canLearn(ModCraftingTypes.BREWING);
+    }
+
+    @Override
+    protected boolean isSupportedSlot(@NotNull Slot slot)
+    {
+        return slot.index >= 0 && slot.index <= 3;
+    }
+
+    @Override
+    protected void updateServer(@NotNull final WindowBrewingstandCrafting gui)
+    {
+        final Map<Integer, ItemStack> matrix = new HashMap<>();
+        final ContainerCraftingBrewingstand inventory = gui.getMenu();
+
+        matrix.put(0, inventory.getSlot(0).getItem());
+        for (int slot = 1; slot <= 3; ++slot)
+        {
+            final ItemStack container = inventory.getSlot(1).getItem();
+            if (!container.isEmpty())
+            {
+                matrix.put(1, container);
+                break;
+            }
+        }
+
+        final TransferRecipeCraftingTeachingMessage message = new TransferRecipeCraftingTeachingMessage(matrix, false);
+        Network.getNetwork().sendToServer(message);
+    }
+}

--- a/src/main/java/com/minecolonies/coremod/compatibility/jei/transfer/PrivateBrewingTeachingTransferHandler.java
+++ b/src/main/java/com/minecolonies/coremod/compatibility/jei/transfer/PrivateBrewingTeachingTransferHandler.java
@@ -1,0 +1,69 @@
+package com.minecolonies.coremod.compatibility.jei.transfer;
+
+import com.minecolonies.api.inventory.container.ContainerCraftingBrewingstand;
+import com.minecolonies.coremod.Network;
+import com.minecolonies.coremod.network.messages.server.TransferRecipeCraftingTeachingMessage;
+import mezz.jei.api.gui.IRecipeLayout;
+import mezz.jei.api.gui.ingredient.IGuiIngredient;
+import mezz.jei.api.gui.ingredient.IGuiItemStackGroup;
+import mezz.jei.api.recipe.transfer.IRecipeTransferError;
+import mezz.jei.api.recipe.transfer.IRecipeTransferHandler;
+import mezz.jei.api.recipe.transfer.IRecipeTransferHandlerHelper;
+import net.minecraft.entity.player.PlayerEntity;
+import net.minecraft.item.ItemStack;
+import org.jetbrains.annotations.NotNull;
+
+import javax.annotation.Nullable;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * JEI recipe transfer handler for teaching brewing recipes
+ */
+public class PrivateBrewingTeachingTransferHandler implements IRecipeTransferHandler<ContainerCraftingBrewingstand>
+{
+    private final IRecipeTransferHandlerHelper handlerHelper;
+
+    public PrivateBrewingTeachingTransferHandler(@NotNull final IRecipeTransferHandlerHelper handlerHelper)
+    {
+        this.handlerHelper = handlerHelper;
+    }
+
+    @NotNull
+    @Override
+    public Class<ContainerCraftingBrewingstand> getContainerClass()
+    {
+        return ContainerCraftingBrewingstand.class;
+    }
+
+    @Nullable
+    @Override
+    public IRecipeTransferError transferRecipe(
+            @NotNull final ContainerCraftingBrewingstand craftingGUIBuilding,
+            @NotNull final Object recipe,
+            @NotNull final IRecipeLayout recipeLayout,
+            @NotNull final PlayerEntity player,
+            final boolean maxTransfer,
+            final boolean doTransfer)
+    {
+        final IGuiItemStackGroup itemStackGroup = recipeLayout.getItemStacks();
+
+        final IGuiIngredient<ItemStack> container = itemStackGroup.getGuiIngredients().get(0);
+        final IGuiIngredient<ItemStack> ingredient = itemStackGroup.getGuiIngredients().get(3);
+
+        final Map<Integer, ItemStack> guiIngredients = new HashMap<>();
+        guiIngredients.put(0, ingredient.getDisplayedIngredient());
+        guiIngredients.put(1, container.getDisplayedIngredient());
+
+        if (doTransfer)
+        {
+            craftingGUIBuilding.setInput(ingredient.getDisplayedIngredient());
+            craftingGUIBuilding.setContainer(container.getDisplayedIngredient());
+
+            final TransferRecipeCraftingTeachingMessage message = new TransferRecipeCraftingTeachingMessage(guiIngredients, false);
+            Network.getNetwork().sendToServer(message);
+        }
+
+        return null;
+    }
+}

--- a/src/main/java/com/minecolonies/coremod/generation/defaults/DefaultItemTagsProvider.java
+++ b/src/main/java/com/minecolonies/coremod/generation/defaults/DefaultItemTagsProvider.java
@@ -176,7 +176,8 @@ public class DefaultItemTagsProvider extends ItemTagsProvider
                 .addTag(ModTags.crafterProduct.get(TagConstants.CRAFTING_MECHANIC))
                 .addTag(ModTags.crafterProduct.get(TagConstants.CRAFTING_SAWMILL))
                 .addTag(ModTags.crafterProduct.get(TagConstants.CRAFTING_STONEMASON))
-                .add(Items.FIREWORK_STAR);
+                .add(Items.FIREWORK_STAR)
+                .add(Items.GLISTERING_MELON_SLICE);
 
         tag(ModTags.crafterIngredient.get(TagConstants.CRAFTING_COOK))
                 .addTag(ItemTags.FISHES)
@@ -216,7 +217,9 @@ public class DefaultItemTagsProvider extends ItemTagsProvider
                 .addTag(Tags.Items.SEEDS)
                 .add(ModBlocks.blockCompostedDirt.asItem())
                 .add(Items.MELON)
-                .add(Items.COARSE_DIRT);
+                .add(Items.COARSE_DIRT)
+                .add(Items.FERMENTED_SPIDER_EYE)
+                .add(Items.GLISTERING_MELON_SLICE);
         tag(ModTags.crafterProductExclusions.get(TagConstants.CRAFTING_FARMER));
 
         tag(ModTags.crafterIngredient.get(TagConstants.CRAFTING_FLETCHER))

--- a/src/main/java/com/minecolonies/coremod/network/messages/server/TransferRecipeCraftingTeachingMessage.java
+++ b/src/main/java/com/minecolonies/coremod/network/messages/server/TransferRecipeCraftingTeachingMessage.java
@@ -1,6 +1,7 @@
 package com.minecolonies.coremod.network.messages.server;
 
 import com.minecolonies.api.inventory.container.ContainerCrafting;
+import com.minecolonies.api.inventory.container.ContainerCraftingBrewingstand;
 import com.minecolonies.api.inventory.container.ContainerCraftingFurnace;
 import com.minecolonies.api.network.IMessage;
 import com.minecolonies.api.util.ItemStackUtils;
@@ -116,6 +117,13 @@ public class TransferRecipeCraftingTeachingMessage implements IMessage
             final ContainerCraftingFurnace container = (ContainerCraftingFurnace) player.containerMenu;
 
             container.setFurnaceInput(itemStacks.getOrDefault(0, ItemStack.EMPTY));
+        }
+        else if (player.containerMenu instanceof ContainerCraftingBrewingstand)
+        {
+            final ContainerCraftingBrewingstand container = (ContainerCraftingBrewingstand) player.containerMenu;
+
+            container.setInput(itemStacks.getOrDefault(0, ItemStack.EMPTY));
+            container.setContainer(itemStacks.getOrDefault(1, ItemStack.EMPTY));
         }
     }
 }

--- a/src/main/java/com/minecolonies/coremod/recipes/BrewingCraftingType.java
+++ b/src/main/java/com/minecolonies/coremod/recipes/BrewingCraftingType.java
@@ -60,8 +60,8 @@ public class BrewingCraftingType extends CraftingType
                         actualOutput.setCount(3);
 
                         recipes.add(new GenericRecipe(null, actualOutput, Collections.emptyList(),
-                                Arrays.asList(Collections.singletonList(actualInput), Collections.singletonList(ingredient)),
-                                4, Blocks.BREWING_STAND, null, Collections.emptyList(), -1));
+                                Arrays.asList(Collections.singletonList(ingredient), Collections.singletonList(actualInput)),
+                                1, Blocks.BREWING_STAND, null, Collections.emptyList(), -1));
                     }
                 }
             }

--- a/src/main/resources/assets/minecolonies/lang/manual_en_us.json
+++ b/src/main/resources/assets/minecolonies/lang/manual_en_us.json
@@ -1543,6 +1543,7 @@
   "com.minecolonies.coremod.jei.chanceskill.tip": "§e%d%% base chance §a+ skill modifier",
   "com.minecolonies.coremod.jei.chancenegskill.tip": "§e%d%% base chance §c- skill modifier",
   "com.minecolonies.coremod.jei.conditions.tip": "§bSpecial conditions apply",
+  "com.minecolonies.coremod.jei.alchemist": "Brews potions; also gathers mistletoe and netherwart.",
   "com.minecolonies.coremod.jei.baker": "Bakes bread, and other things at higher levels. Can be taught extra recipes starting at level 3.",
   "com.minecolonies.coremod.jei.beekeeper": "Takes care of beehives, harvesting either honey or honeycomb.",
   "com.minecolonies.coremod.jei.blacksmith": "Crafts tools, weapons, armour, and many other things made of metal.",


### PR DESCRIPTION
Closes [Discord request](https://discord.com/channels/472875599422291968/473575384445878273/974977517809184838)

# Changes proposed in this pull request:
- Allows alchemist to learn splash and lingering potions too, not just normal potions.
- Adds JEI indication that alchemist produces mistletoe and netherwart
- Adds ghost ingredient dragging from JEI to brewing crafting GUI
- Adds vanilla brewing recipe teaching button to JEI for brewing teaching GUI
- Fixes missing job description in JEI
- Fixes some inconsistencies in audit and JEI recipe filtering.
- Moves some alchemy ingredients to the farmer
   - Fermented spider eye couldn't be crafted by anyone
   - Glistering melon slice used to be blacksmith

Review please

This is an interim solution; the intent is to move some of this code over to `CraftingType` to make it more generic and reduce custom classes needed for new crafting types.  Still pondering the best API shape to use for that, especially since DO crafting is very different from the others.  (or do we perhaps want to change that to be more like the others?  i.e. display the actual cutter gui slots when teaching?)  Also some of the classes aren't currently in the API and I'm reluctant to expose them (although I guess that doesn't matter *too* much).

[Spreadsheet](https://docs.google.com/spreadsheets/d/1_Qune8CPbL3XIJcYnNoPkXQ_CIiOmg4fMBqXHZE3plE/edit?usp=sharing)