### PR TITLE
Enable quest translation

### DIFF
--- a/src/api/java/com/minecolonies/api/quests/IDialogueObjectiveTemplate.java
+++ b/src/api/java/com/minecolonies/api/quests/IDialogueObjectiveTemplate.java
@@ -34,7 +34,7 @@ public interface IDialogueObjectiveTemplate extends IQuestObjectiveTemplate
         /**
          * The text the participant says.
          */
-        private final String text;
+        private final Component text;
 
         /**
          * The player options.
@@ -46,7 +46,7 @@ public interface IDialogueObjectiveTemplate extends IQuestObjectiveTemplate
          * @param text the participant.
          * @param answers the player answers.
          */
-        public DialogueElement(final String text, final List<AnswerElement> answers)
+        public DialogueElement(final Component text, final List<AnswerElement> answers)
         {
             this.text = text;
             this.answers = answers;
@@ -59,7 +59,7 @@ public interface IDialogueObjectiveTemplate extends IQuestObjectiveTemplate
          */
         public static DialogueElement parse(final JsonObject jsonObject)
         {
-            final String text = jsonObject.get(TEXT_ID).getAsString();
+            final Component text = Component.translatable(jsonObject.get(TEXT_ID).getAsString());
             final List<AnswerElement> answerElementList = new ArrayList<>();
             for (final JsonElement answerOption : jsonObject.getAsJsonArray(OPTIONS_ID))
             {
@@ -72,7 +72,7 @@ public interface IDialogueObjectiveTemplate extends IQuestObjectiveTemplate
          * Getter for the element text.
          * @return the text.
          */
-        public String getText()
+        public Component getText()
         {
             return this.text;
         }
@@ -83,7 +83,7 @@ public interface IDialogueObjectiveTemplate extends IQuestObjectiveTemplate
          */
         public List<Component> getOptions()
         {
-            return answers.stream().map(answerElement -> Component.literal(answerElement.text)).collect(Collectors.toList());
+            return answers.stream().map(answerElement -> answerElement.text).collect(Collectors.toList());
         }
 
         /**
@@ -106,7 +106,7 @@ public interface IDialogueObjectiveTemplate extends IQuestObjectiveTemplate
         /**
          * The text the player displays.
          */
-        private final String text;
+        private final Component text;
 
         /**
          * The result from the player answer.
@@ -118,7 +118,7 @@ public interface IDialogueObjectiveTemplate extends IQuestObjectiveTemplate
          * @param text the text for the player.
          * @param answerResult the result from the choice.
          */
-        public AnswerElement(final String text, final IQuestDialogueAnswer answerResult)
+        public AnswerElement(final Component text, final IQuestDialogueAnswer answerResult)
         {
             this.text = text;
             this.answerResult = answerResult;
@@ -132,7 +132,7 @@ public interface IDialogueObjectiveTemplate extends IQuestObjectiveTemplate
         public static AnswerElement parse(final JsonObject jsonObject)
         {
             final JsonObject resultObj = jsonObject.getAsJsonObject(RESULT_ID);
-            return new AnswerElement(jsonObject.get(ANSWER_ID).getAsString(), IMinecoloniesAPI.getInstance().getQuestDialogueAnswerRegistry().getValue(new ResourceLocation(resultObj.get(TYPE_ID).getAsString())).produce(resultObj));
+            return new AnswerElement(Component.translatable(jsonObject.get(ANSWER_ID).getAsString()), IMinecoloniesAPI.getInstance().getQuestDialogueAnswerRegistry().getValue(new ResourceLocation(resultObj.get(TYPE_ID).getAsString())).produce(resultObj));
         }
     }
 }

--- a/src/api/java/com/minecolonies/api/quests/IQuestDeliveryObjective.java
+++ b/src/api/java/com/minecolonies/api/quests/IQuestDeliveryObjective.java
@@ -5,7 +5,7 @@ import net.minecraft.world.entity.player.Player;
 /**
  * Quest objective interface for deliveries.
  */
-public interface IQuestDeliveryObjective
+public interface IQuestDeliveryObjective extends IDialogueObjectiveTemplate
 {
     /**
      * Check if the objective is ready to move on.

--- a/src/api/java/com/minecolonies/api/quests/IQuestTemplate.java
+++ b/src/api/java/com/minecolonies/api/quests/IQuestTemplate.java
@@ -1,6 +1,7 @@
 package com.minecolonies.api.quests;
 
 import com.minecolonies.api.colony.IColony;
+import net.minecraft.network.chat.Component;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.entity.player.Player;
 
@@ -57,7 +58,7 @@ public interface IQuestTemplate
      * The name of the quest.
      * @return the name of the quest.
      */
-    String getName();
+    Component getName();
 
     /**
      * Get the list of parent quests.

--- a/src/main/java/com/minecolonies/coremod/colony/interactionhandling/QuestDeliveryInteraction.java
+++ b/src/main/java/com/minecolonies/coremod/colony/interactionhandling/QuestDeliveryInteraction.java
@@ -129,15 +129,15 @@ public class QuestDeliveryInteraction extends QuestDialogueInteraction
      */
     private void triggerResponseState(final Player player, final IQuestObjectiveTemplate objective)
     {
-        if (objective instanceof IQuestDeliveryObjective)
+        if (objective instanceof final IQuestDeliveryObjective delivery)
         {
-            if (((IQuestDeliveryObjective) objective).hasItem(player, colonyQuest))
+            if (delivery.hasItem(player, colonyQuest))
             {
-                currentElement = ((IQuestDeliveryObjective) objective).getReadyDialogueTree();
+                currentElement = delivery.getReadyDialogueTree();
             }
             else
             {
-                currentElement = ((IDialogueObjectiveTemplate) objective).getDialogueTree();
+                currentElement = delivery.getDialogueTree();
             }
         }
     }

--- a/src/main/java/com/minecolonies/coremod/colony/interactionhandling/QuestDialogueInteraction.java
+++ b/src/main/java/com/minecolonies/coremod/colony/interactionhandling/QuestDialogueInteraction.java
@@ -180,16 +180,17 @@ public class QuestDialogueInteraction extends StandardInteraction
     @Override
     public Component getInquiry()
     {
-        return Component.literal(processText(currentElement.getText()));
+        return processText(currentElement.getText());
     }
 
     /**
      * Process the text to include the participant names.
      * @return the processed text.
      */
-    private String processText(final String text)
+    private Component processText(final Component text)
     {
-        String localText = text;
+        // TODO: this is not ideal, we should do something more clever and preserve the item subcomponents for tooltips etc
+        String localText = text.getString();
         if (localText.contains("$"))
         {
             localText = localText.replace("$0", citizen.getColony().getCitizen(this.colonyQuest.getQuestGiverId()).getName());
@@ -203,7 +204,7 @@ public class QuestDialogueInteraction extends StandardInteraction
         {
             localText = localText.replace("%d", String.valueOf(colonyQuest.getCurrentObjectiveInstance().getMissingQuantity()));
         }
-        return localText;
+        return Component.literal(localText);
     }
 
     @Override
@@ -215,7 +216,7 @@ public class QuestDialogueInteraction extends StandardInteraction
     @Override
     public List<Component> getPossibleResponses()
     {
-        return currentElement == null ? Collections.emptyList() : currentElement.getOptions().stream().map(str -> Component.literal(processText(str.getString()))).collect(Collectors.toList());
+        return currentElement == null ? Collections.emptyList() : currentElement.getOptions().stream().map(this::processText).collect(Collectors.toList());
     }
 
     @Override

--- a/src/main/java/com/minecolonies/coremod/datalistener/QuestJsonListener.java
+++ b/src/main/java/com/minecolonies/coremod/datalistener/QuestJsonListener.java
@@ -15,6 +15,7 @@ import com.minecolonies.api.quests.IQuestTriggerTemplate;
 import com.minecolonies.api.quests.ITriggerReturnData;
 import io.netty.buffer.Unpooled;
 import net.minecraft.network.FriendlyByteBuf;
+import net.minecraft.network.chat.Component;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.server.packs.resources.ResourceManager;
@@ -178,7 +179,7 @@ public class QuestJsonListener extends SimpleJsonResourceReloadListener
             questTimeout = 10;
         }
 
-        final String questName = jsonObject.get(NAME).getAsString();
+        final Component questName = Component.translatable(jsonObject.get(NAME).getAsString());
 
         final List<IQuestRewardTemplate> questRewards = new ArrayList<>();
         for (final JsonElement objectivesJson : jsonObject.get(QUEST_REWARDS).getAsJsonArray())

--- a/src/main/java/com/minecolonies/coremod/network/messages/server/colony/InteractionResponse.java
+++ b/src/main/java/com/minecolonies/coremod/network/messages/server/colony/InteractionResponse.java
@@ -41,18 +41,18 @@ public class InteractionResponse extends AbstractColonyServerMessage
     /**
      * Trigger the server response handler.
      *
-     * @param colonyId  the colony id.
-     * @param citizenId the citizen id.
-     * @param dimension the dimension the colony and citizen are in.
-     * @param key       the key of the handler.
-     * @param response  the response to trigger.
+     * @param colonyId   the colony id.
+     * @param citizenId  the citizen id.
+     * @param dimension  the dimension the colony and citizen are in.
+     * @param key        the key of the handler.
+     * @param responseId the response to trigger.
      */
     public InteractionResponse(
       final int colonyId,
       final int citizenId,
       final ResourceKey<Level> dimension,
       @NotNull final Component key,
-      @NotNull final int responseId)
+      final int responseId)
     {
         super(dimension, colonyId);
         this.citizenId = citizenId;

--- a/src/main/java/com/minecolonies/coremod/quests/QuestTemplate.java
+++ b/src/main/java/com/minecolonies/coremod/quests/QuestTemplate.java
@@ -3,6 +3,7 @@ package com.minecolonies.coremod.quests;
 import com.minecolonies.api.colony.IColony;
 import com.minecolonies.api.quests.*;
 import com.minecolonies.api.quests.IQuestTemplate;
+import net.minecraft.network.chat.Component;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.entity.player.Player;
 
@@ -36,7 +37,7 @@ public class QuestTemplate implements IQuestTemplate
 
     private final int maxOccurrence;
 
-    private final String name;
+    private final Component name;
 
     /**
      * How long the quest stays active/available.
@@ -54,7 +55,7 @@ public class QuestTemplate implements IQuestTemplate
      * @param questTimeout the time until it times out.
      * @param questRewards its rewards
      */
-    public QuestTemplate(final ResourceLocation questID, final String name,
+    public QuestTemplate(final ResourceLocation questID, final Component name,
       final List<ResourceLocation> parents,
       final int maxOccurrence, final Function<IColony, List<ITriggerReturnData>> questTriggerList, final List<IQuestObjectiveTemplate> questObjectives, final int questTimeout, final List<IQuestRewardTemplate> questRewards)
     {
@@ -114,7 +115,7 @@ public class QuestTemplate implements IQuestTemplate
     }
 
     @Override
-    public String getName()
+    public Component getName()
     {
         return this.name;
     }

--- a/src/main/java/com/minecolonies/coremod/quests/objectives/BreakBlockObjectiveTemplate.java
+++ b/src/main/java/com/minecolonies/coremod/quests/objectives/BreakBlockObjectiveTemplate.java
@@ -1,23 +1,25 @@
 package com.minecolonies.coremod.quests.objectives;
 
 import com.google.gson.JsonObject;
+import com.minecolonies.api.quests.IObjectiveInstance;
 import com.minecolonies.api.quests.IQuestDialogueAnswer;
 import com.minecolonies.api.quests.IQuestInstance;
-import com.minecolonies.api.quests.IObjectiveInstance;
 import com.minecolonies.api.quests.IQuestObjectiveTemplate;
 import com.minecolonies.coremod.colony.Colony;
 import com.minecolonies.coremod.event.QuestObjectiveEventHandler;
 import net.minecraft.nbt.CompoundTag;
+import net.minecraft.network.chat.Component;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.level.block.Block;
 import net.minecraftforge.registries.ForgeRegistries;
+import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.List;
 
-import static com.minecolonies.api.util.constant.NbtTagConstants.TAG_QUANTITY;
 import static com.minecolonies.api.quests.QuestParseConstant.*;
+import static com.minecolonies.api.util.constant.NbtTagConstants.TAG_QUANTITY;
 
 /**
  * Objective type tracking block mining.
@@ -49,11 +51,21 @@ public class BreakBlockObjectiveTemplate extends DialogueObjectiveTemplateTempla
      */
     public BreakBlockObjectiveTemplate(final int target, final int blocksToMine, final Block blockToMine, final int nextObjective, final List<Integer> rewards)
     {
-        super(target, new DialogueElement("I am still waiting for you to mine %d " + blockToMine.getName().getString() + " !",
-          List.of(new AnswerElement("Sorry, be right back!", new IQuestDialogueAnswer.CloseUIDialogueAnswer()), new AnswerElement("I don't have time for this!", new IQuestDialogueAnswer.QuestCancellationDialogueAnswer()))), rewards);
+        super(target, buildDialogueTree(blockToMine), rewards);
         this.blocksToMine = blocksToMine;
         this.nextObjective = nextObjective;
         this.blockToMine = blockToMine;
+    }
+
+    @NotNull
+    private static DialogueElement buildDialogueTree(final Block blockToMine)
+    {
+        final Component text = Component.translatable("com.minecolonies.coremod.questobjectives.breakblock", blockToMine.getName());
+        final AnswerElement answer1 = new AnswerElement(Component.translatable("com.minecolonies.coremod.questobjectives.answer.later"),
+                new IQuestDialogueAnswer.CloseUIDialogueAnswer());
+        final AnswerElement answer2 = new AnswerElement(Component.translatable("com.minecolonies.coremod.questobjectives.answer.cancel"),
+                new IQuestDialogueAnswer.QuestCancellationDialogueAnswer());
+        return new DialogueElement(text, List.of(answer1, answer2));
     }
 
     /**

--- a/src/main/java/com/minecolonies/coremod/quests/objectives/DeliveryObjectiveTemplateTemplate.java
+++ b/src/main/java/com/minecolonies/coremod/quests/objectives/DeliveryObjectiveTemplateTemplate.java
@@ -8,6 +8,7 @@ import com.minecolonies.api.util.ItemStackUtils;
 import com.minecolonies.api.util.Log;
 import com.mojang.brigadier.exceptions.CommandSyntaxException;
 import net.minecraft.nbt.TagParser;
+import net.minecraft.network.chat.Component;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.util.GsonHelper;
 import net.minecraft.world.entity.player.Player;
@@ -70,11 +71,19 @@ public class DeliveryObjectiveTemplateTemplate extends DialogueObjectiveTemplate
 
     private void buildDialogueTrees()
     {
-        this.readyDialogueElement = new DialogueElement("Oh hey, you brought " + item.getDisplayName().getString() + " can I have it?",
-          List.of(new AnswerElement("Yes, here you are!", new IQuestDialogueAnswer.NextObjectiveDialogueAnswer(this.nextObjective)), new AnswerElement("No, wait!", new IQuestDialogueAnswer.CloseUIDialogueAnswer())));
+        final Component ready = Component.translatable("com.minecolonies.coremod.questobjectives.delivery.ready", item.getDisplayName());
+        final AnswerElement ready1 = new AnswerElement(Component.translatable("com.minecolonies.coremod.questobjectives.delivery.ready.give"),
+                new IQuestDialogueAnswer.NextObjectiveDialogueAnswer(this.nextObjective));
+        final AnswerElement ready2 = new AnswerElement(Component.translatable("com.minecolonies.coremod.questobjectives.delivery.ready.later"),
+                new IQuestDialogueAnswer.CloseUIDialogueAnswer());
+        this.readyDialogueElement = new DialogueElement(ready, List.of(ready1, ready2));
 
-        this.waitingDialogueElement = new DialogueElement("I am still waiting for " + item.getDisplayName().getString() + " !",
-          List.of(new AnswerElement("Sorry, be right back!", new IQuestDialogueAnswer.CloseUIDialogueAnswer()), new AnswerElement("I don't have any of it!", new IQuestDialogueAnswer.QuestCancellationDialogueAnswer())));
+        final Component waiting = Component.translatable("com.minecolonies.coremod.questobjectives.delivery.waiting", item.getDisplayName());
+        final AnswerElement waiting1 = new AnswerElement(Component.translatable("com.minecolonies.coremod.questobjectives.answer.later"),
+                new IQuestDialogueAnswer.CloseUIDialogueAnswer());
+        final AnswerElement waiting2 = new AnswerElement(Component.translatable("com.minecolonies.coremod.questobjectives.delivery.waiting.cancel"),
+                new IQuestDialogueAnswer.QuestCancellationDialogueAnswer());
+        this.waitingDialogueElement = new DialogueElement(waiting, List.of(waiting1, waiting2));
     }
 
     /**

--- a/src/main/java/com/minecolonies/coremod/quests/objectives/KillEntityObjectiveTemplateTemplate.java
+++ b/src/main/java/com/minecolonies/coremod/quests/objectives/KillEntityObjectiveTemplateTemplate.java
@@ -1,23 +1,25 @@
 package com.minecolonies.coremod.quests.objectives;
 
 import com.google.gson.JsonObject;
+import com.minecolonies.api.quests.IObjectiveInstance;
 import com.minecolonies.api.quests.IQuestDialogueAnswer;
 import com.minecolonies.api.quests.IQuestInstance;
-import com.minecolonies.api.quests.IObjectiveInstance;
 import com.minecolonies.api.quests.IQuestObjectiveTemplate;
 import com.minecolonies.coremod.colony.Colony;
 import com.minecolonies.coremod.event.QuestObjectiveEventHandler;
 import net.minecraft.nbt.CompoundTag;
+import net.minecraft.network.chat.Component;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.entity.EntityType;
 import net.minecraft.world.entity.player.Player;
 import net.minecraftforge.registries.ForgeRegistries;
+import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.List;
 
-import static com.minecolonies.api.util.constant.NbtTagConstants.TAG_QUANTITY;
 import static com.minecolonies.api.quests.QuestParseConstant.*;
+import static com.minecolonies.api.util.constant.NbtTagConstants.TAG_QUANTITY;
 
 /**
  * Objective type entity killing mining.
@@ -47,11 +49,21 @@ public class KillEntityObjectiveTemplateTemplate extends DialogueObjectiveTempla
      */
     public KillEntityObjectiveTemplateTemplate(final int target, final int entitiesToKill, final EntityType<?> entityToKill, final int nextObjective, final List<Integer> rewards)
     {
-        super(target, new DialogueElement("I am still waiting for you to kill %d " + entityToKill.getDescription().getString() + " !",
-          List.of(new AnswerElement("Sorry, be right back!", new IQuestDialogueAnswer.CloseUIDialogueAnswer()), new AnswerElement("I don't have time for this!", new IQuestDialogueAnswer.QuestCancellationDialogueAnswer()))), rewards);
+        super(target, buildDialogueTree(entityToKill), rewards);
         this.entitiesToKill = entitiesToKill;
         this.nextObjective = nextObjective;
         this.entityToKill = entityToKill;
+    }
+
+    @NotNull
+    private static DialogueElement buildDialogueTree(final EntityType<?> entityToKill)
+    {
+        final Component text = Component.translatable("com.minecolonies.coremod.questobjectives.kill", entityToKill.getDescription());
+        final AnswerElement answer1 = new AnswerElement(Component.translatable("com.minecolonies.coremod.questobjectives.answer.later"),
+                new IQuestDialogueAnswer.CloseUIDialogueAnswer());
+        final AnswerElement answer2 = new AnswerElement(Component.translatable("com.minecolonies.coremod.questobjectives.answer.cancel"),
+                new IQuestDialogueAnswer.QuestCancellationDialogueAnswer());
+        return new DialogueElement(text, List.of(answer1, answer2));
     }
 
     /**

--- a/src/main/resources/assets/minecolonies/lang/manual_en_us.json
+++ b/src/main/resources/assets/minecolonies/lang/manual_en_us.json
@@ -2384,5 +2384,15 @@
   "com.minecolonies.coremod.gui.townHall.map": "Town Map",
   "com.minecolonies.coremod.townhall.map.warning": "Drop-off a normal scale Minecraft map in the Town Hall inventory first to unlock the map.",
   "com.minecolonies.gui.edit": "Edit",
-  "com.minecolonies.gui.details": "More Details..."
+  "com.minecolonies.gui.details": "More Details...",
+
+  "com.minecolonies.coremod.questobjectives.answer.later": "Sorry, be right back!",
+  "com.minecolonies.coremod.questobjectives.answer.cancel": "I don't have time for this!",
+  "com.minecolonies.coremod.questobjectives.breakblock": "I am still waiting for you to mine %%d %s!",
+  "com.minecolonies.coremod.questobjectives.delivery.waiting": "I am still waiting for %s!",
+  "com.minecolonies.coremod.questobjectives.delivery.waiting.cancel": "I don't have any of it!",
+  "com.minecolonies.coremod.questobjectives.delivery.ready": "Oh hey, you brought %s; can I have it?",
+  "com.minecolonies.coremod.questobjectives.delivery.ready.give": "Yes, here you are!",
+  "com.minecolonies.coremod.questobjectives.delivery.ready.later": "No, wait!",
+  "com.minecolonies.coremod.questobjectives.kill": "I am still waiting for you to kill %%d %s!"
 }


### PR DESCRIPTION
Relates to #9080 (doesn't solve it yet)

# Changes proposed in this pull request:
- Allows quests to use translated text.
    - Does not (yet) actually add translation keys to the default quests.
- Does make the hard-coded quest objective dialogues translatable.

Review please (could port)

For my next trick, I'm thinking about making a datagen somewhat similar to the research one, to assign translation keys to the default quests.

Although as an alternative to exactly like the research (i.e. any in-mod quests would be written in code, not in JSON), there's another option which would mean the existing quest JSON files could remain as-is.  Any strong preferences between the two?  (Addon mod quests could be done either way as well, though data pack and mod pack quests would have to be JSON only.)