### PR TITLE
Don't target invisible citizens

### DIFF
--- a/src/main/java/com/minecolonies/coremod/entity/mobs/aitasks/RaiderMeleeAI.java
+++ b/src/main/java/com/minecolonies/coremod/entity/mobs/aitasks/RaiderMeleeAI.java
@@ -11,11 +11,10 @@ import com.minecolonies.coremod.entity.ai.combat.AttackMoveAI;
 import com.minecolonies.coremod.entity.citizen.EntityCitizen;
 import com.minecolonies.coremod.util.NamedDamageSource;
 import net.minecraft.network.chat.contents.TranslatableContents;
+import net.minecraft.sounds.SoundEvents;
+import net.minecraft.world.InteractionHand;
 import net.minecraft.world.entity.LivingEntity;
 import net.minecraft.world.entity.player.Player;
-import net.minecraft.world.InteractionHand;
-import net.minecraft.sounds.SoundEvents;
-import net.minecraft.network.chat.Component;
 
 import static com.minecolonies.api.entity.mobs.RaiderMobUtils.MOB_ATTACK_DAMAGE;
 
@@ -82,7 +81,7 @@ public class RaiderMeleeAI<T extends AbstractEntityMinecoloniesMob & IThreatTabl
     @Override
     protected boolean isAttackableTarget(final LivingEntity target)
     {
-        return target instanceof EntityCitizen || (target instanceof Player && !((Player) target).isCreative() && !target.isSpectator());
+        return (target instanceof EntityCitizen && !target.isInvisible()) || (target instanceof Player && !((Player) target).isCreative() && !target.isSpectator());
     }
 
     @Override

--- a/src/main/java/com/minecolonies/coremod/entity/mobs/aitasks/RaiderRangedAI.java
+++ b/src/main/java/com/minecolonies/coremod/entity/mobs/aitasks/RaiderRangedAI.java
@@ -163,7 +163,7 @@ public class RaiderRangedAI<T extends AbstractEntityMinecoloniesMob & IThreatTab
     @Override
     protected boolean isAttackableTarget(final LivingEntity target)
     {
-        return target instanceof EntityCitizen || (target instanceof Player && !((Player) target).isCreative() && !target.isSpectator());
+        return (target instanceof EntityCitizen && !target.isInvisible()) || (target instanceof Player && !((Player) target).isCreative() && !target.isSpectator());
     }
 
     @Override

--- a/src/main/java/com/minecolonies/coremod/event/EventHandler.java
+++ b/src/main/java/com/minecolonies/coremod/event/EventHandler.java
@@ -1,6 +1,5 @@
 package com.minecolonies.coremod.event;
 
-import com.ldtteam.structurize.items.ModItems;
 import com.minecolonies.api.blocks.AbstractBlockHut;
 import com.minecolonies.api.blocks.interfaces.IRSComponentBlock;
 import com.minecolonies.api.colony.*;
@@ -133,7 +132,7 @@ public class EventHandler
               .getType()
               .is(ModTags.mobAttackBlacklist)))
             {
-                ((Mob) event.getEntity()).targetSelector.addGoal(6, new NearestAttackableTargetGoal<>((Mob) event.getEntity(), EntityCitizen.class, true));
+                ((Mob) event.getEntity()).targetSelector.addGoal(6, new NearestAttackableTargetGoal<>((Mob) event.getEntity(), EntityCitizen.class, true, citizen -> !citizen.isInvisible()));
                 ((Mob) event.getEntity()).targetSelector.addGoal(7, new NearestAttackableTargetGoal<>((Mob) event.getEntity(), EntityMercenary.class, true));
             }
         }


### PR DESCRIPTION
Closes [discord report](https://discord.com/channels/139070364159311872/244066364573089793/1054920276938342410)

# Changes proposed in this pull request:
- Prevents raiders and regular mobs from targeting invisible citizens.
    - This is mostly intended to avoid targeting a netherworker who is "away", but it seems reasonable to avoid targeting anyone affected by an invisibility potion too.  (Perhaps a research could make druids do that deliberately in the future.)

Review please (could backport)
