### PR TITLE
1.19-specific fix for mob serialisation

### DIFF
--- a/src/main/java/com/minecolonies/coremod/colony/buildings/modules/expedition/ExpeditionLog.java
+++ b/src/main/java/com/minecolonies/coremod/colony/buildings/modules/expedition/ExpeditionLog.java
@@ -258,7 +258,7 @@ public class ExpeditionLog
         for (final Map.Entry<EntityType<?>, Integer> entry : this.mobs.entrySet())
         {
             final CompoundTag mob = new CompoundTag();
-            mob.putString(TAG_TYPE, entry.getKey().getDescriptionId());
+            mob.putString(TAG_TYPE, ForgeRegistries.ENTITY_TYPES.getKey(entry.getKey()).toString());
             mob.putInt(TAG_COUNT, entry.getValue());
             mobs.add(mob);
         }


### PR DESCRIPTION
# Changes proposed in this pull request:
- Fixes a 1.19 porting error with the expedition log

Review please

I haven't been able to actually compile or test this, since maven is acting up at the moment.  But this should be correct. 😁 