### PR TITLE
Claim all chunks within building bounds

### DIFF
--- a/src/main/java/com/minecolonies/coremod/colony/buildings/AbstractBuilding.java
+++ b/src/main/java/com/minecolonies/coremod/colony/buildings/AbstractBuilding.java
@@ -6,7 +6,6 @@ import com.google.common.collect.Lists;
 import com.google.common.reflect.TypeToken;
 import com.ldtteam.structurize.blueprints.v1.Blueprint;
 import com.ldtteam.structurize.storage.StructurePacks;
-import com.ldtteam.structurize.util.PlacementSettings;
 import com.minecolonies.api.MinecoloniesAPIProxy;
 import com.minecolonies.api.blocks.AbstractBlockHut;
 import com.minecolonies.api.colony.ICitizenData;
@@ -63,8 +62,8 @@ import net.minecraft.core.BlockPos;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.nbt.ListTag;
 import net.minecraft.network.FriendlyByteBuf;
-import net.minecraft.network.chat.MutableComponent;
 import net.minecraft.network.chat.Component;
+import net.minecraft.network.chat.MutableComponent;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.util.Tuple;
 import net.minecraft.world.entity.player.Player;
@@ -333,7 +332,7 @@ public abstract class AbstractBuilding extends AbstractBuildingContainer
     @Override
     public void onPlacement()
     {
-        ChunkDataHelper.claimBuildingChunks(colony, true, getPosition(), getClaimRadius(getBuildingLevel()));
+        ChunkDataHelper.claimBuildingChunks(colony, true, getPosition(), getClaimRadius(getBuildingLevel()), getCorners());
     }
 
     /**
@@ -425,7 +424,7 @@ public abstract class AbstractBuilding extends AbstractBuildingContainer
             world.updateNeighbourForOutputSignal(this.getPosition(), block);
         }
 
-        ChunkDataHelper.claimBuildingChunks(colony, false, this.getID(), getClaimRadius(getBuildingLevel()));
+        ChunkDataHelper.claimBuildingChunks(colony, false, this.getID(), getClaimRadius(getBuildingLevel()), getCorners());
         ConstructionTapeHelper.removeConstructionTape(getCorners(), world);
 
         getModules(IBuildingEventsModule.class).forEach(IBuildingEventsModule::onDestroyed);
@@ -939,7 +938,7 @@ public abstract class AbstractBuilding extends AbstractBuildingContainer
     public void onUpgradeComplete(final int newLevel)
     {
         cachedRotation = -1;
-        ChunkDataHelper.claimBuildingChunks(colony, true, this.getID(), this.getClaimRadius(newLevel));
+        ChunkDataHelper.claimBuildingChunks(colony, true, this.getID(), this.getClaimRadius(newLevel), getCorners());
         recheckGuardBuildingNear = true;
 
         ConstructionTapeHelper.removeConstructionTape(getCorners(), colony.getWorld());

--- a/src/main/java/com/minecolonies/coremod/colony/buildings/workerbuildings/BuildingBarracksTower.java
+++ b/src/main/java/com/minecolonies/coremod/colony/buildings/workerbuildings/BuildingBarracksTower.java
@@ -106,7 +106,7 @@ public class BuildingBarracksTower extends AbstractBuildingGuards
         {
             return;
         }
-        ChunkDataHelper.claimBuildingChunks(colony, true, barracks, barrack.getClaimRadius(newLevel));
+        ChunkDataHelper.claimBuildingChunks(colony, true, barracks, barrack.getClaimRadius(newLevel), barrack.getCorners());
 
         if (newLevel == barrack.getMaxBuildingLevel())
         {

--- a/src/main/java/com/minecolonies/coremod/util/BackUpHelper.java
+++ b/src/main/java/com/minecolonies/coremod/util/BackUpHelper.java
@@ -449,7 +449,8 @@ public final class BackUpHelper
                         ChunkDataHelper.claimBuildingChunks(loadedColony,
                           true,
                           building.getPosition(),
-                          building.getClaimRadius(building.getBuildingLevel()));
+                          building.getClaimRadius(building.getBuildingLevel()),
+                          building.getCorners());
                     }
                 }
             }


### PR DESCRIPTION
Closes [discord report](https://discord.com/channels/472875599422291968/486940969737125922/1034693339594899556)

# Changes proposed in this pull request:
- Ensure that a building claims all chunks intersecting its bounding box, in case it's larger than its hut's claim range.
    - This makes dark corners of large builds safe from monster spawns
    - This will not retroactively apply to existing buildings until you repair/upgrade them.

Review please  (should be safe to backport)