### PR TITLE
Give the forester a second pass to hunt for saplings

### DIFF
--- a/src/api/java/com/minecolonies/api/entity/ai/statemachine/states/AIWorkerState.java
+++ b/src/api/java/com/minecolonies/api/entity/ai/statemachine/states/AIWorkerState.java
@@ -106,6 +106,10 @@ public enum AIWorkerState implements IAIState
      * There are no trees in his search range.
      */
     LUMBERJACK_NO_TREES_FOUND(true),
+    /**
+     * The Lumberjack is gathering saplings (second pass).
+     */
+    LUMBERJACK_GATHERING_2(true),
 
     /*
 ###Miner###

--- a/src/main/java/com/minecolonies/coremod/entity/ai/basic/AbstractEntityAIInteract.java
+++ b/src/main/java/com/minecolonies/coremod/entity/ai/basic/AbstractEntityAIInteract.java
@@ -16,8 +16,6 @@ import net.minecraft.world.item.enchantment.Enchantments;
 import net.minecraft.world.level.block.AirBlock;
 import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.Blocks;
-import net.minecraft.world.entity.item.ItemEntity;
-import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.phys.AABB;
 import org.jetbrains.annotations.NotNull;
@@ -348,16 +346,28 @@ public abstract class AbstractEntityAIInteract<J extends AbstractJob<?, J>, B ex
     /**
      * Search for all items around the worker. and store them in the items list.
      *
-     * @param boundingBox the area to search.
+     * @param boundingBox     the area to search.
      */
     public void searchForItems(final AABB boundingBox)
     {
         items = world.getEntitiesOfClass(ItemEntity.class, boundingBox)
                   .stream()
                   .filter(item -> item != null && item.isAlive() &&
-                                    (!item.getPersistentData().getAllKeys().contains("PreventRemoteMovement") || !item.getPersistentData().getBoolean("PreventRemoteMovement")))
+                                    (!item.getPersistentData().getAllKeys().contains("PreventRemoteMovement") || !item.getPersistentData().getBoolean("PreventRemoteMovement")) &&
+                          isItemWorthPickingUp(item.getItem()))
                   .map(BlockPosUtil::fromEntity)
                   .collect(Collectors.toList());
+    }
+
+    /**
+     * Check if an item is sufficiently interesting to want to go pick it up.  (This won't stop a
+     * worker picking up something else as they pass by, but it makes them not want to go over to it.)
+     * @param stack the stack to check.
+     * @return      true if the worker wants to go over to it.
+     */
+    protected boolean isItemWorthPickingUp(final ItemStack stack)
+    {
+        return true;
     }
 
     /**


### PR DESCRIPTION
# Changes proposed in this pull request:
- The forester will now hunt harder for saplings if they have nothing better to do.

Review please (could backport)

The previous behaviour was that the forester would chop and replant a tree, and wait a certain amount of time at the base of the tree for saplings and other drops.  Eventually they would give up on that and go back to their hut to drop things off, then return to one corner of their zone (or stay at the hut if no zone is set) and search for more trees.

Meanwhile, if they weren't set to break leaves, and there wasn't a fast decay mod installed, some leaves might not yet have decayed by the time they left.  So they'd be standing in the corner of their zone looking for trees, and then the leaves would decay and more saplings would drop.  Unless it was within range of wherever they happened to be standing, they'd completely ignore it until the next tree grew -- and with an unlucky random tick rate or a large zone, they might miss them entirely.

With this change, when they're standing in the corner waiting for more trees, they'll also periodically check the entire zone (not just near where they are) specifically for saplings (ignoring other drops).  If they find some, they'll go and collect them before going back to waiting for another tree.  If another sapling drops before the next tree grows, they'll go grab that too.

Behaviour is unchanged if not using a zone.  They won't go hunting down loose saplings in the entire colony.  (Unless that's your zone.  But don't do that.)