### PR TITLE
Hide style pack if it doesn't have a camp/ship

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -28,7 +28,7 @@ mappingsVersion=1.19.2
 
 dataGeneratorsVersion=0.1.48-ALPHA
 blockUI_version=1.19-0.0.64-ALPHA
-structurize_version=1.19.2-1.0.452-ALPHA
+structurize_version=1.19.2-1.0.462-ALPHA
 domumOrnamentumVersion=1.19-1.0.58-ALPHA
 multiPistonVersion=1.19-1.2.14-ALPHA
 

--- a/src/main/java/com/minecolonies/coremod/client/gui/WindowSupplies.java
+++ b/src/main/java/com/minecolonies/coremod/client/gui/WindowSupplies.java
@@ -22,6 +22,7 @@ import net.minecraft.core.BlockPos;
 import net.minecraft.network.chat.Component;
 import org.jetbrains.annotations.Nullable;
 
+import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -89,7 +90,7 @@ public class WindowSupplies extends AbstractBlueprintManipulationWindow
             final BlueprintPreviewData previewData = RenderingCache.getOrCreateBlueprintPreviewData("supplies");
             previewData.setBlueprint(null);
             return new WindowSupplies(previewData.getPos(), type);
-        }).open();
+        }, pack -> Files.exists(pack.getPath().resolve("decorations/supplies/" + type + ".blueprint"))).open();
     }
 
     /**


### PR DESCRIPTION
# Changes proposed in this pull request:
- Bumps structurize
- The supply camp/ship will now only show style packs that contain a camp/ship (respectively), to avoid loading errors and blank screens when you select the "wrong" one.

Review please (do not backport)
