### PR TITLE
Avoid a server tick crash by backporting a null check for tile entities

### DIFF
--- a/src/main/java/com/minecolonies/coremod/colony/buildings/AbstractBuildingContainer.java
+++ b/src/main/java/com/minecolonies/coremod/colony/buildings/AbstractBuildingContainer.java
@@ -211,7 +211,7 @@ public abstract class AbstractBuildingContainer extends AbstractSchematicProvide
     public void setTileEntity(final AbstractTileEntityColonyBuilding te)
     {
         tileEntity = te;
-        if (te.isOutdated())
+        if (te != null && te.isOutdated())
         {
             safeUpdateTEDataFromSchematic();
         }


### PR DESCRIPTION
Had this crash on my server and cherry-picking this commit made me able to log in to the server again.

Note that I was running 1.0.309-Release, but I don't believe that makes a difference.

Hope it helps.

(cherry picked from commit 770bd3db2f34e65caafb2f36ed3ad2a512fcca5a)

# Changes proposed in this pull request:
- Avoid the server crashing when tile entities are null
