### PR TITLE
Walk somewhere if no tree stumps

### DIFF
--- a/src/main/java/com/minecolonies/coremod/entity/ai/citizen/lumberjack/EntityAIWorkLumberjack.java
+++ b/src/main/java/com/minecolonies/coremod/entity/ai/citizen/lumberjack/EntityAIWorkLumberjack.java
@@ -433,7 +433,7 @@ public class EntityAIWorkLumberjack extends AbstractEntityAICrafting<JobLumberja
 
         if (job.getTree().hasLogs() || (shouldBreakLeaves && job.getTree().hasLeaves()) || checkedInHut)
         {
-            if (!walkToTree(job.getTree().getStumpLocations().get(0)))
+            if (!walkToTree(job.getTree().getStumpLocations().isEmpty() ? job.getTree().getLocation() : job.getTree().getStumpLocations().get(0)))
             {
                 if (checkIfStuck())
                 {


### PR DESCRIPTION
Closes [report](https://gist.github.com/Steffenator17/0999ca5dc47ded9daccb0b2369e77899)

# Changes proposed in this pull request:
- If we somehow have a tree with no stumps, walk _somewhere_ instead of crashing.  (Completely untested, but seems plausible.)

Review please (could backport)