### PR TITLE
Override `canBeLeashed` flag for civilian entities

### DIFF
--- a/src/api/java/com/minecolonies/api/entity/citizen/AbstractCivilianEntity.java
+++ b/src/api/java/com/minecolonies/api/entity/citizen/AbstractCivilianEntity.java
@@ -87,6 +87,12 @@ public abstract class AbstractCivilianEntity extends AgeableMob implements Npc, 
     public abstract void setCitizenId(int id);
 
     @Override
+    public boolean canBeLeashed(Player player)
+    {
+        return false;
+    }
+
+    @Override
     public boolean canBeStuck()
     {
         return canBeStuck;


### PR DESCRIPTION
This PR adds a simple override for the `boolean canBeLeashed(Player)` method to `AbstractCivilianEntity` that always returns false.

In practice, this is not a problem when running with MineColonies only because the interaction is consumed when a GUI is opened. However, this flag may be used by other mods to determine how an entity should behave. For a specific use case, see https://github.com/ldtteam/minecolonies-features/issues/713.


Closes ldtteam/minecolonies-features#713