### PR TITLE
Use the pack selection menu for supply camp/ship

### DIFF
--- a/src/main/java/com/minecolonies/coremod/client/gui/WindowSupplies.java
+++ b/src/main/java/com/minecolonies/coremod/client/gui/WindowSupplies.java
@@ -1,5 +1,6 @@
 package com.minecolonies.coremod.client.gui;
 
+import com.ldtteam.blockui.controls.Text;
 import com.ldtteam.structurize.Network;
 import com.ldtteam.structurize.client.gui.AbstractBlueprintManipulationWindow;
 import com.ldtteam.structurize.client.gui.WindowSwitchPack;
@@ -105,6 +106,7 @@ public class WindowSupplies extends AbstractBlueprintManipulationWindow
                 blueprint -> {
                     RenderingCache.getOrCreateBlueprintPreviewData("supplies").setBlueprint(blueprint);
                     adjustToGroundOffset();
+                    findPaneOfTypeByID("tip", Text.class).setVisible(false);
                 }));
     }
 

--- a/src/main/java/com/minecolonies/coremod/client/gui/WindowSupplies.java
+++ b/src/main/java/com/minecolonies/coremod/client/gui/WindowSupplies.java
@@ -1,12 +1,8 @@
 package com.minecolonies.coremod.client.gui;
 
-import com.ldtteam.blockui.Pane;
-import com.ldtteam.blockui.controls.Button;
-import com.ldtteam.blockui.controls.ButtonImage;
-import com.ldtteam.blockui.views.ScrollingList;
 import com.ldtteam.structurize.Network;
-import com.ldtteam.structurize.blueprints.v1.Blueprint;
 import com.ldtteam.structurize.client.gui.AbstractBlueprintManipulationWindow;
+import com.ldtteam.structurize.client.gui.WindowSwitchPack;
 import com.ldtteam.structurize.network.messages.BuildToolPlacementMessage;
 import com.ldtteam.structurize.placement.handlers.placement.PlacementError;
 import com.ldtteam.structurize.storage.ClientFutureProcessor;
@@ -23,7 +19,6 @@ import com.minecolonies.coremod.placementhandlers.main.SuppliesHandler;
 import net.minecraft.client.Minecraft;
 import net.minecraft.core.BlockPos;
 import net.minecraft.network.chat.Component;
-import net.minecraft.util.Tuple;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.ArrayList;
@@ -31,9 +26,9 @@ import java.util.List;
 
 import static com.ldtteam.structurize.api.util.constant.Constants.GROUNDSTYLE_LEGACY_CAMP;
 import static com.ldtteam.structurize.api.util.constant.Constants.GROUNDSTYLE_LEGACY_SHIP;
+import static com.ldtteam.structurize.api.util.constant.GUIConstants.BUTTON_SWITCH_STYLE;
 import static com.minecolonies.api.util.constant.TranslationConstants.PARTIAL_WARNING_SUPPLY_BUILDING_ERROR;
 import static com.minecolonies.api.util.constant.TranslationConstants.WARNING_SUPPLY_BUILDING_BAD_BLOCKS;
-import static com.minecolonies.api.util.constant.WindowConstants.BUTTON_TOGGLE;
 import static com.minecolonies.api.util.constant.WindowConstants.SUPPLIES_RESOURCE_SUFFIX;
 
 /**
@@ -41,16 +36,6 @@ import static com.minecolonies.api.util.constant.WindowConstants.SUPPLIES_RESOUR
  */
 public class WindowSupplies extends AbstractBlueprintManipulationWindow
 {
-    /**
-     * Drop down list for section.
-     */
-    private final ScrollingList packList;
-
-    /**
-     * The list of packs that contain a supplycamp.
-     */
-    private static final List<Tuple<String, Blueprint>> matchingPacks = new ArrayList<>();
-
     /**
      *  The displayed boxes category
      */
@@ -62,117 +47,65 @@ public class WindowSupplies extends AbstractBlueprintManipulationWindow
     private static String type;
 
     /**
+     * Current selected structure pack.
+     */
+    private static StructurePackMeta structurePack = null;
+
+    /**
      * Create a new supply tool window.
      * @param pos the pos its initiated at.
      */
     public WindowSupplies(@Nullable final BlockPos pos, final String type)
     {
         super(Constants.MOD_ID + SUPPLIES_RESOURCE_SUFFIX, pos, (type.equals("supplycamp") ? GROUNDSTYLE_LEGACY_CAMP : GROUNDSTYLE_LEGACY_SHIP), "supplies");
-        packList = findPaneOfTypeByID("packs", ScrollingList.class);
-        registerButton(BUTTON_TOGGLE, this::switchPack);
+
+        registerButton(BUTTON_SWITCH_STYLE, this::switchPackClicked);
 
         if (!type.equals(WindowSupplies.type))
         {
             HighlightManager.clearCategory(RENDER_BOX_CATEGORY);
             RenderingCache.removeBlueprint("supplies");
-            matchingPacks.clear();
         }
-        else if (!matchingPacks.isEmpty())
+        else if (RenderingCache.getOrCreateBlueprintPreviewData("supplies").getBlueprint() == null)
         {
-            if (RenderingCache.getOrCreateBlueprintPreviewData("supplies").getBlueprint() == null)
-            {
-                RenderingCache.getOrCreateBlueprintPreviewData("supplies").setBlueprint(matchingPacks.get(0).getB());
-            }
+            loadBlueprint();
         }
         WindowSupplies.type = type;
-
 
         if (pos != null)
         {
             RenderingCache.getOrCreateBlueprintPreviewData("supplies").setPos(pos);
         }
-        updateStyleOptions(type);
     }
 
     /**
-     * Add the matching pack to the list.
-     * @param name the name of the pack.
-     * @param blueprint the fitting blueprint.
+     * Opens the switch style window.
      */
-    private void addOption(final String name, final Blueprint blueprint)
+    private void switchPackClicked()
     {
-        if (matchingPacks.isEmpty())
+        new WindowSwitchPack(() ->
         {
-            if (RenderingCache.getOrCreateBlueprintPreviewData("supplies").getBlueprint() == null)
-            {
-                RenderingCache.getOrCreateBlueprintPreviewData("supplies").setBlueprint(blueprint);
-            }
-            matchingPacks.add(new Tuple<>(name, blueprint));
-        }
-        else
-        {
-            matchingPacks.add(new Tuple<>(name, blueprint));
-            packList.refreshElementPanes();
-        }
+            final BlueprintPreviewData previewData = RenderingCache.getOrCreateBlueprintPreviewData("supplies");
+            previewData.setBlueprint(null);
+            return new WindowSupplies(previewData.getPos(), type);
+        }).open();
     }
 
     /**
-     * Update the different supplycamp/ship options in the dropdown.
-     * @param type the type (camp or ship).
+     * Try to load the appropriate supply blueprint for the selected pack, if there is one
      */
-    public void updateStyleOptions(final String type)
+    private void loadBlueprint()
     {
-        if (matchingPacks.isEmpty())
-        {
-            for (final StructurePackMeta packName : StructurePacks.getPackMetas())
-            {
-                ClientFutureProcessor.queueBlueprint(new ClientFutureProcessor.BlueprintProcessingData(StructurePacks.getBlueprintFuture(packName.getName(),
-                  "decorations/supplies/" + type + ".blueprint"), (blueprint -> {
-                    if (blueprint != null)
-                    {
-                        addOption(packName.getName(), blueprint);
-                    }
-                })));
-            }
-        }
+        RenderingCache.getOrCreateBlueprintPreviewData("supplies").setBlueprint(null);
 
-        packList.setDataProvider(new ScrollingList.DataProvider()
-        {
-            /**
-             * The number of rows of the list.
-             * @return the number.
-             */
-            @Override
-            public int getElementCount()
-            {
-                return matchingPacks.size();
-            }
+        structurePack = StructurePacks.selectedPack;
 
-            @Override
-            public void updateElement(final int index, final Pane rowPane)
-            {
-                final ButtonImage buttonImage = rowPane.findPaneOfTypeByID(BUTTON_TOGGLE, ButtonImage.class);
-                buttonImage.setText(Component.literal(matchingPacks.get(index).getA()));
-                if (RenderingCache.getOrCreateBlueprintPreviewData("supplies").getBlueprint() != null && RenderingCache.getOrCreateBlueprintPreviewData("supplies").getBlueprint().equals(matchingPacks.get(index).getB()))
-                {
-                    buttonImage.disable();
-                }
-                else
-                {
-                    buttonImage.enable();
-                }
-            }
-        });
-    }
-
-    /**
-     * Select a pack.
-     * @param button the clicked button.
-     */
-    private void switchPack(final Button button)
-    {
-        RenderingCache.getOrCreateBlueprintPreviewData("supplies").setBlueprint(matchingPacks.get(this.packList.getListElementIndexByPane(button)).getB());
-        adjustToGroundOffset();
+        ClientFutureProcessor.queueBlueprint(new ClientFutureProcessor.BlueprintProcessingData(
+                StructurePacks.getBlueprintFuture(structurePack.getName(), "decorations/supplies/" + type + ".blueprint"),
+                blueprint -> {
+                    RenderingCache.getOrCreateBlueprintPreviewData("supplies").setBlueprint(blueprint);
+                    adjustToGroundOffset();
+                }));
     }
 
     @Override
@@ -193,21 +126,7 @@ public class WindowSupplies extends AbstractBlueprintManipulationWindow
     protected void handlePlacement(final BuildToolPlacementMessage.HandlerType handlerType, final String handlerId)
     {
         final BlueprintPreviewData previewData = RenderingCache.getOrCreateBlueprintPreviewData("supplies");
-        if (previewData.getBlueprint() == null)
-        {
-            return;
-        }
-
-        String pack = "";
-        for (final Tuple<String, Blueprint> element : matchingPacks)
-        {
-            if (element.getB().equals(previewData.getBlueprint()))
-            {
-                pack = element.getA();
-            }
-        }
-
-        if (pack.isEmpty())
+        if (structurePack == null || previewData.getBlueprint() == null)
         {
             return;
         }
@@ -221,8 +140,8 @@ public class WindowSupplies extends AbstractBlueprintManipulationWindow
             {
                 Network.getNetwork()
                   .sendToServer(new BuildToolPlacementMessage(handlerType, handlerId,
-                    pack,
-                      StructurePacks.getStructurePack(pack).getSubPath(previewData.getBlueprint().getFilePath().resolve(previewData.getBlueprint().getFileName() + ".blueprint")),
+                          structurePack.getName(),
+                          structurePack.getSubPath(previewData.getBlueprint().getFilePath().resolve(previewData.getBlueprint().getFileName() + ".blueprint")),
                     previewData.getPos(),
                     previewData.getRotation(),
                     previewData.getMirror()));
@@ -239,8 +158,8 @@ public class WindowSupplies extends AbstractBlueprintManipulationWindow
             {
                 Network.getNetwork()
                   .sendToServer(new BuildToolPlacementMessage(handlerType, handlerId,
-                    pack,
-                    StructurePacks.getStructurePack(pack).getSubPath(previewData.getBlueprint().getFilePath().resolve(previewData.getBlueprint().getFileName() + ".blueprint")),
+                          structurePack.getName(),
+                          structurePack.getSubPath(previewData.getBlueprint().getFilePath().resolve(previewData.getBlueprint().getFileName() + ".blueprint")),
                     previewData.getPos(),
                     previewData.getRotation(),
                     previewData.getMirror()));

--- a/src/main/resources/assets/minecolonies/gui/windowsupplies.xml
+++ b/src/main/resources/assets/minecolonies/gui/windowsupplies.xml
@@ -3,10 +3,5 @@
 
     <layout source="structurize:gui/layoutmanipulation.xml"/>
 
-    <list id="packs" size="100 75" pos="5 5">
-        <buttonimage id="toggle" size="86 17" label="" pos="0 0"
-                     source="minecolonies:textures/gui/builderhut/builder_button_medium.png"
-                     disabled="minecolonies:textures/gui/builderhut/builder_button_medium_dark.png"
-                     textcolor="black"/>
-    </list>
+    <button id="switch" source="structurize:textures/gui/buildtool/button_medium.png" label="$(structurize.gui.buildtool.switchpack)" size="86 17" pos="5 5" textcolor="black" texthovercolor="gray"/>
 </window>


### PR DESCRIPTION
# Changes proposed in this pull request:
- Makes the supply camp/ship use the standard pack selection menu, both for consistency and because it lets you read the descriptions when you're constructing your very first thing.

![supply](https://user-images.githubusercontent.com/539951/188309315-7cb837ed-ed5f-4669-a31b-6ad5078813ac.gif)

Review please

One behavioural change (which could be either good or bad) is that it no longer caches all the blueprints from all styles on opening the window; instead it only tries to load each one as you select it, and does not cache the result (beyond the single selection).  This does introduce a slight lag when switching styles, but also reduces memory usage and is better for remotely-hosted styles.

(The tip text being always visible over the top of the preview after switching styles has been fixed later.)