### PR TITLE
Lumberjack zone is actually 3D

### DIFF
--- a/src/main/java/com/minecolonies/coremod/items/ItemScepterLumberjack.java
+++ b/src/main/java/com/minecolonies/coremod/items/ItemScepterLumberjack.java
@@ -79,28 +79,31 @@ public class ItemScepterLumberjack extends AbstractItemMinecolonies
 
     private void storeRestrictedArea(final Player player, final CompoundTag compound, final Level worldIn)
     {
-        final BlockPos startRestriction = BlockPosUtil.read(compound, NBT_START_POS).atY(worldIn.getMinBuildHeight());
-        final BlockPos endRestriction = BlockPosUtil.read(compound, NBT_END_POS).atY(worldIn.getMaxBuildHeight());
+        final BlockPos startRestriction = BlockPosUtil.read(compound, NBT_START_POS);
+        final BlockPos endRestriction = BlockPosUtil.read(compound, NBT_END_POS);
 
         // Check restricted area isn't too large
         final int minX = Math.min(startRestriction.getX(), endRestriction.getX());
+        final int minY = Math.min(startRestriction.getY(), endRestriction.getY());
         final int minZ = Math.min(startRestriction.getZ(), endRestriction.getZ());
         final int maxX = Math.max(startRestriction.getX(), endRestriction.getX());
+        final int maxY = Math.max(startRestriction.getY(), endRestriction.getY());
         final int maxZ = Math.max(startRestriction.getZ(), endRestriction.getZ());
 
         final int distX = maxX - minX;
+        final int distY = maxY - minY;
         final int distZ = maxZ - minZ;
 
-        final int area = distX * distZ;
-        final int maxArea = (int) Math.floor(2 * Math.pow(EntityAIWorkLumberjack.SEARCH_RANGE, 2));
+        final int volume = distX * distY * distZ;
+        final int maxVolume = (int) Math.floor(2 * Math.pow(EntityAIWorkLumberjack.SEARCH_RANGE, 3));
 
-        if (area > maxArea)
+        if (volume > maxVolume)
         {
-            MessageUtils.format(TOOL_LUMBERJACK_SCEPTER_AREA_TOO_BIG, area, maxArea).sendTo(player);
+            MessageUtils.format(TOOL_LUMBERJACK_SCEPTER_AREA_TOO_BIG, volume, maxVolume).sendTo(player);
             return;
         }
 
-        MessageUtils.format(TOOL_LUMBERJACK_SCEPTER_AREA_SET, minX, maxX, minZ, maxZ, area, maxArea).sendTo(player);
+        MessageUtils.format(TOOL_LUMBERJACK_SCEPTER_AREA_SET, minX, maxX, minY, maxY, minZ, maxZ, volume, maxVolume).sendTo(player);
         final IColony colony = IColonyManager.getInstance().getColonyByWorld(compound.getInt(TAG_ID), worldIn);
         final BlockPos hutPos = BlockPosUtil.read(compound, TAG_POS);
         final BuildingLumberjack hut = colony.getBuildingManager().getBuilding(hutPos, BuildingLumberjack.class);

--- a/src/main/java/com/minecolonies/coremod/items/ItemScepterLumberjack.java
+++ b/src/main/java/com/minecolonies/coremod/items/ItemScepterLumberjack.java
@@ -7,21 +7,19 @@ import com.minecolonies.api.util.MessageUtils;
 import com.minecolonies.api.util.constant.Constants;
 import com.minecolonies.coremod.colony.buildings.workerbuildings.BuildingLumberjack;
 import com.minecolonies.coremod.entity.ai.citizen.lumberjack.EntityAIWorkLumberjack;
-import net.minecraft.world.level.block.state.BlockState;
+import net.minecraft.core.BlockPos;
+import net.minecraft.nbt.CompoundTag;
+import net.minecraft.world.InteractionResult;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.context.UseOnContext;
-import net.minecraft.nbt.CompoundTag;
-import net.minecraft.world.InteractionResult;
-import net.minecraft.core.BlockPos;
 import net.minecraft.world.level.Level;
+import net.minecraft.world.level.block.state.BlockState;
 import org.jetbrains.annotations.NotNull;
 
 import static com.minecolonies.api.util.constant.NbtTagConstants.TAG_ID;
 import static com.minecolonies.api.util.constant.NbtTagConstants.TAG_POS;
 import static com.minecolonies.api.util.constant.translation.ToolTranslationConstants.*;
-
-import net.minecraft.world.item.Item.Properties;
 
 /**
  * Lumberjack Scepter Item class. Used to give tasks to Lumberjacks.
@@ -81,8 +79,8 @@ public class ItemScepterLumberjack extends AbstractItemMinecolonies
 
     private void storeRestrictedArea(final Player player, final CompoundTag compound, final Level worldIn)
     {
-        final BlockPos startRestriction = BlockPosUtil.read(compound, NBT_START_POS);
-        final BlockPos endRestriction = BlockPosUtil.read(compound, NBT_END_POS);
+        final BlockPos startRestriction = BlockPosUtil.read(compound, NBT_START_POS).atY(worldIn.getMinBuildHeight());
+        final BlockPos endRestriction = BlockPosUtil.read(compound, NBT_END_POS).atY(worldIn.getMaxBuildHeight());
 
         // Check restricted area isn't too large
         final int minX = Math.min(startRestriction.getX(), endRestriction.getX());

--- a/src/main/resources/assets/minecolonies/lang/manual_en_us.json
+++ b/src/main/resources/assets/minecolonies/lang/manual_en_us.json
@@ -73,8 +73,8 @@
   "item.minecolonies.scepterlumberjack": "Forest Tool",
   "item.minecolonies.scepterlumberjack.usedend": "Position A set. Select Position B with a right-click or left-click the same position to finish.",
   "item.minecolonies.scepterlumberjack.usedstart": "Position B set. Select Position A with a left-click or right-click the same position to finish.",
-  "item.minecolonies.scepterlumberjack.restrictiontoobig": "An area of %d blocks is too large. The maximum restricted area for the Forester is %d blocks.",
-  "item.minecolonies.scepterlumberjack.restrictionset": "Forester restricted area set (x: %d to %d, z: %d to %d, area: %d blocks). The max size is %d blocks.",
+  "item.minecolonies.scepterlumberjack.restrictiontoobig": "An volume of %d blocks is too large. The maximum restricted volume for the Forester is %d blocks.",
+  "item.minecolonies.scepterlumberjack.restrictionset": "Forester restricted volume set (x: %d to %d, y: %d to %d, z: %d to %d, volume: %d blocks). The max size is %d blocks.",
 
   "minecolonies.config.maxtreesize": "Max Tree Size",
   "minecolonies.config.maxtreesize.comment": "Max log count in one tree for the Forester to check during their tree search.",
@@ -1399,7 +1399,7 @@
   "com.minecolonies.coremod.info.miner.4": "As all workers do, Miners level up while working.\n At higher levels, the Miner's speed increases. The higher their hut level and Intelligence skill, the quicker they level up. \n However, their level is capped by the level of their home. Thus, if they are unhappy with their living conditions, they will stop leveling until you provide them with better housing.",
 
   "com.minecolonies.coremod.info.lumberjack.0.name": "Introduction",
-  "com.minecolonies.coremod.info.lumberjack.0": "The Forester is one of the production workers for your colony. Give them an axe and they'll cut down any trees around them. They'll also replant a sapling where the tree was if he has any.\n If you wish to apply restrictions on what trees they can or can't cut, take a look at the second page.\n Even cooler is the third page. Here you can tell the Forester to not replant saplings and tell them to be restricted to a certain area (selected with the tool given by the third button on the page).",
+  "com.minecolonies.coremod.info.lumberjack.0": "The Forester is one of the production workers for your colony. Give them an axe and they'll cut down any trees around them. They'll also replant a sapling where the tree was if he has any.\n If you wish to apply restrictions on what trees they can or can't cut, take a look at the second page.\n Even cooler is the third page. Here you can tell the Forester to not replant saplings and tell them to be restricted to a certain volume (selected with the tool given by the third button on the page).",
   "com.minecolonies.coremod.info.lumberjack.1.name": "Restrictions",
   "com.minecolonies.coremod.info.lumberjack.1": "Now let's cover restrictions:\n\n 1. Foresters unlock certain tool levels per their hut level:\n   lvl 0. Wood/Gold Tools\n   lvl 1. Stone Tools\n   lvl 2. Iron Tools\n   lvl 3. Diamond Tools\n   lvl 4-5. Enchanted Tools\n\n 2. Foresters are able to search for trees within 150 blocks of them (not their hut). While searching, they start with a 50 block range and then increase that range by 5 if they do not find a tree.",
   "com.minecolonies.coremod.info.lumberjack.2.name": "Tree Detection",
@@ -2000,7 +2000,7 @@
   "com.minecolonies.coremod.setting.minecolonies:replant": "Replanting:",
   "com.minecolonies.coremod.setting.minecolonies:restrict": "Zoning Mode:",
   "com.minecolonies.coremod.setting.minecolonies:defoliate": "Break Leaves:",
-  "com.minecolonies.coremod.gui.tooldesc.scepterlumberjack": "Restrict the Forester's working area by right-clicking one corner and left-clicking the opposite corner with the tool.",
+  "com.minecolonies.coremod.gui.tooldesc.scepterlumberjack": "Restrict the Forester's working volume by right-clicking one corner and left-clicking the opposite corner with the tool (allowing for height if needed).",
   "com.minecolonies.coremod.gui.tooldesc.scepterguard": "Right click positions to mark as guard or patrol points. Right-click the same position to close and discard.",
 
   "com.minecolonies.coremod.setting.minecolonies:fertilize": "Request Fertilizer",

--- a/src/main/resources/assets/minecolonies/lang/manual_en_us.json
+++ b/src/main/resources/assets/minecolonies/lang/manual_en_us.json
@@ -73,8 +73,8 @@
   "item.minecolonies.scepterlumberjack": "Forest Tool",
   "item.minecolonies.scepterlumberjack.usedend": "Position A set. Select Position B with a right-click or left-click the same position to finish.",
   "item.minecolonies.scepterlumberjack.usedstart": "Position B set. Select Position A with a left-click or right-click the same position to finish.",
-  "item.minecolonies.scepterlumberjack.restrictiontoobig": "A volume of %d blocks is too large. The maximum restricted volume for the Forester is %d blocks.",
-  "item.minecolonies.scepterlumberjack.restrictionset": "Forester restricted volume set (x: %d to %d, y: %d to %d, z: %d to %d, volume: %d blocks). The max size is %d blocks.",
+  "item.minecolonies.scepterlumberjack.restrictiontoobig": "A zone of %d blocks is too large. The maximum restricted volume for the Forester is %d blocks.",
+  "item.minecolonies.scepterlumberjack.restrictionset": "Forester restricted zone set (x: %d to %d, y: %d to %d, z: %d to %d, total: %d blocks). The max size is %d blocks.",
 
   "minecolonies.config.maxtreesize": "Max Tree Size",
   "minecolonies.config.maxtreesize.comment": "Max log count in one tree for the Forester to check during their tree search.",
@@ -1399,7 +1399,7 @@
   "com.minecolonies.coremod.info.miner.4": "As all workers do, Miners level up while working.\n At higher levels, the Miner's speed increases. The higher their hut level and Intelligence skill, the quicker they level up. \n However, their level is capped by the level of their home. Thus, if they are unhappy with their living conditions, they will stop leveling until you provide them with better housing.",
 
   "com.minecolonies.coremod.info.lumberjack.0.name": "Introduction",
-  "com.minecolonies.coremod.info.lumberjack.0": "The Forester is one of the production workers for your colony. Give them an axe and they'll cut down any trees around them. They'll also replant a sapling where the tree was if he has any.\n If you wish to apply restrictions on what trees they can or can't cut, take a look at the second page.\n Even cooler is the third page. Here you can tell the Forester to not replant saplings and tell them to be restricted to a certain volume (selected with the tool given by the third button on the page).",
+  "com.minecolonies.coremod.info.lumberjack.0": "The Forester is one of the production workers for your colony. Give them an axe and they'll cut down any trees around them. They'll also replant a sapling where the tree was if he has any.\n If you wish to apply restrictions on what trees they can or can't cut, take a look at the second page.\n Even cooler is the third page. Here you can tell the Forester to not replant saplings and tell them to be restricted to a certain 3D box (selected with the tool given by the third button on the page).",
   "com.minecolonies.coremod.info.lumberjack.1.name": "Restrictions",
   "com.minecolonies.coremod.info.lumberjack.1": "Now let's cover restrictions:\n\n 1. Foresters unlock certain tool levels per their hut level:\n   lvl 0. Wood/Gold Tools\n   lvl 1. Stone Tools\n   lvl 2. Iron Tools\n   lvl 3. Diamond Tools\n   lvl 4-5. Enchanted Tools\n\n 2. Foresters are able to search for trees within 150 blocks of them (not their hut). While searching, they start with a 50 block range and then increase that range by 5 if they do not find a tree.",
   "com.minecolonies.coremod.info.lumberjack.2.name": "Tree Detection",
@@ -2000,7 +2000,7 @@
   "com.minecolonies.coremod.setting.minecolonies:replant": "Replanting:",
   "com.minecolonies.coremod.setting.minecolonies:restrict": "Zoning Mode:",
   "com.minecolonies.coremod.setting.minecolonies:defoliate": "Break Leaves:",
-  "com.minecolonies.coremod.gui.tooldesc.scepterlumberjack": "Restrict the Forester's working volume by right-clicking one corner and left-clicking the opposite corner with the tool (allowing for height if needed).",
+  "com.minecolonies.coremod.gui.tooldesc.scepterlumberjack": "Restrict the Forester's working zone (in 3D) by right-clicking one corner and left-clicking the opposite corner with the tool (allowing for height).",
   "com.minecolonies.coremod.gui.tooldesc.scepterguard": "Right click positions to mark as guard or patrol points. Right-click the same position to close and discard.",
 
   "com.minecolonies.coremod.setting.minecolonies:fertilize": "Request Fertilizer",

--- a/src/main/resources/assets/minecolonies/lang/manual_en_us.json
+++ b/src/main/resources/assets/minecolonies/lang/manual_en_us.json
@@ -73,7 +73,7 @@
   "item.minecolonies.scepterlumberjack": "Forest Tool",
   "item.minecolonies.scepterlumberjack.usedend": "Position A set. Select Position B with a right-click or left-click the same position to finish.",
   "item.minecolonies.scepterlumberjack.usedstart": "Position B set. Select Position A with a left-click or right-click the same position to finish.",
-  "item.minecolonies.scepterlumberjack.restrictiontoobig": "An volume of %d blocks is too large. The maximum restricted volume for the Forester is %d blocks.",
+  "item.minecolonies.scepterlumberjack.restrictiontoobig": "A volume of %d blocks is too large. The maximum restricted volume for the Forester is %d blocks.",
   "item.minecolonies.scepterlumberjack.restrictionset": "Forester restricted volume set (x: %d to %d, y: %d to %d, z: %d to %d, volume: %d blocks). The max size is %d blocks.",
 
   "minecolonies.config.maxtreesize": "Max Tree Size",


### PR DESCRIPTION
# Changes proposed in this pull request:
- The lumberjack zone tool claims to be specifying a 2D area, but it was actually storing a 3D volume restriction.  This meant that unless the trunk base was at the same level (or possibly 1 above too?) as the clicked block, they would reject it and stay "searching for trees" forever.
    - ~~The zone area will have to be set again after this fix is applied to correct the Y matching.  If the lumberjack zone was already working before, it will continue to work.~~
    - This updates the messages to show that it is actually a 3D area.
      ![image](https://user-images.githubusercontent.com/539951/226161977-7d884080-603f-4617-b3b2-d04fd8eaba74.png)

Review please (could backport)
