### PR TITLE
Check level 1 for rotation if there's no level 0

### DIFF
--- a/src/main/java/com/minecolonies/coremod/colony/buildings/AbstractSchematicProvider.java
+++ b/src/main/java/com/minecolonies/coremod/colony/buildings/AbstractSchematicProvider.java
@@ -369,7 +369,11 @@ public abstract class AbstractSchematicProvider implements ISchematicProvider, I
 
         try
         {
-            final Blueprint blueprint = StructurePacks.getBlueprint(this.structurePack, this.path, true);
+            Blueprint blueprint = StructurePacks.getBlueprint(this.structurePack, this.path, true);
+            if (blueprint == null && this.path.endsWith("0.blueprint"))
+            {
+                blueprint = StructurePacks.getBlueprint(this.structurePack, this.path.replace("0.blueprint", "1.blueprint"), true);
+            }
             if (blueprint != null)
             {
                 final BlockState structureState = blueprint.getBlockInfoAsMap().get(blueprint.getPrimaryBlockOffset()).getState();


### PR DESCRIPTION
~~Apparently doesn't #8808~~
Closes [discord report](https://discord.com/channels/139070364159311872/1003402487417548801/1050814935422210169)
Closes #8743 ~~(most likely, but not explicitly tested)~~

# Changes proposed in this pull request:
- Check the level 1 blueprint to determine rotation if a level 0 is not found.

Review please (do not backport)
