### PR TITLE
Fix raids more

### DIFF
--- a/src/api/java/com/minecolonies/api/colony/managers/interfaces/IEventStructureManager.java
+++ b/src/api/java/com/minecolonies/api/colony/managers/interfaces/IEventStructureManager.java
@@ -1,9 +1,8 @@
 package com.minecolonies.api.colony.managers.interfaces;
 
 import com.ldtteam.structurize.blueprints.v1.Blueprint;
-import net.minecraft.nbt.CompoundTag;
-import net.minecraft.world.level.block.Mirror;
 import net.minecraft.core.BlockPos;
+import net.minecraft.nbt.CompoundTag;
 import org.jetbrains.annotations.NotNull;
 
 /**
@@ -17,11 +16,9 @@ public interface IEventStructureManager
      * @param structure        structure thats going to be spawned
      * @param targetSpawnPoint position to spawn at
      * @param eventID          eventID to spawn for
-     * @param rotations        structure rotations
-     * @param mirror           structure mirror
      * @return true if successfully spawned
      */
-    boolean spawnTemporaryStructure(Blueprint structure, BlockPos targetSpawnPoint, int eventID, int rotations, Mirror mirror);
+    boolean spawnTemporaryStructure(Blueprint structure, BlockPos targetSpawnPoint, int eventID);
 
     /**
      * Restores backup schematics for the given event ID, may be more than one.

--- a/src/main/java/com/minecolonies/coremod/colony/colonyEvents/raidEvents/AbstractShipRaidEvent.java
+++ b/src/main/java/com/minecolonies/coremod/colony/colonyEvents/raidEvents/AbstractShipRaidEvent.java
@@ -1,6 +1,5 @@
 package com.minecolonies.coremod.colony.colonyEvents.raidEvents;
 
-import com.ldtteam.structurize.placement.structure.CreativeStructureHandler;
 import com.ldtteam.structurize.storage.ServerFutureProcessor;
 import com.ldtteam.structurize.storage.StructurePacks;
 import com.ldtteam.structurize.util.PlacementSettings;
@@ -12,11 +11,15 @@ import com.minecolonies.api.colony.colonyEvents.IColonyStructureSpawnEvent;
 import com.minecolonies.api.entity.mobs.AbstractEntityMinecoloniesMob;
 import com.minecolonies.api.entity.mobs.RaiderMobUtils;
 import com.minecolonies.api.entity.pathfinding.PathResult;
-import com.minecolonies.api.util.*;
+import com.minecolonies.api.util.BlockPosUtil;
+import com.minecolonies.api.util.MessageUtils;
+import com.minecolonies.api.util.Tuple;
+import com.minecolonies.api.util.WorldUtil;
 import com.minecolonies.coremod.MineColonies;
 import com.minecolonies.coremod.colony.colonyEvents.raidEvents.pirateEvent.ShipBasedRaiderUtils;
 import com.minecolonies.coremod.colony.colonyEvents.raidEvents.pirateEvent.ShipSize;
 import com.minecolonies.coremod.util.CreativeRaiderStructureHandler;
+import net.minecraft.ChatFormatting;
 import net.minecraft.core.BlockPos;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.nbt.ListTag;
@@ -24,7 +27,6 @@ import net.minecraft.nbt.NbtUtils;
 import net.minecraft.nbt.Tag;
 import net.minecraft.network.chat.Component;
 import net.minecraft.network.chat.MutableComponent;
-
 import net.minecraft.server.level.ServerBossEvent;
 import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.world.BossEvent;
@@ -206,7 +208,7 @@ public abstract class AbstractShipRaidEvent implements IColonyRaidEvent, IColony
                 spawnPoint = spawnPoint.below();
             }
 
-            if (!ShipBasedRaiderUtils.spawnPirateShip(spawnPoint, colony.getWorld(), colony, shipSize.schematicPrefix + this.getShipDesc(), this, shipRotation))
+            if (!ShipBasedRaiderUtils.spawnPirateShip(spawnPoint, colony, structure.getBluePrint(), this))
             {
                 // Ship event not successfully started.
                 status = EventStatus.CANCELED;

--- a/src/main/java/com/minecolonies/coremod/colony/colonyEvents/raidEvents/AbstractShipRaidEvent.java
+++ b/src/main/java/com/minecolonies/coremod/colony/colonyEvents/raidEvents/AbstractShipRaidEvent.java
@@ -217,7 +217,9 @@ public abstract class AbstractShipRaidEvent implements IColonyRaidEvent, IColony
 
             updateRaidBar();
 
-            MessageUtils.format(RAID_EVENT_MESSAGE_PIRATE + shipSize.messageID, BlockPosUtil.calcDirection(colony.getCenter(), spawnPoint), colony.getName())
+            MessageUtils.format(Component.translatable(RAID_EVENT_MESSAGE_PIRATE + shipSize.messageID,
+                                    BlockPosUtil.calcDirection(colony.getCenter(), spawnPoint), colony.getName())
+                    .withStyle(ChatFormatting.DARK_RED))
               .sendTo(colony).forManagers();
             colony.markDirty();
         })));

--- a/src/main/java/com/minecolonies/coremod/colony/colonyEvents/raidEvents/AbstractShipRaidEvent.java
+++ b/src/main/java/com/minecolonies/coremod/colony/colonyEvents/raidEvents/AbstractShipRaidEvent.java
@@ -217,10 +217,10 @@ public abstract class AbstractShipRaidEvent implements IColonyRaidEvent, IColony
 
             updateRaidBar();
 
-            MessageUtils.format(Component.translatable(RAID_EVENT_MESSAGE_PIRATE + shipSize.messageID,
+            MessageUtils.format(RAID_EVENT_MESSAGE_PIRATE + shipSize.messageID,
                                     BlockPosUtil.calcDirection(colony.getCenter(), spawnPoint), colony.getName())
-                    .withStyle(ChatFormatting.DARK_RED))
-              .sendTo(colony).forManagers();
+                    .with(ChatFormatting.DARK_RED)
+                    .sendTo(colony).forManagers();
             colony.markDirty();
         })));
     }

--- a/src/main/java/com/minecolonies/coremod/colony/colonyEvents/raidEvents/HordeRaidEvent.java
+++ b/src/main/java/com/minecolonies/coremod/colony/colonyEvents/raidEvents/HordeRaidEvent.java
@@ -352,9 +352,9 @@ public abstract class HordeRaidEvent implements IColonyRaidEvent, IColonyCampFir
 
         updateRaidBar();
 
-        MessageUtils.format(Component.translatable(RAID_EVENT_MESSAGE + horde.getMessageID(),
+        MessageUtils.format(RAID_EVENT_MESSAGE + horde.getMessageID(),
                         BlockPosUtil.calcDirection(colony.getCenter(), spawnPoint), colony.getName())
-                .withStyle(ChatFormatting.DARK_RED)).sendTo(colony).forManagers();
+                .with(ChatFormatting.DARK_RED).sendTo(colony).forManagers();
 
         PlayAudioMessage audio = new PlayAudioMessage(horde.initialSize <= SMALL_HORDE_SIZE ? RaidSounds.WARNING_EARLY : RaidSounds.WARNING, SoundSource.RECORDS);
         PlayAudioMessage.sendToAll(getColony(), false, false, audio);

--- a/src/main/java/com/minecolonies/coremod/colony/colonyEvents/raidEvents/HordeRaidEvent.java
+++ b/src/main/java/com/minecolonies/coremod/colony/colonyEvents/raidEvents/HordeRaidEvent.java
@@ -17,6 +17,7 @@ import com.minecolonies.api.util.constant.NbtTagConstants;
 import com.minecolonies.coremod.colony.colonyEvents.raidEvents.barbarianEvent.Horde;
 import com.minecolonies.coremod.colony.colonyEvents.raidEvents.pirateEvent.ShipBasedRaiderUtils;
 import com.minecolonies.coremod.network.messages.client.PlayAudioMessage;
+import net.minecraft.ChatFormatting;
 import net.minecraft.core.BlockPos;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.nbt.ListTag;
@@ -351,7 +352,9 @@ public abstract class HordeRaidEvent implements IColonyRaidEvent, IColonyCampFir
 
         updateRaidBar();
 
-        MessageUtils.format(RAID_EVENT_MESSAGE + horde.getMessageID(), BlockPosUtil.calcDirection(colony.getCenter(), spawnPoint), colony.getName()).sendTo(colony).forManagers();
+        MessageUtils.format(Component.translatable(RAID_EVENT_MESSAGE + horde.getMessageID(),
+                        BlockPosUtil.calcDirection(colony.getCenter(), spawnPoint), colony.getName())
+                .withStyle(ChatFormatting.DARK_RED)).sendTo(colony).forManagers();
 
         PlayAudioMessage audio = new PlayAudioMessage(horde.initialSize <= SMALL_HORDE_SIZE ? RaidSounds.WARNING_EARLY : RaidSounds.WARNING, SoundSource.RECORDS);
         PlayAudioMessage.sendToAll(getColony(), false, false, audio);

--- a/src/main/java/com/minecolonies/coremod/colony/colonyEvents/raidEvents/pirateEvent/ShipBasedRaiderUtils.java
+++ b/src/main/java/com/minecolonies/coremod/colony/colonyEvents/raidEvents/pirateEvent/ShipBasedRaiderUtils.java
@@ -2,21 +2,20 @@ package com.minecolonies.coremod.colony.colonyEvents.raidEvents.pirateEvent;
 
 import com.google.common.collect.Lists;
 import com.ldtteam.structurize.blueprints.v1.Blueprint;
-import com.ldtteam.structurize.storage.ServerFutureProcessor;
 import com.ldtteam.structurize.storage.StructurePacks;
 import com.minecolonies.api.colony.IColony;
 import com.minecolonies.api.colony.colonyEvents.IColonyRaidEvent;
 import com.minecolonies.api.util.BlockPosUtil;
 import com.minecolonies.api.util.WorldUtil;
 import com.minecolonies.coremod.MineColonies;
+import net.minecraft.core.BlockPos;
+import net.minecraft.world.entity.EntityType;
+import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.AirBlock;
 import net.minecraft.world.level.block.Blocks;
-import net.minecraft.world.level.material.Material;
-import net.minecraft.world.entity.EntityType;
-import net.minecraft.world.level.block.entity.SpawnerBlockEntity;
 import net.minecraft.world.level.block.Mirror;
-import net.minecraft.core.BlockPos;
-import net.minecraft.world.level.Level;
+import net.minecraft.world.level.block.entity.SpawnerBlockEntity;
+import net.minecraft.world.level.material.Material;
 import net.minecraft.world.level.pathfinder.Path;
 import org.jetbrains.annotations.NotNull;
 
@@ -56,33 +55,20 @@ public final class ShipBasedRaiderUtils
      * Used to trigger a pirate event.
      *
      * @param targetSpawnPoint the target spawn point.
-     * @param world            the target world.
      * @param colony           the target colony.
-     * @param shipSize         the size of the ship.
+     * @param blueprint        the ship blueprint.
      * @param event            the raids event.
-     * @param shipRotation     the shiprotation.
      * @return true if successful.
      */
     public static boolean spawnPirateShip(
       final BlockPos targetSpawnPoint,
-      final Level world,
       final IColony colony,
-      final String shipSize,
-      final IColonyRaidEvent event,
-      final int shipRotation)
+      final Blueprint blueprint,
+      final IColonyRaidEvent event)
     {
-        ServerFutureProcessor.queueBlueprint(new ServerFutureProcessor.BlueprintProcessingData(StructurePacks.getBlueprintFuture(DEFAULT_STYLE,
-          "decorations" + ShipBasedRaiderUtils.SHIP_FOLDER + shipSize + ".blueprint"), colony.getWorld(), (blueprint -> {
-            blueprint.rotateWithMirror(BlockPosUtil.getRotationFromRotations(shipRotation), Mirror.NONE, world);
-            colony.getEventManager()
-              .getStructureManager()
-              .spawnTemporaryStructure(blueprint,
-                targetSpawnPoint,
-                event.getID(),
-                shipRotation,
-                Mirror.NONE);
-        })));
-        return true;
+        return colony.getEventManager()
+                .getStructureManager()
+                .spawnTemporaryStructure(blueprint, targetSpawnPoint, event.getID());
     }
 
     /**

--- a/src/main/java/com/minecolonies/coremod/colony/managers/EventStructureManager.java
+++ b/src/main/java/com/minecolonies/coremod/colony/managers/EventStructureManager.java
@@ -93,7 +93,7 @@ public class EventStructureManager implements IEventStructureManager
         final Level world = colony.getWorld();
 
         final int y = BlueprintTagUtils.getNumberOfGroundLevels(structure, 4) - 1;
-        final BlockPos spawnPos = targetSpawnPoint.offset(0, -y, 0).offset(structure.getPrimaryBlockOffset());
+        final BlockPos spawnPos = targetSpawnPoint.below(y).above(structure.getPrimaryBlockOffset().getY());
         final BlockPos zeroPos = spawnPos.subtract(structure.getPrimaryBlockOffset());
         final BlockPos anchor = new BlockPos(zeroPos.getX() + structure.getSizeX() / 2, zeroPos.getY(), zeroPos.getZ() + structure.getSizeZ() / 2);
 

--- a/src/main/java/com/minecolonies/coremod/colony/managers/EventStructureManager.java
+++ b/src/main/java/com/minecolonies/coremod/colony/managers/EventStructureManager.java
@@ -17,15 +17,13 @@ import com.minecolonies.api.colony.managers.interfaces.IEventStructureManager;
 import com.minecolonies.api.util.BlockPosUtil;
 import com.minecolonies.api.util.Log;
 import com.minecolonies.coremod.util.CreativeRaiderStructureHandler;
+import net.minecraft.core.BlockPos;
 import net.minecraft.nbt.CompoundTag;
-import net.minecraft.nbt.Tag;
 import net.minecraft.nbt.ListTag;
-import net.minecraft.server.level.ServerLevel;
+import net.minecraft.nbt.Tag;
+import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.Mirror;
 import net.minecraft.world.level.block.Rotation;
-import net.minecraft.core.BlockPos;
-import net.minecraft.world.level.Level;
-
 import org.jetbrains.annotations.NotNull;
 
 import java.io.File;
@@ -85,9 +83,7 @@ public class EventStructureManager implements IEventStructureManager
     public boolean spawnTemporaryStructure(
       final Blueprint structure,
       final BlockPos targetSpawnPoint,
-      final int eventID,
-      final int rotations,
-      final Mirror mirror)
+      final int eventID)
     {
         if (eventManager.getEventByID(eventID) == null)
         {
@@ -108,8 +104,8 @@ public class EventStructureManager implements IEventStructureManager
           .resolve(colony.getDimension().location().getNamespace() + colony.getDimension().location().getPath())
                                   .resolve(anchor.toString() + ".blueprint");
 
-        final CompoundTag bp = BlueprintUtil.writeBlueprintToNBT(BlueprintUtil.createBlueprint((ServerLevel) world, zeroPos, true, (short)structure.getSizeX(), (short) structure.getSizeY(), (short) structure.getSizeZ(), anchor.toString(),
-          Optional.of(anchor)));
+        final CompoundTag bp = BlueprintUtil.writeBlueprintToNBT(BlueprintUtil.createBlueprint(world, zeroPos, true,
+                structure.getSizeX(), structure.getSizeY(), structure.getSizeZ(), anchor.toString(), Optional.of(anchor)));
 
         StructurePacks.storeBlueprint(STRUCTURE_BACKUP_FOLDER, bp, outputPath);
 

--- a/src/main/java/com/minecolonies/coremod/colony/managers/RaidManager.java
+++ b/src/main/java/com/minecolonies/coremod/colony/managers/RaidManager.java
@@ -328,7 +328,7 @@ public class RaidManager implements IRaiderManager
             }
 
             // No rotation till spawners are moved into schematics
-            final int shipRotation = new Random().nextInt(3);
+            final int shipRotation = colony.getWorld().random.nextInt(4);
             final Holder<Biome> biome = colony.getWorld().getBiome(colony.getCenter());
             final int rand = colony.getWorld().random.nextInt(100);
             if ((raidType.isEmpty() && (biome.is(BiomeTags.IS_TAIGA) || rand < IGNORE_BIOME_CHANCE)

--- a/src/main/resources/assets/minecolonies/lang/manual_en_us.json
+++ b/src/main/resources/assets/minecolonies/lang/manual_en_us.json
@@ -884,15 +884,15 @@
 
   "com.minecolonies.coremod.mourning": "There has been a death in %s. The citizens will mourn %s tomorrow out of respect.",
 
-  "event.minecolonies.raidmessage1": "§4Mysterious warriors have been spotted %s of %s!",
-  "event.minecolonies.raidmessage2": "§4Citizens report rumors of raiders %s of %s!",
-  "event.minecolonies.raidmessage3": "§4Buckle up cowboy! There's some darn raiders comin' from the %s tonight for %s!",
-  "event.minecolonies.raidmessage4": "§4A huge horde of raiders is comin' from %s toward %s, and they're not here to play!",
+  "event.minecolonies.raidmessage1": "Mysterious warriors have been spotted %s of %s!",
+  "event.minecolonies.raidmessage2": "Citizens report rumors of raiders %s of %s!",
+  "event.minecolonies.raidmessage3": "Buckle up cowboy! There's some darn raiders comin' from the %s tonight for %s!",
+  "event.minecolonies.raidmessage4": "A huge horde of raiders is comin' from %s toward %s, and they're not here to play!",
 
-  "event.minecolonies.raidmessage_p1": "§4Mysterious sailors have been spotted to the %s of %s! They sailed in on a small sloop, you should consider destroying it.",
-  "event.minecolonies.raidmessage_p2": "§4Citizens report rumors of pirates closing in %s of %s! They brought a ship, better destroy it.",
-  "event.minecolonies.raidmessage_p3": "§4Arr Comrade! There's some darn pirates from the %s comin' for %s tonight! They sailed 'ere and will continue attacking until we destroy their caravel.",
-  "event.minecolonies.raidmessage_p4": "§4A huge horde of pirates are sailin' %s of %s and they're not here to play! Their rigorous waves will hit us unless we destroy their galleon!",
+  "event.minecolonies.raidmessage_p1": "Mysterious sailors have been spotted to the %s of %s! They sailed in on a small sloop, you should consider destroying it.",
+  "event.minecolonies.raidmessage_p2": "Citizens report rumors of pirates closing in %s of %s! They brought a ship, better destroy it.",
+  "event.minecolonies.raidmessage_p3": "Arr Comrade! There's some darn pirates from the %s comin' for %s tonight! They sailed 'ere and will continue attacking until we destroy their caravel.",
+  "event.minecolonies.raidmessage_p4": "A huge horde of pirates are sailin' %s of %s and they're not here to play! Their rigorous waves will hit us unless we destroy their galleon!",
 
   "com.minecolonies.coremod.raid.amazon.name": "Amazons",
   "com.minecolonies.coremod.raid.egyptian.name": "Mummies",


### PR DESCRIPTION
# Changes proposed in this pull request:
- Clean up some unused rotation/mirror params, and avoid double-loading ship blueprint
- Fix incorrect offset to spawn location due to anchor placement
- Use proper RNG to pick rotation angle
- Allow picking 270° rotation
- Display entire "raid arrived" message in red (rather than just the part before the first argument)

Review please
