### PR TITLE
Add fallback for mods that hate server-side creative tabs

### DIFF
--- a/src/api/java/com/minecolonies/api/compatibility/CompatibilityManager.java
+++ b/src/api/java/com/minecolonies/api/compatibility/CompatibilityManager.java
@@ -583,7 +583,7 @@ public class CompatibilityManager implements ICompatibilityManager
     }
 
     /**
-     * Create complete list of all existing items, client side only.
+     * Create complete list of all existing items.
      */
     private void discoverAllItems()
     {
@@ -593,7 +593,15 @@ public class CompatibilityManager implements ICompatibilityManager
         for (final Item item : ForgeRegistries.ITEMS.getValues())
         {
             final NonNullList<ItemStack> list = NonNullList.create();
-            item.fillItemCategory(CreativeModeTab.TAB_SEARCH, list);
+            try
+            {
+                item.fillItemCategory(CreativeModeTab.TAB_SEARCH, list);
+            }
+            catch (Exception e)
+            {
+                Log.getLogger().warn("Error populating items for " + ForgeRegistries.ITEMS.getKey(item) + "; using fallback", e);
+                list.add(new ItemStack(item));
+            }
             listBuilder.addAll(list);
 
             for (final ItemStack stack : list)


### PR DESCRIPTION
Closes #9008

# Changes proposed in this pull request:
- Adds workaround for mods that don't implement `fillItemCategory` on server-side properly.  Ideally still needs to be fixed on their side though for proper functionality.

Review please (could backport)

I have not tested this with Create, but I expect that it will work around the issue (somewhat) until they fix it on their side.