### PR TITLE
Enchanter doesn't drain any more

### DIFF
--- a/src/main/resources/assets/minecolonies/lang/manual_en_us.json
+++ b/src/main/resources/assets/minecolonies/lang/manual_en_us.json
@@ -1122,8 +1122,7 @@
 
   "com.minecolonies.coremod.job.enchanter": "Enchanter",
   "com.minecolonies.gui.workerhuts.enchanter.workers": "Gather Targets",
-  "com.minecolonies.gui.workerhuts.enchanter.daily": "Daily XP drain",
-  "com.minecolonies.coremod.enchanter.nodrainingsset": "Please configure some workers I can drain experience from so I can work!",
+  "com.minecolonies.coremod.enchanter.nodrainingsset": "Please configure some workers I can study so I can work!",
 
   "com.minecolonies.gui.workerhuts.expeditionlog": "Expedition Log",
   "com.minecolonies.gui.workerhuts.expedition.none": "No expedition",


### PR DESCRIPTION
Closes [discord report](https://discord.com/channels/139070364159311872/1003402487417548801/1034977435424403506)

# Changes proposed in this pull request:
- The enchanter studies other workers, they don't drain them any more.
    - Well, technically they do practice on them too, but it's mostly harmless.

Review please (can backport)
