### PR TITLE
Dynmap compatability

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -37,6 +37,9 @@ jmapApiVersion=1.18.1-1.8-SNAPSHOT
 jmapMcVersion=1.18.1
 jmapVersion=5.8.0beta11
 tinkersConstructVersion=3.5.0.17
+dynmapApiVersion=3.4
+dynmapMcVersion=1.18.2
+dynmapVersion=3.4
 mantleVersion=1.9.20
 dynamicTreesVersion=0.11.0-Beta4
 # some mods include the MC version as part of their "real" version number, others
@@ -46,6 +49,10 @@ dynamicTreesVersion=0.11.0-Beta4
 # Journeymap doesn't have a maven (other than cursemaven); so if you want to use it in dev
 # then drop the regular jar into the "libs" dir and set this to true (editing version if needed)
 runWithJourneymap=false
+
+# Dynmap doesn't have a maven for its release artifacts so if you want to use it in dev
+# then drop the Dynmap jar into the "libs" dir and set this to true (editing version if needed)
+runWithDynmap=false
 
 useShadowJar=true
 

--- a/gradle/configuration.gradle
+++ b/gradle/configuration.gradle
@@ -9,4 +9,5 @@ project.ext.customChangelogHeader = "\n" +
         "- JEI: ${project.jei_version} (or above)\n" +
         "- Dynamic Trees: ${project.dynamicTreesVersion} (or above)\n" +
         "- Journeymap: ${project.jmapVersion} (or above)\n" +
+        "- Dynmap: ${project.dynmapVersion} (or above)\n" +
         "\n"

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -11,6 +11,10 @@ repositories {
         name "JourneyMap"
         url "https://jm.gserv.me/repository/maven-public/"
     }
+    maven {
+        name "Dynmap"
+        url = "https://repo.mikeprimm.com/"
+    }
 }
 
 dependencies {
@@ -57,6 +61,12 @@ dependencies {
     if (project.hasProperty("runWithJourneymap") && project.runWithJourneymap.toBoolean()) {
         runtimeOnly fg.deobf("flat:journeymap:${project.jmapMcVersion}-${project.jmapVersion}")
     }
+
+    apiCompileOnly fg.deobf("us.dynmap:DynmapCoreAPI:${project.dynmapApiVersion}")
+    if (project.hasProperty("runWithDynmap") && project.runWithDynmap.toBoolean()) {
+        runtimeOnly fg.deobf("flat:dynmap:${project.dynmapMcVersion}-${project.dynmapVersion}")
+    }
+
     // replace "compileOnly" with "library" when you want to include it for testing
     compileOnly fg.deobf("slimeknights.tconstruct:TConstruct:${project.exactMinecraftVersion}-${project.tinkersConstructVersion}")
     compileOnly fg.deobf("slimeknights.mantle:Mantle:${project.exactMinecraftVersion}-${project.mantleVersion}")

--- a/src/api/java/com/minecolonies/api/compatibility/Compatibility.java
+++ b/src/api/java/com/minecolonies/api/compatibility/Compatibility.java
@@ -1,17 +1,20 @@
 package com.minecolonies.api.compatibility;
 
+import com.minecolonies.api.colony.IColony;
 import com.minecolonies.api.compatibility.dynamictrees.DynamicTreeProxy;
+import com.minecolonies.api.compatibility.dynmap.DynmapProxy;
 import com.minecolonies.api.compatibility.resourcefulbees.IBeehiveCompat;
-import com.minecolonies.api.compatibility.tinkers.*;
+import com.minecolonies.api.compatibility.tinkers.SlimeTreeProxy;
+import com.minecolonies.api.compatibility.tinkers.TinkersToolProxy;
 import com.minecolonies.api.util.constant.IToolType;
-import net.minecraft.world.level.block.Block;
-import net.minecraft.world.level.block.state.BlockState;
+import net.minecraft.core.BlockPos;
+import net.minecraft.core.NonNullList;
 import net.minecraft.world.item.Item;
 import net.minecraft.world.item.ItemStack;
-import net.minecraft.core.NonNullList;
-import net.minecraft.core.BlockPos;
-import net.minecraft.world.level.LevelAccessor;
 import net.minecraft.world.level.Level;
+import net.minecraft.world.level.LevelAccessor;
+import net.minecraft.world.level.block.Block;
+import net.minecraft.world.level.block.state.BlockState;
 import net.minecraftforge.fml.ModList;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -31,10 +34,11 @@ public final class Compatibility
         throw new IllegalAccessError("Utility class");
     }
 
-    public static IBeehiveCompat beeHiveCompat = new IBeehiveCompat() {};
+    public static IBeehiveCompat   beeHiveCompat = new IBeehiveCompat() {};
     public static SlimeTreeProxy   tinkersSlimeCompat = new SlimeTreeProxy();
     public static TinkersToolProxy tinkersCompat      = new TinkersToolProxy();
     public static DynamicTreeProxy dynamicTreesCompat = new DynamicTreeProxy();
+    public static DynmapProxy      dynmapCompat       = new DynmapProxy();
 
     /**
      * This method checks to see if STACK is able to mine anything. It goes through all compatibility checks.
@@ -295,5 +299,53 @@ public final class Compatibility
     public static List<ItemStack> getCombsFromHive(BlockPos pos, Level world, int amount)
     {
         return beeHiveCompat.getCombsFromHive(pos, world, amount);
+    }
+
+    /**
+     * Registers the Dynmap integration
+     */
+    public static void registerDynmap()
+    {
+        dynmapCompat.registerIntegration();
+    }
+
+    /**
+     * Update the colony name
+     *
+     * @param colony The colony
+     */
+    public static void updateColonyName(final IColony colony)
+    {
+        dynmapCompat.updateColonyName(colony);
+    }
+
+    /**
+     * Update the colony team color
+     *
+     * @param colony The colony
+     */
+    public static void updateColonyTeamColor(final IColony colony)
+    {
+        dynmapCompat.updateColonyTeamColor(colony);
+    }
+
+    /**
+     * Update the colony name
+     *
+     * @param colony The colony
+     */
+    public static void updateColonyBorders(final IColony colony)
+    {
+        dynmapCompat.updateColonyBorders(colony);
+    }
+
+    /**
+     * Update the colony citizen count
+     *
+     * @param colony The colony
+     */
+    public static void updateColonyCitizenCount(final IColony colony)
+    {
+        dynmapCompat.updateColonyCitizenCount(colony);
     }
 }

--- a/src/api/java/com/minecolonies/api/compatibility/CompatibilityManager.java
+++ b/src/api/java/com/minecolonies/api/compatibility/CompatibilityManager.java
@@ -6,6 +6,7 @@ import com.google.common.collect.ImmutableSet;
 import com.minecolonies.api.MinecoloniesAPIProxy;
 import com.minecolonies.api.colony.requestsystem.StandardFactoryController;
 import com.minecolonies.api.compatibility.dynamictrees.DynamicTreeCompat;
+import com.minecolonies.api.compatibility.dynmap.DynmapCompat;
 import com.minecolonies.api.compatibility.resourcefulbees.ResourcefulBeesCompat;
 import com.minecolonies.api.compatibility.tinkers.SlimeTreeCheck;
 import com.minecolonies.api.compatibility.tinkers.TinkersToolHelper;
@@ -936,6 +937,11 @@ public class CompatibilityManager implements ICompatibilityManager
         if (ModList.get().isLoaded("dynamictrees"))
         {
             Compatibility.dynamicTreesCompat = new DynamicTreeCompat();
+        }
+        if (ModList.get().isLoaded("dynmap"))
+        {
+            Compatibility.dynmapCompat = new DynmapCompat();
+            Compatibility.dynmapCompat.registerIntegration();
         }
     }
 

--- a/src/api/java/com/minecolonies/api/compatibility/dynmap/ColonyChunkClaimCalculator.java
+++ b/src/api/java/com/minecolonies/api/compatibility/dynmap/ColonyChunkClaimCalculator.java
@@ -1,0 +1,74 @@
+package com.minecolonies.api.compatibility.dynmap;
+
+import com.minecolonies.api.IMinecoloniesAPI;
+import com.minecolonies.api.colony.IColony;
+import com.minecolonies.api.colony.buildings.IBuilding;
+import net.minecraft.world.level.ChunkPos;
+
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.Set;
+
+public class ColonyChunkClaimCalculator
+{
+    public static Collection<ChunkPos> getAllClaimedChunks(final IColony colony)
+    {
+        var claimedChunks = new HashSet<ChunkPos>();
+
+        // Claim the protection area
+        getProtectionArea(colony, claimedChunks);
+
+        // Claim all the buildings
+        colony.getBuildingManager().getBuildings().values().forEach(f -> claimBuilding(f, claimedChunks));
+
+        return claimedChunks;
+    }
+
+    private static void getProtectionArea(final IColony colony, Set<ChunkPos> claimedChunks)
+    {
+        var protectionAreaCenterChunk = new ChunkPos(colony.getCenter());
+        var protectionAreaRadius = IMinecoloniesAPI.getInstance().getConfig().getServer().initialColonySize.get();
+        for (var i = -protectionAreaRadius; i <= protectionAreaRadius; i++)
+        {
+            for (var j = -protectionAreaRadius; j <= protectionAreaRadius; j++)
+            {
+                claimedChunks.add(new ChunkPos(protectionAreaCenterChunk.x + i, protectionAreaCenterChunk.z + j));
+            }
+        }
+    }
+
+    private static void claimBuilding(final IBuilding building, Set<ChunkPos> claimedChunks)
+    {
+        // Add the building center to the claimed chunks
+        var buildingCenterChunk = new ChunkPos(building.getPosition());
+        claimedChunks.add(buildingCenterChunk);
+
+        // Add the overlaying schematic to the claimed chunks
+        var corners = building.getCorners();
+        var bottomLeft = new ChunkPos(corners.getA());
+        var topRight = new ChunkPos(corners.getB());
+        if (!bottomLeft.equals(topRight))
+        {
+            // Chunks do not appear on the same XZ coordinate, so this means the building uses multiple chunks
+            var chunksHorizontal = ((topRight.getMinBlockX() - bottomLeft.getMinBlockX()) / 16) + 1;
+            var chunksVertical = ((topRight.getMinBlockZ() - bottomLeft.getMinBlockZ()) / 16) + 1;
+            for (var i = 0; i < chunksHorizontal; i++)
+            {
+                for (var j = 0; j < chunksVertical; j++)
+                {
+                    claimedChunks.add(new ChunkPos(bottomLeft.x + i, bottomLeft.z + j));
+                }
+            }
+        }
+
+        // Add the claim radius to the claimed chunks
+        var radius = building.getClaimRadius(building.getBuildingLevel());
+        for (var i = -radius; i <= radius; i++)
+        {
+            for (var j = -radius; j <= radius; j++)
+            {
+                claimedChunks.add(new ChunkPos(buildingCenterChunk.x + i, buildingCenterChunk.z + j));
+            }
+        }
+    }
+}

--- a/src/api/java/com/minecolonies/api/compatibility/dynmap/Constants.java
+++ b/src/api/java/com/minecolonies/api/compatibility/dynmap/Constants.java
@@ -1,0 +1,11 @@
+package com.minecolonies.api.compatibility.dynmap;
+
+public final class Constants
+{
+    public static final String DYNMAP_COLONY_MARKER_SET_ID      = "minecolonies:colony_markers";
+    public static final String DYNMAP_COLONY_MARKER_SET_NAME    = "Colonies";
+    public static final String DYNMAP_COLONY_MARKER_FORMAT      = "minecolonies:colony:%d";
+    public static final String DYNMAP_COLONY_DESCRIPTION_FORMAT = "<h2>%s</h2><p>Mayor: %s</p><p>Population: %d</p>";
+
+    private Constants() {}
+}

--- a/src/api/java/com/minecolonies/api/compatibility/dynmap/DynmapApiListener.java
+++ b/src/api/java/com/minecolonies/api/compatibility/dynmap/DynmapApiListener.java
@@ -1,0 +1,32 @@
+package com.minecolonies.api.compatibility.dynmap;
+
+import com.minecolonies.api.util.Log;
+import org.dynmap.DynmapCommonAPI;
+import org.dynmap.DynmapCommonAPIListener;
+
+import java.util.function.Consumer;
+
+public class DynmapApiListener extends DynmapCommonAPIListener
+{
+    private final Consumer<DynmapIntegration> integrationConsumer;
+
+    public DynmapApiListener(Consumer<DynmapIntegration> integrationConsumer)
+    {
+
+        this.integrationConsumer = integrationConsumer;
+    }
+
+    public void registerListener()
+    {
+        DynmapCommonAPIListener.register(this);
+    }
+
+    @Override
+    public void apiEnabled(final DynmapCommonAPI dynmapCommonAPI)
+    {
+        Log.getLogger().info("Dynmap API enabled, registering markers...");
+        var markerApi = dynmapCommonAPI.getMarkerAPI();
+
+        integrationConsumer.accept(new DynmapIntegration(markerApi));
+    }
+}

--- a/src/api/java/com/minecolonies/api/compatibility/dynmap/DynmapCompat.java
+++ b/src/api/java/com/minecolonies/api/compatibility/dynmap/DynmapCompat.java
@@ -1,0 +1,10 @@
+package com.minecolonies.api.compatibility.dynmap;
+
+public class DynmapCompat extends DynmapProxy
+{
+    @Override
+    public boolean isDynmapPresent()
+    {
+        return true;
+    }
+}

--- a/src/api/java/com/minecolonies/api/compatibility/dynmap/DynmapIntegration.java
+++ b/src/api/java/com/minecolonies/api/compatibility/dynmap/DynmapIntegration.java
@@ -1,0 +1,119 @@
+package com.minecolonies.api.compatibility.dynmap;
+
+import com.minecolonies.api.IMinecoloniesAPI;
+import com.minecolonies.api.colony.IColony;
+import com.minecolonies.api.compatibility.dynmap.area.AreaGenerator;
+import net.minecraft.world.level.storage.ServerLevelData;
+import org.dynmap.markers.MarkerAPI;
+import org.dynmap.markers.MarkerSet;
+
+import java.awt.*;
+
+import static com.minecolonies.api.compatibility.dynmap.Constants.*;
+
+public class DynmapIntegration
+{
+    private final MarkerSet colonySet;
+
+    public DynmapIntegration(MarkerAPI markerApi)
+    {
+        var colonySetInternal = markerApi.getMarkerSet(DYNMAP_COLONY_MARKER_SET_ID);
+        if (colonySetInternal == null)
+        {
+            colonySetInternal = markerApi.createMarkerSet(DYNMAP_COLONY_MARKER_SET_ID, DYNMAP_COLONY_MARKER_SET_NAME, null, false);
+        }
+        this.colonySet = colonySetInternal;
+
+        var colonies = IMinecoloniesAPI.getInstance().getColonyManager().getAllColonies();
+        colonies.forEach(this::createColonyMarker);
+    }
+
+    private void createColonyMarker(final IColony colony)
+    {
+        var colonyId = getColonyId(colony);
+        var levelData = (ServerLevelData) colony.getWorld().getLevelData();
+
+        colonySet.createAreaMarker(
+          colonyId,
+          colony.getName(),
+          false,
+          levelData.getLevelName(),
+          new double[0],
+          new double[0],
+          false
+        );
+
+        updateDescription(colony);
+        updateTeamColor(colony);
+        updateBorders(colony);
+    }
+
+    private String getColonyId(final IColony colony)
+    {
+        return String.format(DYNMAP_COLONY_MARKER_FORMAT, colony.getID());
+    }
+
+    public void updateDescription(final IColony colony)
+    {
+        var colonyId = getColonyId(colony);
+        var colonyMarker = colonySet.findAreaMarker(colonyId);
+
+        if (colonyMarker != null)
+        {
+            colonyMarker.setDescription(DYNMAP_COLONY_DESCRIPTION_FORMAT.formatted(
+              colony.getName(),
+              colony.getPermissions().getOwnerName(),
+              colony.getCitizenManager().getCurrentCitizenCount()
+            ));
+        }
+    }
+
+    public void updateTeamColor(final IColony colony)
+    {
+        var colonyId = getColonyId(colony);
+        var colonyMarker = colonySet.findAreaMarker(colonyId);
+
+        if (colonyMarker != null)
+        {
+            var color = colony.getTeam().getColor().getColor();
+            if (color == null)
+            {
+                color = 16777215;
+            }
+            colonyMarker.setLineStyle(colonyMarker.getLineWeight(), colonyMarker.getLineOpacity(), getBorderColor(color));
+            colonyMarker.setFillStyle(colonyMarker.getFillOpacity(), color);
+        }
+    }
+
+    public void updateBorders(final IColony colony)
+    {
+        var colonyId = getColonyId(colony);
+        var colonyMarker = colonySet.findAreaMarker(colonyId);
+
+        if (colonyMarker != null)
+        {
+            var claimedChunks = ColonyChunkClaimCalculator.getAllClaimedChunks(colony);
+            var area = AreaGenerator.generateAreaFromChunks(claimedChunks);
+            colonyMarker.setCornerLocations(area.toXArray(), area.toZArray());
+        }
+    }
+
+    private int getBorderColor(int color)
+    {
+        // We cannot directly call `Color.getRGB()` because this includes the alpha bytes, which Dynmap it's line style does not expect.
+        // Thus, we manually have to extract the RGB bits.
+        var darkerColor = new Color(color).darker();
+        return (darkerColor.getRed() & 0xff) << 16 | (darkerColor.getGreen() & 0xff) << 8 | darkerColor.getBlue() & 0xff;
+    }
+
+    public void updateName(final IColony colony)
+    {
+        var colonyMarker = colonySet.findAreaMarker(getColonyId(colony));
+
+        if (colonyMarker != null)
+        {
+            colonyMarker.setLabel(colony.getName());
+            updateDescription(colony);
+        }
+    }
+}

--- a/src/api/java/com/minecolonies/api/compatibility/dynmap/DynmapProxy.java
+++ b/src/api/java/com/minecolonies/api/compatibility/dynmap/DynmapProxy.java
@@ -1,0 +1,86 @@
+package com.minecolonies.api.compatibility.dynmap;
+
+import com.minecolonies.api.colony.IColony;
+import com.minecolonies.api.util.Log;
+
+public class DynmapProxy
+{
+    private DynmapIntegration integration;
+
+    /**
+     * Registers the Dynmap integration.
+     */
+    public final void registerIntegration()
+    {
+        if (!isDynmapPresent())
+        {
+            Log.getLogger().info("Dynmap compat is not active");
+            return;
+        }
+        Log.getLogger().info("Dynmap compat is active");
+
+        new DynmapApiListener(it -> this.integration = it).registerListener();
+    }
+
+    /**
+     * Default method for when dynmap is not present, returns false
+     *
+     * @return true if so.
+     */
+    public boolean isDynmapPresent()
+    {
+        return false;
+    }
+
+    /**
+     * Update the name for a given colony, only works if Dynmap is present and as soon as the Dynmap compat is active.
+     *
+     * @param colony The colony to update the name for.
+     */
+    public void updateColonyName(final IColony colony)
+    {
+        if (isDynmapPresent() && integration != null)
+        {
+            integration.updateName(colony);
+        }
+    }
+
+    /**
+     * Update the team color for a given colony, only works if Dynmap is present and as soon as the Dynmap compat is active.
+     *
+     * @param colony The colony to update the team color for.
+     */
+    public void updateColonyTeamColor(final IColony colony)
+    {
+        if (isDynmapPresent() && integration != null)
+        {
+            integration.updateTeamColor(colony);
+        }
+    }
+
+    /**
+     * Update the borders for a given colony, only works if Dynmap is present and as soon as the Dynmap compat is active.
+     *
+     * @param colony The colony to update the borders for.
+     */
+    public void updateColonyBorders(final IColony colony)
+    {
+        if (isDynmapPresent() && integration != null)
+        {
+            integration.updateBorders(colony);
+        }
+    }
+
+    /**
+     * Update the citizen count for a given colony, only works if Dynmap is present and as soon as the Dynmap compat is active.
+     *
+     * @param colony The colony to update the citizen count for.
+     */
+    public void updateColonyCitizenCount(final IColony colony)
+    {
+        if (isDynmapPresent() && integration != null)
+        {
+            integration.updateDescription(colony);
+        }
+    }
+}

--- a/src/api/java/com/minecolonies/api/compatibility/dynmap/area/AreaGenerator.java
+++ b/src/api/java/com/minecolonies/api/compatibility/dynmap/area/AreaGenerator.java
@@ -1,0 +1,69 @@
+package com.minecolonies.api.compatibility.dynmap.area;
+
+import net.minecraft.world.level.ChunkPos;
+
+import java.awt.*;
+import java.awt.geom.Area;
+import java.awt.geom.PathIterator;
+import java.util.ArrayList;
+import java.util.Collection;
+
+public class AreaGenerator
+{
+    private AreaGenerator()
+    {
+    }
+
+    public static ColonyArea generateAreaFromChunks(Collection<ChunkPos> chunks)
+    {
+        var holes = new ArrayList<ColonyArea>();
+        ColonyArea colonyArea = null;
+
+        var area = createArea(chunks);
+        var iterator = area.getPathIterator(null);
+        final double[] points = new double[6];
+        while (!iterator.isDone())
+        {
+            final int type = iterator.currentSegment(points);
+            if (type == PathIterator.SEG_MOVETO)
+            {
+                if (colonyArea != null)
+                {
+                    holes.add(colonyArea);
+                }
+                colonyArea = new ColonyArea();
+            }
+
+            if (colonyArea != null && (type == PathIterator.SEG_MOVETO || type == PathIterator.SEG_LINETO))
+            {
+                colonyArea.addPoint(points[0], points[1]);
+            }
+
+            iterator.next();
+        }
+
+        if (colonyArea == null)
+        {
+            throw new IllegalArgumentException("Generator could not create an area, did you pass an empty list of chunks?");
+        }
+
+        for (var hole : holes)
+        {
+            colonyArea.addHole(hole);
+        }
+
+        colonyArea.close();
+
+        return colonyArea;
+    }
+
+    private static Area createArea(Collection<ChunkPos> chunks)
+    {
+        final Area area = new Area();
+        for (final ChunkPos chunkPos : chunks)
+        {
+            area.add(new Area(new Rectangle(chunkPos.getMinBlockX(), chunkPos.getMinBlockZ(), 16, 16)));
+        }
+        return area;
+    }
+}

--- a/src/api/java/com/minecolonies/api/compatibility/dynmap/area/ColonyArea.java
+++ b/src/api/java/com/minecolonies/api/compatibility/dynmap/area/ColonyArea.java
@@ -1,0 +1,121 @@
+package com.minecolonies.api.compatibility.dynmap.area;
+
+import javax.annotation.Nonnull;
+import java.awt.geom.Point2D;
+import java.util.ArrayList;
+import java.util.List;
+
+public class ColonyArea
+{
+    private final List<Point2D.Double> points;
+
+    private Point2D.Double secondLast;
+    private Point2D.Double last;
+
+    public ColonyArea()
+    {
+        this.points = new ArrayList<>();
+    }
+
+    public void addPoint(double x, double z)
+    {
+        var newPoint = new Point2D.Double(x, z);
+
+        // If the current X or Z values match at least 2 items back, we remove the last (middle of the comparison) item
+        // from the deque for simplification.
+        if ((last != null && secondLast != null) && ((last.x == x && secondLast.x == x) || (last.y == z && secondLast.y == z)))
+        {
+            this.points.remove(this.points.size() - 1);
+        }
+
+        this.points.add(newPoint);
+
+        if (last != null)
+        {
+            secondLast = new Point2D.Double(last.x, last.y);
+        }
+        last = newPoint;
+    }
+
+    public void addHole(@Nonnull final ColonyArea hole)
+    {
+        // Find the closest distance between any point of the current area and the hole.
+        var minimumDistance = -1d;
+        var selectedAreaPointIndex = -1;
+        var selectedHolePointIndex = -1;
+
+        var areaPointIndex = 0;
+        var holePointIndex = 0;
+        for (var point : points)
+        {
+            holePointIndex = 0;
+            for (var holePoint : hole.points)
+            {
+                var distance = point.distance(holePoint);
+                if (distance < minimumDistance || minimumDistance == -1)
+                {
+                    minimumDistance = distance;
+                    selectedAreaPointIndex = areaPointIndex;
+                    selectedHolePointIndex = holePointIndex;
+                }
+                holePointIndex++;
+            }
+            areaPointIndex++;
+        }
+
+        if (selectedAreaPointIndex >= 0 && selectedHolePointIndex >= 0)
+        {
+            var newPoints = new ArrayList<Point2D.Double>();
+
+            // We need to intersect the area with the hole at the selected points.
+            var currentPosition = selectedHolePointIndex;
+            var round = false;
+            while (!round)
+            {
+                var point = hole.points.get(currentPosition);
+                newPoints.add(new Point2D.Double(point.x, point.y));
+
+                currentPosition++;
+                if (currentPosition >= hole.points.size())
+                {
+                    currentPosition = 0;
+                }
+
+                if (currentPosition == selectedHolePointIndex)
+                {
+                    var initialPoint = hole.points.get(currentPosition);
+                    newPoints.add(new Point2D.Double(initialPoint.x, initialPoint.y));
+                    round = true;
+                }
+            }
+
+            // Add the selected area point at the end of the list again in order to return the line back to the original area
+            var areaPoint = this.points.get(selectedAreaPointIndex);
+            newPoints.add(new Point2D.Double(areaPoint.x, areaPoint.y));
+
+            this.points.addAll(selectedAreaPointIndex + 1, newPoints);
+        }
+    }
+
+    public void close()
+    {
+        this.points.add(new Point2D.Double(this.points.get(0).x, this.points.get(0).y));
+    }
+
+    public void reset()
+    {
+        this.points.clear();
+        this.last = null;
+        this.secondLast = null;
+    }
+
+    public double[] toXArray()
+    {
+        return points.stream().mapToDouble(i -> i.x).toArray();
+    }
+
+    public double[] toZArray()
+    {
+        return points.stream().mapToDouble(i -> i.y).toArray();
+    }
+}

--- a/src/api/java/com/minecolonies/api/compatibility/dynmap/package-info.java
+++ b/src/api/java/com/minecolonies/api/compatibility/dynmap/package-info.java
@@ -1,0 +1,8 @@
+/*
+ * # About the Dynmap plugin
+ *
+ * The Dynmap plugin currently provides the responsibility to render colonies
+ * on your Dynmap instance, it is able to render the borders along with some basic information
+ * regarding each colony.
+ */
+package com.minecolonies.api.compatibility.dynmap;

--- a/src/main/java/com/minecolonies/coremod/colony/managers/CitizenManager.java
+++ b/src/main/java/com/minecolonies/coremod/colony/managers/CitizenManager.java
@@ -7,6 +7,7 @@ import com.minecolonies.api.colony.ICivilianData;
 import com.minecolonies.api.colony.IColony;
 import com.minecolonies.api.colony.buildings.IBuilding;
 import com.minecolonies.api.colony.managers.interfaces.ICitizenManager;
+import com.minecolonies.api.compatibility.Compatibility;
 import com.minecolonies.api.entity.ModEntities;
 import com.minecolonies.api.entity.citizen.AbstractCivilianEntity;
 import com.minecolonies.api.entity.citizen.AbstractEntityCitizen;
@@ -28,14 +29,13 @@ import com.minecolonies.coremod.colony.jobs.JobUndertaker;
 import com.minecolonies.coremod.entity.citizen.EntityCitizen;
 import com.minecolonies.coremod.network.messages.client.colony.ColonyViewCitizenViewMessage;
 import com.minecolonies.coremod.network.messages.client.colony.ColonyViewRemoveCitizenMessage;
-import net.minecraft.nbt.Tag;
-import net.minecraft.server.level.ServerPlayer;
+import net.minecraft.core.BlockPos;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.nbt.ListTag;
-import net.minecraft.core.BlockPos;
+import net.minecraft.nbt.Tag;
+import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.world.entity.Entity;
 import net.minecraft.world.level.Level;
-
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -319,6 +319,8 @@ public class CitizenManager implements ICitizenManager
         citizenData.initForNewCivilian();
         citizens.put(citizenData.getId(), citizenData);
 
+        Compatibility.updateColonyCitizenCount(colony);
+
         return citizenData;
     }
 
@@ -345,6 +347,9 @@ public class CitizenManager implements ICitizenManager
         citizenData.onResurrect();
         citizens.put(citizenData.getId(), citizenData);
         spawnOrCreateCitizen(citizenData, world, spawnPos);
+
+        Compatibility.updateColonyCitizenCount(colony);
+
         return citizenData;
     }
 
@@ -378,6 +383,8 @@ public class CitizenManager implements ICitizenManager
         calculateMaxCitizens();
         markDirty();
         colony.markDirty();
+
+        Compatibility.updateColonyCitizenCount(colony);
     }
 
     @Override

--- a/src/main/java/com/minecolonies/coremod/entity/ai/basic/AbstractEntityAIStructureWithWorkOrder.java
+++ b/src/main/java/com/minecolonies/coremod/entity/ai/basic/AbstractEntityAIStructureWithWorkOrder.java
@@ -8,6 +8,7 @@ import com.ldtteam.structurize.util.PlacementSettings;
 import com.minecolonies.api.colony.buildings.IBuilding;
 import com.minecolonies.api.colony.workorders.IWorkOrder;
 import com.minecolonies.api.colony.workorders.WorkOrderType;
+import com.minecolonies.api.compatibility.Compatibility;
 import com.minecolonies.api.crafting.ItemStorage;
 import com.minecolonies.api.entity.ai.statemachine.states.IAIState;
 import com.minecolonies.api.tileentities.AbstractTileEntityColonyBuilding;
@@ -426,6 +427,8 @@ public abstract class AbstractEntityAIStructureWithWorkOrder<J extends AbstractJ
             }
         }
         building.resetNeededResources();
+
+        Compatibility.updateColonyBorders(job.getColony());
     }
 
     /**

--- a/src/main/java/com/minecolonies/coremod/network/messages/server/colony/TeamColonyColorChangeMessage.java
+++ b/src/main/java/com/minecolonies/coremod/network/messages/server/colony/TeamColonyColorChangeMessage.java
@@ -2,9 +2,10 @@ package com.minecolonies.coremod.network.messages.server.colony;
 
 import com.minecolonies.api.colony.IColony;
 import com.minecolonies.api.colony.buildings.views.IBuildingView;
+import com.minecolonies.api.compatibility.Compatibility;
 import com.minecolonies.coremod.network.messages.server.AbstractColonyServerMessage;
-import net.minecraft.network.FriendlyByteBuf;
 import net.minecraft.ChatFormatting;
+import net.minecraft.network.FriendlyByteBuf;
 import net.minecraftforge.network.NetworkEvent;
 import org.jetbrains.annotations.NotNull;
 
@@ -65,5 +66,9 @@ public class TeamColonyColorChangeMessage extends AbstractColonyServerMessage
     protected void onExecute(final NetworkEvent.Context ctxIn, final boolean isLogicalServer, final IColony colony)
     {
         colony.setColonyColor(ChatFormatting.values()[colorOrdinal]);
+
+        if (isLogicalServer) {
+            Compatibility.updateColonyTeamColor(colony);
+        }
     }
 }

--- a/src/main/java/com/minecolonies/coremod/network/messages/server/colony/TownHallRenameMessage.java
+++ b/src/main/java/com/minecolonies/coremod/network/messages/server/colony/TownHallRenameMessage.java
@@ -2,6 +2,7 @@ package com.minecolonies.coremod.network.messages.server.colony;
 
 import com.minecolonies.api.colony.IColony;
 import com.minecolonies.api.colony.IColonyView;
+import com.minecolonies.api.compatibility.Compatibility;
 import com.minecolonies.coremod.Network;
 import com.minecolonies.coremod.network.messages.server.AbstractColonyServerMessage;
 import net.minecraft.network.FriendlyByteBuf;
@@ -58,6 +59,10 @@ public class TownHallRenameMessage extends AbstractColonyServerMessage
         if (ctxIn.getSender() != null)
         {
             Network.getNetwork().sendToEveryone(this);
+        }
+
+        if (isLogicalServer) {
+            Compatibility.updateColonyName(colony);
         }
     }
 }

--- a/src/main/resources/META-INF/mods.toml
+++ b/src/main/resources/META-INF/mods.toml
@@ -95,3 +95,9 @@ MineColonies is a colony simulator within Minecraft! There are numerous types of
     versionRange="[${project.minecraftVersion}-${project.dynamicTreesVersion},)"
     ordering="NONE"
     side="BOTH"
+[[dependencies.minecolonies]]
+    modId="dynmap"
+    mandatory=false
+    versionRange="[${project.dynmapVersion},)"
+    ordering="NONE"
+    side="BOTH"


### PR DESCRIPTION
# Changes proposed in this pull request:
- Ability to render borders of colonies on Dynmap using a new marker set "Colonies".
- Renders the colony name, owner and population count on the description of the colony.
- Automatically updates Dynmap when the following occur:
  - The colony name gets changed
  - The colony it's team color is changed
  - The colony borders change when a building is constructured/repaired/removed
  - The colony it's population count changes, either when colonists are born or die.

What is not added in the pull request:
- Ability for Minecolonies specific blocks (primarly hut blocks) to render on Dynmap
- Ability for DO blocks to render on Dynmap (this would have to be implemented from within DO, should not appear here)

Review please
