### PR TITLE
make sure raids do not choose a spawnpoint in another colony

### DIFF
--- a/src/main/java/com/minecolonies/coremod/colony/managers/RaidManager.java
+++ b/src/main/java/com/minecolonies/coremod/colony/managers/RaidManager.java
@@ -3,6 +3,7 @@ package com.minecolonies.coremod.colony.managers;
 import com.minecolonies.api.MinecoloniesAPIProxy;
 import com.minecolonies.api.colony.ICitizenData;
 import com.minecolonies.api.colony.IColony;
+import com.minecolonies.api.colony.IColonyTagCapability;
 import com.minecolonies.api.colony.buildings.IBuilding;
 import com.minecolonies.api.colony.colonyEvents.EventStatus;
 import com.minecolonies.api.colony.colonyEvents.IColonyEvent;
@@ -35,7 +36,6 @@ import com.minecolonies.coremod.entity.pathfinding.pathjobs.PathJobRaiderPathing
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Holder;
 import net.minecraft.nbt.CompoundTag;
-
 import net.minecraft.network.chat.Component;
 import net.minecraft.tags.BiomeTags;
 import net.minecraft.util.Mth;
@@ -47,6 +47,7 @@ import org.jetbrains.annotations.NotNull;
 
 import java.util.*;
 
+import static com.minecolonies.api.colony.IColony.CLOSE_COLONY_CAP;
 import static com.minecolonies.api.util.BlockPosUtil.DOUBLE_AIR_POS_SELECTOR;
 import static com.minecolonies.api.util.BlockPosUtil.SOLID_AIR_POS_SELECTOR;
 import static com.minecolonies.api.util.constant.ColonyConstants.BIG_HORDE_SIZE;
@@ -365,7 +366,7 @@ public class RaidManager implements IRaiderManager
                     event = new EgyptianRaidEvent(colony);
                 }
                 else if (((biome.is(BiomeTags.IS_JUNGLE) || (rand > IGNORE_BIOME_CHANCE * 2 && rand < IGNORE_BIOME_CHANCE * 3)
-                                                                    && raidType.isEmpty())) || (raidType.equals(AmazonRaidEvent.AMAZON_RAID_EVENT_TYPE_ID.getPath())))
+                                                              && raidType.isEmpty())) || (raidType.equals(AmazonRaidEvent.AMAZON_RAID_EVENT_TYPE_ID.getPath())))
                 {
                     event = new AmazonRaidEvent(colony);
                 }
@@ -517,7 +518,7 @@ public class RaidManager implements IRaiderManager
 
                 if (WorldUtil.isEntityBlockLoaded(colony.getWorld(), new BlockPos(tempPos)))
                 {
-                    if (isValidSpawnPoint(buildings, new BlockPos(tempPos)))
+                    if (isValidSpawnPoint(buildings, new BlockPos(tempPos)) && !isOtherColony((int) tempPos.x, (int) tempPos.z))
                     {
                         spawnPos = new BlockPos(tempPos);
                         validChunkCount++;
@@ -544,6 +545,18 @@ public class RaidManager implements IRaiderManager
         }
 
         return null;
+    }
+
+    /**
+     * Check if the spawn position is within another colony
+     *
+     * @param pos
+     * @return
+     */
+    private boolean isOtherColony(final int x, final int z)
+    {
+        final IColonyTagCapability cap = colony.getWorld().getChunk(x >> 4, z >> 4).getCapability(CLOSE_COLONY_CAP, null).orElseGet(null);
+        return cap != null && cap.getOwningColony() != 0 && cap.getOwningColony() != colony.getID();
     }
 
     /**


### PR DESCRIPTION
Closes #
Closes #
Closes #

# Changes proposed in this pull request:
-make sure raids do not choose a spawnpoint in another colony

Review please
