### PR TITLE
Fix ignoring of NBT on research costs for tools as well

### DIFF
--- a/src/api/java/com/minecolonies/api/util/ItemStackUtils.java
+++ b/src/api/java/com/minecolonies/api/util/ItemStackUtils.java
@@ -1037,6 +1037,16 @@ public final class ItemStackUtils
     }
 
     /**
+     * Reports if this stack has a custom Tag value that is not purely a damage value.
+     * @param stack the stack to inspect
+     * @return      true if the stack has a non-damage tag value
+     */
+    public static boolean hasTag(@NotNull final ItemStack stack)
+    {
+        return stack.getTag() != null && stack.getTag().size() > (stack.isDamageableItem() ? 1 : 0);
+    }
+
+    /**
      * Obtains a list of all basic items in the game, plus any extra items present in the player's
      * inventory (allowing for items with custom NBT, e.g. DO blocks or dyed armour).
      *

--- a/src/main/java/com/minecolonies/coremod/research/GlobalResearch.java
+++ b/src/main/java/com/minecolonies/coremod/research/GlobalResearch.java
@@ -12,16 +12,13 @@ import com.minecolonies.api.util.InventoryUtils;
 import com.minecolonies.api.util.ItemStackUtils;
 import com.minecolonies.api.util.Log;
 import com.minecolonies.coremod.MineColonies;
-import com.mojang.brigadier.exceptions.CommandSyntaxException;
 import net.minecraft.client.Minecraft;
-import net.minecraft.network.chat.MutableComponent;
+import net.minecraft.network.chat.Component;
 import net.minecraft.network.chat.contents.TranslatableContents;
+import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.item.Item;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.Items;
-import net.minecraft.nbt.TagParser;
-import net.minecraft.resources.ResourceLocation;
-import net.minecraft.network.chat.Component;
 import net.minecraftforge.items.IItemHandler;
 import net.minecraftforge.registries.ForgeRegistries;
 import org.jetbrains.annotations.NotNull;
@@ -802,8 +799,8 @@ public class GlobalResearch implements IGlobalResearch
                 if(reqArrayElement.isJsonObject() && reqArrayElement.getAsJsonObject().has(RESEARCH_ITEM_NAME_PROP) &&
                      reqArrayElement.getAsJsonObject().get(RESEARCH_ITEM_NAME_PROP).isJsonPrimitive() && reqArrayElement.getAsJsonObject().get(RESEARCH_ITEM_NAME_PROP).getAsJsonPrimitive().isString())
                 {
-                    final ItemStack itemStack = idToItemStack(reqArrayElement.getAsJsonObject().get(RESEARCH_ITEM_NAME_PROP).getAsString());
-                    final ItemStorage itemStorage = new ItemStorage(itemStack, false, !itemStack.hasTag());
+                    final ItemStack itemStack = ItemStackUtils.idToItemStack(reqArrayElement.getAsJsonObject().get(RESEARCH_ITEM_NAME_PROP).getAsString());
+                    final ItemStorage itemStorage = new ItemStorage(itemStack, false, !ItemStackUtils.hasTag(itemStack));
                     if(reqArrayElement.getAsJsonObject().has(RESEARCH_QUANTITY_PROP) && reqArrayElement.getAsJsonObject().get(RESEARCH_QUANTITY_PROP).isJsonPrimitive()
                          && reqArrayElement.getAsJsonObject().get(RESEARCH_QUANTITY_PROP).getAsJsonPrimitive().isNumber())
                     {
@@ -868,51 +865,6 @@ public class GlobalResearch implements IGlobalResearch
                 }
             }
         }
-    }
-
-    /**
-     * Convert an Item string with NBT to an ItemStack
-     * @param itemData ie: minecraft:potion{Potion=minecraft:water}
-     * @return stack with any defined NBT
-     */
-    private static ItemStack idToItemStack(final String itemData)
-    {
-        String itemId = itemData;
-        final int tagIndex = itemId.indexOf("{");
-        final String tag = tagIndex > 0 ? itemId.substring(tagIndex) : null;
-        itemId = tagIndex > 0 ? itemId.substring(0, tagIndex) : itemId;
-        String[] split = itemId.split(":");
-        if(split.length != 2)
-        {
-            if(split.length == 1)
-            {
-                final String[] tempArray ={"minecraft", split[0]};
-                split = tempArray;
-            }
-            else
-            {
-                Log.getLogger().error("Unable to parse item definition: " + itemData);
-            }
-        }
-        final Item item = ForgeRegistries.ITEMS.getValue(new ResourceLocation(split[0], split[1]));
-        final ItemStack stack = new ItemStack(item);
-        if (tag != null)
-        {
-            try
-            {
-                stack.setTag(TagParser.parseTag(tag));
-            }
-            catch (CommandSyntaxException e1)
-            {
-                //Unable to parse tags, drop them.
-                Log.getLogger().error("Unable to parse item definition: " + itemData);
-            }
-        }
-        if (stack.isEmpty())
-        {
-            Log.getLogger().warn("Parsed item definition returned empty: " + itemData);
-        }
-        return stack;
     }
 
     /**

--- a/src/main/java/com/minecolonies/coremod/research/GlobalResearchFactory.java
+++ b/src/main/java/com/minecolonies/coremod/research/GlobalResearchFactory.java
@@ -10,6 +10,7 @@ import com.minecolonies.api.research.effects.IResearchEffect;
 import com.minecolonies.api.research.effects.registry.IResearchEffectRegistry;
 import com.minecolonies.api.research.factories.IGlobalResearchFactory;
 import com.minecolonies.api.research.registry.IResearchRequirementRegistry;
+import com.minecolonies.api.util.ItemStackUtils;
 import com.minecolonies.api.util.NBTUtils;
 import com.minecolonies.api.util.constant.SerializationIdentifierConstants;
 import com.minecolonies.api.util.constant.TypeConstants;
@@ -144,11 +145,11 @@ public class GlobalResearchFactory implements IGlobalResearchFactory
             {
                 final ItemStack is = new ItemStack(ForgeRegistries.ITEMS.getValue(new ResourceLocation(costParts[0], costParts[1])));
                 is.setCount(Integer.parseInt(costParts[2]));
-                if (compound.hasUUID(TAG_COST_NBT))
+                if (compound.contains(TAG_COST_NBT))
                 {
                     is.setTag(compound.getCompound(TAG_COST_NBT));
                 }
-                research.addCost(new ItemStorage(is, false, !is.hasTag()));
+                research.addCost(new ItemStorage(is, false, !ItemStackUtils.hasTag(is)));
             }
         });
         NBTUtils.streamCompound(nbt.getList(TAG_REQS, Tag.TAG_COMPOUND)).


### PR DESCRIPTION
Closes [discord report](https://discord.com/channels/139070364159311872/1003402520846139533/1058659118208008192)
Closes #8857

# Changes proposed in this pull request:
- Fixes the research item cost checking so that it ignores NBT on items with damage bars as apparently intended.
    - This does increase the risk that it might steal your enchanted or otherwise NBT-carrying tools, but it does still check for 0/matching damage so it won't steal anything that isn't fully repaired, so most in-use tools should be safe.
    - This should fix an incompatibility with Apotheosis and Quark and similar mods that like adding extra NBT to otherwise ordinary tools.
 
Review please (could be backported)

I haven't tested this too thoroughly (including not with Apotheosis) but the changes seem reasonable and in line with previous implementation -- it wasn't previously working because tools that have a damage bar always have NBT even if the research cost didn't explicitly specify it.