### PR TITLE
Neighbour rendering

### DIFF
--- a/src/api/java/com/minecolonies/api/configuration/ClientConfiguration.java
+++ b/src/api/java/com/minecolonies/api/configuration/ClientConfiguration.java
@@ -22,7 +22,7 @@ public class ClientConfiguration extends AbstractConfiguration
         createCategory(builder, "gameplay");
         citizenVoices = defineBoolean(builder, "enablecitizenvoices", true);
         neighborbuildingrendering = defineBoolean(builder, "neighborbuildingrendering", true);
-        neighborbuildingrange = defineInteger(builder, "neighborbuildingrange", 5, 0, 16);
+        neighborbuildingrange = defineInteger(builder, "neighborbuildingrange", 4, -2, 16);
         colonyteamborders = defineBoolean(builder, "colonyteamborders", true);
 
         swapToCategory(builder, "pathfinding");

--- a/src/api/java/com/minecolonies/api/configuration/ClientConfiguration.java
+++ b/src/api/java/com/minecolonies/api/configuration/ClientConfiguration.java
@@ -9,6 +9,7 @@ public class ClientConfiguration extends AbstractConfiguration
 {
     public final ForgeConfigSpec.BooleanValue citizenVoices;
     public final ForgeConfigSpec.BooleanValue neighborbuildingrendering;
+    public final ForgeConfigSpec.IntValue neighborbuildingrange;
     public final ForgeConfigSpec.BooleanValue colonyteamborders;
 
     /**
@@ -21,6 +22,7 @@ public class ClientConfiguration extends AbstractConfiguration
         createCategory(builder, "gameplay");
         citizenVoices = defineBoolean(builder, "enablecitizenvoices", true);
         neighborbuildingrendering = defineBoolean(builder, "neighborbuildingrendering", true);
+        neighborbuildingrange = defineInteger(builder, "neighborbuildingrange", 5, 0, 16);
         colonyteamborders = defineBoolean(builder, "colonyteamborders", true);
 
         swapToCategory(builder, "pathfinding");

--- a/src/main/java/com/minecolonies/coremod/client/render/worldevent/NearColonyBuildingsRenderer.java
+++ b/src/main/java/com/minecolonies/coremod/client/render/worldevent/NearColonyBuildingsRenderer.java
@@ -103,7 +103,8 @@ public class NearColonyBuildingsRenderer
         final Map<BlockPos, RenderData> newCache = new HashMap<>();
         final Blueprint blueprint = RenderingCache.getOrCreateBlueprintPreviewData("blueprint").getBlueprint();
         final BlockPos zeroPos = activePosition.subtract(blueprint.getPrimaryBlockOffset());
-        final AABB blueprintAABB = new AABB(zeroPos.offset(-1, -1, -1), zeroPos.offset(blueprint.getSizeX() , blueprint.getSizeY() , blueprint.getSizeZ() ));
+        final AABB blueprintAABB = new AABB(zeroPos, zeroPos.offset(blueprint.getSizeX() - 1, blueprint.getSizeY() - 1, blueprint.getSizeZ() - 1))
+                .inflate(1 + MinecoloniesAPIProxy.getInstance().getConfig().getClient().neighborbuildingrange.get());
 
         for (final IBuildingView buildingView : ctx.nearestColony.getBuildings())
         {

--- a/src/main/java/com/minecolonies/coremod/client/render/worldevent/NearColonyBuildingsRenderer.java
+++ b/src/main/java/com/minecolonies/coremod/client/render/worldevent/NearColonyBuildingsRenderer.java
@@ -104,7 +104,7 @@ public class NearColonyBuildingsRenderer
         final Blueprint blueprint = RenderingCache.getOrCreateBlueprintPreviewData("blueprint").getBlueprint();
         final BlockPos zeroPos = activePosition.subtract(blueprint.getPrimaryBlockOffset());
         final AABB blueprintAABB = new AABB(zeroPos, zeroPos.offset(blueprint.getSizeX() - 1, blueprint.getSizeY() - 1, blueprint.getSizeZ() - 1))
-                .inflate(1 + MinecoloniesAPIProxy.getInstance().getConfig().getClient().neighborbuildingrange.get());
+                .inflate(2 + MinecoloniesAPIProxy.getInstance().getConfig().getClient().neighborbuildingrange.get());
 
         for (final IBuildingView buildingView : ctx.nearestColony.getBuildings())
         {

--- a/src/main/java/com/minecolonies/coremod/entity/ai/citizen/builder/ConstructionTapeHelper.java
+++ b/src/main/java/com/minecolonies/coremod/entity/ai/citizen/builder/ConstructionTapeHelper.java
@@ -57,6 +57,7 @@ public final class ConstructionTapeHelper
     {
         ServerFutureProcessor.queueBlueprint(new ServerFutureProcessor.BlueprintProcessingData(StructurePacks.getBlueprintFuture(building.getStructurePack(), building.getBlueprintPath()), world, (blueprint -> {
             final Tuple<BlockPos, BlockPos> corners = ColonyUtils.calculateCorners(building.getPosition(), world, blueprint, building.getRotation(), building.isMirrored());
+            building.setCorners(corners.getA(), corners.getB());
             placeConstructionTape(corners, world);
         })));
     }

--- a/src/main/resources/assets/minecolonies/lang/manual_en_us.json
+++ b/src/main/resources/assets/minecolonies/lang/manual_en_us.json
@@ -27,6 +27,9 @@
   "minecolonies.config.neighborbuildingrendering": "Neighbor Building Rendering",
   "minecolonies.config.neighborbuildingrendering.comment": "By default, when placing a schematic near other buildings, the already-placed buildings will show as if they were at level 5 and have a blue outline around them. You can disable that by setting this to false.",
 
+  "minecolonies.config.neighborbuildingrange": "Neighbor Building Range",
+  "minecolonies.config.neighborbuildingrange.comment": "How close a building needs to be to another to be considered a neighbor, in blocks. 0 = intersecting, 1 = touching",
+
   "minecolonies.config.colonyteamborders": "Show Colony Borders in Team Colors",
   "minecolonies.config.colonyteamborders.comment": "When true, the colony borders shown when holding the build tool will be in the colony's team color. When false, the colony you're inside will be white and any other colony will be red.",
 

--- a/src/main/resources/assets/minecolonies/lang/manual_en_us.json
+++ b/src/main/resources/assets/minecolonies/lang/manual_en_us.json
@@ -28,7 +28,7 @@
   "minecolonies.config.neighborbuildingrendering.comment": "By default, when placing a schematic near other buildings, the already-placed buildings will show as if they were at level 5 and have a blue outline around them. You can disable that by setting this to false.",
 
   "minecolonies.config.neighborbuildingrange": "Neighbor Building Range",
-  "minecolonies.config.neighborbuildingrange.comment": "How close a building needs to be to another to be considered a neighbor, in blocks. 0 = intersecting, 1 = touching",
+  "minecolonies.config.neighborbuildingrange.comment": "How close a building needs to be to another to be considered a neighbor, in blocks. -1 = intersecting, 0 = touching",
 
   "minecolonies.config.colonyteamborders": "Show Colony Borders in Team Colors",
   "minecolonies.config.colonyteamborders.comment": "When true, the colony borders shown when holding the build tool will be in the colony's team color. When false, the colony you're inside will be white and any other colony will be red.",


### PR DESCRIPTION
# Changes proposed in this pull request:
- Fixes town hall corners (and likely activated abandoned buildings too) not being properly calculated
    - It would be fixed once the building is actually built or upgraded, but until then it wouldn't react properly to neighbour rendering
- Adds a client configuration setting to allow increasing the range of neighbour rendering beyond "intersecting"
    - The New Build Tool behavioural changes, while an improvement for larger buildings, caused a range regression for small and regular-sized buildings.  So the new default has been extended a bit.

Review please
