### PR TITLE
UX improvements for scepters

### DIFF
--- a/src/api/java/com/minecolonies/api/colony/buildings/modules/settings/ISetting.java
+++ b/src/api/java/com/minecolonies/api/colony/buildings/modules/settings/ISetting.java
@@ -74,8 +74,5 @@ public interface ISetting
      * Allow updating a setting with new data.
      * @param iSetting the setting with new data
      */
-    default void updateSetting(final ISetting iSetting)
-    {
-
-    }
+    void updateSetting(final ISetting iSetting);
 }

--- a/src/api/java/com/minecolonies/api/colony/buildings/modules/settings/IStringSetting.java
+++ b/src/api/java/com/minecolonies/api/colony/buildings/modules/settings/IStringSetting.java
@@ -36,4 +36,13 @@ public interface IStringSetting extends ISetting
      * @param value the value to set.
      */
     void set(final String value);
+
+    @Override
+    default void updateSetting(final ISetting iSetting)
+    {
+        if (iSetting instanceof final IStringSetting other)
+        {
+            set(other.getValue());
+        }
+    }
 }

--- a/src/main/java/com/minecolonies/coremod/colony/buildings/modules/settings/BlockSetting.java
+++ b/src/main/java/com/minecolonies/coremod/colony/buildings/modules/settings/BlockSetting.java
@@ -156,6 +156,15 @@ public class BlockSetting implements ISetting
 
     }
 
+    @Override
+    public void updateSetting(final ISetting iSetting)
+    {
+        if (iSetting instanceof final BlockSetting other)
+        {
+            setValue(other.getValue());
+        }
+    }
+
     /**
      * Special block getter for shapes.
      */

--- a/src/main/java/com/minecolonies/coremod/colony/buildings/modules/settings/BoolSetting.java
+++ b/src/main/java/com/minecolonies/coremod/colony/buildings/modules/settings/BoolSetting.java
@@ -97,4 +97,13 @@ public class BoolSetting implements ISetting
     {
         this.value = !this.value;
     }
+
+    @Override
+    public void updateSetting(final ISetting iSetting)
+    {
+        if (iSetting instanceof final BoolSetting other)
+        {
+            this.value = other.value;
+        }
+    }
 }

--- a/src/main/java/com/minecolonies/coremod/colony/buildings/modules/settings/IntSetting.java
+++ b/src/main/java/com/minecolonies/coremod/colony/buildings/modules/settings/IntSetting.java
@@ -117,6 +117,15 @@ public class IntSetting implements ISetting
 
     }
 
+    @Override
+    public void updateSetting(final ISetting iSetting)
+    {
+        if (iSetting instanceof final IntSetting other)
+        {
+            setValue(other.getValue());
+        }
+    }
+
     /**
      * Set a new int value.
      * @param value the int to set.

--- a/src/main/java/com/minecolonies/coremod/colony/buildings/modules/settings/RecipeSetting.java
+++ b/src/main/java/com/minecolonies/coremod/colony/buildings/modules/settings/RecipeSetting.java
@@ -186,4 +186,13 @@ public class RecipeSetting implements ICraftingSetting
         final CraftingModuleView craftingModule = module.getBuildingView().getModuleViewMatching(CraftingModuleView.class, m -> m.getId().equals(craftingModuleId));
         return craftingModule != null && !craftingModule.getRecipes().isEmpty() ;
     }
+
+    @Override
+    public void updateSetting(final ISetting iSetting)
+    {
+        if (iSetting instanceof final RecipeSetting other)
+        {
+            currentIndex = other.currentIndex;
+        }
+    }
 }

--- a/src/main/java/com/minecolonies/coremod/colony/buildings/workerbuildings/BuildingLumberjack.java
+++ b/src/main/java/com/minecolonies/coremod/colony/buildings/workerbuildings/BuildingLumberjack.java
@@ -247,6 +247,13 @@ public class BuildingLumberjack extends AbstractBuilding
     {
         this.startRestriction = startPosition;
         this.endRestriction = endPosition;
+
+        final boolean areaIsDefined = startPosition != null && endPosition != null;
+        if (getSetting(RESTRICT).getValue() != areaIsDefined)
+        {
+            getSetting(RESTRICT).trigger();
+        }
+        markDirty();
     }
 
     public BlockPos getStartRestriction()

--- a/src/main/java/com/minecolonies/coremod/items/ItemScepterBeekeeper.java
+++ b/src/main/java/com/minecolonies/coremod/items/ItemScepterBeekeeper.java
@@ -38,6 +38,7 @@ import static com.minecolonies.api.util.constant.translation.ToolTranslationCons
  */
 public class ItemScepterBeekeeper extends AbstractItemMinecolonies implements IBlockOverlayItem
 {
+    private static final int RED_OVERLAY = 0xFFFF0000;
     private static final int YELLOW_OVERLAY = 0xFFFFFF00;
 
     /**
@@ -112,10 +113,13 @@ public class ItemScepterBeekeeper extends AbstractItemMinecolonies implements IB
     {
         final CompoundTag compound = stack.getOrCreateTag();
         final IColonyView colony = IColonyManager.getInstance().getColonyView(compound.getInt(TAG_ID), world.dimension());
+        final BlockPos pos = BlockPosUtil.read(compound, TAG_POS);
 
-        if (colony != null && colony.getBuilding(BlockPosUtil.read(compound, TAG_POS)) instanceof final BuildingBeekeeper.View hut)
+        if (colony != null && colony.getBuilding(pos) instanceof final BuildingBeekeeper.View hut)
         {
             final List<OverlayBox> overlays = new ArrayList<>();
+
+            overlays.add(new OverlayBox(new AABB(pos), RED_OVERLAY, 0.02f, true));
 
             for (final BlockPos hive : hut.getHives())
             {

--- a/src/main/resources/assets/minecolonies/lang/manual_en_us.json
+++ b/src/main/resources/assets/minecolonies/lang/manual_en_us.json
@@ -71,8 +71,8 @@
   "minecolonies.config.listofplantables.comment": "The items and item-tags that the Florist can plant.",
 
   "item.minecolonies.scepterlumberjack": "Forest Tool",
-  "item.minecolonies.scepterlumberjack.usedend": "Position A set. Select Position B with a right-click or left-click the same position to finish.",
-  "item.minecolonies.scepterlumberjack.usedstart": "Position B set. Select Position A with a left-click or right-click the same position to finish.",
+  "item.minecolonies.scepterlumberjack.usedend": "Position A set. Select Position B with a right-click or discard tool when finished.",
+  "item.minecolonies.scepterlumberjack.usedstart": "Position B set. Select Position A with a left-click or discard tool when finished.",
   "item.minecolonies.scepterlumberjack.restrictiontoobig": "A zone of %d blocks is too large. The maximum restricted volume for the Forester is %d blocks.",
   "item.minecolonies.scepterlumberjack.restrictionset": "Forester restricted zone set (x: %d to %d, y: %d to %d, z: %d to %d, total: %d blocks). The max size is %d blocks.",
 


### PR DESCRIPTION
Closes [discord report](https://discord.com/channels/472875599422291968/1099891821452210226/1099891821452210226)

# Changes proposed in this pull request:
- Fixes hut settings values not syncing if already received
    - e.g. two officers are logged in and at the same colony.  One changes the settings on a hut.  The other will only see the old settings forever, until they relog or otherwise manage to completely clear their local colony view (leave the border and return?).
    - this also meant that settings changes made by the server itself did not sync to client until relog (or otherwise first colony sync).
    - now, there will still be a little lag (it will wait until next view resync) but the current values will be synched too.
- Beekeeper tool now shows a red box around the associated apiary hut, as a reminder of which one it is editing (in case you keep it around, or otherwise forget).
- Forest tool now does the same for its respective forester hut.
- Several additional usability improvements for the forest tool, based on user feedback:
    - The tool will no longer vanish itself on second click of the same block.  While I couldn't personally reproduce accidental double-clicking, this does seem to be a thing that gets reported from time to time, and with the new box rendering in particular it's very inconvenient if the tool spontaneously vanishes.  Now, when you're done with it, you just need to throw it away.  Or you can stash it somewhere (item frame in the hut?) until next time if you really want.
    - On obtaining a tool from a never-before-set hut and clicking a single point, it will not show a box stretching off to 0,0,0 for the other corner any more, but instead wait until you've set a second point before showing anything.
    - Previously, with each fresh tool, you had to click two opposite corners before it would save anything (even if it was still showing a box from a previous setup -- though the chat messages did make this clear).  Now, it will save changes whenever it has two corners, regardless of whether these were new or old.
    - Whenever it saves new corners for the zone, it automatically enables the zone restriction.  (This change may not immediately reflect in the hut GUI; it is deferred until next view resync.)

Review please (could port)