### PR TITLE
But I *just* cleaned the floor!

### DIFF
--- a/src/datagen/generated/minecolonies/data/minecolonies/tags/items/baker_product_excluded.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/tags/items/baker_product_excluded.json
@@ -3,6 +3,7 @@
     "minecraft:bread",
     "minecraft:cake",
     "minecraft:cookie",
-    "minecraft:pumpkin_pie"
+    "minecraft:pumpkin_pie",
+    "minecraft:packed_mud"
   ]
 }

--- a/src/datagen/generated/minecolonies/data/minecolonies/tags/items/farmer_product.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/tags/items/farmer_product.json
@@ -6,6 +6,9 @@
     "minecraft:melon",
     "minecraft:coarse_dirt",
     "minecraft:fermented_spider_eye",
-    "minecraft:glistering_melon_slice"
+    "minecraft:glistering_melon_slice",
+    "minecraft:mud_bricks",
+    "minecraft:packed_mud",
+    "minecraft:muddy_mangrove_roots"
   ]
 }

--- a/src/datagen/generated/minecolonies/data/minecolonies/tags/items/sawmill_product.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/tags/items/sawmill_product.json
@@ -1,6 +1,7 @@
 {
   "values": [
     "minecolonies:barrel_block",
-    "minecolonies:blockhutcrusher"
+    "minecolonies:blockhutcrusher",
+    "#minecraft:chest_boats"
   ]
 }

--- a/src/main/java/com/minecolonies/coremod/colony/buildings/workerbuildings/BuildingPlantation.java
+++ b/src/main/java/com/minecolonies/coremod/colony/buildings/workerbuildings/BuildingPlantation.java
@@ -4,6 +4,7 @@ import com.google.common.collect.ImmutableMap;
 import com.minecolonies.api.colony.IColony;
 import com.minecolonies.api.colony.buildings.modules.settings.ISettingKey;
 import com.minecolonies.api.colony.jobs.registry.JobEntry;
+import com.minecolonies.api.crafting.GenericRecipe;
 import com.minecolonies.api.crafting.IGenericRecipe;
 import com.minecolonies.api.util.CraftingUtils;
 import com.minecolonies.api.util.ItemStackUtils;
@@ -30,10 +31,7 @@ import net.minecraft.world.level.block.Blocks;
 
 import org.jetbrains.annotations.NotNull;
 
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
+import java.util.*;
 import java.util.function.BiPredicate;
 import java.util.stream.Collectors;
 
@@ -257,6 +255,24 @@ public class BuildingPlantation extends AbstractBuilding
             }
             final Optional<Boolean> isRecipeAllowed = CraftingUtils.isRecipeCompatibleBasedOnTags(recipe, CRAFTING_PLANTATION);
             return isRecipeAllowed.orElse(false);
+        }
+
+        @Override
+        public @NotNull List<IGenericRecipe> getAdditionalRecipesForDisplayPurposesOnly()
+        {
+            final List<IGenericRecipe> recipes = new ArrayList<>(super.getAdditionalRecipesForDisplayPurposesOnly());
+
+            // indicate which plants we can grow
+            for (final Map.Entry<Item, PlantationItem> entry : COMBINATIONS.entrySet())
+            {
+                recipes.add(new GenericRecipe(null,
+                        new ItemStack(entry.getKey(), entry.getValue().getMinimumLength() + 1),
+                        Collections.emptyList(),
+                        Collections.singletonList(Collections.singletonList(new ItemStack(entry.getKey()))),
+                        1, Blocks.AIR, null, Collections.emptyList(), -1));
+            }
+
+            return recipes;
         }
     }
 

--- a/src/main/java/com/minecolonies/coremod/generation/defaults/DefaultItemTagsProvider.java
+++ b/src/main/java/com/minecolonies/coremod/generation/defaults/DefaultItemTagsProvider.java
@@ -170,7 +170,8 @@ public class DefaultItemTagsProvider extends ItemTagsProvider
         tag(ModTags.crafterIngredientExclusions.get(TagConstants.CRAFTING_BAKER));
         tag(ModTags.crafterProduct.get(TagConstants.CRAFTING_BAKER));
         tag(ModTags.crafterProductExclusions.get(TagConstants.CRAFTING_BAKER))
-                .add(Items.BREAD, Items.CAKE, Items.COOKIE, Items.PUMPKIN_PIE);
+                .add(Items.BREAD, Items.CAKE, Items.COOKIE, Items.PUMPKIN_PIE)
+                .add(Items.PACKED_MUD);
 
         tag(ModTags.crafterIngredient.get(TagConstants.CRAFTING_BLACKSMITH))
                 .addTags(Tags.Items.NUGGETS, Tags.Items.INGOTS)
@@ -232,7 +233,8 @@ public class DefaultItemTagsProvider extends ItemTagsProvider
                 .add(Items.MELON)
                 .add(Items.COARSE_DIRT)
                 .add(Items.FERMENTED_SPIDER_EYE)
-                .add(Items.GLISTERING_MELON_SLICE);
+                .add(Items.GLISTERING_MELON_SLICE)
+                .add(Items.MUD_BRICKS, Items.PACKED_MUD, Items.MUDDY_MANGROVE_ROOTS);
         tag(ModTags.crafterProductExclusions.get(TagConstants.CRAFTING_FARMER));
 
         tag(ModTags.crafterIngredient.get(TagConstants.CRAFTING_FLETCHER))
@@ -333,7 +335,8 @@ public class DefaultItemTagsProvider extends ItemTagsProvider
                 .addTag(Tags.Items.DUSTS_REDSTONE)
                 .addTag(Tags.Items.STRING);
         tag(ModTags.crafterProduct.get(TagConstants.CRAFTING_SAWMILL))
-                .add(ModBlocks.blockBarrel.asItem(), ModBlocks.blockHutCrusher.asItem());
+                .add(ModBlocks.blockBarrel.asItem(), ModBlocks.blockHutCrusher.asItem())
+                .addTags(ItemTags.CHEST_BOATS);
         tag(ModTags.crafterProductExclusions.get(TagConstants.CRAFTING_SAWMILL))
                 .addTag(ModTags.crafterProduct.get(TagConstants.CRAFTING_MECHANIC))
                 .add(Items.MAGMA_CREAM);

--- a/src/main/resources/data/minecolonies/crafterrecipes/farmer/mud.json
+++ b/src/main/resources/data/minecolonies/crafterrecipes/farmer/mud.json
@@ -1,0 +1,18 @@
+{
+  "type" : "recipe",
+  "crafter": "farmer_crafting",
+  "inputs": [
+    {
+      "item" : "minecraft:dirt",
+      "count": 1
+    },
+    {
+      "item" : "minecraft:potion{Potion:\"minecraft:water\"}",
+      "count": 1
+    }
+  ],
+  "result": "minecraft:mud",
+  "count": 1,
+  "loot-table" : "minecolonies:recipes/mud",
+  "intermediate" : "minecraft:air"
+}

--- a/src/main/resources/data/minecolonies/loot_tables/recipes/mud.json
+++ b/src/main/resources/data/minecolonies/loot_tables/recipes/mud.json
@@ -1,0 +1,21 @@
+{
+  "pools": [
+    {
+      "name": "minecolonies:recipes/mud",
+      "rolls": 1,
+      "entries": [
+        {
+          "type": "empty",
+          "weight": 100,
+          "quality": -1
+        },
+        {
+          "type": "item",
+          "weight": 0,
+          "quality": 1,
+          "name": "minecraft:glass_bottle"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
Closes discord request

# Changes proposed in this pull request:
- Adds recipes for mud
    - Farmer inherently knows how to make mud from dirt and water bottles
    - Farmer can be taught how to make packed mud and mud bricks
    - Baker can no longer be taught how to make packed mud (mud pies are not very tasty, despite what the kids say)
- Sawmill can be taught how to add chests to boats, because why not
- JEI now shows that the plantation is a source of bamboo, sugar cane, and cactus

Review please (do not backport; at least not in current form)

[Before/after spreadsheet](https://docs.google.com/spreadsheets/d/1DaGFlFcnce4bHXHylzztr5_Rwnm3P42c6o_xXqgyyr8/edit?usp=sharing)
Another change from that spreadsheet we might want to consider is which of the new `enchanted_book`s we should add to the enchanter... or perhaps come up with a system to do this automatically so that it supports modded enchants too (without needing a datapack)...