### PR TITLE
Hide Monster Encounter token

### DIFF
--- a/src/main/java/com/minecolonies/coremod/items/ItemAdventureToken.java
+++ b/src/main/java/com/minecolonies/coremod/items/ItemAdventureToken.java
@@ -1,13 +1,9 @@
 package com.minecolonies.coremod.items;
 
-import com.minecolonies.api.creativetab.ModCreativeTabs;
-import com.minecolonies.api.util.constant.TranslationConstants;
-
 import net.minecraft.ChatFormatting;
 import net.minecraft.network.chat.Component;
 import net.minecraft.network.chat.MutableComponent;
 import net.minecraft.network.chat.Style;
-import net.minecraft.network.chat.Component;
 import net.minecraft.world.entity.EntityType;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.TooltipFlag;
@@ -17,13 +13,9 @@ import org.jetbrains.annotations.Nullable;
 
 import java.util.List;
 
-import java.util.List;
-
 import static com.minecolonies.api.util.constant.NbtTagConstants.TAG_ENTITY_TYPE;
 import static com.minecolonies.api.util.constant.TranslationConstants.COM_MINECOLONIES_COREMOD_ADVENTURE_TOKEN_NAME_GUI;
 import static com.minecolonies.api.util.constant.TranslationConstants.COM_MINECOLONIES_COREMOD_ADVENTURE_TOKEN_TOOLTIP_GUI;
-
-import net.minecraft.world.item.Item.Properties;
 
 public class ItemAdventureToken extends AbstractItemMinecolonies
 {
@@ -33,7 +25,7 @@ public class ItemAdventureToken extends AbstractItemMinecolonies
      */
     public ItemAdventureToken(Properties properties)
     {
-        super("adventure_token", properties.tab(ModCreativeTabs.MINECOLONIES));
+        super("adventure_token", properties);
     }
 
     @Override


### PR DESCRIPTION
Closes [discord report](https://discord.com/channels/139070364159311872/1003402520846139533/1092304544312066058)

# Changes proposed in this pull request:
- Hides the Monster Encounter token from the creative menu and JEI.
     - There's no reason to spawn one, and it causes confusion when people see it (despite the tooltip).

Review please (could port)
