### PR TITLE
Quick fix for instant xp gain in library if worker has no paper/book …

### DIFF
--- a/src/main/java/com/minecolonies/coremod/entity/ai/citizen/student/EntityAIStudy.java
+++ b/src/main/java/com/minecolonies/coremod/entity/ai/citizen/student/EntityAIStudy.java
@@ -136,12 +136,15 @@ public class EntityAIStudy extends AbstractEntityAISkill<JobStudent, BuildingLib
                 final int bSlot = InventoryUtils.findFirstSlotInProviderWith(building, studyItem.getItem());
                 if (bSlot > -1)
                 {
+                    //Need to move this here. Since worker's previous position was a bookshelf, he'll always walk to the building and then return getState, never actually grabbing the item.
+                    //This causes him to loop back and forth getting the free xp on line 131 and never hitting the delay on 173
+                    takeItemStackFromProvider(building, bSlot); 
                     if (walkToBuilding())
                     {
                         setDelay(WALK_DELAY);
                         return getState();
                     }
-                    takeItemStackFromProvider(building, bSlot);
+                    
                 }
                 else
                 {


### PR DESCRIPTION
…in own inventory and paper/book exists in building

Observed some behavior that made me look at the Study AI. Essentially workers without studyItems where study items are present in the hut inventory go into a pacing behavior where they rapidly gain xp. 
The go to the bookshelf, get the xp, see that there are items to grab, go to the hut block then return out of the function before grabbing anything, and then go back to the bookshelf to start over getting xp on each trip.

I've added comments to the code to explain it a bit better.

Review please
