### PR TITLE
Support for mangrove trees

### DIFF
--- a/src/api/java/com/minecolonies/api/items/ModTags.java
+++ b/src/api/java/com/minecolonies/api/items/ModTags.java
@@ -27,6 +27,8 @@ public class ModTags
     public static final TagKey<Item>  concretePowder  = ItemTags.create(TagConstants.CONCRETE_POWDER);
     public static final TagKey<Block> concreteBlock = BlockTags.create(TagConstants.CONCRETE_BLOCK);
     public static final TagKey<Block> pathingBlocks = BlockTags.create(TagConstants.PATHING_BLOCKS);
+    public static final TagKey<Block> mangroveTree = BlockTags.create(TagConstants.MANGROVE_TREE_BLOCKS);
+    public static final TagKey<Block> tree = BlockTags.create(TagConstants.TREE_BLOCKS);
 
     public static final TagKey<Block> colonyProtectionException = BlockTags.create(TagConstants.COLONYPROTECTIONEXCEPTION);
     public static final TagKey<Block> indestructible = BlockTags.create(TagConstants.INDESTRUCTIBLE);

--- a/src/api/java/com/minecolonies/api/util/constant/TagConstants.java
+++ b/src/api/java/com/minecolonies/api/util/constant/TagConstants.java
@@ -13,6 +13,8 @@ public final class TagConstants
     public static final ResourceLocation CONCRETE_POWDER = new ResourceLocation(MOD_ID, "concrete_powder");
     public static final ResourceLocation CONCRETE_BLOCK  = new ResourceLocation(MOD_ID, "concrete");
     public static final ResourceLocation PATHING_BLOCKS = new ResourceLocation(MOD_ID, "pathblocks");
+    public static final ResourceLocation MANGROVE_TREE_BLOCKS = new ResourceLocation(MOD_ID, "mangrove_tree");
+    public static final ResourceLocation TREE_BLOCKS = new ResourceLocation(MOD_ID, "tree");
     public static final ResourceLocation FLORIST_FLOWERS = new ResourceLocation(MOD_ID, "florist_flowers");
     public static final ResourceLocation EXCLUDED_FOOD = new ResourceLocation(MOD_ID, "excluded_food");
     public static final ResourceLocation ORECHANCEBLOCKS = new ResourceLocation(MOD_ID, "orechanceblocks");

--- a/src/datagen/generated/minecolonies/data/minecolonies/tags/blocks/mangrove_tree.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/tags/blocks/mangrove_tree.json
@@ -1,0 +1,6 @@
+{
+  "values": [
+    "minecraft:mangrove_log",
+    "minecraft:mangrove_roots"
+  ]
+}

--- a/src/datagen/generated/minecolonies/data/minecolonies/tags/blocks/tree.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/tags/blocks/tree.json
@@ -1,0 +1,6 @@
+{
+  "values": [
+    "#minecraft:logs",
+    "#minecolonies:mangrove_tree"
+  ]
+}

--- a/src/main/java/com/minecolonies/coremod/entity/ai/citizen/lumberjack/EntityAIWorkLumberjack.java
+++ b/src/main/java/com/minecolonies/coremod/entity/ai/citizen/lumberjack/EntityAIWorkLumberjack.java
@@ -477,6 +477,7 @@ public class EntityAIWorkLumberjack extends AbstractEntityAICrafting<JobLumberja
         if (building.shouldRestrict() && !BlockPosUtil.isInArea(building.getStartRestriction(), building.getEndRestriction(), job.getTree().getLocation()))
         {
             job.setTree(null);
+            pathResult = null;
             return START_WORKING;
         }
 
@@ -506,6 +507,7 @@ public class EntityAIWorkLumberjack extends AbstractEntityAICrafting<JobLumberja
             else
             {
                 job.setTree(null);
+                pathResult = null;
                 checkedInHut = false;
             }
 
@@ -627,10 +629,10 @@ public class EntityAIWorkLumberjack extends AbstractEntityAICrafting<JobLumberja
         {
             pathToTree = ((MinecoloniesAdvancedPathNavigate) worker.getNavigation()).setPathJob(new PathJobMoveToWithPassable(world,
               AbstractPathJob.prepareStart(worker),
-              workAt,
+              workFrom,
               SEARCH_RANGE,
               worker,
-              this::isPassable), workAt, 1.0d, true);
+              this::isPassable), workFrom, 1.0d, true);
         }
 
         return false;
@@ -763,6 +765,7 @@ public class EntityAIWorkLumberjack extends AbstractEntityAICrafting<JobLumberja
         if (plantSapling(job.getTree().getLocation()))
         {
             job.setTree(null);
+            pathResult = null;
             checkedInHut = false;
         }
     }

--- a/src/main/java/com/minecolonies/coremod/generation/defaults/DefaultBlockTagsProvider.java
+++ b/src/main/java/com/minecolonies/coremod/generation/defaults/DefaultBlockTagsProvider.java
@@ -128,6 +128,14 @@ public class DefaultBlockTagsProvider extends BlockTagsProvider
                 .add(Blocks.DEEPSLATE_TILE_STAIRS)
                 .addTag(com.ldtteam.domumornamentum.tag.ModTags.BRICKS);
 
+        tag(ModTags.mangroveTree)
+                .add(Blocks.MANGROVE_LOG)
+                .add(Blocks.MANGROVE_ROOTS);
+
+        tag(ModTags.tree)
+                .addTag(BlockTags.LOGS)
+                .addTag(ModTags.mangroveTree);
+
         tag(ModTags.colonyProtectionException)
                 .addOptional(new ResourceLocation("waystones:waystone"))
                 .addOptional(new ResourceLocation("waystones:sandy_waystone"))


### PR DESCRIPTION
Closes #8720

# Changes proposed in this pull request:
- Fixes some pathing issues for the forester
    - If they were working on a tree when you change their zone, they could get stuck trying to still work on the old tree but aborting because it wasn't in the same zone, resulting in not doing anything at all until relog.
    - If they could not get within 3 blocks of the tree base, they would stop near it and then do nothing at all.
- Improves forester support for mangrove trees.
    - Previously, they could chop the mangrove trunks, but only if you don't set a zone, or set your zone with a high enough Y level.  They would not chop the roots or replant.
    - Now, they will chop roots and (mostly) replant.
        - They will only chop the regular roots, both above and below water.  They will not chop muddy roots underground.
        - They will not replant underwater, but they will replant above-ground.  They will plant one sapling per tree, approximately in the centre of the tree area.  Due to the way mangroves grow, they may move around the tree-farm area and possibly even escape entirely.
    - For best results, make a dedicated tree farm with a large flat space of grass/dirt/mud for each possible tree.  They _can_ cut natural mangrove swamp too, but since these are very densely packed (and often underwater, so no replanting) they can often appear to be making no progress because they're working on a "supertree" (several merged trees) and thus working a further distance away than they appear.  They should eventually get it all though.
    - They do need to be able to path to a root or log -- occasionally natural gen will put only leaf blocks above water, and they don't consider this to be a tree.  You'll either need to chop those yourself or locate the trunk and extend it above the waterline.

Review please (do not backport... except maybe for one commit)

This PR does not enable the forester to strip mangrove logs -- but another current PR does.

I was hoping to make this less special-case-y than it is, but couldn't see a good way to do that given the way that the vanilla tags and blocks are structured.