### PR TITLE
Re-enabling Compatibility for Dynamic Trees

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -38,6 +38,7 @@ jmapMcVersion=1.18.1
 jmapVersion=5.8.0beta11
 tinkersConstructVersion=3.5.0.17
 mantleVersion=1.9.20
+dynamicTreesVersion=0.11.0-Alpha2
 # some mods include the MC version as part of their "real" version number, others
 # store them separately (even if they look like they're included in the filename).
 # it's important to get them the right way around for mods.toml to work properly.

--- a/gradle/configuration.gradle
+++ b/gradle/configuration.gradle
@@ -7,5 +7,6 @@ project.ext.customChangelogHeader = "\n" +
         "\n" +
         "### Optional Dependencies\n" +
         "- JEI: ${project.jei_version} (or above)\n" +
+        "- Dynamic Trees: ${project.dynamicTreesVersion} (or above)\n" +
         "- Journeymap: ${project.jmapVersion} (or above)\n" +
         "\n"

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -1,5 +1,9 @@
 repositories {
     maven {
+        name "DynamicTrees"
+        url "https://harleyoconnor.com/maven/"
+    }
+    maven {
         name "JEI"
         url 'https://dvs1.progwml6.com/files/maven/'
     }
@@ -56,7 +60,9 @@ dependencies {
     // replace "compileOnly" with "library" when you want to include it for testing
     compileOnly fg.deobf("slimeknights.tconstruct:TConstruct:${project.exactMinecraftVersion}-${project.tinkersConstructVersion}")
     compileOnly fg.deobf("slimeknights.mantle:Mantle:${project.exactMinecraftVersion}-${project.mantleVersion}")
+    compileOnly fg.deobf("com.ferreusveritas.dynamictrees:DynamicTrees-${project.minecraftVersion}:${project.dynamicTreesVersion}")
 
     apiCompileOnly fg.deobf("slimeknights.mantle:Mantle:${project.exactMinecraftVersion}-${project.mantleVersion}")
     apiCompileOnly fg.deobf("slimeknights.tconstruct:TConstruct:${project.exactMinecraftVersion}-${project.tinkersConstructVersion}")
+    apiCompileOnly fg.deobf("com.ferreusveritas.dynamictrees:DynamicTrees-${project.minecraftVersion}:${project.dynamicTreesVersion}")
 }

--- a/src/api/java/com/minecolonies/api/compatibility/dynamictrees/DynamicTreeCompat.java
+++ b/src/api/java/com/minecolonies/api/compatibility/dynamictrees/DynamicTreeCompat.java
@@ -1,5 +1,10 @@
 package com.minecolonies.api.compatibility.dynamictrees;
 
+import com.ferreusveritas.dynamictrees.blocks.branches.BranchBlock;
+import com.ferreusveritas.dynamictrees.blocks.branches.TrunkShellBlock;
+import com.ferreusveritas.dynamictrees.blocks.leaves.DynamicLeavesBlock;
+import com.ferreusveritas.dynamictrees.items.Seed;
+import com.ferreusveritas.dynamictrees.trees.Family;
 import com.minecolonies.api.util.Log;
 import com.mojang.authlib.GameProfile;
 import net.minecraft.core.BlockPos;
@@ -13,6 +18,7 @@ import net.minecraft.world.level.block.Block;
 import net.minecraft.resources.ResourceKey;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.state.BlockState;
+import net.minecraft.world.level.material.FluidState;
 import net.minecraftforge.common.util.FakePlayer;
 import org.jetbrains.annotations.NotNull;
 
@@ -65,12 +71,11 @@ public final class DynamicTreeCompat extends DynamicTreeProxy
     @Override
     public boolean checkForDynamicTreeBlock(@NotNull final Block block)
     {
-        return false;
-        //return block instanceof BranchBlock;
+        return block instanceof BranchBlock;
     }
 
     /**
-     * Check wether the block is part of a dynamic Tree
+     * Check whether the block is part of a dynamic Tree
      *
      * @param block Block to check
      * @return true if so.
@@ -81,19 +86,18 @@ public final class DynamicTreeCompat extends DynamicTreeProxy
     }
 
     /**
-     * Check wether the block is a dynamic leaf
+     * Check whether the block is a dynamic leaf
      *
      * @param block Block to check
      */
     @Override
     public boolean checkForDynamicLeavesBlock(final Block block)
     {
-        return false;
-        //return block instanceof DynamicLeavesBlock;
+        return block instanceof DynamicLeavesBlock;
     }
 
     /**
-     * Check wether the block is a dynamic leaf
+     * Check whether the block is a dynamic leaf
      *
      * @param block Block to check
      * @return true if so.
@@ -112,8 +116,7 @@ public final class DynamicTreeCompat extends DynamicTreeProxy
     @Override
     public boolean checkForDynamicTrunkShellBlock(final Block block)
     {
-        return false;
-        //return block instanceof TrunkShellBlock;
+        return block instanceof TrunkShellBlock;
     }
 
     /**
@@ -132,7 +135,7 @@ public final class DynamicTreeCompat extends DynamicTreeProxy
      *
      * @param world      world the Leaf is in
      * @param pos        position of the Leaf
-     * @param blockstate Blockstate of the Leaf
+     * @param blockState Blockstate of the Leaf
      * @param fortune    amount of fortune to use
      * @param leaf       The leaf to check
      */
@@ -140,17 +143,17 @@ public final class DynamicTreeCompat extends DynamicTreeProxy
     public NonNullList<ItemStack> getDropsForLeaf(
       final LevelAccessor world,
       final BlockPos pos,
-      final BlockState blockstate,
+      final BlockState blockState,
       final int fortune,
       final Block leaf)
     {
-        /*if (isDynamicLeavesBlock(leaf))
+        if (isDynamicLeavesBlock(leaf))
         {
             ItemStack stack = ((DynamicLeavesBlock) leaf).getFamily(blockState, world, pos).getCommonSpecies().getSeedStack(1);
             final NonNullList<ItemStack> list = NonNullList.create();
             list.add(stack);
             return list;
-        }*/
+        }
         return NonNullList.create();
     }
 
@@ -170,19 +173,18 @@ public final class DynamicTreeCompat extends DynamicTreeProxy
     }
 
     /**
-     * Check wether the item is a dynamic Sapling
+     * Check whether the item is a dynamic Sapling
      *
      * @param item Item to check
      */
     @Override
     public boolean checkForDynamicSapling(@NotNull final Item item)
     {
-        return false;
-        //return item instanceof Seed;
+       return item instanceof Seed;
     }
 
     /**
-     * Check wether the item is a dynamic Sapling
+     * Check whether the item is a dynamic Sapling
      *
      * @param item Item to check
      * @return true if so.
@@ -193,7 +195,7 @@ public final class DynamicTreeCompat extends DynamicTreeProxy
     }
 
     /**
-     * Check wether the Itemstack is a dynamic Sapling
+     * Check whether the Itemstack is a dynamic Sapling
      *
      * @param stack Itemstack to check
      * @return true if it is a dynamic Sapling
@@ -217,7 +219,7 @@ public final class DynamicTreeCompat extends DynamicTreeProxy
     {
         return () ->
         {
-            /*final BlockState curBlockState = world.getBlockState(blockToBreak);
+            final BlockState curBlockState = world.getBlockState(blockToBreak);
             final Block curBlock = curBlockState.getBlock();
 
             if (world.getServer() == null)
@@ -244,9 +246,11 @@ public final class DynamicTreeCompat extends DynamicTreeProxy
             if (toolToUse != null)
             {
                 fake.setItemInHand(InteractionHand.MAIN_HAND, toolToUse);
+
             }
 
-            curBlock.removedByPlayer(curBlockState, world, blockToBreak, fake, true, world.getFluidState(blockToBreak));*/
+            FluidState fluidState = world.getFluidState(blockToBreak);
+            curBlock.onDestroyedByPlayer(curBlockState, world, blockToBreak, fake, true, fluidState);
         };
     }
 
@@ -275,11 +279,11 @@ public final class DynamicTreeCompat extends DynamicTreeProxy
     @Override
     public boolean plantDynamicSaplingCompat(@NotNull final Level world, @NotNull final BlockPos location, @NotNull final ItemStack saplingStack)
     {
-        /*if (saplingStack.getItem() instanceof Seed)
+        if (saplingStack.getItem() instanceof Seed)
         {
             return ((Seed) saplingStack.getItem()).getSpecies().plantSapling(world, location, false);
         }
-        else*/
+        else
         {
             return false;
         }
@@ -319,13 +323,13 @@ public final class DynamicTreeCompat extends DynamicTreeProxy
     @Override
     public boolean hasFittingTreeFamilyCompat(@NotNull final BlockPos block1, @NotNull final BlockPos block2, @NotNull final LevelAccessor world)
     {
-        /*Family fam1 = getFamilyForBlock(block1, world);
+        Family fam1 = getFamilyForBlock(block1, world);
         Family fam2 = getFamilyForBlock(block2, world);
 
         if (fam1 != null && fam2 != null)
         {
             return fam1 == fam2;
-        }*/
+        }
         return false;
     }
 
@@ -336,7 +340,7 @@ public final class DynamicTreeCompat extends DynamicTreeProxy
      * @param world    world
      * @return dynamic tree family
      */
-    /*private static Family getFamilyForBlock(@NotNull final BlockPos blockPos, @NotNull final IWorld world)
+    private static Family getFamilyForBlock(@NotNull final BlockPos blockPos, @NotNull final LevelAccessor world)
     {
         final Block block = world.getBlockState(blockPos).getBlock();
         if (block instanceof BranchBlock)
@@ -349,7 +353,7 @@ public final class DynamicTreeCompat extends DynamicTreeProxy
         }
 
         return null;
-    }*/
+    }
 
     /**
      * Method to check if two given blocks have the same Tree family

--- a/src/main/java/com/minecolonies/coremod/entity/ai/citizen/lumberjack/Tree.java
+++ b/src/main/java/com/minecolonies/coremod/entity/ai/citizen/lumberjack/Tree.java
@@ -267,7 +267,7 @@ public class Tree
                     continue;
                 }
 
-                if (stack.is(ItemTags.SAPLINGS))
+                if (stack.is(ItemTags.SAPLINGS) || (isDynamicTree() && Compatibility.isDynamicTreeSapling(stack)))
                 {
                     IColonyManager.getInstance().getCompatibilityManager().connectLeafToSapling(blockState, stack);
                     return stack;

--- a/src/main/resources/META-INF/mods.toml
+++ b/src/main/resources/META-INF/mods.toml
@@ -89,3 +89,9 @@ MineColonies is a colony simulator within Minecraft! There are numerous types of
     versionRange="[${project.jmapVersion},)"
     ordering="NONE"
     side="BOTH"
+[[dependencies.minecolonies]]
+    modId="dynamictrees"
+    mandatory=false
+    versionRange="[${project.minecraftVersion}-${project.dynamicTreesVersion},)"
+    ordering="NONE"
+    side="BOTH"


### PR DESCRIPTION
Closes Issue: https://github.com/ldtteam/minecolonies/issues/8511

# Changes proposed in this pull request:
- Uncomments existing code for compatibility support with Dynamic Trees, following [this commit](https://github.com/ldtteam/minecolonies/pull/7171/files#diff-9714b5e946ce245773343d1de3cd4cb835ca8d7291bc83583329a6b0cae16dd7) as a reference for minor tweaks
- Adds a few gradle changes to accommodate that uncommenting (such as adding compile dependency for DynamicTrees)
- A few minor typo nits (`wether` to `whether`)

This commit addresses both issues conveyed in that one issue ticket: the reported crash is resolved, and the foresters chop the trees from the bottom. Also confirmed that they can plant new dynamic tree saplings. Everything seemed to work pretty well after watching the foresters work for like 10 minutes :) 

Review please
