### PR TITLE
Make the supply camp error boxes visible again

### DIFF
--- a/src/main/java/com/minecolonies/coremod/client/gui/WindowSupplies.java
+++ b/src/main/java/com/minecolonies/coremod/client/gui/WindowSupplies.java
@@ -182,7 +182,7 @@ public class WindowSupplies extends AbstractBlueprintManipulationWindow
                   .setPos(error.getPos())
                   .setRemovalTimePoint(Minecraft.getInstance().level.getGameTime() + 120 * 20 * 60)
                   .addText(Component.translatable(PARTIAL_WARNING_SUPPLY_BUILDING_ERROR + error.getType().toString().toLowerCase()).getString())
-                  .setColor(0xFF0000));
+                  .setColor(0x80FF0000));
             }
         }
     }

--- a/src/main/java/com/minecolonies/coremod/client/render/worldevent/HighlightManager.java
+++ b/src/main/java/com/minecolonies/coremod/client/render/worldevent/HighlightManager.java
@@ -3,13 +3,10 @@ package com.minecolonies.coremod.client.render.worldevent;
 import com.ldtteam.structurize.util.WorldRenderMacros;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.renderer.MultiBufferSource;
-import net.minecraft.client.renderer.RenderBuffers;
 import net.minecraft.core.BlockPos;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Map;
+import net.minecraft.world.phys.AABB;
+
+import java.util.*;
 
 public class HighlightManager
 {
@@ -46,14 +43,13 @@ public class HighlightManager
                 }
 
                 final MultiBufferSource.BufferSource buffer = Minecraft.getInstance().renderBuffers().bufferSource();
-                WorldRenderMacros.renderLineBox(buffer.getBuffer(
-                    WorldRenderMacros.GLINT_LINES_WITH_WIDTH), ctx.poseStack, boxRenderData.pos, boxRenderData.argbColor, 0.025f);
+                ColonyWorldRenderMacros.renderLineBox(ctx.poseStack, buffer, new AABB(boxRenderData.pos), 0.025f, boxRenderData.argbColor, true);
                 if (!boxRenderData.text.isEmpty())
                 {
                    WorldRenderMacros.renderDebugText(boxRenderData.pos, boxRenderData.text, ctx.poseStack, true, 3, buffer);
                 }
+                ColonyWorldRenderMacros.endRenderLineBox(buffer);
                 buffer.endBatch();
-
             }
 
             if (boxes.isEmpty())

--- a/src/main/java/com/minecolonies/coremod/client/render/worldevent/ItemOverlayBoxesRenderer.java
+++ b/src/main/java/com/minecolonies/coremod/client/render/worldevent/ItemOverlayBoxesRenderer.java
@@ -1,9 +1,6 @@
 package com.minecolonies.coremod.client.render.worldevent;
 
-import com.ldtteam.structurize.util.WorldRenderMacros;
 import com.minecolonies.api.items.IBlockOverlayItem;
-import com.mojang.blaze3d.vertex.PoseStack;
-import com.mojang.blaze3d.vertex.VertexConsumer;
 
 import java.util.List;
 
@@ -30,17 +27,5 @@ public class ItemOverlayBoxesRenderer
 
             ColonyWorldRenderMacros.endRenderLineBox(ctx.bufferSource);
         }
-    }
-
-    private static void renderLineBox(final PoseStack poseStack, final VertexConsumer buffer,
-                                      final float minX, final float minY, final float minZ,
-                                      final float minX2, final float minY2, final float minZ2,
-                                      final float maxX, final float maxY, final float maxZ,
-                                      final float maxX2, final float maxY2, final float maxZ2,
-                                      final int red, final int green, final int blue, final int alpha)
-    {
-        buffer.defaultColor(red, green, blue, alpha);
-        WorldRenderMacros.populateRenderLineBox(minX, minY, minZ, minX2, minY2, minZ2, maxX, maxY, maxZ, maxX2, maxY2, maxZ2, poseStack.last().pose(), buffer);
-        buffer.unsetDefaultColor();
     }
 }

--- a/src/main/java/com/minecolonies/coremod/items/ItemSupplyCampDeployer.java
+++ b/src/main/java/com/minecolonies/coremod/items/ItemSupplyCampDeployer.java
@@ -135,7 +135,7 @@ public class ItemSupplyCampDeployer extends AbstractItemMinecolonies
 
                 if (world.getBlockState(new BlockPos(x, groundLevel + 1, z)).getMaterial().isSolid())
                 {
-                    final PlacementError placementError = new PlacementError(PlacementError.PlacementErrorType.NEEDS_AIR_ABOVE, new BlockPos(x, pos.getY(), z));
+                    final PlacementError placementError = new PlacementError(PlacementError.PlacementErrorType.NEEDS_AIR_ABOVE, new BlockPos(x, groundLevel + 1, z));
                     placementErrorList.add(placementError);
                 }
             }


### PR DESCRIPTION
Closes [discord report](https://discord.com/channels/472875599422291968/473575384445878273/1118772333826560042)
Closes #8760

# Changes proposed in this pull request:
- Make the supply camp error boxes visible again
- Fixes "needs air above" appearing at anchor y level instead of just above ground

Review please (could port)
