### PR TITLE
fix 8623

### DIFF
--- a/src/api/java/com/minecolonies/api/util/Pond.java
+++ b/src/api/java/com/minecolonies/api/util/Pond.java
@@ -15,7 +15,7 @@ public final class Pond
      * The minimum pond requirements.
      */
     private static final int WATER_POOL_WIDTH_REQUIREMENT  = 6;
-    private static final int WATER_POOL_LENGTH_REQUIREMENT = 3;
+    private static final int WATER_POOL_LENGTH_REQUIREMENT = 2;
 
     /**
      * Checks if on position "water" really is water, if the water is connected to land and if the pond is big enough (bigger then 20).

--- a/src/main/java/com/minecolonies/coremod/entity/pathfinding/pathjobs/PathJobFindWater.java
+++ b/src/main/java/com/minecolonies/coremod/entity/pathfinding/pathjobs/PathJobFindWater.java
@@ -121,7 +121,7 @@ public class PathJobFindWater extends AbstractPathJob
             }
         }
 
-        return !ponds.contains(new Tuple<>(n.pos, n.parent.pos)) && !pondsAreNear(ponds, n.pos);
+        return getResult().pond != null && !ponds.contains(new Tuple<>(n.pos, n.parent.pos)) && !pondsAreNear(ponds, n.pos);
     }
 
     /**


### PR DESCRIPTION
Closes #8623
Closes #
Closes #

# Changes proposed in this pull request:
- Fixes the pathfinding of the fisher finding an invalid water target with a null pos (and then stopping to scan).
- Slightly relaxes the pond rule.
-

Review please
