### PR TITLE
Load the RS System configuration when the common configuration gets loaded, and also output additional log entries.

### DIFF
--- a/src/main/java/com/minecolonies/coremod/MineColonies.java
+++ b/src/main/java/com/minecolonies/coremod/MineColonies.java
@@ -218,6 +218,17 @@ public class MineColonies
         }
     }
 
+    @SubscribeEvent
+    public static void onConfigLoaded(final ModConfigEvent.Loading event)
+    {
+        if (event.getConfig().getType() == ModConfig.Type.COMMON)
+        {
+            // ModConfig fires for each of server, client, and common.
+            // Request Systems logging only really needs to be changed on the server, and this reduced log spam.
+            RequestSystemInitializer.reconfigureLogging();
+        }
+    }
+
     /**
      * Get the config handler.
      *

--- a/src/main/java/com/minecolonies/coremod/colony/requestsystem/init/RequestSystemInitializer.java
+++ b/src/main/java/com/minecolonies/coremod/colony/requestsystem/init/RequestSystemInitializer.java
@@ -41,6 +41,8 @@ public class RequestSystemInitializer
 
     public static void reconfigureLogging()
     {
+        LogManager.getLogger(MineColonies.class.getName()).warn("Reconfiguring logging for RS.");
+
         final LoggerContext ctx = (LoggerContext) LogManager.getContext(false);
         final Configuration config = ctx.getConfiguration();
         final LoggerConfig loggerConfig = getLoggerConfiguration(config, String.format("%s.requestsystem", Constants.MOD_ID));
@@ -53,6 +55,8 @@ public class RequestSystemInitializer
 
         LogManager.getLogger(String.format("%s.requestsystem", Constants.MOD_ID)).warn(String.format("Updated logging config. RS Debug logging enabled: %s",
           MineColonies.getConfig().getCommon().rsEnableDebugLogging.get()));
+
+        LogManager.getLogger(MineColonies.class.getName()).warn("Reconfigured logging for RS.");
     }
 
     private static LoggerConfig getLoggerConfiguration(@NotNull final Configuration configuration, @NotNull final String loggerName)


### PR DESCRIPTION
Closes: #9099
Closes: #9097

See changes.