### PR TITLE
Scepter overlays

### DIFF
--- a/src/api/java/com/minecolonies/api/items/IBlockOverlayItem.java
+++ b/src/api/java/com/minecolonies/api/items/IBlockOverlayItem.java
@@ -1,0 +1,31 @@
+package com.minecolonies.api.items;
+
+import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.level.Level;
+import net.minecraft.world.phys.AABB;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.List;
+
+/**
+ * An interface to be implemented by items that want to render overlays while the player is holding the item.
+ */
+public interface IBlockOverlayItem
+{
+    /**
+     * Called client-side only.
+     * @return a list of overlay boxes that should be rendered for this item.
+     */
+    @NotNull
+    List<OverlayBox> getOverlayBoxes(@NotNull final Level world, @NotNull final Player player, @NotNull final ItemStack stack);
+
+    /**
+     * Details about the overlay box to draw.
+     * @param bounds  the bounds of the box.
+     * @param color   the line color.
+     * @param width   the line width.
+     * @param clipped false to display through blocks.
+     */
+    record OverlayBox(AABB bounds, int color, float width, boolean clipped) { }
+}

--- a/src/api/java/com/minecolonies/api/items/IBlockOverlayItem.java
+++ b/src/api/java/com/minecolonies/api/items/IBlockOverlayItem.java
@@ -22,10 +22,10 @@ public interface IBlockOverlayItem
 
     /**
      * Details about the overlay box to draw.
-     * @param bounds  the bounds of the box.
-     * @param color   the line color.
-     * @param width   the line width.
-     * @param clipped false to display through blocks.
+     * @param bounds            the bounds of the box.
+     * @param color             the line color.
+     * @param width             the line width.
+     * @param showThroughBlocks true to display through blocks.
      */
-    record OverlayBox(AABB bounds, int color, float width, boolean clipped) { }
+    record OverlayBox(AABB bounds, int color, float width, boolean showThroughBlocks) { }
 }

--- a/src/main/java/com/minecolonies/apiimp/initializer/ModBuildingsInitializer.java
+++ b/src/main/java/com/minecolonies/apiimp/initializer/ModBuildingsInitializer.java
@@ -605,7 +605,7 @@ public final class ModBuildingsInitializer
         ModBuildings.beekeeper = DEFERRED_REGISTER.register(ModBuildings.BEEKEEPER_ID, () -> new BuildingEntry.Builder()
                                    .setBuildingBlock(ModBlocks.blockHutBeekeeper)
                                    .setBuildingProducer(BuildingBeekeeper::new)
-                                   .setBuildingViewProducer(() -> EmptyView::new)
+                                   .setBuildingViewProducer(() -> BuildingBeekeeper.View::new)
                                    .setRegistryName(new ResourceLocation(Constants.MOD_ID, ModBuildings.BEEKEEPER_ID))
                                    .addBuildingModuleProducer(MinimumStockModule::new, () -> MinimumStockModuleView::new)
                                    .addBuildingModuleProducer(() -> new WorkerBuildingModule(ModJobs.beekeeper.get(), Skill.Dexterity, Skill.Adaptability, false, (b) -> 1), () -> WorkerBuildingModuleView::new)

--- a/src/main/java/com/minecolonies/apiimp/initializer/ModBuildingsInitializer.java
+++ b/src/main/java/com/minecolonies/apiimp/initializer/ModBuildingsInitializer.java
@@ -286,7 +286,7 @@ public final class ModBuildingsInitializer
         ModBuildings.lumberjack = DEFERRED_REGISTER.register(ModBuildings.LUMBERJACK_ID, () -> new BuildingEntry.Builder()
                                     .setBuildingBlock(ModBlocks.blockHutLumberjack)
                                     .setBuildingProducer(BuildingLumberjack::new)
-                                    .setBuildingViewProducer(() -> EmptyView::new)
+                                    .setBuildingViewProducer(() -> BuildingLumberjack.View::new)
                                     .setRegistryName(new ResourceLocation(Constants.MOD_ID, ModBuildings.LUMBERJACK_ID))
                                     .addBuildingModuleProducer(() -> new BuildingLumberjack.CraftingModule(ModJobs.lumberjack.get()), () -> CraftingModuleView::new)
                                     .addBuildingModuleProducer(() -> new ItemListModule(SAPLINGS_LIST), () -> () -> new ItemListModuleView(SAPLINGS_LIST, RequestSystemTranslationConstants.REQUESTS_TYPE_SAPLINGS, true,

--- a/src/main/java/com/minecolonies/coremod/client/render/worldevent/ColonyBlueprintRenderer.java
+++ b/src/main/java/com/minecolonies/coremod/client/render/worldevent/ColonyBlueprintRenderer.java
@@ -7,7 +7,6 @@ import com.ldtteam.structurize.storage.rendering.RenderingCache;
 import com.ldtteam.structurize.storage.rendering.types.BlueprintPreviewData;
 import com.ldtteam.structurize.storage.rendering.types.BoxPreviewData;
 import com.ldtteam.structurize.util.PlacementSettings;
-import com.ldtteam.structurize.util.WorldRenderMacros;
 import com.minecolonies.api.MinecoloniesAPIProxy;
 import com.minecolonies.api.colony.buildings.ModBuildings;
 import com.minecolonies.api.colony.buildings.views.IBuildingView;
@@ -139,25 +138,22 @@ public class ColonyBlueprintRenderer
 
             if (buildingData.box().getPos1() != INVALID_POS)
             {
-                WorldRenderMacros.renderLineBox(ctx.bufferSource.getBuffer(WorldRenderMacros.LINES_WITH_WIDTH),
-                        ctx.poseStack,
-                        buildingData.box().getPos1(),
-                        buildingData.box().getPos2(),
-                        0,
-                        0,
-                        255,
-                        255,
-                        0.08f);
+                ColonyWorldRenderMacros.renderLineBox(ctx.poseStack, ctx.bufferSource,
+                        new AABB(buildingData.box().getPos1(), buildingData.box().getPos2().offset(1, 1, 1)),
+                        0.08f, 0xFF0000FF, false);
             }
 
             buildingData.box().getAnchor().ifPresent(pos ->
             {
                 if (ctx.clientPlayer.isShiftKeyDown())
                 {
-                    WorldRenderMacros.renderRedGlintLineBox(ctx.bufferSource, ctx.poseStack, pos, pos, 0.02f);
+                    ColonyWorldRenderMacros.renderLineBox(ctx.poseStack, ctx.bufferSource,
+                            new AABB(pos), 0.02f, 0xFFFF0000, true);
                 }
             });
         }
+
+        ColonyWorldRenderMacros.endRenderLineBox(ctx.bufferSource);
     }
 
     private static void rebuildCache(final WorldEventContext ctx, final List<IRenderBlueprintRule> rules)

--- a/src/main/java/com/minecolonies/coremod/client/render/worldevent/ColonyBlueprintRenderer.java
+++ b/src/main/java/com/minecolonies/coremod/client/render/worldevent/ColonyBlueprintRenderer.java
@@ -75,7 +75,7 @@ public class ColonyBlueprintRenderer
      *
      * @param ctx rendering context
      */
-    static void render(final WorldEventContext ctx)
+    static void renderBlueprints(final WorldEventContext ctx)
     {
         if (!ctx.hasNearestColony())
         {
@@ -122,6 +122,20 @@ public class ColonyBlueprintRenderer
             {
                 StructureClientHandler.renderStructureAtPos(buildingData.blueprint, ctx.partialTicks, position, ctx.poseStack);
             }
+        }
+    }
+
+    /**
+     * Renders boxes into the client.  Must be called after {@link #renderBlueprints}.
+     *
+     * @param ctx rendering context
+     */
+    static void renderBoxes(final WorldEventContext ctx)
+    {
+        for (final Map.Entry<BlockPos, RenderData> entry : blueprintCache.entrySet())
+        {
+            final RenderData buildingData = entry.getValue();
+            if (buildingData == null) { continue; }
 
             if (buildingData.box().getPos1() != INVALID_POS)
             {
@@ -140,7 +154,7 @@ public class ColonyBlueprintRenderer
             {
                 if (ctx.clientPlayer.isShiftKeyDown())
                 {
-                    WorldRenderMacros.renderRedGlintLineBox(WorldRenderMacros.getBufferSource(), ctx.poseStack, pos, pos, 0.02f);
+                    WorldRenderMacros.renderRedGlintLineBox(ctx.bufferSource, ctx.poseStack, pos, pos, 0.02f);
                 }
             });
         }

--- a/src/main/java/com/minecolonies/coremod/client/render/worldevent/ColonyWorldRenderMacros.java
+++ b/src/main/java/com/minecolonies/coremod/client/render/worldevent/ColonyWorldRenderMacros.java
@@ -1,0 +1,101 @@
+package com.minecolonies.coremod.client.render.worldevent;
+
+import com.ldtteam.structurize.util.WorldRenderMacros;
+import com.mojang.blaze3d.vertex.PoseStack;
+import com.mojang.blaze3d.vertex.VertexConsumer;
+import net.minecraft.client.renderer.MultiBufferSource;
+import net.minecraft.util.FastColor;
+import net.minecraft.world.phys.AABB;
+
+/**
+ * Extra {@link com.ldtteam.structurize.util.WorldRenderMacros}.  Maybe port it to Structurize at some point.
+ */
+public class ColonyWorldRenderMacros
+{
+    /**
+     * Render a wireframe box.
+     * @param poseStack         pose stack
+     * @param bufferSource      buffer source
+     * @param bounds            bounding box to draw
+     * @param width             line width
+     * @param color             line color (ARGB)
+     * @param showThroughBlocks true to render through existing blocks, false to only render in air
+     */
+    public static void renderLineBox(final PoseStack poseStack, final MultiBufferSource.BufferSource bufferSource,
+                                     final AABB bounds, final float width, final int color, final boolean showThroughBlocks)
+    {
+        final float halfLine = width / 2.0f;
+        final float minX = (float) (bounds.minX - halfLine);
+        final float minY = (float) (bounds.minY - halfLine);
+        final float minZ = (float) (bounds.minZ - halfLine);
+        final float minX2 = minX + width;
+        final float minY2 = minY + width;
+        final float minZ2 = minZ + width;
+
+        final float maxX = (float) (bounds.maxX + halfLine);
+        final float maxY = (float) (bounds.maxY + halfLine);
+        final float maxZ = (float) (bounds.maxZ + halfLine);
+        final float maxX2 = maxX - width;
+        final float maxY2 = maxY - width;
+        final float maxZ2 = maxZ - width;
+
+        final int red = FastColor.ARGB32.red(color);
+        final int green = FastColor.ARGB32.green(color);
+        final int blue = FastColor.ARGB32.blue(color);
+        final int alpha = FastColor.ARGB32.alpha(color);
+
+        renderLineBox(poseStack, bufferSource.getBuffer(RenderTypes.LINES_OUTSIDE_BLOCKS),
+                minX, minY, minZ, minX2, minY2, minZ2, maxX, maxY, maxZ, maxX2, maxY2, maxZ2,
+                red, green, blue, alpha);
+
+        if (showThroughBlocks)
+        {
+            renderLineBox(poseStack, bufferSource.getBuffer(RenderTypes.LINES_INSIDE_BLOCKS),
+                    minX, minY, minZ, minX2, minY2, minZ2, maxX, maxY, maxZ, maxX2, maxY2, maxZ2,
+                    red / 2, green / 2, blue / 2, alpha / 2);
+        }
+    }
+
+    /**
+     * Call after a series of {@link #renderLineBox(PoseStack, MultiBufferSource.BufferSource, AABB, float, int, boolean)}
+     * @param bufferSource buffer source
+     */
+    public static void endRenderLineBox(final MultiBufferSource.BufferSource bufferSource)
+    {
+        bufferSource.endBatch(RenderTypes.LINES_INSIDE_BLOCKS);
+        bufferSource.endBatch(RenderTypes.LINES_OUTSIDE_BLOCKS);
+    }
+
+    /**
+     * Render a wireframe box.
+     * @param poseStack pose stack
+     * @param buffer    buffer
+     * @param minX      min X
+     * @param minY      min Y
+     * @param minZ      min Z
+     * @param minX2     min X + width
+     * @param minY2     min Y + width
+     * @param minZ2     min Z + width
+     * @param maxX      max X
+     * @param maxY      max Y
+     * @param maxZ      max Z
+     * @param maxX2     max X - width
+     * @param maxY2     max Y - width
+     * @param maxZ2     max Z - width
+     * @param red       red
+     * @param green     green
+     * @param blue      blue
+     * @param alpha     alpha
+     */
+    private static void renderLineBox(final PoseStack poseStack, final VertexConsumer buffer,
+                                      final float minX, final float minY, final float minZ,
+                                      final float minX2, final float minY2, final float minZ2,
+                                      final float maxX, final float maxY, final float maxZ,
+                                      final float maxX2, final float maxY2, final float maxZ2,
+                                      final int red, final int green, final int blue, final int alpha)
+    {
+        buffer.defaultColor(red, green, blue, alpha);
+        WorldRenderMacros.populateRenderLineBox(minX, minY, minZ, minX2, minY2, minZ2, maxX, maxY, maxZ, maxX2, maxY2, maxZ2, poseStack.last().pose(), buffer);
+        buffer.unsetDefaultColor();
+    }
+}

--- a/src/main/java/com/minecolonies/coremod/client/render/worldevent/ColonyWorldRenderMacros.java
+++ b/src/main/java/com/minecolonies/coremod/client/render/worldevent/ColonyWorldRenderMacros.java
@@ -44,16 +44,16 @@ public class ColonyWorldRenderMacros
         final int blue = FastColor.ARGB32.blue(color);
         final int alpha = FastColor.ARGB32.alpha(color);
 
-        renderLineBox(poseStack, bufferSource.getBuffer(RenderTypes.LINES_OUTSIDE_BLOCKS),
-                minX, minY, minZ, minX2, minY2, minZ2, maxX, maxY, maxZ, maxX2, maxY2, maxZ2,
-                red, green, blue, alpha);
-
         if (showThroughBlocks)
         {
             renderLineBox(poseStack, bufferSource.getBuffer(RenderTypes.LINES_INSIDE_BLOCKS),
                     minX, minY, minZ, minX2, minY2, minZ2, maxX, maxY, maxZ, maxX2, maxY2, maxZ2,
                     red / 2, green / 2, blue / 2, alpha / 2);
         }
+
+        renderLineBox(poseStack, bufferSource.getBuffer(RenderTypes.LINES_OUTSIDE_BLOCKS),
+                minX, minY, minZ, minX2, minY2, minZ2, maxX, maxY, maxZ, maxX2, maxY2, maxZ2,
+                red, green, blue, alpha);
     }
 
     /**

--- a/src/main/java/com/minecolonies/coremod/client/render/worldevent/ItemOverlayBoxesRenderer.java
+++ b/src/main/java/com/minecolonies/coremod/client/render/worldevent/ItemOverlayBoxesRenderer.java
@@ -2,9 +2,8 @@ package com.minecolonies.coremod.client.render.worldevent;
 
 import com.ldtteam.structurize.util.WorldRenderMacros;
 import com.minecolonies.api.items.IBlockOverlayItem;
+import com.mojang.blaze3d.vertex.PoseStack;
 import com.mojang.blaze3d.vertex.VertexConsumer;
-import net.minecraft.client.renderer.RenderType;
-import net.minecraft.util.FastColor;
 
 import java.util.List;
 
@@ -26,28 +25,22 @@ public class ItemOverlayBoxesRenderer
 
             for (final IBlockOverlayItem.OverlayBox box : boxes)
             {
-                final RenderType renderType = box.clipped() ? WorldRenderMacros.LINES_WITH_WIDTH : WorldRenderMacros.GLINT_LINES_WITH_WIDTH;
-                final VertexConsumer buffer = ctx.bufferSource.getBuffer(renderType);
-
-                final float halfLine = box.width() / 2.0f;
-                final float minX = (float) (box.bounds().minX - halfLine);
-                final float minY = (float) (box.bounds().minY - halfLine);
-                final float minZ = (float) (box.bounds().minZ - halfLine);
-                final float minX2 = minX + box.width();
-                final float minY2 = minY + box.width();
-                final float minZ2 = minZ + box.width();
-
-                final float maxX = (float) (box.bounds().maxX + halfLine);
-                final float maxY = (float) (box.bounds().maxY + halfLine);
-                final float maxZ = (float) (box.bounds().maxZ + halfLine);
-                final float maxX2 = maxX - box.width();
-                final float maxY2 = maxY - box.width();
-                final float maxZ2 = maxZ - box.width();
-
-                buffer.defaultColor(FastColor.ARGB32.red(box.color()), FastColor.ARGB32.green(box.color()), FastColor.ARGB32.blue(box.color()), FastColor.ARGB32.alpha(box.color()));
-                WorldRenderMacros.populateRenderLineBox(minX, minY, minZ, minX2, minY2, minZ2, maxX, maxY, maxZ, maxX2, maxY2, maxZ2, ctx.poseStack.last().pose(), buffer);
-                buffer.unsetDefaultColor();
+                ColonyWorldRenderMacros.renderLineBox(ctx.poseStack, ctx.bufferSource, box.bounds(), box.width(), box.color(), box.showThroughBlocks());
             }
+
+            ColonyWorldRenderMacros.endRenderLineBox(ctx.bufferSource);
         }
+    }
+
+    private static void renderLineBox(final PoseStack poseStack, final VertexConsumer buffer,
+                                      final float minX, final float minY, final float minZ,
+                                      final float minX2, final float minY2, final float minZ2,
+                                      final float maxX, final float maxY, final float maxZ,
+                                      final float maxX2, final float maxY2, final float maxZ2,
+                                      final int red, final int green, final int blue, final int alpha)
+    {
+        buffer.defaultColor(red, green, blue, alpha);
+        WorldRenderMacros.populateRenderLineBox(minX, minY, minZ, minX2, minY2, minZ2, maxX, maxY, maxZ, maxX2, maxY2, maxZ2, poseStack.last().pose(), buffer);
+        buffer.unsetDefaultColor();
     }
 }

--- a/src/main/java/com/minecolonies/coremod/client/render/worldevent/ItemOverlayBoxesRenderer.java
+++ b/src/main/java/com/minecolonies/coremod/client/render/worldevent/ItemOverlayBoxesRenderer.java
@@ -1,0 +1,53 @@
+package com.minecolonies.coremod.client.render.worldevent;
+
+import com.ldtteam.structurize.util.WorldRenderMacros;
+import com.minecolonies.api.items.IBlockOverlayItem;
+import com.mojang.blaze3d.vertex.VertexConsumer;
+import net.minecraft.client.renderer.RenderType;
+import net.minecraft.util.FastColor;
+
+import java.util.List;
+
+/**
+ * Renders boxes for {@link com.minecolonies.api.items.IBlockOverlayItem}
+ */
+public class ItemOverlayBoxesRenderer
+{
+    /**
+     * Renders overlay boxes into the client.
+     *
+     * @param ctx rendering context
+     */
+    static void render(final WorldEventContext ctx)
+    {
+        if (ctx.mainHandItem.getItem() instanceof final IBlockOverlayItem overlayItem)
+        {
+            final List<IBlockOverlayItem.OverlayBox> boxes = overlayItem.getOverlayBoxes(ctx.clientLevel, ctx.clientPlayer, ctx.mainHandItem);
+
+            for (final IBlockOverlayItem.OverlayBox box : boxes)
+            {
+                final RenderType renderType = box.clipped() ? WorldRenderMacros.LINES_WITH_WIDTH : WorldRenderMacros.GLINT_LINES_WITH_WIDTH;
+                final VertexConsumer buffer = ctx.bufferSource.getBuffer(renderType);
+
+                final float halfLine = box.width() / 2.0f;
+                final float minX = (float) (box.bounds().minX - halfLine);
+                final float minY = (float) (box.bounds().minY - halfLine);
+                final float minZ = (float) (box.bounds().minZ - halfLine);
+                final float minX2 = minX + box.width();
+                final float minY2 = minY + box.width();
+                final float minZ2 = minZ + box.width();
+
+                final float maxX = (float) (box.bounds().maxX + halfLine);
+                final float maxY = (float) (box.bounds().maxY + halfLine);
+                final float maxZ = (float) (box.bounds().maxZ + halfLine);
+                final float maxX2 = maxX - box.width();
+                final float maxY2 = maxY - box.width();
+                final float maxZ2 = maxZ - box.width();
+
+                buffer.defaultColor(FastColor.ARGB32.red(box.color()), FastColor.ARGB32.green(box.color()), FastColor.ARGB32.blue(box.color()), FastColor.ARGB32.alpha(box.color()));
+                WorldRenderMacros.populateRenderLineBox(minX, minY, minZ, minX2, minY2, minZ2, maxX, maxY, maxZ, maxX2, maxY2, maxZ2, ctx.poseStack.last().pose(), buffer);
+                buffer.unsetDefaultColor();
+            }
+        }
+    }
+}

--- a/src/main/java/com/minecolonies/coremod/client/render/worldevent/RenderTypes.java
+++ b/src/main/java/com/minecolonies/coremod/client/render/worldevent/RenderTypes.java
@@ -1,14 +1,13 @@
 package com.minecolonies.coremod.client.render.worldevent;
 
-import com.mojang.blaze3d.systems.RenderSystem;
 import com.mojang.blaze3d.vertex.DefaultVertexFormat;
 import com.mojang.blaze3d.vertex.VertexFormat;
 import net.minecraft.Util;
 import net.minecraft.client.renderer.RenderStateShard;
-import net.minecraft.client.renderer.RenderStateShard.DepthTestStateShard;
 import net.minecraft.client.renderer.RenderType;
 import net.minecraft.resources.ResourceLocation;
 import org.lwjgl.opengl.GL11;
+
 import java.util.function.Function;
 
 public class RenderTypes
@@ -36,9 +35,7 @@ public class RenderTypes
 
     public static final class InnerRenderTypes extends RenderType
     {
-        private static final DepthTestStateShard ALWAYS_DEPTH_TEST = new AlwaysDepthTestStateShard();
-        private static final DepthTestStateShard LEQUAL_DEPTH_TEST = new DepthTestStateShard("depth_lequal", GL11.GL_LEQUAL);
-        private static final DepthTestStateShard GREATER_DEPTH_TEST = new DepthTestStateShard("depth_greater", GL11.GL_GREATER);
+        private static final DepthTestStateShard GREATER_DEPTH_TEST = new DepthTestStateShard(">", GL11.GL_GREATER);
 
         private InnerRenderTypes(final String nameIn,
             final VertexFormat formatIn,
@@ -64,7 +61,7 @@ public class RenderTypes
                     .setShaderState(POSITION_TEX_SHADER)
                     .setTextureState(new RenderStateShard.TextureStateShard(p_173202_, false, false))
                     .setTransparencyState(TRANSLUCENT_TRANSPARENCY)
-                    .setDepthTestState(ALWAYS_DEPTH_TEST)
+                    .setDepthTestState(NO_DEPTH_TEST)
                     .createCompositeState(false));
         });
 
@@ -108,17 +105,5 @@ public class RenderTypes
                         .setWriteMaskState(COLOR_WRITE)
                         .createCompositeState(false));
 
-    }
-
-    private static class AlwaysDepthTestStateShard extends DepthTestStateShard
-    {
-        private AlwaysDepthTestStateShard()
-        {
-            super("true_always", -1);
-            setupState = () -> {
-                RenderSystem.enableDepthTest();
-                RenderSystem.depthFunc(GL11.GL_ALWAYS);
-            };
-        }
     }
 }

--- a/src/main/java/com/minecolonies/coremod/client/render/worldevent/RenderTypes.java
+++ b/src/main/java/com/minecolonies/coremod/client/render/worldevent/RenderTypes.java
@@ -24,9 +24,21 @@ public class RenderTypes
         return InnerRenderTypes.WORLD_ENTITY_ICON.apply(resLoc);
     }
 
+    /**
+     * Used to draw overlay lines that only appear outside existing blocks.
+     */
+    public static RenderType LINES_OUTSIDE_BLOCKS = InnerRenderTypes.LINES_OUTSIDE_BLOCKS;
+
+    /**
+     * Used to draw overlay lines that only appear inside existing blocks.
+     */
+    public static RenderType LINES_INSIDE_BLOCKS = InnerRenderTypes.LINES_INSIDE_BLOCKS;
+
     public static final class InnerRenderTypes extends RenderType
     {
         private static final DepthTestStateShard ALWAYS_DEPTH_TEST = new AlwaysDepthTestStateShard();
+        private static final DepthTestStateShard LEQUAL_DEPTH_TEST = new DepthTestStateShard("depth_lequal", GL11.GL_LEQUAL);
+        private static final DepthTestStateShard GREATER_DEPTH_TEST = new DepthTestStateShard("depth_greater", GL11.GL_GREATER);
 
         private InnerRenderTypes(final String nameIn,
             final VertexFormat formatIn,
@@ -55,6 +67,47 @@ public class RenderTypes
                     .setDepthTestState(ALWAYS_DEPTH_TEST)
                     .createCompositeState(false));
         });
+
+        private static final RenderType LINES_OUTSIDE_BLOCKS = create("minecolonies:lines_outside_blocks",
+                DefaultVertexFormat.POSITION_COLOR,
+                VertexFormat.Mode.TRIANGLES,
+                1024,
+                false,
+                false,
+                RenderType.CompositeState.builder()
+                        .setTextureState(NO_TEXTURE)
+                        .setShaderState(POSITION_COLOR_SHADER)
+                        .setTransparencyState(TRANSLUCENT_TRANSPARENCY)
+                        .setDepthTestState(LEQUAL_DEPTH_TEST)
+                        .setCullState(CULL)
+                        .setLightmapState(NO_LIGHTMAP)
+                        .setOverlayState(NO_OVERLAY)
+                        .setLayeringState(NO_LAYERING)
+                        .setOutputState(MAIN_TARGET)
+                        .setTexturingState(DEFAULT_TEXTURING)
+                        .setWriteMaskState(COLOR_WRITE)
+                        .createCompositeState(false));
+
+        private static final RenderType LINES_INSIDE_BLOCKS = create("minecolonies:lines_inside_blocks",
+                DefaultVertexFormat.POSITION_COLOR,
+                VertexFormat.Mode.TRIANGLES,
+                1024,
+                false,
+                false,
+                RenderType.CompositeState.builder()
+                        .setTextureState(NO_TEXTURE)
+                        .setShaderState(POSITION_COLOR_SHADER)
+                        .setTransparencyState(TRANSLUCENT_TRANSPARENCY)
+                        .setDepthTestState(GREATER_DEPTH_TEST)
+                        .setCullState(CULL)
+                        .setLightmapState(NO_LIGHTMAP)
+                        .setOverlayState(NO_OVERLAY)
+                        .setLayeringState(NO_LAYERING)
+                        .setOutputState(MAIN_TARGET)
+                        .setTexturingState(DEFAULT_TEXTURING)
+                        .setWriteMaskState(COLOR_WRITE)
+                        .createCompositeState(false));
+
     }
 
     private static class AlwaysDepthTestStateShard extends DepthTestStateShard

--- a/src/main/java/com/minecolonies/coremod/client/render/worldevent/RenderTypes.java
+++ b/src/main/java/com/minecolonies/coremod/client/render/worldevent/RenderTypes.java
@@ -1,9 +1,11 @@
 package com.minecolonies.coremod.client.render.worldevent;
 
+import com.mojang.blaze3d.systems.RenderSystem;
 import com.mojang.blaze3d.vertex.DefaultVertexFormat;
 import com.mojang.blaze3d.vertex.VertexFormat;
 import net.minecraft.Util;
 import net.minecraft.client.renderer.RenderStateShard;
+import net.minecraft.client.renderer.RenderStateShard.DepthTestStateShard;
 import net.minecraft.client.renderer.RenderType;
 import net.minecraft.resources.ResourceLocation;
 import org.lwjgl.opengl.GL11;
@@ -35,6 +37,7 @@ public class RenderTypes
 
     public static final class InnerRenderTypes extends RenderType
     {
+        private static final DepthTestStateShard ALWAYS_DEPTH_TEST = new AlwaysDepthTestStateShard();
         private static final DepthTestStateShard GREATER_DEPTH_TEST = new DepthTestStateShard(">", GL11.GL_GREATER);
 
         private InnerRenderTypes(final String nameIn,
@@ -61,7 +64,7 @@ public class RenderTypes
                     .setShaderState(POSITION_TEX_SHADER)
                     .setTextureState(new RenderStateShard.TextureStateShard(p_173202_, false, false))
                     .setTransparencyState(TRANSLUCENT_TRANSPARENCY)
-                    .setDepthTestState(NO_DEPTH_TEST)
+                    .setDepthTestState(ALWAYS_DEPTH_TEST)
                     .createCompositeState(false));
         });
 
@@ -105,5 +108,17 @@ public class RenderTypes
                         .setWriteMaskState(COLOR_WRITE)
                         .createCompositeState(false));
 
+    }
+
+    private static class AlwaysDepthTestStateShard extends DepthTestStateShard
+    {
+        private AlwaysDepthTestStateShard()
+        {
+            super("true_always", -1);
+            setupState = () -> {
+                RenderSystem.enableDepthTest();
+                RenderSystem.depthFunc(GL11.GL_ALWAYS);
+            };
+        }
     }
 }

--- a/src/main/java/com/minecolonies/coremod/client/render/worldevent/WorldEventContext.java
+++ b/src/main/java/com/minecolonies/coremod/client/render/worldevent/WorldEventContext.java
@@ -70,6 +70,7 @@ public class WorldEventContext
         else if (event.getStage() == RenderLevelStageEvent.Stage.AFTER_TRIPWIRE_BLOCKS)
         {
             ColonyBlueprintRenderer.renderBoxes(this);
+            ItemOverlayBoxesRenderer.render(this);
             HighlightManager.render(this);
 
             bufferSource.endBatch();

--- a/src/main/java/com/minecolonies/coremod/client/render/worldevent/WorldEventContext.java
+++ b/src/main/java/com/minecolonies/coremod/client/render/worldevent/WorldEventContext.java
@@ -59,7 +59,7 @@ public class WorldEventContext
         if (event.getStage() == RenderLevelStageEvent.Stage.AFTER_CUTOUT_MIPPED_BLOCKS_BLOCKS)
         {
             ColonyBorderRenderer.render(this); // renders directly (not into bufferSource)
-            ColonyBlueprintRenderer.render(this);
+            ColonyBlueprintRenderer.renderBlueprints(this);
             ColonyWaypointRenderer.render(this);
             ColonyPatrolPointRenderer.render(this);
             GuardTowerRallyBannerRenderer.render(this);
@@ -67,9 +67,12 @@ public class WorldEventContext
 
             bufferSource.endBatch();
         }
-        else if (event.getStage() == RenderLevelStageEvent.Stage.AFTER_TRANSLUCENT_BLOCKS)
+        else if (event.getStage() == RenderLevelStageEvent.Stage.AFTER_TRIPWIRE_BLOCKS)
         {
+            ColonyBlueprintRenderer.renderBoxes(this);
             HighlightManager.render(this);
+
+            bufferSource.endBatch();
         }
 
         poseStack.popPose();

--- a/src/main/java/com/minecolonies/coremod/colony/buildings/workerbuildings/BuildingBeekeeper.java
+++ b/src/main/java/com/minecolonies/coremod/colony/buildings/workerbuildings/BuildingBeekeeper.java
@@ -1,6 +1,7 @@
 package com.minecolonies.coremod.colony.buildings.workerbuildings;
 
 import com.minecolonies.api.colony.IColony;
+import com.minecolonies.api.colony.IColonyView;
 import com.minecolonies.api.colony.buildings.modules.settings.ISettingKey;
 import com.minecolonies.api.colony.jobs.ModJobs;
 import com.minecolonies.api.compatibility.CompatibilityManager;
@@ -10,7 +11,7 @@ import com.minecolonies.coremod.colony.buildings.AbstractBuilding;
 import com.minecolonies.coremod.colony.buildings.modules.AnimalHerdingModule;
 import com.minecolonies.coremod.colony.buildings.modules.settings.BeekeeperCollectionSetting;
 import com.minecolonies.coremod.colony.buildings.modules.settings.SettingKey;
-import com.minecolonies.coremod.colony.buildings.modules.settings.StringSetting;
+import com.minecolonies.coremod.colony.buildings.views.AbstractBuildingView;
 import com.minecolonies.coremod.colony.crafting.LootTableAnalyzer;
 import net.minecraft.core.BlockPos;
 import net.minecraft.nbt.CompoundTag;
@@ -23,7 +24,6 @@ import net.minecraft.util.Tuple;
 import net.minecraft.world.entity.EntityType;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.Items;
-
 import org.jetbrains.annotations.NotNull;
 
 import java.util.*;
@@ -118,6 +118,12 @@ public class BuildingBeekeeper extends AbstractBuilding
     public void serializeToView(@NotNull final FriendlyByteBuf buf)
     {
         super.serializeToView(buf);
+
+        buf.writeVarInt(hives.size());
+        for (final BlockPos hive : hives)
+        {
+            buf.writeBlockPos(hive);
+        }
     }
 
     /**
@@ -168,6 +174,43 @@ public class BuildingBeekeeper extends AbstractBuilding
     public int getMaximumHives()
     {
         return (int) Math.pow(2, getBuildingLevel() - 1);
+    }
+
+    /**
+     * The client side representation of the building.
+     */
+    public static class View extends AbstractBuildingView
+    {
+        private Set<BlockPos> hives;
+
+        /**
+         * Instantiates the view of the building.
+         *
+         * @param c the colonyView.
+         * @param l the location of the block.
+         */
+        public View(final IColonyView c, final BlockPos l)
+        {
+            super(c, l);
+        }
+
+        @Override
+        public void deserialize(@NotNull FriendlyByteBuf buf)
+        {
+            super.deserialize(buf);
+
+            final int hiveCount = buf.readVarInt();
+            this.hives = new HashSet<>();
+            for (int i = 0; i < hiveCount; ++i)
+            {
+                this.hives.add(buf.readBlockPos());
+            }
+        }
+
+        public Set<BlockPos> getHives()
+        {
+            return Collections.unmodifiableSet(new HashSet<>(hives));
+        }
     }
 
     /**

--- a/src/main/java/com/minecolonies/coremod/colony/buildings/workerbuildings/BuildingLumberjack.java
+++ b/src/main/java/com/minecolonies/coremod/colony/buildings/workerbuildings/BuildingLumberjack.java
@@ -3,6 +3,7 @@ package com.minecolonies.coremod.colony.buildings.workerbuildings;
 import com.minecolonies.api.colony.ICitizenData;
 import com.minecolonies.api.colony.IColony;
 import com.minecolonies.api.colony.IColonyManager;
+import com.minecolonies.api.colony.IColonyView;
 import com.minecolonies.api.colony.buildings.modules.IItemListModule;
 import com.minecolonies.api.colony.buildings.modules.settings.ISettingKey;
 import com.minecolonies.api.colony.jobs.registry.JobEntry;
@@ -19,11 +20,13 @@ import com.minecolonies.coremod.colony.buildings.modules.WorkerBuildingModule;
 import com.minecolonies.coremod.colony.buildings.modules.settings.BoolSetting;
 import com.minecolonies.coremod.colony.buildings.modules.settings.DynamicTreesSetting;
 import com.minecolonies.coremod.colony.buildings.modules.settings.SettingKey;
+import com.minecolonies.coremod.colony.buildings.views.AbstractBuildingView;
 import net.minecraft.core.BlockPos;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.nbt.ListTag;
 import net.minecraft.nbt.NbtUtils;
 import net.minecraft.nbt.Tag;
+import net.minecraft.network.FriendlyByteBuf;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.server.level.ServerLevel;
 import net.minecraft.util.Tuple;
@@ -33,7 +36,6 @@ import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.Blocks;
 import net.minecraft.world.level.block.BonemealableBlock;
 import net.minecraft.world.level.block.state.BlockState;
-
 import org.jetbrains.annotations.NotNull;
 
 import java.util.*;
@@ -341,6 +343,62 @@ public class BuildingLumberjack extends AbstractBuilding
     {
         super.onColonyTick(colony);
         bonemealFungi();
+    }
+
+    @Override
+    public void serializeToView(@NotNull FriendlyByteBuf buf)
+    {
+        super.serializeToView(buf);
+
+        buf.writeBoolean(shouldRestrict());
+        buf.writeBlockPos(getStartRestriction());
+        buf.writeBlockPos(getEndRestriction());
+    }
+
+    /**
+     * The client side representation of the building.
+     */
+    public static class View extends AbstractBuildingView
+    {
+        private boolean restrict;
+        private BlockPos startRestriction;
+        private BlockPos endRestriction;
+
+        /**
+         * Instantiates the view of the building.
+         *
+         * @param c the colonyView.
+         * @param l the location of the block.
+         */
+        public View(final IColonyView c, final BlockPos l)
+        {
+            super(c, l);
+        }
+
+        @Override
+        public void deserialize(@NotNull FriendlyByteBuf buf)
+        {
+            super.deserialize(buf);
+
+            this.restrict = buf.readBoolean();
+            this.startRestriction = buf.readBlockPos();
+            this.endRestriction = buf.readBlockPos();
+        }
+
+        public boolean shouldRestrict()
+        {
+            return this.restrict;
+        }
+
+        public BlockPos getStartRestriction()
+        {
+            return this.startRestriction;
+        }
+
+        public BlockPos getEndRestriction()
+        {
+            return this.endRestriction;
+        }
     }
 
     public static class CraftingModule extends AbstractCraftingBuildingModule.Custom

--- a/src/main/java/com/minecolonies/coremod/items/ItemScepterBeekeeper.java
+++ b/src/main/java/com/minecolonies/coremod/items/ItemScepterBeekeeper.java
@@ -119,7 +119,7 @@ public class ItemScepterBeekeeper extends AbstractItemMinecolonies implements IB
 
             for (final BlockPos hive : hut.getHives())
             {
-                overlays.add(new OverlayBox(new AABB(hive), YELLOW_OVERLAY, 0.04f, false));
+                overlays.add(new OverlayBox(new AABB(hive), YELLOW_OVERLAY, 0.04f, true));
             }
 
             return overlays;

--- a/src/main/java/com/minecolonies/coremod/items/ItemScepterBeekeeper.java
+++ b/src/main/java/com/minecolonies/coremod/items/ItemScepterBeekeeper.java
@@ -2,34 +2,44 @@ package com.minecolonies.coremod.items;
 
 import com.minecolonies.api.colony.IColony;
 import com.minecolonies.api.colony.IColonyManager;
+import com.minecolonies.api.colony.IColonyView;
 import com.minecolonies.api.colony.buildings.IBuilding;
+import com.minecolonies.api.items.IBlockOverlayItem;
 import com.minecolonies.api.util.BlockPosUtil;
 import com.minecolonies.api.util.MessageUtils;
 import com.minecolonies.api.util.SoundUtils;
+import com.minecolonies.coremod.Network;
 import com.minecolonies.coremod.colony.buildings.workerbuildings.BuildingBeekeeper;
-import net.minecraft.world.level.block.BeehiveBlock;
-import net.minecraft.world.entity.player.Player;
+import com.minecolonies.coremod.network.messages.client.colony.ColonyViewBuildingViewMessage;
+import net.minecraft.core.BlockPos;
+import net.minecraft.nbt.CompoundTag;
 import net.minecraft.server.level.ServerPlayer;
+import net.minecraft.sounds.SoundEvents;
+import net.minecraft.world.InteractionResult;
+import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.context.UseOnContext;
-import net.minecraft.nbt.CompoundTag;
-import net.minecraft.world.InteractionResult;
-import net.minecraft.sounds.SoundEvents;
-import net.minecraft.core.BlockPos;
+import net.minecraft.world.level.Level;
+import net.minecraft.world.level.block.BeehiveBlock;
+import net.minecraft.world.phys.AABB;
+import org.jetbrains.annotations.NotNull;
 
+import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
 
 import static com.minecolonies.api.util.constant.NbtTagConstants.TAG_ID;
 import static com.minecolonies.api.util.constant.NbtTagConstants.TAG_POS;
 import static com.minecolonies.api.util.constant.translation.ToolTranslationConstants.*;
 
-import net.minecraft.world.item.Item.Properties;
-
 /**
  * Beekeeper Scepter Item class. Used to give tasks to Beekeeper.
  */
-public class ItemScepterBeekeeper extends AbstractItemMinecolonies
+public class ItemScepterBeekeeper extends AbstractItemMinecolonies implements IBlockOverlayItem
 {
+    private static final int YELLOW_OVERLAY = 0xFFFFFF00;
+
     /**
      * BeekeeperScepter constructor. Sets max stack to 1, like other tools.
      *
@@ -70,6 +80,7 @@ public class ItemScepterBeekeeper extends AbstractItemMinecolonies
                 MessageUtils.format(TOOL_BEEHIVE_SCEPTER_REMOVE_HIVE).sendTo(useContext.getPlayer());
                 building.removeHive(pos);
                 SoundUtils.playSoundForPlayer((ServerPlayer) player, SoundEvents.NOTE_BLOCK_BELL, (float) SoundUtils.VOLUME * 2, 0.5f);
+                Network.getNetwork().sendToPlayer(new ColonyViewBuildingViewMessage(building), (ServerPlayer) player);
             }
             else
             {
@@ -78,6 +89,7 @@ public class ItemScepterBeekeeper extends AbstractItemMinecolonies
                     MessageUtils.format(TOOL_BEEHIVE_SCEPTER_ADD_HIVE).sendTo(useContext.getPlayer());
                     building.addHive(pos);
                     SoundUtils.playSuccessSound(player, player.blockPosition());
+                    Network.getNetwork().sendToPlayer(new ColonyViewBuildingViewMessage(building), (ServerPlayer) player);
                 }
                 if (positions.size() >= building.getMaximumHives())
                 {
@@ -92,5 +104,27 @@ public class ItemScepterBeekeeper extends AbstractItemMinecolonies
         }
 
         return super.useOn(useContext);
+    }
+
+    @NotNull
+    @Override
+    public List<OverlayBox> getOverlayBoxes(@NotNull final Level world, @NotNull final Player player, @NotNull ItemStack stack)
+    {
+        final CompoundTag compound = stack.getOrCreateTag();
+        final IColonyView colony = IColonyManager.getInstance().getColonyView(compound.getInt(TAG_ID), world.dimension());
+
+        if (colony != null && colony.getBuilding(BlockPosUtil.read(compound, TAG_POS)) instanceof final BuildingBeekeeper.View hut)
+        {
+            final List<OverlayBox> overlays = new ArrayList<>();
+
+            for (final BlockPos hive : hut.getHives())
+            {
+                overlays.add(new OverlayBox(new AABB(hive), YELLOW_OVERLAY, 0.04f, false));
+            }
+
+            return overlays;
+        }
+
+        return Collections.emptyList();
     }
 }

--- a/src/main/java/com/minecolonies/coremod/items/ItemScepterLumberjack.java
+++ b/src/main/java/com/minecolonies/coremod/items/ItemScepterLumberjack.java
@@ -32,7 +32,7 @@ import static com.minecolonies.api.util.constant.translation.ToolTranslationCons
  */
 public class ItemScepterLumberjack extends AbstractItemMinecolonies implements IBlockOverlayItem
 {
-    private static final int GREEN_OVERLAY = 0xCC00FF00;
+    private static final int GREEN_OVERLAY = 0xFF00FF00;
     private static final String NBT_START_POS = Constants.MOD_ID + ":" + "start_pos";
     private static final String NBT_END_POS   = Constants.MOD_ID + ":" + "end_pos";
 

--- a/src/main/java/com/minecolonies/coremod/items/ItemScepterLumberjack.java
+++ b/src/main/java/com/minecolonies/coremod/items/ItemScepterLumberjack.java
@@ -9,14 +9,14 @@ import com.minecolonies.api.util.MessageUtils;
 import com.minecolonies.api.util.constant.Constants;
 import com.minecolonies.coremod.colony.buildings.workerbuildings.BuildingLumberjack;
 import com.minecolonies.coremod.entity.ai.citizen.lumberjack.EntityAIWorkLumberjack;
-import net.minecraft.world.level.block.state.BlockState;
+import net.minecraft.core.BlockPos;
+import net.minecraft.nbt.CompoundTag;
+import net.minecraft.world.InteractionResult;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.context.UseOnContext;
-import net.minecraft.nbt.CompoundTag;
-import net.minecraft.world.InteractionResult;
-import net.minecraft.core.BlockPos;
 import net.minecraft.world.level.Level;
+import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.phys.AABB;
 import org.jetbrains.annotations.NotNull;
 
@@ -26,8 +26,6 @@ import java.util.List;
 import static com.minecolonies.api.util.constant.NbtTagConstants.TAG_ID;
 import static com.minecolonies.api.util.constant.NbtTagConstants.TAG_POS;
 import static com.minecolonies.api.util.constant.translation.ToolTranslationConstants.*;
-
-import net.minecraft.world.item.Item.Properties;
 
 /**
  * Lumberjack Scepter Item class. Used to give tasks to Lumberjacks.
@@ -159,7 +157,7 @@ public class ItemScepterLumberjack extends AbstractItemMinecolonies implements I
             final AABB bounds = new AABB(startRestriction, endRestriction.offset(1, 1, 1)).inflate(1);
             // inflate(1) is due to implementation of BlockPosUtil.isInArea
 
-            return Collections.singletonList(new OverlayBox(bounds, GREEN_OVERLAY, 0.02f, false));
+            return Collections.singletonList(new OverlayBox(bounds, GREEN_OVERLAY, 0.02f, true));
         }
 
         return Collections.emptyList();


### PR DESCRIPTION
# Changes proposed in this pull request:
- Fixes some weirdness with box overlays drawing underneath grass.
    - ~~Doesn't fix them not drawing through blocks consistently, though.~~
- Adds overlay while holding the forester restriction tool, showing the zone (the base log of each tree must be inside the box).
    ![image](https://user-images.githubusercontent.com/539951/226564822-1b308d92-a7a5-4936-929a-8fa6a709f335.png)
- Adds overlay while holding the beekeeper hive tool, showing the assigned hives.
    ![image](https://user-images.githubusercontent.com/539951/226565120-c2f6cd25-ec8f-46b9-b386-bb8a24bc8877.png)

Review please (could backport)