### PR TITLE
Improve 8947

### DIFF
--- a/src/api/java/com/minecolonies/api/colony/requestsystem/requestable/IStackBasedTask.java
+++ b/src/api/java/com/minecolonies/api/colony/requestsystem/requestable/IStackBasedTask.java
@@ -1,0 +1,28 @@
+package com.minecolonies.api.colony.requestsystem.requestable;
+
+import net.minecraft.network.chat.MutableComponent;
+import net.minecraft.world.item.ItemStack;
+
+/**
+ * Stack based requests interface for display purposes.
+ */
+public interface IStackBasedTask
+{
+    /**
+     * Get the stack associated to the task.
+     * @return the stack.
+     */
+    ItemStack getTaskStack();
+
+    /**
+     * Get the request related count.
+     * @return the count.
+     */
+    int getDisplayCount();
+
+    /**
+     * Get a display prefix component.
+     * @return the component.
+     */
+    MutableComponent getDisplayPrefix();
+}

--- a/src/main/java/com/minecolonies/coremod/client/gui/modules/WindowHutCrafterTaskModule.java
+++ b/src/main/java/com/minecolonies/coremod/client/gui/modules/WindowHutCrafterTaskModule.java
@@ -1,19 +1,25 @@
 package com.minecolonies.coremod.client.gui.modules;
 
 import com.ldtteam.blockui.Pane;
+import com.ldtteam.blockui.PaneBuilders;
 import com.ldtteam.blockui.controls.Image;
+import com.ldtteam.blockui.controls.ItemIcon;
 import com.ldtteam.blockui.controls.Text;
 import com.ldtteam.blockui.views.ScrollingList;
 import com.minecolonies.api.colony.ICitizenDataView;
 import com.minecolonies.api.colony.buildings.views.IBuildingView;
 import com.minecolonies.api.colony.requestsystem.request.IRequest;
+import com.minecolonies.api.colony.requestsystem.request.RequestState;
+import com.minecolonies.api.colony.requestsystem.requestable.IStackBasedTask;
 import com.minecolonies.api.colony.requestsystem.requestable.deliveryman.IDeliverymanRequestable;
 import com.minecolonies.api.colony.requestsystem.token.IToken;
 import com.minecolonies.coremod.client.gui.AbstractModuleWindow;
 import com.minecolonies.coremod.colony.buildings.moduleviews.WorkerBuildingModuleView;
 import com.minecolonies.coremod.colony.jobs.views.CrafterJobView;
 import com.minecolonies.coremod.colony.jobs.views.DmanJobView;
+import net.minecraft.ChatFormatting;
 import net.minecraft.network.chat.Component;
+import net.minecraft.world.item.ItemStack;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.ArrayList;
@@ -21,6 +27,7 @@ import java.util.List;
 
 import static com.minecolonies.api.util.constant.TranslationConstants.COM_MINECOLONIES_COREMOD_ENTITY_DELIVERYMAN_PRIORITY;
 import static com.minecolonies.api.util.constant.WindowConstants.*;
+import static com.minecolonies.api.util.constant.translation.GuiTranslationConstants.LABEL_MAIN_TAB_NAME;
 
 /**
  * Task list module.
@@ -68,8 +75,7 @@ public class WindowHutCrafterTaskModule extends AbstractModuleWindow
             }
         }
 
-        final ScrollingList deliveryList = findPaneOfTypeByID(LIST_TASKS, ScrollingList.class);
-        deliveryList.setDataProvider(new ScrollingList.DataProvider()
+        findPaneOfTypeByID(LIST_TASKS, ScrollingList.class).setDataProvider(new ScrollingList.DataProvider()
         {
             @Override
             public int getElementCount()
@@ -83,23 +89,45 @@ public class WindowHutCrafterTaskModule extends AbstractModuleWindow
             {
                 final IRequest<?> request = buildingView.getColony().getRequestManager().getRequestForToken(tasks.get(index));
 
-                final IRequest<?> parent = buildingView.getColony().getRequestManager().getRequestForToken(request.getParent());
+                IRequest<?> parent = buildingView.getColony().getRequestManager().getRequestForToken(request.getParent());
 
-                if (parent != null)
+                while (parent != null && parent.getRequester().getLocation().equals(request.getRequester().getLocation()))
                 {
-                    rowPane.findPaneOfTypeByID(REQUESTER, Text.class)
-                      .setText(Component.literal(request.getRequester().getRequesterDisplayName(buildingView.getColony().getRequestManager(), request).getString() + " ->"));
-                    rowPane.findPaneOfTypeByID(PARENT, Text.class)
-                      .setText(parent.getRequester().getRequesterDisplayName(buildingView.getColony().getRequestManager(), parent));
+                    final IRequest<?> tempParent = buildingView.getColony().getRequestManager().getRequestForToken(parent.getParent());
+                    if (tempParent != null)
+                    {
+                        parent = tempParent;
+                    }
+                }
+
+                if (parent == null)
+                {
+                    rowPane.findPaneOfTypeByID(REQUESTER, Text.class).setText(request.getRequester().getRequesterDisplayName(buildingView.getColony().getRequestManager(), request));
                 }
                 else
                 {
                     rowPane.findPaneOfTypeByID(REQUESTER, Text.class)
-                      .setText(request.getRequester().getRequesterDisplayName(buildingView.getColony().getRequestManager(), request));
-                    rowPane.findPaneOfTypeByID(PARENT, Text.class).clearText();
+                      .setText(Component.literal(request.getRequester().getRequesterDisplayName(buildingView.getColony().getRequestManager(), request).getString() + " -> " + parent.getRequester().getRequesterDisplayName(buildingView.getColony().getRequestManager(), parent).getString()));
+                    PaneBuilders.tooltipBuilder().hoverPane(rowPane.findPaneOfTypeByID(REQUESTER, Text.class))
+                      .build().setText(Component.literal(request.getRequester().getLocation().getInDimensionLocation().toShortString() + " -> " + parent.getRequester().getLocation().getInDimensionLocation().toShortString()));
+
                 }
 
-                rowPane.findPaneOfTypeByID(REQUEST_SHORT_DETAIL, Text.class).setText(Component.literal(request.getShortDisplayString().getString().replace("§f", "")));
+                // Add an extra thing with an Interface about having a stack to display, if we have this, then also add a method for a shorter string.
+                if (request instanceof IStackBasedTask)
+                {
+                    final ItemIcon icon = rowPane.findPaneOfTypeByID("detailIcon", ItemIcon.class);
+                    final ItemStack copyStack = ((IStackBasedTask) request).getTaskStack().copy();
+                    copyStack.setCount(((IStackBasedTask) request).getDisplayCount());
+                    icon.setItem(copyStack);
+                    icon.setVisible(true);
+                    rowPane.findPaneOfTypeByID(REQUEST_SHORT_DETAIL, Text.class).setText(((IStackBasedTask) request).getDisplayPrefix().withStyle(request.getState() == RequestState.IN_PROGRESS ? ChatFormatting.DARK_GREEN : ChatFormatting.BLACK));
+                }
+                else
+                {
+                    rowPane.findPaneOfTypeByID("detailIcon", ItemIcon.class).setVisible(false);
+                    rowPane.findPaneOfTypeByID(REQUEST_SHORT_DETAIL, Text.class).setText(Component.literal(request.getShortDisplayString().getString().replace("§f", "")).withStyle(request.getState() == RequestState.IN_PROGRESS ? ChatFormatting.DARK_GREEN : ChatFormatting.BLACK));
+                }
 
                 if (request.getRequest() instanceof IDeliverymanRequestable)
                 {

--- a/src/main/java/com/minecolonies/coremod/colony/requestsystem/requests/StandardRequests.java
+++ b/src/main/java/com/minecolonies/coremod/colony/requestsystem/requests/StandardRequests.java
@@ -227,7 +227,7 @@ public final class StandardRequests
     /**
      * Generic delivery request.
      */
-    public static class DeliveryRequest extends AbstractRequest<Delivery>
+    public static class DeliveryRequest extends AbstractRequest<Delivery> implements IStackBasedTask
     {
         public DeliveryRequest(@NotNull final IRequester requester, @NotNull final IToken<?> token, @NotNull final RequestState state, @NotNull final Delivery requested)
         {
@@ -247,10 +247,10 @@ public final class StandardRequests
         @Override
         public Component getShortDisplayString()
         {
-            final MutableComponent result = Component.literal("");
-            result.append(Component.translatable(RequestSystemTranslationConstants.REQUESTS_TYPE_DELIVERY).append(Component.literal(
-              getRequest().getStack().getCount() + " ")).append(getRequest().getStack().getDisplayName()));
-            return result;
+            return Component.literal("")
+                     .append(Component.translatable(RequestSystemTranslationConstants.REQUESTS_TYPE_DELIVERY)
+                               .append(Component.literal(getRequest().getStack().getCount() + " "))
+                               .append(getRequest().getStack().getDisplayName()));
         }
 
         @NotNull
@@ -258,6 +258,24 @@ public final class StandardRequests
         public List<ItemStack> getDisplayStacks()
         {
             return ImmutableList.of();
+        }
+
+        @Override
+        public MutableComponent getDisplayPrefix()
+        {
+            return Component.translatable(RequestSystemTranslationConstants.REQUESTS_TYPE_DELIVERY);
+        }
+
+        @Override
+        public int getDisplayCount()
+        {
+            return getRequest().getStack().getCount();
+        }
+
+        @Override
+        public ItemStack getTaskStack()
+        {
+            return getRequest().getStack();
         }
 
         @Override
@@ -343,7 +361,7 @@ public final class StandardRequests
     /**
      * An abstract implementation for crafting requests
      */
-    public abstract static class AbstractCraftingRequest<C extends AbstractCrafting> extends AbstractRequest<C>
+    public abstract static class AbstractCraftingRequest<C extends AbstractCrafting> extends AbstractRequest<C> implements IStackBasedTask
     {
 
         protected AbstractCraftingRequest(@NotNull final IRequester requester, @NotNull final IToken<?> token, @NotNull final C requested)
@@ -365,6 +383,24 @@ public final class StandardRequests
         public final Component getShortDisplayString()
         {
             return Component.translatable(RequestSystemTranslationConstants.REQUEST_SYSTEM_CRAFTING_DISPLAY, Component.literal(String.valueOf(getRequest().getMinCount())), getRequest().getStack().getDisplayName());
+        }
+
+        @Override
+        public MutableComponent getDisplayPrefix()
+        {
+            return Component.translatable(RequestSystemTranslationConstants.REQUEST_SYSTEM_CRAFTING_DISPLAY, Component.literal(String.valueOf(getRequest().getMinCount())));
+        }
+
+        @Override
+        public int getDisplayCount()
+        {
+            return getRequest().getCount();
+        }
+
+        @Override
+        public ItemStack getTaskStack()
+        {
+            return getRequest().getStack();
         }
 
         protected abstract String getTranslationKey();

--- a/src/main/java/com/minecolonies/coremod/colony/requestsystem/resolvers/core/AbstractWarehouseRequestResolver.java
+++ b/src/main/java/com/minecolonies/coremod/colony/requestsystem/resolvers/core/AbstractWarehouseRequestResolver.java
@@ -250,9 +250,8 @@ public abstract class AbstractWarehouseRequestResolver extends AbstractRequestRe
                 final Delivery delivery =
                   new Delivery(itemStackLocation, completedRequest.getRequester().getLocation(), matchingStack, getDefaultDeliveryPriority(true));
 
-                final IToken<?> requestToken =
-                  manager.createRequest(manager.getFactoryController()
-                                          .getNewInstance(TypeToken.of(this.getClass()), completedRequest.getRequester().getLocation(), completedRequest.getId()), delivery);
+
+                final IToken<?> requestToken = manager.createRequest(this, delivery);
                 deliveries.add(manager.getRequestForToken(requestToken));
                 remainingCount -= count;
 

--- a/src/main/resources/assets/minecolonies/gui/layouthuts/layouttasklist.xml
+++ b/src/main/resources/assets/minecolonies/gui/layouthuts/layouttasklist.xml
@@ -4,13 +4,14 @@
            label="$(com.minecolonies.coremod.gui.workerhuts.crafter.tasks)"/>
 
     <list id="tasks" size="164 185" pos="13 29">
-        <box size="100% 43" linewidth="1">
+        <box size="100% 34" linewidth="1">
             <image id="deliveryImage" source="minecraft:textures/misc/shadow.png" size="16 16" pos="1 3"/>
 
             <label id="shortDetail" size="130 9" pos="20 2" color="black"/>
-            <label id="requester" size="130 9" pos="20 12" color="black"/>
-            <label id="parent" size="130 9" pos="20 22" color="black"/>
-            <label id="priority" size="130 9" pos="20 32" color="black"/>
+            <itemicon id="detailIcon" size="9 9" pos="80 1" color="black" visible="false"/>
+            <label id="priority" size="130 9" pos="20 12" color="black"/>
+
+            <label id="requester" size="130 9" pos="2 22" color="black"/>
         </box>
     </list>
 </window>


### PR DESCRIPTION
Closes #8947
Closes #
Closes #

# Changes proposed in this pull request:
- Improve the presentation of the task lists at courier/crafters
-> Display stacks as icons
-> Query the next parent in list and not just a parent resolver of the same building
- Also correctly assign the warehousereqresovler and not create a new one each time

Review please
