### PR TITLE
Don't require hut-yoyo when gathering items

### DIFF
--- a/src/main/java/com/minecolonies/coremod/entity/ai/basic/AbstractEntityAIBasic.java
+++ b/src/main/java/com/minecolonies/coremod/entity/ai/basic/AbstractEntityAIBasic.java
@@ -5,7 +5,6 @@ import com.google.common.collect.Lists;
 import com.google.common.reflect.TypeToken;
 import com.minecolonies.api.colony.ICitizenData;
 import com.minecolonies.api.colony.buildings.IBuilding;
-import com.minecolonies.api.colony.buildings.IBuilding;
 import com.minecolonies.api.colony.interactionhandling.ChatPriority;
 import com.minecolonies.api.colony.jobs.IJob;
 import com.minecolonies.api.colony.requestsystem.location.ILocation;
@@ -38,17 +37,18 @@ import com.minecolonies.coremod.colony.jobs.JobDeliveryman;
 import com.minecolonies.coremod.colony.requestsystem.resolvers.StationRequestResolver;
 import com.minecolonies.coremod.entity.pathfinding.EntityCitizenWalkToProxy;
 import com.minecolonies.coremod.util.WorkerUtil;
+import net.minecraft.core.BlockPos;
+import net.minecraft.core.Direction;
+import net.minecraft.network.chat.Component;
+import net.minecraft.tags.BlockTags;
 import net.minecraft.tags.TagKey;
-import net.minecraft.world.level.block.state.BlockState;
+import net.minecraft.world.InteractionHand;
 import net.minecraft.world.item.Item;
 import net.minecraft.world.item.ItemStack;
-import net.minecraft.tags.BlockTags;
-import net.minecraft.world.level.block.entity.ChestBlockEntity;
 import net.minecraft.world.level.block.entity.BlockEntity;
-import net.minecraft.core.Direction;
-import net.minecraft.world.InteractionHand;
-import net.minecraft.core.BlockPos;
-import net.minecraft.network.chat.Component;
+import net.minecraft.world.level.block.entity.ChestBlockEntity;
+import net.minecraft.world.level.block.state.BlockState;
+import net.minecraftforge.common.capabilities.ForgeCapabilities;
 import net.minecraftforge.common.capabilities.ICapabilityProvider;
 import net.minecraftforge.fml.loading.FMLEnvironment;
 import net.minecraftforge.items.IItemHandler;
@@ -68,7 +68,6 @@ import static com.minecolonies.api.util.constant.Constants.*;
 import static com.minecolonies.api.util.constant.ToolLevelConstants.TOOL_LEVEL_WOOD_OR_GOLD;
 import static com.minecolonies.api.util.constant.TranslationConstants.*;
 import static com.minecolonies.coremod.entity.ai.basic.AbstractEntityAIInteract.RENDER_META_WORKING;
-import net.minecraftforge.common.capabilities.ForgeCapabilities;
 
 /**
  * This class provides basic ai functionality.
@@ -269,7 +268,7 @@ public abstract class AbstractEntityAIBasic<J extends AbstractJob<?, J>, B exten
     }
 
     /**
-     * Retrieve a material from the building. For this go to the building if no position has been set. Then check for the chest with the required material and set the position and
+     * Retrieve a material from the building. For this check for the chest with the required material and set the position and
      * return.
      * <p>
      * If the position has been set navigate to it. On arrival transfer to inventory and return to StartWorking.
@@ -279,11 +278,6 @@ public abstract class AbstractEntityAIBasic<J extends AbstractJob<?, J>, B exten
     private IAIState getNeededItem()
     {
         worker.getCitizenStatusHandler().setLatestStatus(Component.translatable(COM_MINECOLONIES_COREMOD_STATUS_GATHERING));
-
-        if (walkTo == null && walkToBuilding())
-        {
-            return getState();
-        }
 
         if (needsCurrently == null)
         {


### PR DESCRIPTION
Closes [discord report](https://discord.com/channels/139070364159311872/1003402520846139533/1099100385320378408)
Closes [discord report](https://discord.com/channels/449079260070674443/449081206345039872/1099106742287212625)
Closes ldtteam/minecolonies-features#510

# Changes proposed in this pull request:
- Removes the requirement for the builder (or anyone) to revisit their hut block in between gathering each item type.  Instead, they can go directly to the rack containing the item, then to the next rack for the next item.
    - This "fixes" most of the annoyance with the medieval builder, since their racks are a long way away and up or down stairs from the hut block.
    - They will still be a bit derpy, since they might decide to pick up an item from upstairs, then downstairs, then upstairs again.  But that's less terrible than having to go up/downstairs for each and every different item type regardless.
    - They will still have to go to their hut block at other times (such as waiting for requests, or when starting a job), just not quite as frequently.
    - They will also still return to their hut block first when returning from the work site (due to passing through `INVENTORY_FULL`) first, to drop off dirt blocks etc collected from the site.

Review please (could port)

I've only tested the effect of this with the builder, although it will affect others.  I don't anticipate it will cause any significant issues though, as the racks will typically be in the vicinity of the hut block anyway, so it will still require some kind of pathing.