### PR TITLE
Fix shift clicking in alchemist teaching GUI

### DIFF
--- a/src/api/java/com/minecolonies/api/inventory/container/ContainerCraftingBrewingstand.java
+++ b/src/api/java/com/minecolonies/api/inventory/container/ContainerCraftingBrewingstand.java
@@ -11,6 +11,7 @@ import net.minecraft.item.ItemStack;
 import net.minecraft.network.PacketBuffer;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.World;
+import net.minecraftforge.common.brewing.BrewingRecipeRegistry;
 import net.minecraftforge.items.IItemHandler;
 import net.minecraftforge.items.IItemHandlerModifiable;
 import net.minecraftforge.items.SlotItemHandler;
@@ -252,10 +253,10 @@ public class ContainerCraftingBrewingstand extends Container
     {
         if (slotId >= 0 && slotId < brewingStandInventory.getSlots())
         {
-            // 1 is shift-click
             if (mode == ClickType.PICKUP
                   || mode == ClickType.PICKUP_ALL
-                  || mode == ClickType.SWAP)
+                  || mode == ClickType.SWAP
+                  || mode == ClickType.QUICK_MOVE)
             {
                 final Slot slot = this.slots.get(slotId);
                 return handleSlotClick(slot, playerIn.inventory.getCarried());
@@ -323,54 +324,34 @@ public class ContainerCraftingBrewingstand extends Container
     @Override
     public ItemStack quickMoveStack(final PlayerEntity playerIn, final int index)
     {
-        if (index <= brewingStandInventory.getSlots())
-        {
-            return ItemStack.EMPTY;
-        }
-        final int furnaceSlots = brewingStandInventory.getSlots();
-        final int totalSlots = playerInventory.getContainerSize() + furnaceSlots;
-
-        ItemStack itemstack = ItemStackUtils.EMPTY;
         final Slot slot = this.slots.get(index);
         if (slot != null && slot.hasItem())
         {
-            final ItemStack itemstack1 = slot.getItem();
-            itemstack = itemstack1.copy();
-            if (index == 0)
+            final ItemStack stack = slot.getItem();
+            if (index < 3)
             {
-                if (!this.moveItemStackTo(itemstack1, furnaceSlots, totalSlots, true))
-                {
-                    return ItemStackUtils.EMPTY;
-                }
-                slot.onQuickCraft(itemstack1, itemstack);
-            }
-            else if (index < HOTBAR_START)
-            {
-                if (!this.moveItemStackTo(itemstack1, HOTBAR_START, totalSlots, false))
-                {
-                    return ItemStackUtils.EMPTY;
-                }
-            }
-            else if ((index < totalSlots
-                        && !this.moveItemStackTo(itemstack1, furnaceSlots, HOTBAR_START, false))
-                       || !this.moveItemStackTo(itemstack1, furnaceSlots, totalSlots, false))
-            {
+                setContainer(ItemStack.EMPTY);
                 return ItemStack.EMPTY;
             }
-            if (itemstack1.getCount() == 0)
+            if (index == 3)
             {
-                slot.set(ItemStackUtils.EMPTY);
+                setInput(ItemStack.EMPTY);
+                return ItemStack.EMPTY;
             }
-            else
+
+            if (BrewingRecipeRegistry.isValidIngredient(stack))
             {
-                slot.setChanged();
+                setInput(stack);
+                return ItemStack.EMPTY;
             }
-            if (itemstack1.getCount() == itemstack.getCount())
+            else if (BrewingRecipeRegistry.isValidInput(stack) && stack.getCount() == 1)
             {
-                return ItemStackUtils.EMPTY;
+                setContainer(stack);
+                return ItemStack.EMPTY;
             }
         }
-        return itemstack;
+
+        return ItemStack.EMPTY;
     }
 
     /**


### PR DESCRIPTION
Closes https://pastebin.com/b1gDA499 (once ported)

# Changes proposed in this pull request:
- Fix crash when shift-clicking player inventory slot in alchemist teaching gui
- Make shift-clicking items in alchemist teaching gui do reasonably sensible things

Review please

(I haven't tried it, but this should probably port fairly easily to 1.18.)