### PR TITLE
Fixing Amazon Spear To be Thrown From Thrower Position

### DIFF
--- a/src/api/java/com/minecolonies/api/entity/SpearEntity.java
+++ b/src/api/java/com/minecolonies/api/entity/SpearEntity.java
@@ -69,6 +69,8 @@ public class SpearEntity extends ThrownTrident implements ICustomAttackSound
         super(ModEntities.SPEAR, world);
         this.weapon = thrownWeapon.copy();
         this.setOwner(thrower);
+        this.setPos(thrower.getX(), thrower.getEyeY() - 0.1, thrower.getZ());
+        this.shootFromRotation(thrower, thrower.getXRot(), thrower.getYRot(), 0.0F, 2.5F, 1.0F);
         getAddEntityPacket();
     }
 

--- a/src/main/java/com/minecolonies/coremod/items/ItemSpear.java
+++ b/src/main/java/com/minecolonies/coremod/items/ItemSpear.java
@@ -57,7 +57,7 @@ public class ItemSpear extends TridentItem
                 {
                     stack.hurtAndBreak(1, playerEntity, playerEntity1 -> playerEntity1.broadcastBreakEvent(entityLiving.getUsedItemHand()));
                     SpearEntity spearEntity = new SpearEntity(worldIn, playerEntity, stack);
-                    spearEntity.shootFromRotation(playerEntity, playerEntity.getXRot(), playerEntity.getYRot(), 0.0F, 2.5F, 1.0F);
+
                     if (playerEntity.getAbilities().instabuild)
                     {
                         spearEntity.pickup = AbstractArrow.Pickup.CREATIVE_ONLY;


### PR DESCRIPTION
Closes https://github.com/ldtteam/minecolonies/issues/8472


# Changes proposed in this pull request:
- Sets position of spear entity when created, to be from thrower position instead of default 0,0,0
- Moves the code for defining spear direction to be as part of constructor, since it could be abstracted there along with spear position

Confirmed that the spear is thrown as expected, and can be picked up. Also spawned an amazon raid to confirm that their spears cannot be picked up, and their spears also throw as expected.

Review please
