### PR TITLE
Return for the requester the name of the building if citizen is not valid

### DIFF
--- a/src/main/java/com/minecolonies/coremod/colony/buildings/AbstractBuilding.java
+++ b/src/main/java/com/minecolonies/coremod/colony/buildings/AbstractBuilding.java
@@ -1969,11 +1969,17 @@ public abstract class AbstractBuilding extends AbstractBuildingContainer
         }
 
         final int citizenId = getCitizensByRequest().get(request.getId());
+        if (citizenId == -1)
+        {
+            return new TranslatableComponent(getBuildingDisplayName());
+        }
+
         final ICitizenData citizenData = colony.getCitizenManager().getCivilian(citizenId);
         if (citizenData.getJob() == null)
         {
             return new TextComponent(citizenData.getName());
         }
+
         final MutableComponent jobName = new TranslatableComponent(citizenData.getJob().getJobRegistryEntry().getTranslationKey().toLowerCase());
         return jobName.append(new TextComponent(" " + citizenData.getName()));
     }


### PR DESCRIPTION
Closes #8493 

# Changes proposed in this pull request:
- `getRequesterDisplayName` throws an NPE if something which is not a citizen (Like min stock food for the restaurant) has a request. `getRequesterDisplayName` now returns a `TranslatableComponent` of the building display name if the citizen id is -1.

![image](https://user-images.githubusercontent.com/67484093/178149450-653ee091-096a-4101-8c57-dd5cd50880f2.png)

