### PR TITLE
small PR to ignore those blocks

### DIFF
--- a/src/main/java/com/minecolonies/coremod/placementhandlers/BuilderIgnorePlacementHandler.java
+++ b/src/main/java/com/minecolonies/coremod/placementhandlers/BuilderIgnorePlacementHandler.java
@@ -1,0 +1,76 @@
+package com.minecolonies.coremod.placementhandlers;
+
+import com.ldtteam.structurize.placement.handlers.placement.IPlacementHandler;
+import com.ldtteam.structurize.util.BlockUtils;
+import com.ldtteam.structurize.util.PlacementSettings;
+import com.minecolonies.api.util.Log;
+import com.minecolonies.api.util.WorldUtil;
+import net.minecraft.core.BlockPos;
+import net.minecraft.nbt.CompoundTag;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.level.Level;
+import net.minecraft.world.level.block.JigsawBlock;
+import net.minecraft.world.level.block.StructureBlock;
+import net.minecraft.world.level.block.StructureVoidBlock;
+import net.minecraft.world.level.block.state.BlockState;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.Collections;
+import java.util.List;
+
+import static com.ldtteam.structurize.placement.handlers.placement.PlacementHandlers.handleTileEntityPlacement;
+
+/**
+ * Handler for some specific blocks that we want only to paste/cost in the complete mode.
+ */
+public class BuilderIgnorePlacementHandler implements IPlacementHandler
+{
+    @Override
+    public boolean canHandle(@NotNull final Level world, @NotNull final BlockPos pos, @NotNull final BlockState blockState)
+    {
+        return blockState.getBlock() instanceof JigsawBlock || blockState.getBlock() instanceof StructureBlock || blockState.getBlock() instanceof StructureVoidBlock;
+    }
+
+    @Override
+    public ActionProcessingResult handle(
+      @NotNull final Level world,
+      @NotNull final BlockPos pos,
+      @NotNull final BlockState blockState,
+      @Nullable final CompoundTag tileEntityData,
+      final boolean complete,
+      final BlockPos centerPos,
+      final PlacementSettings settings)
+    {
+        if (complete)
+        {
+            WorldUtil.setBlockState(world, pos, blockState, com.ldtteam.structurize.api.util.constant.Constants.UPDATE_FLAG);
+            if (tileEntityData != null)
+            {
+                try
+                {
+                    handleTileEntityPlacement(tileEntityData, world, pos, settings);
+                    blockState.getBlock().setPlacedBy(world, pos, blockState, null, BlockUtils.getItemStackFromBlockState(blockState));
+                }
+                catch (final Exception ex)
+                {
+                    Log.getLogger().warn("Unable to place TileEntity");
+                }
+            }
+            return ActionProcessingResult.SUCCESS;
+        }
+
+        return ActionProcessingResult.SUCCESS;
+    }
+
+    @Override
+    public List<ItemStack> getRequiredItems(
+      @NotNull final Level world,
+      @NotNull final BlockPos pos,
+      @NotNull final BlockState blockState,
+      @Nullable final CompoundTag tileEntityData,
+      final boolean complete)
+    {
+        return Collections.emptyList();
+    }
+}

--- a/src/main/java/com/minecolonies/coremod/placementhandlers/PlacementHandlerInitializer.java
+++ b/src/main/java/com/minecolonies/coremod/placementhandlers/PlacementHandlerInitializer.java
@@ -20,6 +20,7 @@ public final class PlacementHandlerInitializer
     public static void initHandlers()
     {
         PlacementHandlers.add(new GeneralBlockPlacementHandler(), PlacementHandlers.GeneralBlockPlacementHandler.class);
+        PlacementHandlers.add(new BuilderIgnorePlacementHandler());
         PlacementHandlers.add(new DoBlockPlacementHandler());
         PlacementHandlers.add(new DoDoorBlockPlacementHandler());
         PlacementHandlers.add(new BarracksTowerHandler());


### PR DESCRIPTION
This is part one of the specific compat for vanilla structure handling.
This allows setting up the jigsaw blocks etc within a schematic area but then have it ignored by the builder.

I want to invite a two-fold discussion here.

a) Do we want to render them?
b) Do we want to make this maybe a block tag?
c) If we make this a block tag, we can also use this tag for conditional rendering then (similar as the void blocks).

So maybe two tags?

One for conditional rendering.
One for "ignored blocks" ?



Furtheremore, for part two of the compat I had the following planned:

a) A "special scan tool" 
- This scan tool will create a vanilla structure file, however it will do two things:
a) It will fill in the necessary data of the jigsaw blocks (tool will have building/road/field toggles) and a textfield for "stylename" and one for "buildingname".
b) It will also apply the correct tags to the buildings.

This would make it trivial to setup the worldgen stuff for new styles.

Review please
