### PR TITLE
Fix special recipes

### DIFF
--- a/src/api/java/com/minecolonies/api/crafting/RecipeCraftingType.java
+++ b/src/api/java/com/minecolonies/api/crafting/RecipeCraftingType.java
@@ -59,7 +59,7 @@ public class RecipeCraftingType<C extends Container, T extends Recipe<C>> extend
                                                @NotNull final Recipe<?> recipe,
                                                @Nullable final Level world)
     {
-        if (recipe.getResultItem().isEmpty()) return;     // invalid or special recipes
+        if (recipe.isSpecial() || recipe.getResultItem().isEmpty()) return;     // invalid or special recipes
         try
         {
             final IGenericRecipe genericRecipe = GenericRecipe.of(recipe, world);

--- a/src/main/java/com/minecolonies/coremod/compatibility/CraftingTagAuditor.java
+++ b/src/main/java/com/minecolonies/coremod/compatibility/CraftingTagAuditor.java
@@ -107,11 +107,15 @@ public class CraftingTagAuditor
         {
             writeItemData(writer, item);
 
-            item.getTags().forEach(t -> {
+            item.getTags()
+                    .map(t -> t.location().toString())
+                    .sorted()
+                    .forEach(t ->
+            {
                 try
                 {
                     writer.write(',');
-                    writer.write(t.location().toString());
+                    writer.write(t);
                 }
                 catch (IOException e)
                 {

--- a/src/main/resources/assets/minecolonies/lang/manual_en_us.json
+++ b/src/main/resources/assets/minecolonies/lang/manual_en_us.json
@@ -223,7 +223,7 @@
   "minecolonies.config.fishingroddurabilityadjustt2": "Adjustment for T2 Fishing Huts",
   "minecolonies.config.fishingroddurabilityadjustt2.comment": "Offset for the maximum durability unenchanted rod a T2 Fishing Hut can use, compared to iron tools (250). Thermal Foundation Iron requires +6. T3 huts can use unenchanted rods of any durability level, so long as they can take damage at all. Anything below -250 will only allow vanilla rods, except as allowed by T1.",
   "minecolonies.config.auditcraftingtags": "Audit Crafting Tags",
-  "minecolonies.config.auditcraftingtags.comment": "Generate crafting_audit.csv on loading recipes to verify tags.",
+  "minecolonies.config.auditcraftingtags.comment": "When loading recipes, generate audit CSV files to help debug datapacks or extra mods.",
   "minecolonies.config.debuginventories": "Debug Inventories",
   "minecolonies.config.debuginventories.comment": "Enable inventory debugging.",
   "minecolonies.config.blueprintbuildmode": "Blueprint Build Mode",


### PR DESCRIPTION
Closes #8639

# Changes proposed in this pull request:
- Ignore recipes explicitly marked as special in addition to those that report an unspecified output (hides facade recipes).
- Sorts the tags in the tag audit file so they're easier to "diff"
- Updates the config comment for auditing to be more explanatory

Review please
