### PR TITLE
Don't allow kids to be born into explicitly manual housing.

### DIFF
--- a/src/api/java/com/minecolonies/api/colony/buildings/HiringMode.java
+++ b/src/api/java/com/minecolonies/api/colony/buildings/HiringMode.java
@@ -9,7 +9,8 @@ public enum HiringMode
 {
     DEFAULT(HIRING_MODE_DEFAULT),
     AUTO(HIRING_MODE_AUTOMATIC),
-    MANUAL(HIRING_MODE_MANUAL);
+    MANUAL(HIRING_MODE_MANUAL),
+    LOCKED(HIRING_MODE_LOCKED);
 
     private final String translationKey;
 

--- a/src/api/java/com/minecolonies/api/util/constant/TranslationConstants.java
+++ b/src/api/java/com/minecolonies/api/util/constant/TranslationConstants.java
@@ -442,6 +442,8 @@ public final class TranslationConstants
     @NonNls
     public static final String HIRING_MODE_MANUAL                                                   = "com.minecolonies.coremod.gui.hiringmode.manual";
     @NonNls
+    public static final String HIRING_MODE_LOCKED                                                   = "com.minecolonies.coremod.gui.hiringmode.locked";
+    @NonNls
     public static final String WARNING_SUPPLY_SHIP_IN_WATER                                         = "item.supplychestdeployer.invalid";
     @NonNls
     public static final String WARNING_SUPPLY_BUILDING_BAD_BLOCKS                                   = "item.supply.badblocks";

--- a/src/main/java/com/minecolonies/coremod/client/gui/WindowAssignCitizen.java
+++ b/src/main/java/com/minecolonies/coremod/client/gui/WindowAssignCitizen.java
@@ -292,7 +292,7 @@ public class WindowAssignCitizen extends AbstractWindowSkeleton implements Butto
                     currentLivingLabel.setText(Component.translatable("com.minecolonies.coremod.gui.home.liveshere"));
                 }
 
-                if ((colony.isManualHousing() || building.getHiringMode() == HiringMode.MANUAL)
+                if ((colony.isManualHousing() || building.getHiringMode() != HiringMode.DEFAULT)
                       && !(building.getHiringMode() == HiringMode.AUTO)
                       && (!assign || building.getResidents().size() < building.getMax()))
                 {

--- a/src/main/java/com/minecolonies/coremod/client/gui/WindowHireWorker.java
+++ b/src/main/java/com/minecolonies/coremod/client/gui/WindowHireWorker.java
@@ -5,7 +5,6 @@ import com.ldtteam.blockui.PaneBuilders;
 import com.ldtteam.blockui.controls.AbstractTextBuilder.TextBuilder;
 import com.ldtteam.blockui.controls.Button;
 import com.ldtteam.blockui.controls.Text;
-import com.ldtteam.blockui.controls.ToggleButton;
 import com.ldtteam.blockui.views.ScrollingList;
 import com.minecolonies.api.colony.ICitizenDataView;
 import com.minecolonies.api.colony.IColonyView;
@@ -22,12 +21,12 @@ import com.minecolonies.coremod.colony.buildings.moduleviews.WorkerBuildingModul
 import com.minecolonies.coremod.colony.buildings.views.AbstractBuildingView;
 import com.minecolonies.coremod.network.messages.server.colony.citizen.PauseCitizenMessage;
 import com.minecolonies.coremod.network.messages.server.colony.citizen.RestartCitizenMessage;
+import net.minecraft.ChatFormatting;
+import net.minecraft.core.BlockPos;
 import net.minecraft.network.chat.Component;
 import net.minecraft.network.chat.MutableComponent;
-import net.minecraft.util.Tuple;
-import net.minecraft.core.BlockPos;
 import net.minecraft.network.chat.Style;
-import net.minecraft.ChatFormatting;
+import net.minecraft.util.Tuple;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.*;
@@ -144,6 +143,7 @@ public class WindowHireWorker extends AbstractWindowSkeleton
     private void switchHiringMode(final Button settingsButton)
     {
         int index = selectedModule.getHiringMode().ordinal() + 1;
+        if (index == HiringMode.LOCKED.ordinal()) { ++index; }  // only homes can be locked, not workplaces
 
         if (index >= HiringMode.values().length)
         {

--- a/src/main/java/com/minecolonies/coremod/colony/managers/CitizenManager.java
+++ b/src/main/java/com/minecolonies/coremod/colony/managers/CitizenManager.java
@@ -411,7 +411,7 @@ public class CitizenManager implements ICitizenManager
                 else if (b.hasModule(LivingBuildingModule.class))
                 {
                     final LivingBuildingModule module = b.getFirstModuleOccurance(LivingBuildingModule.class);
-                    if (HiringMode.MANUAL.equals(module.getHiringMode()))
+                    if (HiringMode.LOCKED.equals(module.getHiringMode()))
                     {
                         newMaxCitizens += module.getAssignedCitizen().size();
                     }

--- a/src/main/java/com/minecolonies/coremod/colony/managers/CitizenManager.java
+++ b/src/main/java/com/minecolonies/coremod/colony/managers/CitizenManager.java
@@ -5,6 +5,7 @@ import com.minecolonies.api.colony.ICitizenData;
 import com.minecolonies.api.colony.ICitizenDataManager;
 import com.minecolonies.api.colony.ICivilianData;
 import com.minecolonies.api.colony.IColony;
+import com.minecolonies.api.colony.buildings.HiringMode;
 import com.minecolonies.api.colony.buildings.IBuilding;
 import com.minecolonies.api.colony.managers.interfaces.ICitizenManager;
 import com.minecolonies.api.entity.ModEntities;
@@ -409,11 +410,19 @@ public class CitizenManager implements ICitizenManager
                 }
                 else if (b.hasModule(LivingBuildingModule.class))
                 {
-                    newMaxCitizens += b.getFirstModuleOccurance(LivingBuildingModule.class).getModuleMax();
+                    final LivingBuildingModule module = b.getFirstModuleOccurance(LivingBuildingModule.class);
+                    if (HiringMode.MANUAL.equals(module.getHiringMode()))
+                    {
+                        newMaxCitizens += module.getAssignedCitizen().size();
+                    }
+                    else
+                    {
+                        newMaxCitizens += module.getModuleMax();
+                    }
                 }
             }
         }
-        if (getMaxCitizens() != newMaxCitizens)
+        if (getMaxCitizens() != newMaxCitizens || getPotentialMaxCitizens() != potentialMax + newMaxCitizens)
         {
             setMaxCitizens(newMaxCitizens);
             setPotentialMaxCitizens(potentialMax + newMaxCitizens);

--- a/src/main/java/com/minecolonies/coremod/colony/managers/RegisteredStructureManager.java
+++ b/src/main/java/com/minecolonies/coremod/colony/managers/RegisteredStructureManager.java
@@ -5,10 +5,7 @@ import com.google.common.collect.ImmutableMap;
 import com.minecolonies.api.colony.ICitizenData;
 import com.minecolonies.api.colony.IColony;
 import com.minecolonies.api.colony.IColonyTagCapability;
-import com.minecolonies.api.colony.buildings.IBuilding;
-import com.minecolonies.api.colony.buildings.IGuardBuilding;
-import com.minecolonies.api.colony.buildings.IMysticalSite;
-import com.minecolonies.api.colony.buildings.IRSComponent;
+import com.minecolonies.api.colony.buildings.*;
 import com.minecolonies.api.colony.buildings.registry.IBuildingDataManager;
 import com.minecolonies.api.colony.buildings.workerbuildings.ITownHall;
 import com.minecolonies.api.colony.buildings.workerbuildings.IWareHouse;
@@ -465,6 +462,10 @@ public class RegisteredStructureManager implements IRegisteredStructureManager
             if (building.hasModule(LivingBuildingModule.class))
             {
                 final LivingBuildingModule module = building.getFirstModuleOccurance(LivingBuildingModule.class);
+                if (HiringMode.MANUAL.equals(module.getHiringMode()))
+                {
+                    continue;
+                }
                 if (module.getAssignedCitizen().size() < module.getModuleMax())
                 {
                     return building;

--- a/src/main/java/com/minecolonies/coremod/colony/managers/RegisteredStructureManager.java
+++ b/src/main/java/com/minecolonies/coremod/colony/managers/RegisteredStructureManager.java
@@ -462,7 +462,7 @@ public class RegisteredStructureManager implements IRegisteredStructureManager
             if (building.hasModule(LivingBuildingModule.class))
             {
                 final LivingBuildingModule module = building.getFirstModuleOccurance(LivingBuildingModule.class);
-                if (HiringMode.MANUAL.equals(module.getHiringMode()))
+                if (HiringMode.LOCKED.equals(module.getHiringMode()))
                 {
                     continue;
                 }

--- a/src/main/java/com/minecolonies/coremod/network/messages/server/colony/building/worker/BuildingHiringModeMessage.java
+++ b/src/main/java/com/minecolonies/coremod/network/messages/server/colony/building/worker/BuildingHiringModeMessage.java
@@ -86,6 +86,7 @@ public class BuildingHiringModeMessage extends AbstractBuildingServerMessage<IBu
         if (isLivingBuildingModule)
         {
             building.getFirstModuleOccurance(LivingBuildingModule.class).setHiringMode(mode);
+            building.getColony().getCitizenManager().calculateMaxCitizens();
         }
         else
         {

--- a/src/main/resources/assets/minecolonies/lang/manual_en_us.json
+++ b/src/main/resources/assets/minecolonies/lang/manual_en_us.json
@@ -1087,6 +1087,7 @@
   "com.minecolonies.coremod.gui.hiringmode.default": "Default (colony override)",
   "com.minecolonies.coremod.gui.hiringmode.auto": "Automatic",
   "com.minecolonies.coremod.gui.hiringmode.manual": "Manual",
+  "com.minecolonies.coremod.gui.hiringmode.locked": "Locked (no kids)",
   "com.minecolonies.coremod.gui.name.toolong": "We reduced the string to \"%s\" since it exceeded the limit of 15 letters.",
 
   "block.minecolonies.decorationcontroller": "Decoration Controller",


### PR DESCRIPTION
Closes [discord report](https://discord.com/channels/139070364159311872/1003402520846139533/1092714238012817478)

# Changes proposed in this pull request:
- Adds a new Locked mode to residence/tavern, that otherwise mostly behaves like Manual.
- If a residence/tavern is set explicitly to ~~Manual~~ Locked, then kids won't be born into it, even if it has spare beds.
    - Kids will still be born if set to ~~Default~~ any other mode, regardless of whether the colony as a whole is set to Manual or Auto.

Review please (could port)

In particular, this allows you to deliberately leave some housing vacant, such as leaving a tavern empty once you have level 4/5 housing, or having a single-person house at the edge of your colony for the colonist with the funny smell... (without making them unhappy that they only have a level 1 house)