### PR TITLE
Fix datagen crash in addons

### DIFF
--- a/src/main/java/com/minecolonies/coremod/util/SchemFixerUtil.java
+++ b/src/main/java/com/minecolonies/coremod/util/SchemFixerUtil.java
@@ -27,6 +27,7 @@ public class SchemFixerUtil
     {
         String baseFolder = Paths.get("").toAbsolutePath().getParent().toString() + "/src/main/resources/assets/minecolonies/schematics";
         File baseFolderFile = new File(baseFolder);
+        if (!baseFolderFile.exists()) { return; }
         final List<File> files = Arrays.asList(baseFolderFile.listFiles());
         for (File subFolder :files)
         {


### PR DESCRIPTION
# Changes proposed in this pull request:
- Fix crash in runData from an addon

Review please (could backport)

The datagen events run for addons too, and this particular code crashes when that path doesn't exist -- which it likely won't for an addon.  Not sure if there's a better way to make it only run this code when actually building mcol, or if there might be some benefit in still running it for other mods.