### PR TITLE
Fix racks npe

### DIFF
--- a/src/api/java/com/minecolonies/api/tileentities/AbstractTileEntityRack.java
+++ b/src/api/java/com/minecolonies/api/tileentities/AbstractTileEntityRack.java
@@ -8,11 +8,11 @@ import com.minecolonies.api.colony.buildings.IBuilding;
 import com.minecolonies.api.colony.requestsystem.requestable.IDeliverable;
 import com.minecolonies.api.crafting.ItemStorage;
 import com.minecolonies.api.util.ItemStackUtils;
+import net.minecraft.core.BlockPos;
 import net.minecraft.world.MenuProvider;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.level.block.entity.BlockEntity;
 import net.minecraft.world.level.block.entity.BlockEntityType;
-import net.minecraft.core.BlockPos;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraftforge.items.IItemHandlerModifiable;
 import net.minecraftforge.items.ItemStackHandler;
@@ -106,6 +106,7 @@ public abstract class AbstractTileEntityRack extends BlockEntity implements Menu
 
     /**
      * Create the inventory that belongs to the rack.
+     *
      * @param slots the number of slots.
      * @return the created inventory,
      */
@@ -125,12 +126,17 @@ public abstract class AbstractTileEntityRack extends BlockEntity implements Menu
                 if (IColonyManager.getInstance().isCoordinateInAnyColony(level, worldPosition))
                 {
                     final IColony colony = IColonyManager.getInstance().getClosestColony(level, worldPosition);
-                    if (inWarehouse && colony != null && colony.getRequestManager() != null)
+                    if (colony == null)
+                    {
+                        return;
+                    }
+
+                    if (inWarehouse)
                     {
                         colony.getRequestManager().onColonyUpdate(request ->
                                                                     request.getRequest() instanceof IDeliverable && ((IDeliverable) request.getRequest()).matches(stack));
                     }
-                    else if (!buildingPos.equals(BlockPos.ZERO))
+                    else
                     {
                         final IBuilding building = colony.getBuildingManager().getBuilding(buildingPos);
                         if (building != null)
@@ -222,6 +228,7 @@ public abstract class AbstractTileEntityRack extends BlockEntity implements Menu
 
     /**
      * Get the upgrade size.
+     *
      * @return the upgrade size.
      */
     public abstract int getUpgradeSize();
@@ -318,6 +325,7 @@ public abstract class AbstractTileEntityRack extends BlockEntity implements Menu
 
     /**
      * Set the rack as single (or unset).
+     *
      * @param single if so.
      */
     public void setSingle(final boolean single)


### PR DESCRIPTION
Closes #
Closes #
Closes #

# Changes proposed in this pull request:
- Fixes this npe when no colony is found:
```[18Jun2022 10:14:32.963] [Server thread/WARN] [minecolonies/]: Statemachine for transition com.minecolonies.api.entity.ai.statemachine.AITarget@4c5d0203 threw an exception:
java.lang.NullPointerException: null
	at com.minecolonies.api.tileentities.AbstractTileEntityRack.updateWarehouseIfAvailable(AbstractTileEntityRack.java:134) ~[minecolonies:1.16.5-1.0.815-ALPHA]```

Review please
