### PR TITLE
Fix 8419

### DIFF
--- a/src/api/java/com/minecolonies/api/colony/buildings/modules/ICraftingBuildingModule.java
+++ b/src/api/java/com/minecolonies/api/colony/buildings/modules/ICraftingBuildingModule.java
@@ -6,15 +6,15 @@ import com.minecolonies.api.colony.jobs.registry.JobEntry;
 import com.minecolonies.api.colony.requestsystem.token.IToken;
 import com.minecolonies.api.crafting.IGenericRecipe;
 import com.minecolonies.api.crafting.IRecipeStorage;
-import com.minecolonies.api.entity.citizen.AbstractEntityCitizen;
 import com.minecolonies.api.crafting.registry.CraftingType;
+import com.minecolonies.api.entity.citizen.AbstractEntityCitizen;
 import com.minecolonies.api.util.OptionalPredicate;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.item.ItemStack;
-import net.minecraft.world.item.crafting.RecipeType;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
+import java.util.Collections;
 import java.util.List;
 import java.util.Set;
 import java.util.function.Predicate;
@@ -237,6 +237,20 @@ public interface ICraftingBuildingModule extends IBuildingModule
      */
     @NotNull
     List<IGenericRecipe> getAdditionalRecipesForDisplayPurposesOnly();
+
+    /**
+     * Gets a list of loot tables that should be available for drop
+     * analysis (beyond any already used in recipes).  This is not
+     * intended for actually generating loot, just for display purposes
+     * such as in JEI (e.g. via {@link #getAdditionalRecipesForDisplayPurposesOnly()}).
+     *
+     * @return The list of loot table ids
+     */
+    @NotNull
+    default List<ResourceLocation> getAdditionalLootTables()
+    {
+        return Collections.emptyList();
+    }
 
     /**
      * Add a recipe to the building.

--- a/src/main/java/com/minecolonies/coremod/colony/buildings/workerbuildings/BuildingSmeltery.java
+++ b/src/main/java/com/minecolonies/coremod/colony/buildings/workerbuildings/BuildingSmeltery.java
@@ -21,13 +21,7 @@ import net.minecraft.core.BlockPos;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.server.level.ServerLevel;
 import net.minecraft.util.Tuple;
-import net.minecraft.world.item.ArmorItem;
-import net.minecraft.world.item.BlockItem;
-import net.minecraft.world.item.DiggerItem;
-import net.minecraft.world.item.Item;
-import net.minecraft.world.item.ItemStack;
-import net.minecraft.world.item.Items;
-import net.minecraft.world.item.SwordItem;
+import net.minecraft.world.item.*;
 import net.minecraft.world.item.enchantment.Enchantments;
 import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.Blocks;
@@ -145,7 +139,7 @@ public class BuildingSmeltery extends AbstractBuilding
             final ICompatibilityManager compatibility = IColonyManager.getInstance().getCompatibilityManager();
             for (final ItemStack stack : compatibility.getListOfAllItems())
             {
-                if (ItemStackUtils.IS_SMELTABLE.and(compatibility::isOre).test(stack))
+                if (ItemStackUtils.IS_SMELTABLE.and(compatibility::isOre).and(s -> !s.is(ModTags.breakable_ore)).test(stack))
                 {
                     final ItemStack output = FurnaceRecipes.getInstance().getSmeltingResult(stack);
                     recipes.add(createSmeltingRecipe(new ItemStorage(stack), output, Blocks.FURNACE));
@@ -173,7 +167,44 @@ public class BuildingSmeltery extends AbstractBuilding
             super(jobEntry);
         }
 
-        @Override 
+        @NotNull
+        @Override
+        public List<ResourceLocation> getAdditionalLootTables()
+        {
+            final List<ResourceLocation> lootTables = new ArrayList<>(super.getAdditionalLootTables());
+
+            for (final Item input : ModTags.breakable_ore.getValues())
+            {
+                lootTables.add(getLootTable(input));
+            }
+
+            return lootTables;
+        }
+
+        @NotNull
+        @Override
+        public List<IGenericRecipe> getAdditionalRecipesForDisplayPurposesOnly()
+        {
+            final List<IGenericRecipe> recipes = new ArrayList<>(super.getAdditionalRecipesForDisplayPurposesOnly());
+
+            for (final Item input : ModTags.breakable_ore.getValues())
+            {
+                recipes.add(new GenericRecipe(
+                        null,                    //recipe
+                        ItemStack.EMPTY,            //output
+                        Collections.emptyList(),    //additional outputs
+                        Collections.singletonList(Collections.singletonList(new ItemStack(input))), //inputs
+                        1,                   //grid
+                        Blocks.AIR,                 //intermediate
+                        getLootTable(input),        //loottable
+                        Collections.emptyList(),    //restrictions
+                        -1));               //levelsort
+            }
+
+            return recipes;
+        }
+
+        @Override
         public void checkForWorkerSpecificRecipes()
         {
             super.checkForWorkerSpecificRecipes();

--- a/src/main/java/com/minecolonies/coremod/colony/crafting/CustomRecipeManager.java
+++ b/src/main/java/com/minecolonies/coremod/colony/crafting/CustomRecipeManager.java
@@ -1,6 +1,7 @@
 package com.minecolonies.coremod.colony.crafting;
 
 import com.minecolonies.api.IMinecoloniesAPI;
+import com.minecolonies.api.colony.buildings.modules.ICraftingBuildingModule;
 import com.minecolonies.api.colony.buildings.registry.BuildingEntry;
 import com.minecolonies.api.colony.requestsystem.StandardFactoryController;
 import com.minecolonies.api.crafting.ItemStorage;
@@ -263,11 +264,17 @@ public class CustomRecipeManager
 
         for (final BuildingEntry building : IMinecoloniesAPI.getInstance().getBuildingRegistry())
         {
-            building.getModuleProducers().stream()
-                    .map(Supplier::get)
-                    .filter(m -> m instanceof AnimalHerdingModule)
-                    .map(m -> (AnimalHerdingModule) m)
-                    .forEach(herding -> lootIds.add(herding.getDefaultLootTable()));
+            building.getModuleProducers().stream().map(Supplier::get).forEach(module ->
+            {
+                if (module instanceof AnimalHerdingModule herding)
+                {
+                    lootIds.add(herding.getDefaultLootTable());
+                }
+                if (module instanceof ICraftingBuildingModule crafting)
+                {
+                    lootIds.addAll(crafting.getAdditionalLootTables());
+                }
+            });
         }
 
         lootIds.add(ModLootTables.FISHING);

--- a/src/main/java/com/minecolonies/coremod/compatibility/jei/GenericRecipeCategory.java
+++ b/src/main/java/com/minecolonies/coremod/compatibility/jei/GenericRecipeCategory.java
@@ -47,7 +47,7 @@ public class GenericRecipeCategory extends JobBasedRecipeCategory<IGenericRecipe
         super(job, Objects.requireNonNull(crafting.getUid()), getCatalyst(building), guiHelper);
 
         this.building = building;
-        this.crafting = crafting;
+        this.crafting.add(crafting);
         this.arrow = guiHelper.createDrawable(TEXTURE, 20, 121, 24, 18);
         this.modIdHelper = modIdHelper;
 
@@ -56,7 +56,7 @@ public class GenericRecipeCategory extends JobBasedRecipeCategory<IGenericRecipe
     }
 
     @NotNull private final BuildingEntry building;
-    @NotNull private final ICraftingBuildingModule crafting;
+    @NotNull private final List<ICraftingBuildingModule> crafting = new ArrayList<>();
     @NotNull private final IDrawableStatic arrow;
     @NotNull private final IModIdHelper modIdHelper;
 
@@ -66,6 +66,11 @@ public class GenericRecipeCategory extends JobBasedRecipeCategory<IGenericRecipe
     private static final int INPUT_SLOT_W = WIDTH - INPUT_SLOT_X;
     private final int outputSlotX;
     private final int outputSlotY;
+
+    public void addModule(@NotNull final ICraftingBuildingModule module)
+    {
+        this.crafting.add(module);
+    }
 
     @NotNull
     @Override
@@ -304,7 +309,11 @@ public class GenericRecipeCategory extends JobBasedRecipeCategory<IGenericRecipe
     @NotNull
     public List<IGenericRecipe> findRecipes(@NotNull final Map<CraftingType, List<IGenericRecipe>> vanilla)
     {
-        final List<IGenericRecipe> recipes = RecipeAnalyzer.findRecipes(vanilla, this.crafting);
+        final List<IGenericRecipe> recipes = new ArrayList<>();
+        for (final ICraftingBuildingModule module : this.crafting)
+        {
+            recipes.addAll(RecipeAnalyzer.findRecipes(vanilla, module));
+        }
 
         return recipes.stream()
                 .sorted(Comparator.comparing(IGenericRecipe::getLevelSort)


### PR DESCRIPTION
Closes #8419

# Changes proposed in this pull request:
- Fixes some 1.18-specific changes to loot tables causing poor analysis (particularly of resulting item counts)
- Fixes JEI reporting for smelter behaviour (breakable ore changes)
- Merges multiple crafting modules at the same building to a single JEI tab
    - The cowherd still gets two tabs, because they have a crafting module and a herding module, which can't currently be merged

Review please

This is 1.18+ specific.  (The tabs-merge could be backported but doesn't really need to be as it's less common there.)