### PR TITLE
Put food away before doing something else

### DIFF
--- a/src/main/java/com/minecolonies/coremod/entity/ai/citizen/herders/AbstractEntityAIHerder.java
+++ b/src/main/java/com/minecolonies/coremod/entity/ai/citizen/herders/AbstractEntityAIHerder.java
@@ -364,6 +364,7 @@ public abstract class AbstractEntityAIHerder<J extends AbstractJob<?, J>, B exte
 
         breedTwoAnimals(animalOne, animalTwo);
         worker.decreaseSaturationForContinuousAction();
+        worker.getCitizenItemHandler().removeHeldItem();
         return DECIDE;
     }
 
@@ -402,6 +403,7 @@ public abstract class AbstractEntityAIHerder<J extends AbstractJob<?, J>, B exte
             InventoryUtils.reduceStackInItemHandler(worker.getInventoryCitizen(), getBreedingItem());
             worker.getCitizenExperienceHandler().addExperience(XP_PER_ACTION);
             animalOne.playSound(SoundEvents.GENERIC_EAT, 1.0F, 1.0F);
+            worker.getCitizenItemHandler().removeHeldItem();
             return DECIDE;
         }
 


### PR DESCRIPTION
Closes #8882

# Changes proposed in this pull request:
- Herders will put the animal feed away after they breed or feed.
    - This makes the animals less likely to follow the worker if they decide to leave the pen.

Review please (could backport)

I haven't tested this, but it seems plausible.  (I did confirm that in the vanilla code, animals will indeed follow any entity holding their food item.)