### PR TITLE
not needed anymore

### DIFF
--- a/src/main/java/com/minecolonies/coremod/entity/pathfinding/Pathfinding.java
+++ b/src/main/java/com/minecolonies/coremod/entity/pathfinding/Pathfinding.java
@@ -58,9 +58,7 @@ public final class Pathfinding
      */
     public static void shutdown()
     {
-        getExecutor().shutdownNow();
         jobQueue.clear();
-        executor = null;
     }
 
     private Pathfinding()


### PR DESCRIPTION
This comes from the time before we had deamon threads. This is not needed anymore and can in rare cases cause classloading issues.