### PR TITLE
Fix permission events

### DIFF
--- a/src/api/java/com/minecolonies/api/colony/buildings/workerbuildings/ITownHall.java
+++ b/src/api/java/com/minecolonies/api/colony/buildings/workerbuildings/ITownHall.java
@@ -3,6 +3,8 @@ package com.minecolonies.api.colony.buildings.workerbuildings;
 import com.minecolonies.api.colony.buildings.IBuilding;
 import com.minecolonies.api.colony.permissions.PermissionEvent;
 
+import java.util.UUID;
+
 public interface ITownHall extends IBuilding
 {
     /**
@@ -11,4 +13,10 @@ public interface ITownHall extends IBuilding
      * @param event the event to add.
      */
     void addPermissionEvent(PermissionEvent event);
+
+    /**
+     * Removes all permission events with the given player id (because they were just given permissions)
+     * @param id the player id
+     */
+    void removePermissionEvents(UUID id);
 }

--- a/src/main/java/com/minecolonies/coremod/client/gui/townhall/WindowInfoPage.java
+++ b/src/main/java/com/minecolonies/coremod/client/gui/townhall/WindowInfoPage.java
@@ -2,7 +2,8 @@ package com.minecolonies.coremod.client.gui.townhall;
 
 import com.ldtteam.blockui.Pane;
 import com.ldtteam.blockui.PaneBuilders;
-import com.ldtteam.blockui.controls.*;
+import com.ldtteam.blockui.controls.Button;
+import com.ldtteam.blockui.controls.Text;
 import com.ldtteam.blockui.views.ScrollingList;
 import com.minecolonies.api.MinecoloniesAPIProxy;
 import com.minecolonies.api.colony.ICitizenDataView;
@@ -23,7 +24,6 @@ import com.minecolonies.coremod.colony.colonyEvents.citizenEvents.CitizenDiedEve
 import com.minecolonies.coremod.network.messages.PermissionsMessage;
 import net.minecraft.network.chat.Component;
 import net.minecraft.network.chat.MutableComponent;
-import net.minecraft.network.chat.Component;
 import org.jetbrains.annotations.NotNull;
 
 import java.math.RoundingMode;
@@ -233,10 +233,7 @@ public class WindowInfoPage extends AbstractWindowTownHall
                     nameLabel.setText(Component.literal(event.getName() + (event.getId() == null ? " <fake>" : "")));
                     rowPane.findPaneOfTypeByID(POS_LABEL, Text.class).setText(Component.literal(event.getPosition().getX() + " " + event.getPosition().getY() + " " + event.getPosition().getZ()));
 
-                    if (event.getId() == null)
-                    {
-                        rowPane.findPaneOfTypeByID(BUTTON_ADD_PLAYER_OR_FAKEPLAYER, Button.class).hide();
-                    }
+                    rowPane.findPaneOfTypeByID(BUTTON_ADD_PLAYER_OR_FAKEPLAYER, Button.class).setVisible(event.getId() != null);
 
                     actionLabel.setText(Component.translatable(KEY_TO_PERMISSIONS + event.getAction().toString().toLowerCase(Locale.US)));
                 }

--- a/src/main/java/com/minecolonies/coremod/colony/buildings/workerbuildings/BuildingTownHall.java
+++ b/src/main/java/com/minecolonies/coremod/colony/buildings/workerbuildings/BuildingTownHall.java
@@ -21,6 +21,7 @@ import org.jetbrains.annotations.NotNull;
 
 import java.util.LinkedList;
 import java.util.List;
+import java.util.UUID;
 
 import static com.minecolonies.api.util.constant.ColonyConstants.MAX_COLONY_EVENTS;
 import static com.minecolonies.api.util.constant.Constants.MOD_ID;
@@ -72,13 +73,22 @@ public class BuildingTownHall extends AbstractBuilding implements ITownHall
     @Override
     public void addPermissionEvent(final PermissionEvent event)
     {
-        if (getBuildingLevel() >= 1 && !permissionEvents.contains(event))
+        if (!permissionEvents.contains(event))
         {
             if (permissionEvents.size() >= MAX_COLONY_EVENTS)
             {
                 permissionEvents.removeFirst();
             }
             permissionEvents.add(event);
+            markDirty();
+        }
+    }
+
+    @Override
+    public void removePermissionEvents(@NotNull final UUID id)
+    {
+        if (permissionEvents.removeIf(e -> id.equals(e.getId())))
+        {
             markDirty();
         }
     }
@@ -176,6 +186,7 @@ public class BuildingTownHall extends AbstractBuilding implements ITownHall
 
             canPlayerUseTP = buf.readBoolean();
             final int permissionEventsSize = buf.readInt();
+            permissionEvents.clear();
             for (int i = 0; i < permissionEventsSize; i++)
             {
                 permissionEvents.add(new PermissionEvent(buf));

--- a/src/main/java/com/minecolonies/coremod/network/messages/PermissionsMessage.java
+++ b/src/main/java/com/minecolonies/coremod/network/messages/PermissionsMessage.java
@@ -9,6 +9,7 @@ import com.minecolonies.api.colony.permissions.Rank;
 import com.minecolonies.api.network.IMessage;
 import com.minecolonies.api.network.PacketUtils;
 import com.minecolonies.api.util.Log;
+import com.minecolonies.api.util.SoundUtils;
 import com.minecolonies.coremod.colony.Colony;
 import io.netty.buffer.Unpooled;
 import net.minecraft.core.Registry;
@@ -401,6 +402,7 @@ public class PermissionsMessage
             if (colony != null && colony.getPermissions().hasPermission(ctxIn.getSender(), Action.EDIT_PERMISSIONS) && colony.getWorld() != null)
             {
                 colony.getPermissions().addPlayer(id, playerName, colony.getPermissions().getRank(colony.getPermissions().NEUTRAL_RANK_ID));
+                SoundUtils.playSuccessSound(ctxIn.getSender(), ctxIn.getSender().blockPosition());
             }
             else
             {

--- a/src/main/java/com/minecolonies/coremod/network/messages/PermissionsMessage.java
+++ b/src/main/java/com/minecolonies/coremod/network/messages/PermissionsMessage.java
@@ -26,6 +26,7 @@ import net.minecraftforge.network.NetworkEvent;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
+import java.util.Optional;
 import java.util.UUID;
 
 /**
@@ -402,6 +403,7 @@ public class PermissionsMessage
             if (colony != null && colony.getPermissions().hasPermission(ctxIn.getSender(), Action.EDIT_PERMISSIONS) && colony.getWorld() != null)
             {
                 colony.getPermissions().addPlayer(id, playerName, colony.getPermissions().getRank(colony.getPermissions().NEUTRAL_RANK_ID));
+                Optional.ofNullable(colony.getBuildingManager().getTownHall()).ifPresent(th -> th.removePermissionEvents(id));
                 SoundUtils.playSuccessSound(ctxIn.getSender(), ctxIn.getSender().blockPosition());
             }
             else

--- a/src/main/resources/assets/minecolonies/gui/townhall/layoutinfo.xml
+++ b/src/main/resources/assets/minecolonies/gui/townhall/layoutinfo.xml
@@ -14,7 +14,7 @@
             <label id="action" size="140 12" pos="1 1" color="black"/>
             <label id="name" size="100 12" pos="1 12" color="blue"/>
             <label id="pos" size="70 12" pos="1 24" color="black"/>
-            <button id="addfakeplayer" size="35 12" label="$(com.minecolonies.coremod.gui.townhall.add)" pos="105 12"/>
+            <button id="addfakeplayer" size="35 14" label="$(com.minecolonies.coremod.gui.townhall.add)" pos="105 10"/>
         </box>
     </list>
 


### PR DESCRIPTION
Closes [discord report](https://discord.com/channels/139070364159311872/915411380268580864/1025572614430793758)

# Changes proposed in this pull request:
- Makes the "add" button visible properly (it would otherwise be hidden if there were more colony events than permissions events)
- Also resizes it slightly because BlockUI omits text entirely when it doesn't fit instead of clipping it, so the text was invisible
- Plays a sound and removes the permissions events for that player when you Add them, to reduce confusion (clicking Add on an existing player would reset their permission to neutral, perhaps unexpectedly -- there would also otherwise be no feedback that anything happened)
- Allows permission events to be recorded by a level 0 town hall, since it seemed weird it didn't (and the TH is often left unconstructed until later on)

Review please
