### PR TITLE
Implement tooltip for pickup requests

### DIFF
--- a/src/main/java/com/minecolonies/coremod/colony/requestsystem/requests/StandardRequests.java
+++ b/src/main/java/com/minecolonies/coremod/colony/requestsystem/requests/StandardRequests.java
@@ -356,6 +356,35 @@ public final class StandardRequests
             // This can be just the delivery icon. For the user, it's no big deal.
             return new ResourceLocation("minecolonies:textures/gui/citizen/delivery.png");
         }
+
+        @Override
+        public List<MutableComponent> getResolverToolTip(final IColonyView colony)
+        {
+            final String requester = getRequester().getRequesterDisplayName(colony.getRequestManager(), this).getString();
+
+            int posInList = -1;
+            for (IBuildingView view : colony.getBuildings())
+            {
+                if (view.getBuildingType() == ModBuildings.deliveryman.get())
+                {
+                    posInList = getPosInList(colony, view, getId());
+                    if (posInList >= 0)
+                    {
+                        break;
+                    }
+                }
+            }
+
+            if (posInList >= 0)
+            {
+                return posInList == 0 ? ImmutableList.of(Component.translatable(FROM, requester), Component.translatable(IN_PROGRESS)) : ImmutableList.of(Component.translatable(FROM, requester), Component.translatable(IN_QUEUE, posInList));
+            }
+            else
+            {
+                return ImmutableList.of(Component.translatable(FROM, requester));
+            }
+        }
+
     }
 
     /**


### PR DESCRIPTION
Closes #9023
Closes #
Closes #

# Changes proposed in this pull request:
- Add a similar tooltip as delivery and crafting requests have to pickup requests in overviews like the "open requests" tab of citizens
  - This will make it easier to find out how long it takes before a courier will pick up items from those citizens
  - (I couldn't find a reason why pickup requests didn't have it)

Review please (Will be ported)
