### PR TITLE
Pass selected builder when creating deco build requests

### DIFF
--- a/src/main/java/com/minecolonies/coremod/client/gui/WindowBuildDecoration.java
+++ b/src/main/java/com/minecolonies/coremod/client/gui/WindowBuildDecoration.java
@@ -322,7 +322,11 @@ public class WindowBuildDecoration extends AbstractWindowSkeleton
 
     private void confirmedBuild()
     {
-        Network.getNetwork().sendToServer(new DecorationBuildRequestMessage(WorkOrderType.BUILD, structurePos, packMeta, path, Minecraft.getInstance().level.dimension(), rotation, mirror));
+        final BlockPos builder = buildersDropDownList.getSelectedIndex() == 0
+                ? BlockPos.ZERO
+                : builders.get(buildersDropDownList.getSelectedIndex()).getB();
+
+        Network.getNetwork().sendToServer(new DecorationBuildRequestMessage(WorkOrderType.BUILD, structurePos, packMeta, path, Minecraft.getInstance().level.dimension(), rotation, mirror, builder));
         close();
     }
 }


### PR DESCRIPTION
Closes #8790

# Changes proposed in this pull request:
- Pay attention to the selected builder for decoration requests

Review please (do not backport)

Slightly suspicious (but pre-existing) is that decoration work orders (even for deco controller upgrades) are always treated as level 0 work orders.  Which makes sense in some regards (any builder level can claim any deco order) but then begs the question of why an always-zero parameter is passed to `WorkOrderDecoration.create`, which internally does not seem to be expecting that to be the case.  I couldn't find anything that would actually misbehave as a result of this, although that doesn't mean there isn't something.