### PR TITLE
Bump versions

### DIFF
--- a/.github/ISSUE_TEMPLATE/10-bug-report.yaml
+++ b/.github/ISSUE_TEMPLATE/10-bug-report.yaml
@@ -28,7 +28,7 @@ body:
     attributes:
       label: Minecraft Version
       description: Minecraft Version
-      options: [1.18, 1.19.2, 1.19.3]
+      options: [1.18, 1.19.2, 1.19.4]
     validations:
       required: true
   - type: input

--- a/gradle.properties
+++ b/gradle.properties
@@ -12,7 +12,7 @@ fml_range=[38,)
 forge_range=[41.1.0,)
 
 #The currently running forge.
-forgeVersion=43.1.2
+forgeVersion=43.1.47
 #The minimal needed forge, as marked in metadata and curseforge.
 forgeMinVersion=41.1.0
 
@@ -28,15 +28,15 @@ mappingsVersion=1.19.2
 
 dataGeneratorsVersion=0.1.48-ALPHA
 blockUI_version=1.19-0.0.64-ALPHA
-structurize_version=1.19.2-1.0.471-ALPHA
-domumOrnamentumVersion=1.19-1.0.58-ALPHA
+structurize_version=1.19.2-1.0.485-ALPHA
+domumOrnamentumVersion=1.19-1.0.76-ALPHA
 multiPistonVersion=1.19.2-1.2.21-ALPHA
 
 jei_mcversion=1.19
 jei_version=11.1.1.239
 jmapApiVersion=1.19-1.8-SNAPSHOT
-jmapMcVersion=1.19
-jmapVersion=5.8.5rc1-forge
+jmapMcVersion=1.19.2
+jmapVersion=5.9.4
 tinkersConstructVersion=3.5.0.17
 mantleVersion=1.9.20
 # some mods include the MC version as part of their "real" version number, others

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -59,7 +59,7 @@ dependencies {
 
     compileOnly fg.deobf("info.journeymap:journeymap-api:${project.jmapApiVersion}")
     if (project.hasProperty("runWithJourneymap") && project.runWithJourneymap.toBoolean()) {
-         runtimeOnly fg.deobf("flat:journeymap:${project.jmapMcVersion}-${project.jmapVersion}")
+         runtimeOnly fg.deobf("flat:journeymap:${project.jmapMcVersion}-${project.jmapVersion}-forge")
     }
     // replace "compileOnly" with "library" when you want to include it for testing
     // compileOnly fg.deobf("slimeknights.tconstruct:TConstruct:${project.exactMinecraftVersion}-${project.tinkersConstructVersion}")


### PR DESCRIPTION
# Changes proposed in this pull request:
- Bumps dependency/min versions.  Mostly so I don't keep losing my DO light blocks in my test world.
- Also fixes the GH bug template version.

Review please (do not port)