### PR TITLE
Bump JourneyMap to 1.20 versions

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -34,9 +34,9 @@ multiPistonVersion=1.20-1.2.28-ALPHA
 
 jei_mcversion=1.20
 jei_version=14.0.0.5
-jmapApiVersion=1.19.4-1.9-SNAPSHOT
-jmapMcVersion=1.19.4
-jmapVersion=5.9.5
+jmapApiVersion=1.20-1.9-SNAPSHOT
+jmapMcVersion=1.20
+jmapVersion=5.9.8
 tinkersConstructVersion=3.5.0.17
 mantleVersion=1.9.20
 # some mods include the MC version as part of their "real" version number, others


### PR DESCRIPTION
# Changes proposed in this pull request:
- Bumps JourneyMap to version numbers that actually exist in 1.20 😀 

Review please (do not port)
