### PR TITLE
Update to new DT namespaces

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -38,7 +38,7 @@ jmapMcVersion=1.18.1
 jmapVersion=5.8.0beta11
 tinkersConstructVersion=3.5.0.17
 mantleVersion=1.9.20
-dynamicTreesVersion=0.11.0-Alpha2
+dynamicTreesVersion=0.11.0-Beta3
 # some mods include the MC version as part of their "real" version number, others
 # store them separately (even if they look like they're included in the filename).
 # it's important to get them the right way around for mods.toml to work properly.

--- a/src/api/java/com/minecolonies/api/compatibility/dynamictrees/DynamicTreeCompat.java
+++ b/src/api/java/com/minecolonies/api/compatibility/dynamictrees/DynamicTreeCompat.java
@@ -1,10 +1,10 @@
 package com.minecolonies.api.compatibility.dynamictrees;
 
-import com.ferreusveritas.dynamictrees.blocks.branches.BranchBlock;
-import com.ferreusveritas.dynamictrees.blocks.branches.TrunkShellBlock;
-import com.ferreusveritas.dynamictrees.blocks.leaves.DynamicLeavesBlock;
-import com.ferreusveritas.dynamictrees.items.Seed;
-import com.ferreusveritas.dynamictrees.trees.Family;
+import com.ferreusveritas.dynamictrees.block.branch.BranchBlock;
+import com.ferreusveritas.dynamictrees.block.branch.TrunkShellBlock;
+import com.ferreusveritas.dynamictrees.block.leaves.DynamicLeavesBlock;
+import com.ferreusveritas.dynamictrees.item.Seed;
+import com.ferreusveritas.dynamictrees.tree.family.Family;
 import com.minecolonies.api.util.Log;
 import com.mojang.authlib.GameProfile;
 import net.minecraft.core.BlockPos;


### PR DESCRIPTION
Closes [discord report](https://discord.com/channels/139070364159311872/915411380268580864/1040796720344334346)

# Changes proposed in this pull request:
- Updates to latest Dynamic Trees for 1.18 to fix incompatibility due to namespace rename

Review please (do not port forward)

I have not tested this in-game at all, just that it compiles.