### PR TITLE
Fix deco controller

### DIFF
--- a/src/api/java/com/minecolonies/api/util/constant/TranslationConstants.java
+++ b/src/api/java/com/minecolonies/api/util/constant/TranslationConstants.java
@@ -426,6 +426,8 @@ public final class TranslationConstants
     @NonNls
     public static final String ACTION_BUILD                                                         = "com.minecolonies.coremod.gui.workerhuts.build";
     @NonNls
+    public static final String ACTION_UPGRADE                                                       = "com.minecolonies.coremod.gui.workerhuts.upgrade";
+    @NonNls
     public static final String TEXT_PICKUP_PRIORITY                                                 = "com.minecolonies.coremod.gui.workerhuts.buildprio";
     @NonNls
     public static final String TEXT_PICKUP_PRIORITY_NEVER                                           = "com.minecolonies.coremod.gui.workerhuts.deliveryprio.never";

--- a/src/main/java/com/minecolonies/coremod/client/gui/WindowBuildBuilding.java
+++ b/src/main/java/com/minecolonies/coremod/client/gui/WindowBuildBuilding.java
@@ -48,6 +48,8 @@ import java.util.*;
 import java.util.stream.Collectors;
 
 import static com.ldtteam.structurize.placement.AbstractBlueprintIterator.NULL_POS;
+import static com.minecolonies.api.util.constant.TranslationConstants.ACTION_BUILD;
+import static com.minecolonies.api.util.constant.TranslationConstants.ACTION_UPGRADE;
 import static com.minecolonies.api.util.constant.WindowConstants.*;
 
 /**
@@ -148,12 +150,12 @@ public class WindowBuildBuilding extends AbstractWindowSkeleton
         }
         else
         {
-            buttonBuild.setText(Component.translatable("com.minecolonies.coremod.gui.workerhuts.upgrade"));
+            buttonBuild.setText(Component.translatable(ACTION_UPGRADE));
         }
 
         if (building.isDeconstructed())
         {
-            findPaneOfTypeByID(BUTTON_REPAIR, Button.class).setText(Component.translatable("com.minecolonies.coremod.gui.workerhuts.build"));
+            findPaneOfTypeByID(BUTTON_REPAIR, Button.class).setText(Component.translatable(ACTION_BUILD));
             findPaneOfTypeByID(BUTTON_PICKUP_BUILDING, Button.class).show();
         }
     }

--- a/src/main/java/com/minecolonies/coremod/client/gui/WindowDecorationController.java
+++ b/src/main/java/com/minecolonies/coremod/client/gui/WindowDecorationController.java
@@ -19,13 +19,10 @@ import com.minecolonies.coremod.tileentities.TileEntityDecorationController;
 import net.minecraft.client.Minecraft;
 import net.minecraft.core.BlockPos;
 import net.minecraft.network.chat.Component;
-import net.minecraft.util.StringUtil;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.state.BlockState;
 
 import java.util.Optional;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 
 import static com.minecolonies.api.util.constant.TranslationConstants.*;
 import static com.minecolonies.api.util.constant.WindowConstants.*;
@@ -63,7 +60,7 @@ public class WindowDecorationController extends AbstractWindowSkeleton
         registerButton(BUTTON_REPAIR, this::repairClicked);
         registerButton(BUTTON_CANCEL, this::cancelClicked);
 
-        findPaneOfTypeByID(LABEL_NAME, Text.class).setText(Component.literal(controller.getSchematicName()));
+        findPaneOfTypeByID(LABEL_NAME, Text.class).setText(Component.literal(controller.getSchematicPath()));
 
         final IColonyView view = IColonyManager.getInstance().getClosestColonyView(world, controller.getBlockPos());
 
@@ -75,7 +72,7 @@ public class WindowDecorationController extends AbstractWindowSkeleton
         {
             final Optional<IWorkOrderView> wo = view.getWorkOrders().stream().filter(w -> w.getLocation().equals(this.controller.getBlockPos())).findFirst();
 
-            int level = Utils.getBlueprintLevel(controller.getSchematicName());
+            int level = Utils.getBlueprintLevel(controller.getSchematicPath());
             if (wo.isPresent())
             {
                 findPaneByID(BUTTON_BUILD).show();
@@ -88,7 +85,7 @@ public class WindowDecorationController extends AbstractWindowSkeleton
             }
             else
             {
-                buttonBuild.setText(Component.translatable(ACTION_BUILD));
+                buttonBuild.setText(Component.translatable(ACTION_UPGRADE));
 
                 try
                 {
@@ -143,7 +140,7 @@ public class WindowDecorationController extends AbstractWindowSkeleton
      */
     private void buildClicked()
     {
-        final int level = Utils.getBlueprintLevel(this.controller.getSchematicName());
+        final int level = Utils.getBlueprintLevel(this.controller.getSchematicPath());
         Network.getNetwork().sendToServer(new DecorationBuildRequestMessage(WorkOrderType.BUILD,
           controller.getBlockPos(),
           controller.getPackName(),

--- a/src/main/java/com/minecolonies/coremod/client/gui/WindowDecorationController.java
+++ b/src/main/java/com/minecolonies/coremod/client/gui/WindowDecorationController.java
@@ -12,9 +12,7 @@ import com.minecolonies.api.colony.workorders.WorkOrderType;
 import com.minecolonies.api.util.Log;
 import com.minecolonies.api.util.Utils;
 import com.minecolonies.api.util.constant.Constants;
-import com.minecolonies.coremod.Network;
 import com.minecolonies.coremod.colony.buildings.AbstractBuilding;
-import com.minecolonies.coremod.network.messages.server.DecorationBuildRequestMessage;
 import com.minecolonies.coremod.tileentities.TileEntityDecorationController;
 import net.minecraft.client.Minecraft;
 import net.minecraft.core.BlockPos;
@@ -141,14 +139,11 @@ public class WindowDecorationController extends AbstractWindowSkeleton
     private void buildClicked()
     {
         final int level = Utils.getBlueprintLevel(this.controller.getSchematicPath());
-        Network.getNetwork().sendToServer(new DecorationBuildRequestMessage(WorkOrderType.BUILD,
-          controller.getBlockPos(),
-          controller.getPackName(),
-          controller.getBlueprintPath().replace(level + ".blueprint", (level + 1) + ".blueprint"),
-          world.dimension(),
-          controller.getRotation(),
-          controller.getMirror()));
+
         close();
+        new WindowBuildDecoration(controller.getBlockPos(), controller.getPackName(),
+                controller.getSchematicPath().replace(level + ".blueprint", (level + 1) + ".blueprint"),
+                controller.getRotation(), controller.getMirror()).open();
     }
 
     /**
@@ -156,13 +151,9 @@ public class WindowDecorationController extends AbstractWindowSkeleton
      */
     private void repairClicked()
     {
-        Network.getNetwork().sendToServer(new DecorationBuildRequestMessage(WorkOrderType.BUILD,
-          controller.getBlockPos(),
-          controller.getPackName(),
-          controller.getSchematicPath(),
-          world.dimension(),
-          controller.getRotation(),
-          controller.getMirror()));
         close();
+        new WindowBuildDecoration(controller.getBlockPos(), controller.getPackName(),
+                controller.getSchematicPath(),
+                controller.getRotation(), controller.getMirror()).open();
     }
 }

--- a/src/main/java/com/minecolonies/coremod/entity/ai/basic/AbstractEntityAIStructure.java
+++ b/src/main/java/com/minecolonies/coremod/entity/ai/basic/AbstractEntityAIStructure.java
@@ -596,7 +596,7 @@ public abstract class AbstractEntityAIStructure<J extends AbstractJobStructure<?
                 building.setTotalStages(2);
             }
             else if ((colonyBuilding != null && (colonyBuilding.getBuildingLevel() > 0 || colonyBuilding.hasParent())) ||
-                       (entity instanceof TileEntityDecorationController && Utils.getBlueprintLevel(((TileEntityDecorationController) entity).getSchematicName()) != -1))
+                       (entity instanceof TileEntityDecorationController && Utils.getBlueprintLevel(((TileEntityDecorationController) entity).getSchematicPath()) != -1))
             {
                 structure = new BuildingStructureHandler<>(world,
                   position,

--- a/src/main/java/com/minecolonies/coremod/placementhandlers/main/SurvivalHandler.java
+++ b/src/main/java/com/minecolonies/coremod/placementhandlers/main/SurvivalHandler.java
@@ -226,7 +226,7 @@ public class SurvivalHandler implements ISurvivalBlueprintHandler
         {
             if (blueprint.getBlockState(blueprint.getPrimaryBlockOffset()).getBlock() instanceof ILeveledBlueprintAnchorBlock)
             {
-                int level = Utils.getBlueprintLevel(blueprint.getFileName().replace(".blueprint", ""));
+                int level = Utils.getBlueprintLevel(blueprint.getFileName());
                 if (level == -1)
                 {
                     Network.getNetwork().sendToPlayer(new OpenDecoWindowMessage(blockPos, packName, blueprintPath, placementSettings.getRotation(), placementSettings.mirror), (ServerPlayer) player);

--- a/src/main/java/com/minecolonies/coremod/tileentities/TileEntityDecorationController.java
+++ b/src/main/java/com/minecolonies/coremod/tileentities/TileEntityDecorationController.java
@@ -163,7 +163,7 @@ public class TileEntityDecorationController extends BlockEntity implements IBlue
         {
             this.schematicPath = compound.getString(TAG_NAME);
             final String[] split = Utils.splitPath(this.schematicPath);
-            this.schematicName = split[split.length - 1];
+            this.schematicName = split[split.length - 1].replace(".blueprint", "");
         }
 
         if (compound.contains(TAG_PACK))
@@ -220,6 +220,11 @@ public class TileEntityDecorationController extends BlockEntity implements IBlue
         this.mirror = compound.getBoolean(TAG_MIRROR);
         this.schematicPath = compound.getString(TAG_NAME);
         this.packName = compound.getString(TAG_PACK);
+
+        if (!this.schematicPath.endsWith(".blueprint"))
+        {
+            this.schematicPath = this.schematicPath + ".blueprint";
+        }
     }
 
     @Override
@@ -244,6 +249,10 @@ public class TileEntityDecorationController extends BlockEntity implements IBlue
     public void setBlueprintPath(final String filePath)
     {
         this.schematicPath = filePath;
+        if (!this.schematicPath.endsWith(".blueprint"))
+        {
+            this.schematicPath = this.schematicPath + ".blueprint";
+        }
     }
 
     @Override


### PR DESCRIPTION
Closes #8663

# Changes proposed in this pull request:
- Lets deco controller find the correct blueprint files again (a little hacky)
    - An alternative might be to go the other way and ensure that `.blueprint` is removed from the paths instead of adding it.  Not sure which way we want to go.
- Changes the "build" button to "upgrade", since it's only shown for upgrades
    - Also changes some similar text elsewhere to use translation constants
- Clicking "repair" or "upgrade" in the deco controller will now show the window that lets you preview resources and pick a builder

Review please

I've tested this with both ye olde scanned-before-1.19 deco (specifically, one of the fortress rails), as well as a freshly scanned empty-data controller.  Seems to work.