### PR TITLE
Netherite smithing templates

### DIFF
--- a/src/datagen/generated/minecolonies/data/minecolonies/advancements/military/army_30.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/advancements/military/army_30.json
@@ -28,5 +28,6 @@
     [
       "population_5"
     ]
-  ]
+  ],
+  "sends_telemetry_event": true
 }

--- a/src/datagen/generated/minecolonies/data/minecolonies/advancements/military/army_8.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/advancements/military/army_8.json
@@ -28,5 +28,6 @@
     [
       "population_5"
     ]
-  ]
+  ],
+  "sends_telemetry_event": true
 }

--- a/src/datagen/generated/minecolonies/data/minecolonies/advancements/military/army_80.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/advancements/military/army_80.json
@@ -28,5 +28,6 @@
     [
       "population_5"
     ]
-  ]
+  ],
+  "sends_telemetry_event": true
 }

--- a/src/datagen/generated/minecolonies/data/minecolonies/advancements/military/build_all_barracks_towers.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/advancements/military/build_all_barracks_towers.json
@@ -25,5 +25,6 @@
     [
       "towers"
     ]
-  ]
+  ],
+  "sends_telemetry_event": true
 }

--- a/src/datagen/generated/minecolonies/data/minecolonies/advancements/military/build_archery.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/advancements/military/build_archery.json
@@ -28,5 +28,6 @@
     [
       "archery"
     ]
-  ]
+  ],
+  "sends_telemetry_event": true
 }

--- a/src/datagen/generated/minecolonies/data/minecolonies/advancements/military/build_barracks.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/advancements/military/build_barracks.json
@@ -28,5 +28,6 @@
     [
       "barracks"
     ]
-  ]
+  ],
+  "sends_telemetry_event": true
 }

--- a/src/datagen/generated/minecolonies/data/minecolonies/advancements/military/build_barracks_tower.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/advancements/military/build_barracks_tower.json
@@ -28,5 +28,6 @@
     [
       "barracks_tower"
     ]
-  ]
+  ],
+  "sends_telemetry_event": true
 }

--- a/src/datagen/generated/minecolonies/data/minecolonies/advancements/military/build_combat_academy.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/advancements/military/build_combat_academy.json
@@ -28,5 +28,6 @@
     [
       "combat_academy"
     ]
-  ]
+  ],
+  "sends_telemetry_event": true
 }

--- a/src/datagen/generated/minecolonies/data/minecolonies/advancements/military/root.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/advancements/military/root.json
@@ -28,5 +28,6 @@
     [
       "guardtower"
     ]
-  ]
+  ],
+  "sends_telemetry_event": true
 }

--- a/src/datagen/generated/minecolonies/data/minecolonies/advancements/minecolonies/build_builder.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/advancements/minecolonies/build_builder.json
@@ -28,5 +28,6 @@
     [
       "builders_hut"
     ]
-  ]
+  ],
+  "sends_telemetry_event": true
 }

--- a/src/datagen/generated/minecolonies/data/minecolonies/advancements/minecolonies/build_builder_2.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/advancements/minecolonies/build_builder_2.json
@@ -28,5 +28,6 @@
     [
       "builders_hut"
     ]
-  ]
+  ],
+  "sends_telemetry_event": true
 }

--- a/src/datagen/generated/minecolonies/data/minecolonies/advancements/minecolonies/build_citizen.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/advancements/minecolonies/build_citizen.json
@@ -28,5 +28,6 @@
     [
       "citizens_hut"
     ]
-  ]
+  ],
+  "sends_telemetry_event": true
 }

--- a/src/datagen/generated/minecolonies/data/minecolonies/advancements/minecolonies/build_guard_tower.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/advancements/minecolonies/build_guard_tower.json
@@ -28,5 +28,6 @@
     [
       "guard_tower"
     ]
-  ]
+  ],
+  "sends_telemetry_event": true
 }

--- a/src/datagen/generated/minecolonies/data/minecolonies/advancements/minecolonies/build_mysticalsite.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/advancements/minecolonies/build_mysticalsite.json
@@ -28,5 +28,6 @@
     [
       "mysticalsite"
     ]
-  ]
+  ],
+  "sends_telemetry_event": true
 }

--- a/src/datagen/generated/minecolonies/data/minecolonies/advancements/minecolonies/build_mysticalsite_5.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/advancements/minecolonies/build_mysticalsite_5.json
@@ -28,5 +28,6 @@
     [
       "mysticalsite"
     ]
-  ]
+  ],
+  "sends_telemetry_event": true
 }

--- a/src/datagen/generated/minecolonies/data/minecolonies/advancements/minecolonies/build_tavern.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/advancements/minecolonies/build_tavern.json
@@ -28,5 +28,6 @@
     [
       "tavern"
     ]
-  ]
+  ],
+  "sends_telemetry_event": true
 }

--- a/src/datagen/generated/minecolonies/data/minecolonies/advancements/minecolonies/build_town_hall.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/advancements/minecolonies/build_town_hall.json
@@ -28,5 +28,6 @@
     [
       "town_hall"
     ]
-  ]
+  ],
+  "sends_telemetry_event": true
 }

--- a/src/datagen/generated/minecolonies/data/minecolonies/advancements/minecolonies/build_town_hall_5.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/advancements/minecolonies/build_town_hall_5.json
@@ -28,5 +28,6 @@
     [
       "town_hall"
     ]
-  ]
+  ],
+  "sends_telemetry_event": true
 }

--- a/src/datagen/generated/minecolonies/data/minecolonies/advancements/minecolonies/building_add_recipe_door.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/advancements/minecolonies/building_add_recipe_door.json
@@ -114,5 +114,6 @@
     [
       "add_recipe_acacia_door"
     ]
-  ]
+  ],
+  "sends_telemetry_event": true
 }

--- a/src/datagen/generated/minecolonies/data/minecolonies/advancements/minecolonies/building_add_recipe_torch.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/advancements/minecolonies/building_add_recipe_torch.json
@@ -34,5 +34,6 @@
     [
       "add_recipe_torch"
     ]
-  ]
+  ],
+  "sends_telemetry_event": true
 }

--- a/src/datagen/generated/minecolonies/data/minecolonies/advancements/minecolonies/check_out_guide.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/advancements/minecolonies/check_out_guide.json
@@ -28,5 +28,6 @@
     [
       "click_gui_button_close"
     ]
-  ]
+  ],
+  "sends_telemetry_event": true
 }

--- a/src/datagen/generated/minecolonies/data/minecolonies/advancements/minecolonies/citizen_bury.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/advancements/minecolonies/citizen_bury.json
@@ -25,5 +25,6 @@
     [
       "buried"
     ]
-  ]
+  ],
+  "sends_telemetry_event": true
 }

--- a/src/datagen/generated/minecolonies/data/minecolonies/advancements/minecolonies/citizen_eat_food_first.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/advancements/minecolonies/citizen_eat_food_first.json
@@ -25,5 +25,6 @@
     [
       "citizen_eat_anything"
     ]
-  ]
+  ],
+  "sends_telemetry_event": true
 }

--- a/src/datagen/generated/minecolonies/data/minecolonies/advancements/minecolonies/citizen_eat_food_rotten_flesh.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/advancements/minecolonies/citizen_eat_food_rotten_flesh.json
@@ -33,5 +33,6 @@
     [
       "citizen_eat_rotten_flesh"
     ]
-  ]
+  ],
+  "sends_telemetry_event": true
 }

--- a/src/datagen/generated/minecolonies/data/minecolonies/advancements/minecolonies/citizen_resurrect.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/advancements/minecolonies/citizen_resurrect.json
@@ -25,5 +25,6 @@
     [
       "resurrected"
     ]
-  ]
+  ],
+  "sends_telemetry_event": true
 }

--- a/src/datagen/generated/minecolonies/data/minecolonies/advancements/minecolonies/colony_population_10.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/advancements/minecolonies/colony_population_10.json
@@ -27,5 +27,6 @@
     [
       "population_10"
     ]
-  ]
+  ],
+  "sends_telemetry_event": true
 }

--- a/src/datagen/generated/minecolonies/data/minecolonies/advancements/minecolonies/colony_population_25.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/advancements/minecolonies/colony_population_25.json
@@ -27,5 +27,6 @@
     [
       "population_25"
     ]
-  ]
+  ],
+  "sends_telemetry_event": true
 }

--- a/src/datagen/generated/minecolonies/data/minecolonies/advancements/minecolonies/colony_population_5.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/advancements/minecolonies/colony_population_5.json
@@ -27,5 +27,6 @@
     [
       "population_5"
     ]
-  ]
+  ],
+  "sends_telemetry_event": true
 }

--- a/src/datagen/generated/minecolonies/data/minecolonies/advancements/minecolonies/colony_population_50.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/advancements/minecolonies/colony_population_50.json
@@ -27,5 +27,6 @@
     [
       "population_50"
     ]
-  ]
+  ],
+  "sends_telemetry_event": true
 }

--- a/src/datagen/generated/minecolonies/data/minecolonies/advancements/minecolonies/colony_population_75.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/advancements/minecolonies/colony_population_75.json
@@ -27,5 +27,6 @@
     [
       "population_75"
     ]
-  ]
+  ],
+  "sends_telemetry_event": true
 }

--- a/src/datagen/generated/minecolonies/data/minecolonies/advancements/minecolonies/fulfill_request.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/advancements/minecolonies/fulfill_request.json
@@ -36,5 +36,6 @@
       "click_gui_button_fulfill",
       "click_request_button_fulfill"
     ]
-  ]
+  ],
+  "sends_telemetry_event": true
 }

--- a/src/datagen/generated/minecolonies/data/minecolonies/advancements/minecolonies/place_townhall.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/advancements/minecolonies/place_townhall.json
@@ -27,5 +27,6 @@
     [
       "build_tool_place_town_hall"
     ]
-  ]
+  ],
+  "sends_telemetry_event": true
 }

--- a/src/datagen/generated/minecolonies/data/minecolonies/advancements/minecolonies/root.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/advancements/minecolonies/root.json
@@ -25,5 +25,6 @@
     [
       "supply_ship_placed"
     ]
-  ]
+  ],
+  "sends_telemetry_event": true
 }

--- a/src/datagen/generated/minecolonies/data/minecolonies/advancements/minecolonies/start_builder.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/advancements/minecolonies/start_builder.json
@@ -28,5 +28,6 @@
     [
       "builder_request"
     ]
-  ]
+  ],
+  "sends_telemetry_event": true
 }

--- a/src/datagen/generated/minecolonies/data/minecolonies/advancements/minecolonies/undertaker_totem.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/advancements/minecolonies/undertaker_totem.json
@@ -25,5 +25,6 @@
     [
       "totem"
     ]
-  ]
+  ],
+  "sends_telemetry_event": true
 }

--- a/src/datagen/generated/minecolonies/data/minecolonies/advancements/minecraft/craft_supply.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/advancements/minecraft/craft_supply.json
@@ -25,5 +25,6 @@
     [
       "supply_ship"
     ]
-  ]
+  ],
+  "sends_telemetry_event": true
 }

--- a/src/datagen/generated/minecolonies/data/minecolonies/advancements/production/build_all_herders.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/advancements/production/build_all_herders.json
@@ -68,5 +68,6 @@
     [
       "rabbits"
     ]
-  ]
+  ],
+  "sends_telemetry_event": true
 }

--- a/src/datagen/generated/minecolonies/data/minecolonies/advancements/production/build_baker.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/advancements/production/build_baker.json
@@ -28,5 +28,6 @@
     [
       "bakery"
     ]
-  ]
+  ],
+  "sends_telemetry_event": true
 }

--- a/src/datagen/generated/minecolonies/data/minecolonies/advancements/production/build_blacksmith.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/advancements/production/build_blacksmith.json
@@ -28,5 +28,6 @@
     [
       "blacksmith"
     ]
-  ]
+  ],
+  "sends_telemetry_event": true
 }

--- a/src/datagen/generated/minecolonies/data/minecolonies/advancements/production/build_composter.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/advancements/production/build_composter.json
@@ -28,5 +28,6 @@
     [
       "composter"
     ]
-  ]
+  ],
+  "sends_telemetry_event": true
 }

--- a/src/datagen/generated/minecolonies/data/minecolonies/advancements/production/build_cook.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/advancements/production/build_cook.json
@@ -28,5 +28,6 @@
     [
       "cook"
     ]
-  ]
+  ],
+  "sends_telemetry_event": true
 }

--- a/src/datagen/generated/minecolonies/data/minecolonies/advancements/production/build_crusher.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/advancements/production/build_crusher.json
@@ -28,5 +28,6 @@
     [
       "crusher"
     ]
-  ]
+  ],
+  "sends_telemetry_event": true
 }

--- a/src/datagen/generated/minecolonies/data/minecolonies/advancements/production/build_delivery_person.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/advancements/production/build_delivery_person.json
@@ -28,5 +28,6 @@
     [
       "delivery_person"
     ]
-  ]
+  ],
+  "sends_telemetry_event": true
 }

--- a/src/datagen/generated/minecolonies/data/minecolonies/advancements/production/build_enchanter.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/advancements/production/build_enchanter.json
@@ -28,5 +28,6 @@
     [
       "enchanter"
     ]
-  ]
+  ],
+  "sends_telemetry_event": true
 }

--- a/src/datagen/generated/minecolonies/data/minecolonies/advancements/production/build_farmer.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/advancements/production/build_farmer.json
@@ -28,5 +28,6 @@
     [
       "farmer"
     ]
-  ]
+  ],
+  "sends_telemetry_event": true
 }

--- a/src/datagen/generated/minecolonies/data/minecolonies/advancements/production/build_fisherman.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/advancements/production/build_fisherman.json
@@ -28,5 +28,6 @@
     [
       "fisherman"
     ]
-  ]
+  ],
+  "sends_telemetry_event": true
 }

--- a/src/datagen/generated/minecolonies/data/minecolonies/advancements/production/build_florist.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/advancements/production/build_florist.json
@@ -28,5 +28,6 @@
     [
       "florist"
     ]
-  ]
+  ],
+  "sends_telemetry_event": true
 }

--- a/src/datagen/generated/minecolonies/data/minecolonies/advancements/production/build_library.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/advancements/production/build_library.json
@@ -28,5 +28,6 @@
     [
       "library"
     ]
-  ]
+  ],
+  "sends_telemetry_event": true
 }

--- a/src/datagen/generated/minecolonies/data/minecolonies/advancements/production/build_lumberjack.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/advancements/production/build_lumberjack.json
@@ -28,5 +28,6 @@
     [
       "lumberjack"
     ]
-  ]
+  ],
+  "sends_telemetry_event": true
 }

--- a/src/datagen/generated/minecolonies/data/minecolonies/advancements/production/build_miner.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/advancements/production/build_miner.json
@@ -28,5 +28,6 @@
     [
       "miner"
     ]
-  ]
+  ],
+  "sends_telemetry_event": true
 }

--- a/src/datagen/generated/minecolonies/data/minecolonies/advancements/production/build_sawmill.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/advancements/production/build_sawmill.json
@@ -28,5 +28,6 @@
     [
       "sawmill"
     ]
-  ]
+  ],
+  "sends_telemetry_event": true
 }

--- a/src/datagen/generated/minecolonies/data/minecolonies/advancements/production/build_sifter.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/advancements/production/build_sifter.json
@@ -28,5 +28,6 @@
     [
       "sifter"
     ]
-  ]
+  ],
+  "sends_telemetry_event": true
 }

--- a/src/datagen/generated/minecolonies/data/minecolonies/advancements/production/build_smeltery.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/advancements/production/build_smeltery.json
@@ -28,5 +28,6 @@
     [
       "smeltery"
     ]
-  ]
+  ],
+  "sends_telemetry_event": true
 }

--- a/src/datagen/generated/minecolonies/data/minecolonies/advancements/production/build_smeltery_3.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/advancements/production/build_smeltery_3.json
@@ -28,5 +28,6 @@
     [
       "smeltery"
     ]
-  ]
+  ],
+  "sends_telemetry_event": true
 }

--- a/src/datagen/generated/minecolonies/data/minecolonies/advancements/production/build_smeltery_5.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/advancements/production/build_smeltery_5.json
@@ -28,5 +28,6 @@
     [
       "smeltery"
     ]
-  ]
+  ],
+  "sends_telemetry_event": true
 }

--- a/src/datagen/generated/minecolonies/data/minecolonies/advancements/production/build_stone_smeltery.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/advancements/production/build_stone_smeltery.json
@@ -28,5 +28,6 @@
     [
       "stone_smeltery"
     ]
-  ]
+  ],
+  "sends_telemetry_event": true
 }

--- a/src/datagen/generated/minecolonies/data/minecolonies/advancements/production/build_stonemason.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/advancements/production/build_stonemason.json
@@ -28,5 +28,6 @@
     [
       "stonemason"
     ]
-  ]
+  ],
+  "sends_telemetry_event": true
 }

--- a/src/datagen/generated/minecolonies/data/minecolonies/advancements/production/build_warehouse.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/advancements/production/build_warehouse.json
@@ -28,5 +28,6 @@
     [
       "warehouse"
     ]
-  ]
+  ],
+  "sends_telemetry_event": true
 }

--- a/src/datagen/generated/minecolonies/data/minecolonies/advancements/production/deep_mine.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/advancements/production/deep_mine.json
@@ -25,5 +25,6 @@
     [
       "mineshaft"
     ]
-  ]
+  ],
+  "sends_telemetry_event": true
 }

--- a/src/datagen/generated/minecolonies/data/minecolonies/advancements/production/max_fields.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/advancements/production/max_fields.json
@@ -25,5 +25,6 @@
     [
       "fields"
     ]
-  ]
+  ],
+  "sends_telemetry_event": true
 }

--- a/src/datagen/generated/minecolonies/data/minecolonies/advancements/production/post_and_stash.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/advancements/production/post_and_stash.json
@@ -3,13 +3,23 @@
   "criteria": {
     "postbox": {
       "conditions": {
-        "block": "minecolonies:blockpostbox"
+        "location": [
+          {
+            "block": "minecolonies:blockpostbox",
+            "condition": "minecraft:block_state_property"
+          }
+        ]
       },
       "trigger": "minecraft:placed_block"
     },
     "stash": {
       "conditions": {
-        "block": "minecolonies:blockstash"
+        "location": [
+          {
+            "block": "minecolonies:blockstash",
+            "condition": "minecraft:block_state_property"
+          }
+        ]
       },
       "trigger": "minecraft:placed_block"
     }
@@ -36,5 +46,6 @@
     [
       "stash"
     ]
-  ]
+  ],
+  "sends_telemetry_event": true
 }

--- a/src/datagen/generated/minecolonies/data/minecolonies/advancements/production/root.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/advancements/production/root.json
@@ -28,5 +28,6 @@
     [
       "builders_hut"
     ]
-  ]
+  ],
+  "sends_telemetry_event": true
 }

--- a/src/datagen/generated/minecolonies/data/minecolonies/advancements/recipes/misc/baked_bread.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/advancements/recipes/misc/baked_bread.json
@@ -30,5 +30,6 @@
     "recipes": [
       "minecolonies:baked_bread"
     ]
-  }
+  },
+  "sends_telemetry_event": false
 }

--- a/src/datagen/generated/minecolonies/data/minecolonies/advancements/recipes/misc/baked_bread_campfire_cooking.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/advancements/recipes/misc/baked_bread_campfire_cooking.json
@@ -30,5 +30,6 @@
     "recipes": [
       "minecolonies:baked_bread_campfire_cooking"
     ]
-  }
+  },
+  "sends_telemetry_event": false
 }

--- a/src/datagen/generated/minecolonies/data/minecolonies/advancements/recipes/misc/baked_bread_smoking.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/advancements/recipes/misc/baked_bread_smoking.json
@@ -30,5 +30,6 @@
     "recipes": [
       "minecolonies:baked_bread_smoking"
     ]
-  }
+  },
+  "sends_telemetry_event": false
 }

--- a/src/datagen/generated/minecolonies/data/minecolonies/advancements/recipes/misc/baked_cake.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/advancements/recipes/misc/baked_cake.json
@@ -30,5 +30,6 @@
     "recipes": [
       "minecolonies:baked_cake"
     ]
-  }
+  },
+  "sends_telemetry_event": false
 }

--- a/src/datagen/generated/minecolonies/data/minecolonies/advancements/recipes/misc/baked_cake_campfire_cooking.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/advancements/recipes/misc/baked_cake_campfire_cooking.json
@@ -30,5 +30,6 @@
     "recipes": [
       "minecolonies:baked_cake_campfire_cooking"
     ]
-  }
+  },
+  "sends_telemetry_event": false
 }

--- a/src/datagen/generated/minecolonies/data/minecolonies/advancements/recipes/misc/baked_cake_smoking.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/advancements/recipes/misc/baked_cake_smoking.json
@@ -30,5 +30,6 @@
     "recipes": [
       "minecolonies:baked_cake_smoking"
     ]
-  }
+  },
+  "sends_telemetry_event": false
 }

--- a/src/datagen/generated/minecolonies/data/minecolonies/advancements/recipes/misc/baked_cookies.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/advancements/recipes/misc/baked_cookies.json
@@ -30,5 +30,6 @@
     "recipes": [
       "minecolonies:baked_cookies"
     ]
-  }
+  },
+  "sends_telemetry_event": false
 }

--- a/src/datagen/generated/minecolonies/data/minecolonies/advancements/recipes/misc/baked_cookies_campfire_cooking.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/advancements/recipes/misc/baked_cookies_campfire_cooking.json
@@ -30,5 +30,6 @@
     "recipes": [
       "minecolonies:baked_cookies_campfire_cooking"
     ]
-  }
+  },
+  "sends_telemetry_event": false
 }

--- a/src/datagen/generated/minecolonies/data/minecolonies/advancements/recipes/misc/baked_cookies_smoking.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/advancements/recipes/misc/baked_cookies_smoking.json
@@ -30,5 +30,6 @@
     "recipes": [
       "minecolonies:baked_cookies_smoking"
     ]
-  }
+  },
+  "sends_telemetry_event": false
 }

--- a/src/datagen/generated/minecolonies/data/minecolonies/advancements/recipes/misc/baked_pumpkin_pie.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/advancements/recipes/misc/baked_pumpkin_pie.json
@@ -30,5 +30,6 @@
     "recipes": [
       "minecolonies:baked_pumpkin_pie"
     ]
-  }
+  },
+  "sends_telemetry_event": false
 }

--- a/src/datagen/generated/minecolonies/data/minecolonies/advancements/recipes/misc/baked_pumpkin_pie_campfire_cooking.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/advancements/recipes/misc/baked_pumpkin_pie_campfire_cooking.json
@@ -30,5 +30,6 @@
     "recipes": [
       "minecolonies:baked_pumpkin_pie_campfire_cooking"
     ]
-  }
+  },
+  "sends_telemetry_event": false
 }

--- a/src/datagen/generated/minecolonies/data/minecolonies/advancements/recipes/misc/baked_pumpkin_pie_smoking.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/advancements/recipes/misc/baked_pumpkin_pie_smoking.json
@@ -30,5 +30,6 @@
     "recipes": [
       "minecolonies:baked_pumpkin_pie_smoking"
     ]
-  }
+  },
+  "sends_telemetry_event": false
 }

--- a/src/datagen/generated/minecolonies/data/minecolonies/advancements/recipes/misc/banner_rally_guards.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/advancements/recipes/misc/banner_rally_guards.json
@@ -35,5 +35,6 @@
     "recipes": [
       "minecolonies:banner_rally_guards"
     ]
-  }
+  },
+  "sends_telemetry_event": false
 }

--- a/src/datagen/generated/minecolonies/data/minecolonies/advancements/recipes/misc/barrel_block.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/advancements/recipes/misc/barrel_block.json
@@ -35,5 +35,6 @@
     "recipes": [
       "minecolonies:barrel_block"
     ]
-  }
+  },
+  "sends_telemetry_event": false
 }

--- a/src/datagen/generated/minecolonies/data/minecolonies/advancements/recipes/misc/blockconstructiontape.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/advancements/recipes/misc/blockconstructiontape.json
@@ -28,5 +28,6 @@
     "recipes": [
       "minecolonies:blockconstructiontape"
     ]
-  }
+  },
+  "sends_telemetry_event": false
 }

--- a/src/datagen/generated/minecolonies/data/minecolonies/advancements/recipes/misc/blockhutalchemist.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/advancements/recipes/misc/blockhutalchemist.json
@@ -35,5 +35,6 @@
     "recipes": [
       "minecolonies:blockhutalchemist"
     ]
-  }
+  },
+  "sends_telemetry_event": false
 }

--- a/src/datagen/generated/minecolonies/data/minecolonies/advancements/recipes/misc/blockhutarchery.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/advancements/recipes/misc/blockhutarchery.json
@@ -35,5 +35,6 @@
     "recipes": [
       "minecolonies:blockhutarchery"
     ]
-  }
+  },
+  "sends_telemetry_event": false
 }

--- a/src/datagen/generated/minecolonies/data/minecolonies/advancements/recipes/misc/blockhutbaker.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/advancements/recipes/misc/blockhutbaker.json
@@ -35,5 +35,6 @@
     "recipes": [
       "minecolonies:blockhutbaker"
     ]
-  }
+  },
+  "sends_telemetry_event": false
 }

--- a/src/datagen/generated/minecolonies/data/minecolonies/advancements/recipes/misc/blockhutbarracks.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/advancements/recipes/misc/blockhutbarracks.json
@@ -35,5 +35,6 @@
     "recipes": [
       "minecolonies:blockhutbarracks"
     ]
-  }
+  },
+  "sends_telemetry_event": false
 }

--- a/src/datagen/generated/minecolonies/data/minecolonies/advancements/recipes/misc/blockhutbeekeeper.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/advancements/recipes/misc/blockhutbeekeeper.json
@@ -35,5 +35,6 @@
     "recipes": [
       "minecolonies:blockhutbeekeeper"
     ]
-  }
+  },
+  "sends_telemetry_event": false
 }

--- a/src/datagen/generated/minecolonies/data/minecolonies/advancements/recipes/misc/blockhutblacksmith.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/advancements/recipes/misc/blockhutblacksmith.json
@@ -35,5 +35,6 @@
     "recipes": [
       "minecolonies:blockhutblacksmith"
     ]
-  }
+  },
+  "sends_telemetry_event": false
 }

--- a/src/datagen/generated/minecolonies/data/minecolonies/advancements/recipes/misc/blockhutbuilder.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/advancements/recipes/misc/blockhutbuilder.json
@@ -33,5 +33,6 @@
     "recipes": [
       "minecolonies:blockhutbuilder"
     ]
-  }
+  },
+  "sends_telemetry_event": false
 }

--- a/src/datagen/generated/minecolonies/data/minecolonies/advancements/recipes/misc/blockhutchickenherder.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/advancements/recipes/misc/blockhutchickenherder.json
@@ -35,5 +35,6 @@
     "recipes": [
       "minecolonies:blockhutchickenherder"
     ]
-  }
+  },
+  "sends_telemetry_event": false
 }

--- a/src/datagen/generated/minecolonies/data/minecolonies/advancements/recipes/misc/blockhutcitizen.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/advancements/recipes/misc/blockhutcitizen.json
@@ -35,5 +35,6 @@
     "recipes": [
       "minecolonies:blockhutcitizen"
     ]
-  }
+  },
+  "sends_telemetry_event": false
 }

--- a/src/datagen/generated/minecolonies/data/minecolonies/advancements/recipes/misc/blockhutcombatacademy.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/advancements/recipes/misc/blockhutcombatacademy.json
@@ -35,5 +35,6 @@
     "recipes": [
       "minecolonies:blockhutcombatacademy"
     ]
-  }
+  },
+  "sends_telemetry_event": false
 }

--- a/src/datagen/generated/minecolonies/data/minecolonies/advancements/recipes/misc/blockhutcomposter.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/advancements/recipes/misc/blockhutcomposter.json
@@ -35,5 +35,6 @@
     "recipes": [
       "minecolonies:blockhutcomposter"
     ]
-  }
+  },
+  "sends_telemetry_event": false
 }

--- a/src/datagen/generated/minecolonies/data/minecolonies/advancements/recipes/misc/blockhutconcretemixer.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/advancements/recipes/misc/blockhutconcretemixer.json
@@ -35,5 +35,6 @@
     "recipes": [
       "minecolonies:blockhutconcretemixer"
     ]
-  }
+  },
+  "sends_telemetry_event": false
 }

--- a/src/datagen/generated/minecolonies/data/minecolonies/advancements/recipes/misc/blockhutcook.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/advancements/recipes/misc/blockhutcook.json
@@ -35,5 +35,6 @@
     "recipes": [
       "minecolonies:blockhutcook"
     ]
-  }
+  },
+  "sends_telemetry_event": false
 }

--- a/src/datagen/generated/minecolonies/data/minecolonies/advancements/recipes/misc/blockhutcowboy.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/advancements/recipes/misc/blockhutcowboy.json
@@ -35,5 +35,6 @@
     "recipes": [
       "minecolonies:blockhutcowboy"
     ]
-  }
+  },
+  "sends_telemetry_event": false
 }

--- a/src/datagen/generated/minecolonies/data/minecolonies/advancements/recipes/misc/blockhutcrusher.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/advancements/recipes/misc/blockhutcrusher.json
@@ -35,5 +35,6 @@
     "recipes": [
       "minecolonies:blockhutcrusher"
     ]
-  }
+  },
+  "sends_telemetry_event": false
 }

--- a/src/datagen/generated/minecolonies/data/minecolonies/advancements/recipes/misc/blockhutdeliveryman.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/advancements/recipes/misc/blockhutdeliveryman.json
@@ -35,5 +35,6 @@
     "recipes": [
       "minecolonies:blockhutdeliveryman"
     ]
-  }
+  },
+  "sends_telemetry_event": false
 }

--- a/src/datagen/generated/minecolonies/data/minecolonies/advancements/recipes/misc/blockhutdeliverymaniron.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/advancements/recipes/misc/blockhutdeliverymaniron.json
@@ -35,5 +35,6 @@
     "recipes": [
       "minecolonies:blockhutdeliverymaniron"
     ]
-  }
+  },
+  "sends_telemetry_event": false
 }

--- a/src/datagen/generated/minecolonies/data/minecolonies/advancements/recipes/misc/blockhutdyer.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/advancements/recipes/misc/blockhutdyer.json
@@ -35,5 +35,6 @@
     "recipes": [
       "minecolonies:blockhutdyer"
     ]
-  }
+  },
+  "sends_telemetry_event": false
 }

--- a/src/datagen/generated/minecolonies/data/minecolonies/advancements/recipes/misc/blockhutenchanter.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/advancements/recipes/misc/blockhutenchanter.json
@@ -35,5 +35,6 @@
     "recipes": [
       "minecolonies:blockhutenchanter"
     ]
-  }
+  },
+  "sends_telemetry_event": false
 }

--- a/src/datagen/generated/minecolonies/data/minecolonies/advancements/recipes/misc/blockhutfarmer.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/advancements/recipes/misc/blockhutfarmer.json
@@ -35,5 +35,6 @@
     "recipes": [
       "minecolonies:blockhutfarmer"
     ]
-  }
+  },
+  "sends_telemetry_event": false
 }

--- a/src/datagen/generated/minecolonies/data/minecolonies/advancements/recipes/misc/blockhutfarmerstone.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/advancements/recipes/misc/blockhutfarmerstone.json
@@ -35,5 +35,6 @@
     "recipes": [
       "minecolonies:blockhutfarmerstone"
     ]
-  }
+  },
+  "sends_telemetry_event": false
 }

--- a/src/datagen/generated/minecolonies/data/minecolonies/advancements/recipes/misc/blockhutfield.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/advancements/recipes/misc/blockhutfield.json
@@ -35,5 +35,6 @@
     "recipes": [
       "minecolonies:blockhutfield"
     ]
-  }
+  },
+  "sends_telemetry_event": false
 }

--- a/src/datagen/generated/minecolonies/data/minecolonies/advancements/recipes/misc/blockhutfisherman.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/advancements/recipes/misc/blockhutfisherman.json
@@ -35,5 +35,6 @@
     "recipes": [
       "minecolonies:blockhutfisherman"
     ]
-  }
+  },
+  "sends_telemetry_event": false
 }

--- a/src/datagen/generated/minecolonies/data/minecolonies/advancements/recipes/misc/blockhutfletcher.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/advancements/recipes/misc/blockhutfletcher.json
@@ -35,5 +35,6 @@
     "recipes": [
       "minecolonies:blockhutfletcher"
     ]
-  }
+  },
+  "sends_telemetry_event": false
 }

--- a/src/datagen/generated/minecolonies/data/minecolonies/advancements/recipes/misc/blockhutflorist.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/advancements/recipes/misc/blockhutflorist.json
@@ -35,5 +35,6 @@
     "recipes": [
       "minecolonies:blockhutflorist"
     ]
-  }
+  },
+  "sends_telemetry_event": false
 }

--- a/src/datagen/generated/minecolonies/data/minecolonies/advancements/recipes/misc/blockhutglassblower.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/advancements/recipes/misc/blockhutglassblower.json
@@ -35,5 +35,6 @@
     "recipes": [
       "minecolonies:blockhutglassblower"
     ]
-  }
+  },
+  "sends_telemetry_event": false
 }

--- a/src/datagen/generated/minecolonies/data/minecolonies/advancements/recipes/misc/blockhutgraveyard.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/advancements/recipes/misc/blockhutgraveyard.json
@@ -35,5 +35,6 @@
     "recipes": [
       "minecolonies:blockhutgraveyard"
     ]
-  }
+  },
+  "sends_telemetry_event": false
 }

--- a/src/datagen/generated/minecolonies/data/minecolonies/advancements/recipes/misc/blockhutguardtower.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/advancements/recipes/misc/blockhutguardtower.json
@@ -35,5 +35,6 @@
     "recipes": [
       "minecolonies:blockhutguardtower"
     ]
-  }
+  },
+  "sends_telemetry_event": false
 }

--- a/src/datagen/generated/minecolonies/data/minecolonies/advancements/recipes/misc/blockhuthospital.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/advancements/recipes/misc/blockhuthospital.json
@@ -35,5 +35,6 @@
     "recipes": [
       "minecolonies:blockhuthospital"
     ]
-  }
+  },
+  "sends_telemetry_event": false
 }

--- a/src/datagen/generated/minecolonies/data/minecolonies/advancements/recipes/misc/blockhutlibrary.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/advancements/recipes/misc/blockhutlibrary.json
@@ -35,5 +35,6 @@
     "recipes": [
       "minecolonies:blockhutlibrary"
     ]
-  }
+  },
+  "sends_telemetry_event": false
 }

--- a/src/datagen/generated/minecolonies/data/minecolonies/advancements/recipes/misc/blockhutlumberjack.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/advancements/recipes/misc/blockhutlumberjack.json
@@ -35,5 +35,6 @@
     "recipes": [
       "minecolonies:blockhutlumberjack"
     ]
-  }
+  },
+  "sends_telemetry_event": false
 }

--- a/src/datagen/generated/minecolonies/data/minecolonies/advancements/recipes/misc/blockhutlumberjackstone.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/advancements/recipes/misc/blockhutlumberjackstone.json
@@ -35,5 +35,6 @@
     "recipes": [
       "minecolonies:blockhutlumberjackstone"
     ]
-  }
+  },
+  "sends_telemetry_event": false
 }

--- a/src/datagen/generated/minecolonies/data/minecolonies/advancements/recipes/misc/blockhutmechanic.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/advancements/recipes/misc/blockhutmechanic.json
@@ -35,5 +35,6 @@
     "recipes": [
       "minecolonies:blockhutmechanic"
     ]
-  }
+  },
+  "sends_telemetry_event": false
 }

--- a/src/datagen/generated/minecolonies/data/minecolonies/advancements/recipes/misc/blockhutminer.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/advancements/recipes/misc/blockhutminer.json
@@ -35,5 +35,6 @@
     "recipes": [
       "minecolonies:blockhutminer"
     ]
-  }
+  },
+  "sends_telemetry_event": false
 }

--- a/src/datagen/generated/minecolonies/data/minecolonies/advancements/recipes/misc/blockhutminerstone.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/advancements/recipes/misc/blockhutminerstone.json
@@ -35,5 +35,6 @@
     "recipes": [
       "minecolonies:blockhutminerstone"
     ]
-  }
+  },
+  "sends_telemetry_event": false
 }

--- a/src/datagen/generated/minecolonies/data/minecolonies/advancements/recipes/misc/blockhutmysticalsite.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/advancements/recipes/misc/blockhutmysticalsite.json
@@ -35,5 +35,6 @@
     "recipes": [
       "minecolonies:blockhutmysticalsite"
     ]
-  }
+  },
+  "sends_telemetry_event": false
 }

--- a/src/datagen/generated/minecolonies/data/minecolonies/advancements/recipes/misc/blockhutnetherworker.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/advancements/recipes/misc/blockhutnetherworker.json
@@ -35,5 +35,6 @@
     "recipes": [
       "minecolonies:blockhutnetherworker"
     ]
-  }
+  },
+  "sends_telemetry_event": false
 }

--- a/src/datagen/generated/minecolonies/data/minecolonies/advancements/recipes/misc/blockhutplantation.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/advancements/recipes/misc/blockhutplantation.json
@@ -35,5 +35,6 @@
     "recipes": [
       "minecolonies:blockhutplantation"
     ]
-  }
+  },
+  "sends_telemetry_event": false
 }

--- a/src/datagen/generated/minecolonies/data/minecolonies/advancements/recipes/misc/blockhutrabbithutch.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/advancements/recipes/misc/blockhutrabbithutch.json
@@ -35,5 +35,6 @@
     "recipes": [
       "minecolonies:blockhutrabbithutch"
     ]
-  }
+  },
+  "sends_telemetry_event": false
 }

--- a/src/datagen/generated/minecolonies/data/minecolonies/advancements/recipes/misc/blockhutsawmill.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/advancements/recipes/misc/blockhutsawmill.json
@@ -35,5 +35,6 @@
     "recipes": [
       "minecolonies:blockhutsawmill"
     ]
-  }
+  },
+  "sends_telemetry_event": false
 }

--- a/src/datagen/generated/minecolonies/data/minecolonies/advancements/recipes/misc/blockhutschool.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/advancements/recipes/misc/blockhutschool.json
@@ -35,5 +35,6 @@
     "recipes": [
       "minecolonies:blockhutschool"
     ]
-  }
+  },
+  "sends_telemetry_event": false
 }

--- a/src/datagen/generated/minecolonies/data/minecolonies/advancements/recipes/misc/blockhutshepherd.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/advancements/recipes/misc/blockhutshepherd.json
@@ -35,5 +35,6 @@
     "recipes": [
       "minecolonies:blockhutshepherd"
     ]
-  }
+  },
+  "sends_telemetry_event": false
 }

--- a/src/datagen/generated/minecolonies/data/minecolonies/advancements/recipes/misc/blockhutsifter.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/advancements/recipes/misc/blockhutsifter.json
@@ -35,5 +35,6 @@
     "recipes": [
       "minecolonies:blockhutsifter"
     ]
-  }
+  },
+  "sends_telemetry_event": false
 }

--- a/src/datagen/generated/minecolonies/data/minecolonies/advancements/recipes/misc/blockhutsmeltery.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/advancements/recipes/misc/blockhutsmeltery.json
@@ -35,5 +35,6 @@
     "recipes": [
       "minecolonies:blockhutsmeltery"
     ]
-  }
+  },
+  "sends_telemetry_event": false
 }

--- a/src/datagen/generated/minecolonies/data/minecolonies/advancements/recipes/misc/blockhutstonemason.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/advancements/recipes/misc/blockhutstonemason.json
@@ -35,5 +35,6 @@
     "recipes": [
       "minecolonies:blockhutstonemason"
     ]
-  }
+  },
+  "sends_telemetry_event": false
 }

--- a/src/datagen/generated/minecolonies/data/minecolonies/advancements/recipes/misc/blockhutstonesmeltery.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/advancements/recipes/misc/blockhutstonesmeltery.json
@@ -35,5 +35,6 @@
     "recipes": [
       "minecolonies:blockhutstonesmeltery"
     ]
-  }
+  },
+  "sends_telemetry_event": false
 }

--- a/src/datagen/generated/minecolonies/data/minecolonies/advancements/recipes/misc/blockhutswineherder.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/advancements/recipes/misc/blockhutswineherder.json
@@ -35,5 +35,6 @@
     "recipes": [
       "minecolonies:blockhutswineherder"
     ]
-  }
+  },
+  "sends_telemetry_event": false
 }

--- a/src/datagen/generated/minecolonies/data/minecolonies/advancements/recipes/misc/blockhuttavern.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/advancements/recipes/misc/blockhuttavern.json
@@ -35,5 +35,6 @@
     "recipes": [
       "minecolonies:blockhuttavern"
     ]
-  }
+  },
+  "sends_telemetry_event": false
 }

--- a/src/datagen/generated/minecolonies/data/minecolonies/advancements/recipes/misc/blockhuttownhall.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/advancements/recipes/misc/blockhuttownhall.json
@@ -35,5 +35,6 @@
     "recipes": [
       "minecolonies:blockhuttownhall"
     ]
-  }
+  },
+  "sends_telemetry_event": false
 }

--- a/src/datagen/generated/minecolonies/data/minecolonies/advancements/recipes/misc/blockhutuniversity.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/advancements/recipes/misc/blockhutuniversity.json
@@ -35,5 +35,6 @@
     "recipes": [
       "minecolonies:blockhutuniversity"
     ]
-  }
+  },
+  "sends_telemetry_event": false
 }

--- a/src/datagen/generated/minecolonies/data/minecolonies/advancements/recipes/misc/blockhutwarehouse.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/advancements/recipes/misc/blockhutwarehouse.json
@@ -33,5 +33,6 @@
     "recipes": [
       "minecolonies:blockhutwarehouse"
     ]
-  }
+  },
+  "sends_telemetry_event": false
 }

--- a/src/datagen/generated/minecolonies/data/minecolonies/advancements/recipes/misc/blockminecoloniesrack.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/advancements/recipes/misc/blockminecoloniesrack.json
@@ -30,5 +30,6 @@
     "recipes": [
       "minecolonies:blockminecoloniesrack"
     ]
-  }
+  },
+  "sends_telemetry_event": false
 }

--- a/src/datagen/generated/minecolonies/data/minecolonies/advancements/recipes/misc/blockpostbox.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/advancements/recipes/misc/blockpostbox.json
@@ -33,5 +33,6 @@
     "recipes": [
       "minecolonies:blockpostbox"
     ]
-  }
+  },
+  "sends_telemetry_event": false
 }

--- a/src/datagen/generated/minecolonies/data/minecolonies/advancements/recipes/misc/blockstash.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/advancements/recipes/misc/blockstash.json
@@ -33,5 +33,6 @@
     "recipes": [
       "minecolonies:blockstash"
     ]
-  }
+  },
+  "sends_telemetry_event": false
 }

--- a/src/datagen/generated/minecolonies/data/minecolonies/advancements/recipes/misc/blockwaypoint.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/advancements/recipes/misc/blockwaypoint.json
@@ -30,5 +30,6 @@
     "recipes": [
       "minecolonies:blockwaypoint"
     ]
-  }
+  },
+  "sends_telemetry_event": false
 }

--- a/src/datagen/generated/minecolonies/data/minecolonies/advancements/recipes/misc/build_goggles.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/advancements/recipes/misc/build_goggles.json
@@ -30,5 +30,6 @@
     "recipes": [
       "minecolonies:build_goggles"
     ]
-  }
+  },
+  "sends_telemetry_event": false
 }

--- a/src/datagen/generated/minecolonies/data/minecolonies/advancements/recipes/misc/chainmailboots.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/advancements/recipes/misc/chainmailboots.json
@@ -30,5 +30,6 @@
     "recipes": [
       "minecolonies:chainmailboots"
     ]
-  }
+  },
+  "sends_telemetry_event": false
 }

--- a/src/datagen/generated/minecolonies/data/minecolonies/advancements/recipes/misc/chainmailchestplate.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/advancements/recipes/misc/chainmailchestplate.json
@@ -30,5 +30,6 @@
     "recipes": [
       "minecolonies:chainmailchestplate"
     ]
-  }
+  },
+  "sends_telemetry_event": false
 }

--- a/src/datagen/generated/minecolonies/data/minecolonies/advancements/recipes/misc/chainmailhelmet.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/advancements/recipes/misc/chainmailhelmet.json
@@ -30,5 +30,6 @@
     "recipes": [
       "minecolonies:chainmailhelmet"
     ]
-  }
+  },
+  "sends_telemetry_event": false
 }

--- a/src/datagen/generated/minecolonies/data/minecolonies/advancements/recipes/misc/chainmailleggings.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/advancements/recipes/misc/chainmailleggings.json
@@ -30,5 +30,6 @@
     "recipes": [
       "minecolonies:chainmailleggings"
     ]
-  }
+  },
+  "sends_telemetry_event": false
 }

--- a/src/datagen/generated/minecolonies/data/minecolonies/advancements/recipes/misc/clipboard.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/advancements/recipes/misc/clipboard.json
@@ -30,5 +30,6 @@
     "recipes": [
       "minecolonies:clipboard"
     ]
-  }
+  },
+  "sends_telemetry_event": false
 }

--- a/src/datagen/generated/minecolonies/data/minecolonies/advancements/recipes/misc/colony_banner.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/advancements/recipes/misc/colony_banner.json
@@ -33,5 +33,6 @@
     "recipes": [
       "minecolonies:colony_banner"
     ]
-  }
+  },
+  "sends_telemetry_event": false
 }

--- a/src/datagen/generated/minecolonies/data/minecolonies/advancements/recipes/misc/composted_dirt.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/advancements/recipes/misc/composted_dirt.json
@@ -30,5 +30,6 @@
     "recipes": [
       "minecolonies:composted_dirt"
     ]
-  }
+  },
+  "sends_telemetry_event": false
 }

--- a/src/datagen/generated/minecolonies/data/minecolonies/advancements/recipes/misc/doublefern.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/advancements/recipes/misc/doublefern.json
@@ -30,5 +30,6 @@
     "recipes": [
       "minecolonies:doublefern"
     ]
-  }
+  },
+  "sends_telemetry_event": false
 }

--- a/src/datagen/generated/minecolonies/data/minecolonies/advancements/recipes/misc/doublegrass.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/advancements/recipes/misc/doublegrass.json
@@ -30,5 +30,6 @@
     "recipes": [
       "minecolonies:doublegrass"
     ]
-  }
+  },
+  "sends_telemetry_event": false
 }

--- a/src/datagen/generated/minecolonies/data/minecolonies/advancements/recipes/misc/iron_nugget_from_iron_scimitar_blasting.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/advancements/recipes/misc/iron_nugget_from_iron_scimitar_blasting.json
@@ -30,5 +30,6 @@
     "recipes": [
       "minecolonies:iron_nugget_from_iron_scimitar_blasting"
     ]
-  }
+  },
+  "sends_telemetry_event": false
 }

--- a/src/datagen/generated/minecolonies/data/minecolonies/advancements/recipes/misc/iron_nugget_from_iron_scimitar_smelting.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/advancements/recipes/misc/iron_nugget_from_iron_scimitar_smelting.json
@@ -30,5 +30,6 @@
     "recipes": [
       "minecolonies:iron_nugget_from_iron_scimitar_smelting"
     ]
-  }
+  },
+  "sends_telemetry_event": false
 }

--- a/src/datagen/generated/minecolonies/data/minecolonies/advancements/recipes/misc/mediumquarry.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/advancements/recipes/misc/mediumquarry.json
@@ -35,5 +35,6 @@
     "recipes": [
       "minecolonies:mediumquarry"
     ]
-  }
+  },
+  "sends_telemetry_event": false
 }

--- a/src/datagen/generated/minecolonies/data/minecolonies/advancements/recipes/misc/resourcescroll.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/advancements/recipes/misc/resourcescroll.json
@@ -30,5 +30,6 @@
     "recipes": [
       "minecolonies:resourcescroll"
     ]
-  }
+  },
+  "sends_telemetry_event": false
 }

--- a/src/datagen/generated/minecolonies/data/minecolonies/advancements/recipes/misc/shapetool.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/advancements/recipes/misc/shapetool.json
@@ -30,5 +30,6 @@
     "recipes": [
       "minecolonies:shapetool"
     ]
-  }
+  },
+  "sends_telemetry_event": false
 }

--- a/src/datagen/generated/minecolonies/data/minecolonies/advancements/recipes/misc/simplequarry.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/advancements/recipes/misc/simplequarry.json
@@ -35,5 +35,6 @@
     "recipes": [
       "minecolonies:simplequarry"
     ]
-  }
+  },
+  "sends_telemetry_event": false
 }

--- a/src/datagen/generated/minecolonies/data/minecolonies/advancements/recipes/misc/supplycampdeployer.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/advancements/recipes/misc/supplycampdeployer.json
@@ -28,5 +28,6 @@
     "recipes": [
       "minecolonies:supplycampdeployer"
     ]
-  }
+  },
+  "sends_telemetry_event": false
 }

--- a/src/datagen/generated/minecolonies/data/minecolonies/advancements/recipes/misc/supplychestdeployer.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/advancements/recipes/misc/supplychestdeployer.json
@@ -28,5 +28,6 @@
     "recipes": [
       "minecolonies:supplychestdeployer"
     ]
-  }
+  },
+  "sends_telemetry_event": false
 }

--- a/src/datagen/generated/minecolonies/data/minecolonies/crafterrecipes/blacksmith/netherite_axe.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/crafterrecipes/blacksmith/netherite_axe.json
@@ -1,15 +1,30 @@
 {
   "type": "recipe",
+  "additional-output": [
+    {
+      "item": "minecraft:netherite_upgrade_smithing_template"
+    }
+  ],
   "crafter": "blacksmith_crafting",
   "inputs": [
     {
       "item": "minecraft:diamond_axe"
     },
     {
+      "item": "minecraft:netherite_upgrade_smithing_template"
+    },
+    {
       "item": "minecraft:netherite_ingot"
+    },
+    {
+      "count": 7,
+      "item": "minecraft:diamond"
+    },
+    {
+      "item": "minecraft:netherrack"
     }
   ],
   "intermediate": "minecraft:air",
-  "min-building-level": 5,
+  "min-building-level": 4,
   "result": "minecraft:netherite_axe"
 }

--- a/src/datagen/generated/minecolonies/data/minecolonies/crafterrecipes/blacksmith/netherite_boots.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/crafterrecipes/blacksmith/netherite_boots.json
@@ -1,15 +1,30 @@
 {
   "type": "recipe",
+  "additional-output": [
+    {
+      "item": "minecraft:netherite_upgrade_smithing_template"
+    }
+  ],
   "crafter": "blacksmith_crafting",
   "inputs": [
     {
       "item": "minecraft:diamond_boots"
     },
     {
+      "item": "minecraft:netherite_upgrade_smithing_template"
+    },
+    {
       "item": "minecraft:netherite_ingot"
+    },
+    {
+      "count": 7,
+      "item": "minecraft:diamond"
+    },
+    {
+      "item": "minecraft:netherrack"
     }
   ],
   "intermediate": "minecraft:air",
-  "min-building-level": 5,
+  "min-building-level": 4,
   "result": "minecraft:netherite_boots"
 }

--- a/src/datagen/generated/minecolonies/data/minecolonies/crafterrecipes/blacksmith/netherite_chestplate.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/crafterrecipes/blacksmith/netherite_chestplate.json
@@ -1,15 +1,30 @@
 {
   "type": "recipe",
+  "additional-output": [
+    {
+      "item": "minecraft:netherite_upgrade_smithing_template"
+    }
+  ],
   "crafter": "blacksmith_crafting",
   "inputs": [
     {
       "item": "minecraft:diamond_chestplate"
     },
     {
+      "item": "minecraft:netherite_upgrade_smithing_template"
+    },
+    {
       "item": "minecraft:netherite_ingot"
+    },
+    {
+      "count": 7,
+      "item": "minecraft:diamond"
+    },
+    {
+      "item": "minecraft:netherrack"
     }
   ],
   "intermediate": "minecraft:air",
-  "min-building-level": 5,
+  "min-building-level": 4,
   "result": "minecraft:netherite_chestplate"
 }

--- a/src/datagen/generated/minecolonies/data/minecolonies/crafterrecipes/blacksmith/netherite_helmet.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/crafterrecipes/blacksmith/netherite_helmet.json
@@ -1,15 +1,30 @@
 {
   "type": "recipe",
+  "additional-output": [
+    {
+      "item": "minecraft:netherite_upgrade_smithing_template"
+    }
+  ],
   "crafter": "blacksmith_crafting",
   "inputs": [
     {
       "item": "minecraft:diamond_helmet"
     },
     {
+      "item": "minecraft:netherite_upgrade_smithing_template"
+    },
+    {
       "item": "minecraft:netherite_ingot"
+    },
+    {
+      "count": 7,
+      "item": "minecraft:diamond"
+    },
+    {
+      "item": "minecraft:netherrack"
     }
   ],
   "intermediate": "minecraft:air",
-  "min-building-level": 5,
+  "min-building-level": 4,
   "result": "minecraft:netherite_helmet"
 }

--- a/src/datagen/generated/minecolonies/data/minecolonies/crafterrecipes/blacksmith/netherite_hoe.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/crafterrecipes/blacksmith/netherite_hoe.json
@@ -1,15 +1,30 @@
 {
   "type": "recipe",
+  "additional-output": [
+    {
+      "item": "minecraft:netherite_upgrade_smithing_template"
+    }
+  ],
   "crafter": "blacksmith_crafting",
   "inputs": [
     {
       "item": "minecraft:diamond_hoe"
     },
     {
+      "item": "minecraft:netherite_upgrade_smithing_template"
+    },
+    {
       "item": "minecraft:netherite_ingot"
+    },
+    {
+      "count": 7,
+      "item": "minecraft:diamond"
+    },
+    {
+      "item": "minecraft:netherrack"
     }
   ],
   "intermediate": "minecraft:air",
-  "min-building-level": 5,
+  "min-building-level": 4,
   "result": "minecraft:netherite_hoe"
 }

--- a/src/datagen/generated/minecolonies/data/minecolonies/crafterrecipes/blacksmith/netherite_leggings.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/crafterrecipes/blacksmith/netherite_leggings.json
@@ -1,15 +1,30 @@
 {
   "type": "recipe",
+  "additional-output": [
+    {
+      "item": "minecraft:netherite_upgrade_smithing_template"
+    }
+  ],
   "crafter": "blacksmith_crafting",
   "inputs": [
     {
       "item": "minecraft:diamond_leggings"
     },
     {
+      "item": "minecraft:netherite_upgrade_smithing_template"
+    },
+    {
       "item": "minecraft:netherite_ingot"
+    },
+    {
+      "count": 7,
+      "item": "minecraft:diamond"
+    },
+    {
+      "item": "minecraft:netherrack"
     }
   ],
   "intermediate": "minecraft:air",
-  "min-building-level": 5,
+  "min-building-level": 4,
   "result": "minecraft:netherite_leggings"
 }

--- a/src/datagen/generated/minecolonies/data/minecolonies/crafterrecipes/blacksmith/netherite_pickaxe.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/crafterrecipes/blacksmith/netherite_pickaxe.json
@@ -1,15 +1,30 @@
 {
   "type": "recipe",
+  "additional-output": [
+    {
+      "item": "minecraft:netherite_upgrade_smithing_template"
+    }
+  ],
   "crafter": "blacksmith_crafting",
   "inputs": [
     {
       "item": "minecraft:diamond_pickaxe"
     },
     {
+      "item": "minecraft:netherite_upgrade_smithing_template"
+    },
+    {
       "item": "minecraft:netherite_ingot"
+    },
+    {
+      "count": 7,
+      "item": "minecraft:diamond"
+    },
+    {
+      "item": "minecraft:netherrack"
     }
   ],
   "intermediate": "minecraft:air",
-  "min-building-level": 5,
+  "min-building-level": 4,
   "result": "minecraft:netherite_pickaxe"
 }

--- a/src/datagen/generated/minecolonies/data/minecolonies/crafterrecipes/blacksmith/netherite_shovel.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/crafterrecipes/blacksmith/netherite_shovel.json
@@ -1,15 +1,30 @@
 {
   "type": "recipe",
+  "additional-output": [
+    {
+      "item": "minecraft:netherite_upgrade_smithing_template"
+    }
+  ],
   "crafter": "blacksmith_crafting",
   "inputs": [
     {
       "item": "minecraft:diamond_shovel"
     },
     {
+      "item": "minecraft:netherite_upgrade_smithing_template"
+    },
+    {
       "item": "minecraft:netherite_ingot"
+    },
+    {
+      "count": 7,
+      "item": "minecraft:diamond"
+    },
+    {
+      "item": "minecraft:netherrack"
     }
   ],
   "intermediate": "minecraft:air",
-  "min-building-level": 5,
+  "min-building-level": 4,
   "result": "minecraft:netherite_shovel"
 }

--- a/src/datagen/generated/minecolonies/data/minecolonies/crafterrecipes/blacksmith/netherite_sword.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/crafterrecipes/blacksmith/netherite_sword.json
@@ -1,15 +1,30 @@
 {
   "type": "recipe",
+  "additional-output": [
+    {
+      "item": "minecraft:netherite_upgrade_smithing_template"
+    }
+  ],
   "crafter": "blacksmith_crafting",
   "inputs": [
     {
       "item": "minecraft:diamond_sword"
     },
     {
+      "item": "minecraft:netherite_upgrade_smithing_template"
+    },
+    {
       "item": "minecraft:netherite_ingot"
+    },
+    {
+      "count": 7,
+      "item": "minecraft:diamond"
+    },
+    {
+      "item": "minecraft:netherrack"
     }
   ],
   "intermediate": "minecraft:air",
-  "min-building-level": 5,
+  "min-building-level": 4,
   "result": "minecraft:netherite_sword"
 }

--- a/src/datagen/generated/minecolonies/data/minecolonies/crafterrecipes/netherworker/trip1.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/crafterrecipes/netherworker/trip1.json
@@ -2,6 +2,15 @@
   "type": "recipe",
   "additional-output": [
     {
+      "item": "minecraft:gold_ingot"
+    },
+    {
+      "item": "minecraft:rotten_flesh"
+    },
+    {
+      "item": "minecraft:gold_nugget"
+    },
+    {
       "item": "minecraft:netherrack"
     },
     {
@@ -15,6 +24,36 @@
     },
     {
       "item": "minecraft:soul_soil"
+    },
+    {
+      "item": "minecraft:porkchop"
+    },
+    {
+      "item": "minecraft:leather"
+    },
+    {
+      "item": "minecraft:gunpowder"
+    },
+    {
+      "item": "minecraft:ghast_tear"
+    },
+    {
+      "item": "minecraft:ender_pearl"
+    },
+    {
+      "item": "minecraft:magma_cream"
+    },
+    {
+      "item": "minecraft:pearlescent_froglight"
+    },
+    {
+      "item": "minecraft:verdant_froglight"
+    },
+    {
+      "item": "minecraft:ochre_froglight"
+    },
+    {
+      "item": "minecraft:blaze_rod"
     }
   ],
   "crafter": "netherworker_custom",

--- a/src/datagen/generated/minecolonies/data/minecolonies/crafterrecipes/netherworker/trip1.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/crafterrecipes/netherworker/trip1.json
@@ -2,15 +2,6 @@
   "type": "recipe",
   "additional-output": [
     {
-      "item": "minecraft:gold_ingot"
-    },
-    {
-      "item": "minecraft:rotten_flesh"
-    },
-    {
-      "item": "minecraft:gold_nugget"
-    },
-    {
       "item": "minecraft:netherrack"
     },
     {
@@ -24,36 +15,6 @@
     },
     {
       "item": "minecraft:soul_soil"
-    },
-    {
-      "item": "minecraft:porkchop"
-    },
-    {
-      "item": "minecraft:leather"
-    },
-    {
-      "item": "minecraft:gunpowder"
-    },
-    {
-      "item": "minecraft:ghast_tear"
-    },
-    {
-      "item": "minecraft:ender_pearl"
-    },
-    {
-      "item": "minecraft:magma_cream"
-    },
-    {
-      "item": "minecraft:pearlescent_froglight"
-    },
-    {
-      "item": "minecraft:verdant_froglight"
-    },
-    {
-      "item": "minecraft:ochre_froglight"
-    },
-    {
-      "item": "minecraft:blaze_rod"
     }
   ],
   "crafter": "netherworker_custom",

--- a/src/datagen/generated/minecolonies/data/minecolonies/crafterrecipes/netherworker/trip2.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/crafterrecipes/netherworker/trip2.json
@@ -2,15 +2,6 @@
   "type": "recipe",
   "additional-output": [
     {
-      "item": "minecraft:gold_ingot"
-    },
-    {
-      "item": "minecraft:rotten_flesh"
-    },
-    {
-      "item": "minecraft:gold_nugget"
-    },
-    {
       "item": "minecraft:netherrack"
     },
     {
@@ -32,9 +23,6 @@
       "item": "minecraft:soul_soil"
     },
     {
-      "item": "minecraft:porkchop"
-    },
-    {
       "item": "minecraft:glowstone"
     },
     {
@@ -47,34 +35,7 @@
       "item": "minecraft:crimson_stem"
     },
     {
-      "item": "minecraft:leather"
-    },
-    {
-      "item": "minecraft:gunpowder"
-    },
-    {
       "item": "minecraft:nether_wart"
-    },
-    {
-      "item": "minecraft:ghast_tear"
-    },
-    {
-      "item": "minecraft:ender_pearl"
-    },
-    {
-      "item": "minecraft:magma_cream"
-    },
-    {
-      "item": "minecraft:pearlescent_froglight"
-    },
-    {
-      "item": "minecraft:verdant_froglight"
-    },
-    {
-      "item": "minecraft:ochre_froglight"
-    },
-    {
-      "item": "minecraft:blaze_rod"
     }
   ],
   "crafter": "netherworker_custom",

--- a/src/datagen/generated/minecolonies/data/minecolonies/crafterrecipes/netherworker/trip2.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/crafterrecipes/netherworker/trip2.json
@@ -2,6 +2,15 @@
   "type": "recipe",
   "additional-output": [
     {
+      "item": "minecraft:gold_ingot"
+    },
+    {
+      "item": "minecraft:rotten_flesh"
+    },
+    {
+      "item": "minecraft:gold_nugget"
+    },
+    {
       "item": "minecraft:netherrack"
     },
     {
@@ -23,6 +32,9 @@
       "item": "minecraft:soul_soil"
     },
     {
+      "item": "minecraft:porkchop"
+    },
+    {
       "item": "minecraft:glowstone"
     },
     {
@@ -35,7 +47,34 @@
       "item": "minecraft:crimson_stem"
     },
     {
+      "item": "minecraft:leather"
+    },
+    {
+      "item": "minecraft:gunpowder"
+    },
+    {
       "item": "minecraft:nether_wart"
+    },
+    {
+      "item": "minecraft:ghast_tear"
+    },
+    {
+      "item": "minecraft:ender_pearl"
+    },
+    {
+      "item": "minecraft:magma_cream"
+    },
+    {
+      "item": "minecraft:pearlescent_froglight"
+    },
+    {
+      "item": "minecraft:verdant_froglight"
+    },
+    {
+      "item": "minecraft:ochre_froglight"
+    },
+    {
+      "item": "minecraft:blaze_rod"
     }
   ],
   "crafter": "netherworker_custom",

--- a/src/datagen/generated/minecolonies/data/minecolonies/crafterrecipes/netherworker/trip3.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/crafterrecipes/netherworker/trip3.json
@@ -2,6 +2,15 @@
   "type": "recipe",
   "additional-output": [
     {
+      "item": "minecraft:gold_ingot"
+    },
+    {
+      "item": "minecraft:rotten_flesh"
+    },
+    {
+      "item": "minecraft:gold_nugget"
+    },
+    {
       "item": "minecraft:netherrack"
     },
     {
@@ -18,6 +27,9 @@
     },
     {
       "item": "minecraft:red_mushroom"
+    },
+    {
+      "item": "minecraft:porkchop"
     },
     {
       "item": "minecraft:soul_soil"
@@ -47,7 +59,34 @@
       "item": "minecraft:warped_stem"
     },
     {
+      "item": "minecraft:leather"
+    },
+    {
+      "item": "minecraft:gunpowder"
+    },
+    {
       "item": "minecraft:nether_wart"
+    },
+    {
+      "item": "minecraft:ghast_tear"
+    },
+    {
+      "item": "minecraft:ender_pearl"
+    },
+    {
+      "item": "minecraft:magma_cream"
+    },
+    {
+      "item": "minecraft:pearlescent_froglight"
+    },
+    {
+      "item": "minecraft:verdant_froglight"
+    },
+    {
+      "item": "minecraft:ochre_froglight"
+    },
+    {
+      "item": "minecraft:blaze_rod"
     }
   ],
   "crafter": "netherworker_custom",

--- a/src/datagen/generated/minecolonies/data/minecolonies/crafterrecipes/netherworker/trip3.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/crafterrecipes/netherworker/trip3.json
@@ -2,15 +2,6 @@
   "type": "recipe",
   "additional-output": [
     {
-      "item": "minecraft:gold_ingot"
-    },
-    {
-      "item": "minecraft:rotten_flesh"
-    },
-    {
-      "item": "minecraft:gold_nugget"
-    },
-    {
       "item": "minecraft:netherrack"
     },
     {
@@ -27,9 +18,6 @@
     },
     {
       "item": "minecraft:red_mushroom"
-    },
-    {
-      "item": "minecraft:porkchop"
     },
     {
       "item": "minecraft:soul_soil"
@@ -59,34 +47,7 @@
       "item": "minecraft:warped_stem"
     },
     {
-      "item": "minecraft:leather"
-    },
-    {
-      "item": "minecraft:gunpowder"
-    },
-    {
       "item": "minecraft:nether_wart"
-    },
-    {
-      "item": "minecraft:ghast_tear"
-    },
-    {
-      "item": "minecraft:ender_pearl"
-    },
-    {
-      "item": "minecraft:magma_cream"
-    },
-    {
-      "item": "minecraft:pearlescent_froglight"
-    },
-    {
-      "item": "minecraft:verdant_froglight"
-    },
-    {
-      "item": "minecraft:ochre_froglight"
-    },
-    {
-      "item": "minecraft:blaze_rod"
     }
   ],
   "crafter": "netherworker_custom",

--- a/src/datagen/generated/minecolonies/data/minecolonies/crafterrecipes/netherworker/trip4.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/crafterrecipes/netherworker/trip4.json
@@ -2,10 +2,22 @@
   "type": "recipe",
   "additional-output": [
     {
+      "item": "minecraft:gold_ingot"
+    },
+    {
+      "item": "minecraft:rotten_flesh"
+    },
+    {
+      "item": "minecraft:gold_nugget"
+    },
+    {
       "item": "minecraft:netherrack"
     },
     {
       "item": "minecraft:nether_quartz_ore"
+    },
+    {
+      "item": "minecraft:porkchop"
     },
     {
       "item": "minecraft:soul_sand"
@@ -21,6 +33,9 @@
     },
     {
       "item": "minecraft:soul_soil"
+    },
+    {
+      "item": "minecraft:leather"
     },
     {
       "item": "minecraft:glowstone"
@@ -53,7 +68,31 @@
       "item": "minecraft:blackstone"
     },
     {
+      "item": "minecraft:gunpowder"
+    },
+    {
+      "item": "minecraft:ghast_tear"
+    },
+    {
+      "item": "minecraft:ender_pearl"
+    },
+    {
       "item": "minecraft:nether_wart"
+    },
+    {
+      "item": "minecraft:magma_cream"
+    },
+    {
+      "item": "minecraft:pearlescent_froglight"
+    },
+    {
+      "item": "minecraft:verdant_froglight"
+    },
+    {
+      "item": "minecraft:ochre_froglight"
+    },
+    {
+      "item": "minecraft:blaze_rod"
     }
   ],
   "crafter": "netherworker_custom",

--- a/src/datagen/generated/minecolonies/data/minecolonies/crafterrecipes/netherworker/trip4.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/crafterrecipes/netherworker/trip4.json
@@ -2,22 +2,10 @@
   "type": "recipe",
   "additional-output": [
     {
-      "item": "minecraft:gold_ingot"
-    },
-    {
-      "item": "minecraft:rotten_flesh"
-    },
-    {
-      "item": "minecraft:gold_nugget"
-    },
-    {
       "item": "minecraft:netherrack"
     },
     {
       "item": "minecraft:nether_quartz_ore"
-    },
-    {
-      "item": "minecraft:porkchop"
     },
     {
       "item": "minecraft:soul_sand"
@@ -33,9 +21,6 @@
     },
     {
       "item": "minecraft:soul_soil"
-    },
-    {
-      "item": "minecraft:leather"
     },
     {
       "item": "minecraft:glowstone"
@@ -68,31 +53,7 @@
       "item": "minecraft:blackstone"
     },
     {
-      "item": "minecraft:gunpowder"
-    },
-    {
-      "item": "minecraft:ghast_tear"
-    },
-    {
-      "item": "minecraft:ender_pearl"
-    },
-    {
       "item": "minecraft:nether_wart"
-    },
-    {
-      "item": "minecraft:magma_cream"
-    },
-    {
-      "item": "minecraft:pearlescent_froglight"
-    },
-    {
-      "item": "minecraft:verdant_froglight"
-    },
-    {
-      "item": "minecraft:ochre_froglight"
-    },
-    {
-      "item": "minecraft:blaze_rod"
     }
   ],
   "crafter": "netherworker_custom",

--- a/src/datagen/generated/minecolonies/data/minecolonies/crafterrecipes/netherworker/trip5.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/crafterrecipes/netherworker/trip5.json
@@ -2,22 +2,10 @@
   "type": "recipe",
   "additional-output": [
     {
-      "item": "minecraft:gold_ingot"
-    },
-    {
-      "item": "minecraft:rotten_flesh"
-    },
-    {
-      "item": "minecraft:gold_nugget"
-    },
-    {
       "item": "minecraft:netherrack"
     },
     {
       "item": "minecraft:nether_quartz_ore"
-    },
-    {
-      "item": "minecraft:porkchop"
     },
     {
       "item": "minecraft:soul_sand"
@@ -33,9 +21,6 @@
     },
     {
       "item": "minecraft:soul_soil"
-    },
-    {
-      "item": "minecraft:leather"
     },
     {
       "item": "minecraft:glowstone"
@@ -68,31 +53,7 @@
       "item": "minecraft:blackstone"
     },
     {
-      "item": "minecraft:gunpowder"
-    },
-    {
-      "item": "minecraft:ghast_tear"
-    },
-    {
-      "item": "minecraft:ender_pearl"
-    },
-    {
       "item": "minecraft:nether_wart"
-    },
-    {
-      "item": "minecraft:magma_cream"
-    },
-    {
-      "item": "minecraft:pearlescent_froglight"
-    },
-    {
-      "item": "minecraft:verdant_froglight"
-    },
-    {
-      "item": "minecraft:ochre_froglight"
-    },
-    {
-      "item": "minecraft:blaze_rod"
     },
     {
       "item": "minecraft:ancient_debris"

--- a/src/datagen/generated/minecolonies/data/minecolonies/crafterrecipes/netherworker/trip5.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/crafterrecipes/netherworker/trip5.json
@@ -2,10 +2,22 @@
   "type": "recipe",
   "additional-output": [
     {
+      "item": "minecraft:gold_ingot"
+    },
+    {
+      "item": "minecraft:rotten_flesh"
+    },
+    {
+      "item": "minecraft:gold_nugget"
+    },
+    {
       "item": "minecraft:netherrack"
     },
     {
       "item": "minecraft:nether_quartz_ore"
+    },
+    {
+      "item": "minecraft:porkchop"
     },
     {
       "item": "minecraft:soul_sand"
@@ -21,6 +33,9 @@
     },
     {
       "item": "minecraft:soul_soil"
+    },
+    {
+      "item": "minecraft:leather"
     },
     {
       "item": "minecraft:glowstone"
@@ -53,7 +68,31 @@
       "item": "minecraft:blackstone"
     },
     {
+      "item": "minecraft:gunpowder"
+    },
+    {
+      "item": "minecraft:ghast_tear"
+    },
+    {
+      "item": "minecraft:ender_pearl"
+    },
+    {
       "item": "minecraft:nether_wart"
+    },
+    {
+      "item": "minecraft:magma_cream"
+    },
+    {
+      "item": "minecraft:pearlescent_froglight"
+    },
+    {
+      "item": "minecraft:verdant_froglight"
+    },
+    {
+      "item": "minecraft:ochre_froglight"
+    },
+    {
+      "item": "minecraft:blaze_rod"
     },
     {
       "item": "minecraft:ancient_debris"

--- a/src/datagen/generated/minecolonies/data/minecolonies/loot_tables/blocks/barrel_block.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/loot_tables/blocks/barrel_block.json
@@ -16,5 +16,6 @@
       ],
       "rolls": 1.0
     }
-  ]
+  ],
+  "random_sequence": "minecolonies:blocks/barrel_block"
 }

--- a/src/datagen/generated/minecolonies/data/minecolonies/loot_tables/blocks/blockconstructiontape.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/loot_tables/blocks/blockconstructiontape.json
@@ -16,5 +16,6 @@
       ],
       "rolls": 1.0
     }
-  ]
+  ],
+  "random_sequence": "minecolonies:blocks/blockconstructiontape"
 }

--- a/src/datagen/generated/minecolonies/data/minecolonies/loot_tables/blocks/blockhutalchemist.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/loot_tables/blocks/blockhutalchemist.json
@@ -22,5 +22,6 @@
       ],
       "rolls": 1.0
     }
-  ]
+  ],
+  "random_sequence": "minecolonies:blocks/blockhutalchemist"
 }

--- a/src/datagen/generated/minecolonies/data/minecolonies/loot_tables/blocks/blockhutarchery.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/loot_tables/blocks/blockhutarchery.json
@@ -22,5 +22,6 @@
       ],
       "rolls": 1.0
     }
-  ]
+  ],
+  "random_sequence": "minecolonies:blocks/blockhutarchery"
 }

--- a/src/datagen/generated/minecolonies/data/minecolonies/loot_tables/blocks/blockhutbaker.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/loot_tables/blocks/blockhutbaker.json
@@ -22,5 +22,6 @@
       ],
       "rolls": 1.0
     }
-  ]
+  ],
+  "random_sequence": "minecolonies:blocks/blockhutbaker"
 }

--- a/src/datagen/generated/minecolonies/data/minecolonies/loot_tables/blocks/blockhutbarracks.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/loot_tables/blocks/blockhutbarracks.json
@@ -22,5 +22,6 @@
       ],
       "rolls": 1.0
     }
-  ]
+  ],
+  "random_sequence": "minecolonies:blocks/blockhutbarracks"
 }

--- a/src/datagen/generated/minecolonies/data/minecolonies/loot_tables/blocks/blockhutbarrackstower.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/loot_tables/blocks/blockhutbarrackstower.json
@@ -22,5 +22,6 @@
       ],
       "rolls": 1.0
     }
-  ]
+  ],
+  "random_sequence": "minecolonies:blocks/blockhutbarrackstower"
 }

--- a/src/datagen/generated/minecolonies/data/minecolonies/loot_tables/blocks/blockhutbeekeeper.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/loot_tables/blocks/blockhutbeekeeper.json
@@ -22,5 +22,6 @@
       ],
       "rolls": 1.0
     }
-  ]
+  ],
+  "random_sequence": "minecolonies:blocks/blockhutbeekeeper"
 }

--- a/src/datagen/generated/minecolonies/data/minecolonies/loot_tables/blocks/blockhutblacksmith.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/loot_tables/blocks/blockhutblacksmith.json
@@ -22,5 +22,6 @@
       ],
       "rolls": 1.0
     }
-  ]
+  ],
+  "random_sequence": "minecolonies:blocks/blockhutblacksmith"
 }

--- a/src/datagen/generated/minecolonies/data/minecolonies/loot_tables/blocks/blockhutbuilder.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/loot_tables/blocks/blockhutbuilder.json
@@ -22,5 +22,6 @@
       ],
       "rolls": 1.0
     }
-  ]
+  ],
+  "random_sequence": "minecolonies:blocks/blockhutbuilder"
 }

--- a/src/datagen/generated/minecolonies/data/minecolonies/loot_tables/blocks/blockhutchickenherder.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/loot_tables/blocks/blockhutchickenherder.json
@@ -22,5 +22,6 @@
       ],
       "rolls": 1.0
     }
-  ]
+  ],
+  "random_sequence": "minecolonies:blocks/blockhutchickenherder"
 }

--- a/src/datagen/generated/minecolonies/data/minecolonies/loot_tables/blocks/blockhutcitizen.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/loot_tables/blocks/blockhutcitizen.json
@@ -22,5 +22,6 @@
       ],
       "rolls": 1.0
     }
-  ]
+  ],
+  "random_sequence": "minecolonies:blocks/blockhutcitizen"
 }

--- a/src/datagen/generated/minecolonies/data/minecolonies/loot_tables/blocks/blockhutcombatacademy.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/loot_tables/blocks/blockhutcombatacademy.json
@@ -22,5 +22,6 @@
       ],
       "rolls": 1.0
     }
-  ]
+  ],
+  "random_sequence": "minecolonies:blocks/blockhutcombatacademy"
 }

--- a/src/datagen/generated/minecolonies/data/minecolonies/loot_tables/blocks/blockhutcomposter.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/loot_tables/blocks/blockhutcomposter.json
@@ -22,5 +22,6 @@
       ],
       "rolls": 1.0
     }
-  ]
+  ],
+  "random_sequence": "minecolonies:blocks/blockhutcomposter"
 }

--- a/src/datagen/generated/minecolonies/data/minecolonies/loot_tables/blocks/blockhutconcretemixer.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/loot_tables/blocks/blockhutconcretemixer.json
@@ -22,5 +22,6 @@
       ],
       "rolls": 1.0
     }
-  ]
+  ],
+  "random_sequence": "minecolonies:blocks/blockhutconcretemixer"
 }

--- a/src/datagen/generated/minecolonies/data/minecolonies/loot_tables/blocks/blockhutcook.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/loot_tables/blocks/blockhutcook.json
@@ -22,5 +22,6 @@
       ],
       "rolls": 1.0
     }
-  ]
+  ],
+  "random_sequence": "minecolonies:blocks/blockhutcook"
 }

--- a/src/datagen/generated/minecolonies/data/minecolonies/loot_tables/blocks/blockhutcowboy.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/loot_tables/blocks/blockhutcowboy.json
@@ -22,5 +22,6 @@
       ],
       "rolls": 1.0
     }
-  ]
+  ],
+  "random_sequence": "minecolonies:blocks/blockhutcowboy"
 }

--- a/src/datagen/generated/minecolonies/data/minecolonies/loot_tables/blocks/blockhutcrusher.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/loot_tables/blocks/blockhutcrusher.json
@@ -22,5 +22,6 @@
       ],
       "rolls": 1.0
     }
-  ]
+  ],
+  "random_sequence": "minecolonies:blocks/blockhutcrusher"
 }

--- a/src/datagen/generated/minecolonies/data/minecolonies/loot_tables/blocks/blockhutdeliveryman.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/loot_tables/blocks/blockhutdeliveryman.json
@@ -22,5 +22,6 @@
       ],
       "rolls": 1.0
     }
-  ]
+  ],
+  "random_sequence": "minecolonies:blocks/blockhutdeliveryman"
 }

--- a/src/datagen/generated/minecolonies/data/minecolonies/loot_tables/blocks/blockhutdyer.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/loot_tables/blocks/blockhutdyer.json
@@ -22,5 +22,6 @@
       ],
       "rolls": 1.0
     }
-  ]
+  ],
+  "random_sequence": "minecolonies:blocks/blockhutdyer"
 }

--- a/src/datagen/generated/minecolonies/data/minecolonies/loot_tables/blocks/blockhutenchanter.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/loot_tables/blocks/blockhutenchanter.json
@@ -22,5 +22,6 @@
       ],
       "rolls": 1.0
     }
-  ]
+  ],
+  "random_sequence": "minecolonies:blocks/blockhutenchanter"
 }

--- a/src/datagen/generated/minecolonies/data/minecolonies/loot_tables/blocks/blockhutfarmer.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/loot_tables/blocks/blockhutfarmer.json
@@ -22,5 +22,6 @@
       ],
       "rolls": 1.0
     }
-  ]
+  ],
+  "random_sequence": "minecolonies:blocks/blockhutfarmer"
 }

--- a/src/datagen/generated/minecolonies/data/minecolonies/loot_tables/blocks/blockhutfield.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/loot_tables/blocks/blockhutfield.json
@@ -16,5 +16,6 @@
       ],
       "rolls": 1.0
     }
-  ]
+  ],
+  "random_sequence": "minecolonies:blocks/blockhutfield"
 }

--- a/src/datagen/generated/minecolonies/data/minecolonies/loot_tables/blocks/blockhutfisherman.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/loot_tables/blocks/blockhutfisherman.json
@@ -22,5 +22,6 @@
       ],
       "rolls": 1.0
     }
-  ]
+  ],
+  "random_sequence": "minecolonies:blocks/blockhutfisherman"
 }

--- a/src/datagen/generated/minecolonies/data/minecolonies/loot_tables/blocks/blockhutfletcher.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/loot_tables/blocks/blockhutfletcher.json
@@ -22,5 +22,6 @@
       ],
       "rolls": 1.0
     }
-  ]
+  ],
+  "random_sequence": "minecolonies:blocks/blockhutfletcher"
 }

--- a/src/datagen/generated/minecolonies/data/minecolonies/loot_tables/blocks/blockhutflorist.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/loot_tables/blocks/blockhutflorist.json
@@ -22,5 +22,6 @@
       ],
       "rolls": 1.0
     }
-  ]
+  ],
+  "random_sequence": "minecolonies:blocks/blockhutflorist"
 }

--- a/src/datagen/generated/minecolonies/data/minecolonies/loot_tables/blocks/blockhutglassblower.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/loot_tables/blocks/blockhutglassblower.json
@@ -22,5 +22,6 @@
       ],
       "rolls": 1.0
     }
-  ]
+  ],
+  "random_sequence": "minecolonies:blocks/blockhutglassblower"
 }

--- a/src/datagen/generated/minecolonies/data/minecolonies/loot_tables/blocks/blockhutgraveyard.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/loot_tables/blocks/blockhutgraveyard.json
@@ -22,5 +22,6 @@
       ],
       "rolls": 1.0
     }
-  ]
+  ],
+  "random_sequence": "minecolonies:blocks/blockhutgraveyard"
 }

--- a/src/datagen/generated/minecolonies/data/minecolonies/loot_tables/blocks/blockhutguardtower.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/loot_tables/blocks/blockhutguardtower.json
@@ -22,5 +22,6 @@
       ],
       "rolls": 1.0
     }
-  ]
+  ],
+  "random_sequence": "minecolonies:blocks/blockhutguardtower"
 }

--- a/src/datagen/generated/minecolonies/data/minecolonies/loot_tables/blocks/blockhuthospital.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/loot_tables/blocks/blockhuthospital.json
@@ -22,5 +22,6 @@
       ],
       "rolls": 1.0
     }
-  ]
+  ],
+  "random_sequence": "minecolonies:blocks/blockhuthospital"
 }

--- a/src/datagen/generated/minecolonies/data/minecolonies/loot_tables/blocks/blockhutlibrary.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/loot_tables/blocks/blockhutlibrary.json
@@ -22,5 +22,6 @@
       ],
       "rolls": 1.0
     }
-  ]
+  ],
+  "random_sequence": "minecolonies:blocks/blockhutlibrary"
 }

--- a/src/datagen/generated/minecolonies/data/minecolonies/loot_tables/blocks/blockhutlumberjack.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/loot_tables/blocks/blockhutlumberjack.json
@@ -22,5 +22,6 @@
       ],
       "rolls": 1.0
     }
-  ]
+  ],
+  "random_sequence": "minecolonies:blocks/blockhutlumberjack"
 }

--- a/src/datagen/generated/minecolonies/data/minecolonies/loot_tables/blocks/blockhutmechanic.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/loot_tables/blocks/blockhutmechanic.json
@@ -22,5 +22,6 @@
       ],
       "rolls": 1.0
     }
-  ]
+  ],
+  "random_sequence": "minecolonies:blocks/blockhutmechanic"
 }

--- a/src/datagen/generated/minecolonies/data/minecolonies/loot_tables/blocks/blockhutminer.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/loot_tables/blocks/blockhutminer.json
@@ -22,5 +22,6 @@
       ],
       "rolls": 1.0
     }
-  ]
+  ],
+  "random_sequence": "minecolonies:blocks/blockhutminer"
 }

--- a/src/datagen/generated/minecolonies/data/minecolonies/loot_tables/blocks/blockhutmysticalsite.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/loot_tables/blocks/blockhutmysticalsite.json
@@ -22,5 +22,6 @@
       ],
       "rolls": 1.0
     }
-  ]
+  ],
+  "random_sequence": "minecolonies:blocks/blockhutmysticalsite"
 }

--- a/src/datagen/generated/minecolonies/data/minecolonies/loot_tables/blocks/blockhutnetherworker.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/loot_tables/blocks/blockhutnetherworker.json
@@ -22,5 +22,6 @@
       ],
       "rolls": 1.0
     }
-  ]
+  ],
+  "random_sequence": "minecolonies:blocks/blockhutnetherworker"
 }

--- a/src/datagen/generated/minecolonies/data/minecolonies/loot_tables/blocks/blockhutplantation.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/loot_tables/blocks/blockhutplantation.json
@@ -22,5 +22,6 @@
       ],
       "rolls": 1.0
     }
-  ]
+  ],
+  "random_sequence": "minecolonies:blocks/blockhutplantation"
 }

--- a/src/datagen/generated/minecolonies/data/minecolonies/loot_tables/blocks/blockhutrabbithutch.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/loot_tables/blocks/blockhutrabbithutch.json
@@ -22,5 +22,6 @@
       ],
       "rolls": 1.0
     }
-  ]
+  ],
+  "random_sequence": "minecolonies:blocks/blockhutrabbithutch"
 }

--- a/src/datagen/generated/minecolonies/data/minecolonies/loot_tables/blocks/blockhutsawmill.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/loot_tables/blocks/blockhutsawmill.json
@@ -22,5 +22,6 @@
       ],
       "rolls": 1.0
     }
-  ]
+  ],
+  "random_sequence": "minecolonies:blocks/blockhutsawmill"
 }

--- a/src/datagen/generated/minecolonies/data/minecolonies/loot_tables/blocks/blockhutschool.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/loot_tables/blocks/blockhutschool.json
@@ -22,5 +22,6 @@
       ],
       "rolls": 1.0
     }
-  ]
+  ],
+  "random_sequence": "minecolonies:blocks/blockhutschool"
 }

--- a/src/datagen/generated/minecolonies/data/minecolonies/loot_tables/blocks/blockhutshepherd.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/loot_tables/blocks/blockhutshepherd.json
@@ -22,5 +22,6 @@
       ],
       "rolls": 1.0
     }
-  ]
+  ],
+  "random_sequence": "minecolonies:blocks/blockhutshepherd"
 }

--- a/src/datagen/generated/minecolonies/data/minecolonies/loot_tables/blocks/blockhutsifter.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/loot_tables/blocks/blockhutsifter.json
@@ -22,5 +22,6 @@
       ],
       "rolls": 1.0
     }
-  ]
+  ],
+  "random_sequence": "minecolonies:blocks/blockhutsifter"
 }

--- a/src/datagen/generated/minecolonies/data/minecolonies/loot_tables/blocks/blockhutsmeltery.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/loot_tables/blocks/blockhutsmeltery.json
@@ -22,5 +22,6 @@
       ],
       "rolls": 1.0
     }
-  ]
+  ],
+  "random_sequence": "minecolonies:blocks/blockhutsmeltery"
 }

--- a/src/datagen/generated/minecolonies/data/minecolonies/loot_tables/blocks/blockhutstonemason.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/loot_tables/blocks/blockhutstonemason.json
@@ -22,5 +22,6 @@
       ],
       "rolls": 1.0
     }
-  ]
+  ],
+  "random_sequence": "minecolonies:blocks/blockhutstonemason"
 }

--- a/src/datagen/generated/minecolonies/data/minecolonies/loot_tables/blocks/blockhutstonesmeltery.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/loot_tables/blocks/blockhutstonesmeltery.json
@@ -22,5 +22,6 @@
       ],
       "rolls": 1.0
     }
-  ]
+  ],
+  "random_sequence": "minecolonies:blocks/blockhutstonesmeltery"
 }

--- a/src/datagen/generated/minecolonies/data/minecolonies/loot_tables/blocks/blockhutswineherder.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/loot_tables/blocks/blockhutswineherder.json
@@ -22,5 +22,6 @@
       ],
       "rolls": 1.0
     }
-  ]
+  ],
+  "random_sequence": "minecolonies:blocks/blockhutswineherder"
 }

--- a/src/datagen/generated/minecolonies/data/minecolonies/loot_tables/blocks/blockhuttavern.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/loot_tables/blocks/blockhuttavern.json
@@ -22,5 +22,6 @@
       ],
       "rolls": 1.0
     }
-  ]
+  ],
+  "random_sequence": "minecolonies:blocks/blockhuttavern"
 }

--- a/src/datagen/generated/minecolonies/data/minecolonies/loot_tables/blocks/blockhuttownhall.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/loot_tables/blocks/blockhuttownhall.json
@@ -22,5 +22,6 @@
       ],
       "rolls": 1.0
     }
-  ]
+  ],
+  "random_sequence": "minecolonies:blocks/blockhuttownhall"
 }

--- a/src/datagen/generated/minecolonies/data/minecolonies/loot_tables/blocks/blockhutuniversity.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/loot_tables/blocks/blockhutuniversity.json
@@ -22,5 +22,6 @@
       ],
       "rolls": 1.0
     }
-  ]
+  ],
+  "random_sequence": "minecolonies:blocks/blockhutuniversity"
 }

--- a/src/datagen/generated/minecolonies/data/minecolonies/loot_tables/blocks/blockhutwarehouse.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/loot_tables/blocks/blockhutwarehouse.json
@@ -22,5 +22,6 @@
       ],
       "rolls": 1.0
     }
-  ]
+  ],
+  "random_sequence": "minecolonies:blocks/blockhutwarehouse"
 }

--- a/src/datagen/generated/minecolonies/data/minecolonies/loot_tables/blocks/blockminecoloniesrack.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/loot_tables/blocks/blockminecoloniesrack.json
@@ -22,5 +22,6 @@
       ],
       "rolls": 1.0
     }
-  ]
+  ],
+  "random_sequence": "minecolonies:blocks/blockminecoloniesrack"
 }

--- a/src/datagen/generated/minecolonies/data/minecolonies/loot_tables/blocks/blockpostbox.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/loot_tables/blocks/blockpostbox.json
@@ -22,5 +22,6 @@
       ],
       "rolls": 1.0
     }
-  ]
+  ],
+  "random_sequence": "minecolonies:blocks/blockpostbox"
 }

--- a/src/datagen/generated/minecolonies/data/minecolonies/loot_tables/blocks/blockstash.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/loot_tables/blocks/blockstash.json
@@ -22,5 +22,6 @@
       ],
       "rolls": 1.0
     }
-  ]
+  ],
+  "random_sequence": "minecolonies:blocks/blockstash"
 }

--- a/src/datagen/generated/minecolonies/data/minecolonies/loot_tables/blocks/blockwaypoint.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/loot_tables/blocks/blockwaypoint.json
@@ -16,5 +16,6 @@
       ],
       "rolls": 1.0
     }
-  ]
+  ],
+  "random_sequence": "minecolonies:blocks/blockwaypoint"
 }

--- a/src/datagen/generated/minecolonies/data/minecolonies/loot_tables/blocks/colony_banner.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/loot_tables/blocks/colony_banner.json
@@ -16,5 +16,6 @@
       ],
       "rolls": 1.0
     }
-  ]
+  ],
+  "random_sequence": "minecolonies:blocks/colony_banner"
 }

--- a/src/datagen/generated/minecolonies/data/minecolonies/loot_tables/blocks/colony_wall_banner.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/loot_tables/blocks/colony_wall_banner.json
@@ -16,5 +16,6 @@
       ],
       "rolls": 1.0
     }
-  ]
+  ],
+  "random_sequence": "minecolonies:blocks/colony_wall_banner"
 }

--- a/src/datagen/generated/minecolonies/data/minecolonies/loot_tables/blocks/gate_iron.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/loot_tables/blocks/gate_iron.json
@@ -16,5 +16,6 @@
       ],
       "rolls": 1.0
     }
-  ]
+  ],
+  "random_sequence": "minecolonies:blocks/gate_iron"
 }

--- a/src/datagen/generated/minecolonies/data/minecolonies/loot_tables/blocks/gate_wood.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/loot_tables/blocks/gate_wood.json
@@ -16,5 +16,6 @@
       ],
       "rolls": 1.0
     }
-  ]
+  ],
+  "random_sequence": "minecolonies:blocks/gate_wood"
 }

--- a/src/datagen/generated/minecolonies/data/minecolonies/loot_tables/blocks/mediumquarry.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/loot_tables/blocks/mediumquarry.json
@@ -22,5 +22,6 @@
       ],
       "rolls": 1.0
     }
-  ]
+  ],
+  "random_sequence": "minecolonies:blocks/mediumquarry"
 }

--- a/src/datagen/generated/minecolonies/data/minecolonies/loot_tables/blocks/simplequarry.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/loot_tables/blocks/simplequarry.json
@@ -22,5 +22,6 @@
       ],
       "rolls": 1.0
     }
-  ]
+  ],
+  "random_sequence": "minecolonies:blocks/simplequarry"
 }

--- a/src/datagen/generated/minecolonies/data/minecolonies/loot_tables/chests/supplycamp.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/loot_tables/chests/supplycamp.json
@@ -51,5 +51,6 @@
       ],
       "rolls": 1.0
     }
-  ]
+  ],
+  "random_sequence": "minecolonies:chests/supplycamp"
 }

--- a/src/datagen/generated/minecolonies/data/minecolonies/loot_tables/chests/supplyship.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/loot_tables/chests/supplyship.json
@@ -51,5 +51,6 @@
       ],
       "rolls": 1.0
     }
-  ]
+  ],
+  "random_sequence": "minecolonies:chests/supplyship"
 }

--- a/src/datagen/generated/minecolonies/data/minecolonies/loot_tables/entities/amazon.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/loot_tables/entities/amazon.json
@@ -18,8 +18,8 @@
           "weight": 5
         }
       ],
-      "name": "minecolonies:amazon",
       "rolls": 1.0
     }
-  ]
+  ],
+  "random_sequence": "minecolonies:entities/amazon"
 }

--- a/src/datagen/generated/minecolonies/data/minecolonies/loot_tables/entities/amazonchief.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/loot_tables/entities/amazonchief.json
@@ -18,8 +18,8 @@
           "weight": 30
         }
       ],
-      "name": "minecolonies:amazonchief",
       "rolls": 1.0
     }
-  ]
+  ],
+  "random_sequence": "minecolonies:entities/amazonchief"
 }

--- a/src/datagen/generated/minecolonies/data/minecolonies/loot_tables/entities/amazonspearman.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/loot_tables/entities/amazonspearman.json
@@ -18,8 +18,8 @@
           "weight": 5
         }
       ],
-      "name": "minecolonies:amazonspearman",
       "rolls": 1.0
     }
-  ]
+  ],
+  "random_sequence": "minecolonies:entities/amazonspearman"
 }

--- a/src/datagen/generated/minecolonies/data/minecolonies/loot_tables/entities/archerbarbarian.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/loot_tables/entities/archerbarbarian.json
@@ -18,8 +18,8 @@
           "weight": 5
         }
       ],
-      "name": "minecolonies:archerbarbarian",
       "rolls": 1.0
     }
-  ]
+  ],
+  "random_sequence": "minecolonies:entities/archerbarbarian"
 }

--- a/src/datagen/generated/minecolonies/data/minecolonies/loot_tables/entities/archermummy.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/loot_tables/entities/archermummy.json
@@ -18,8 +18,8 @@
           "weight": 5
         }
       ],
-      "name": "minecolonies:archermummy",
       "rolls": 1.0
     }
-  ]
+  ],
+  "random_sequence": "minecolonies:entities/archermummy"
 }

--- a/src/datagen/generated/minecolonies/data/minecolonies/loot_tables/entities/archerpirate.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/loot_tables/entities/archerpirate.json
@@ -18,8 +18,8 @@
           "weight": 5
         }
       ],
-      "name": "minecolonies:archerpirate",
       "rolls": 1.0
     }
-  ]
+  ],
+  "random_sequence": "minecolonies:entities/archerpirate"
 }

--- a/src/datagen/generated/minecolonies/data/minecolonies/loot_tables/entities/barbarian.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/loot_tables/entities/barbarian.json
@@ -32,8 +32,8 @@
           "weight": 3
         }
       ],
-      "name": "minecolonies:barbarian",
       "rolls": 1.0
     }
-  ]
+  ],
+  "random_sequence": "minecolonies:entities/barbarian"
 }

--- a/src/datagen/generated/minecolonies/data/minecolonies/loot_tables/entities/chiefbarbarian.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/loot_tables/entities/chiefbarbarian.json
@@ -38,8 +38,8 @@
           "weight": 30
         }
       ],
-      "name": "minecolonies:chiefbarbarian",
       "rolls": 1.0
     }
-  ]
+  ],
+  "random_sequence": "minecolonies:entities/chiefbarbarian"
 }

--- a/src/datagen/generated/minecolonies/data/minecolonies/loot_tables/entities/chiefpirate.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/loot_tables/entities/chiefpirate.json
@@ -67,8 +67,8 @@
           "weight": 30
         }
       ],
-      "name": "minecolonies:chiefpirate",
       "rolls": 1.0
     }
-  ]
+  ],
+  "random_sequence": "minecolonies:entities/chiefpirate"
 }

--- a/src/datagen/generated/minecolonies/data/minecolonies/loot_tables/entities/mummy.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/loot_tables/entities/mummy.json
@@ -13,8 +13,8 @@
           "weight": 15
         }
       ],
-      "name": "minecolonies:mummy",
       "rolls": 1.0
     }
-  ]
+  ],
+  "random_sequence": "minecolonies:entities/mummy"
 }

--- a/src/datagen/generated/minecolonies/data/minecolonies/loot_tables/entities/norsemenarcher.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/loot_tables/entities/norsemenarcher.json
@@ -18,8 +18,8 @@
           "weight": 5
         }
       ],
-      "name": "minecolonies:norsemenarcher",
       "rolls": 1.0
     }
-  ]
+  ],
+  "random_sequence": "minecolonies:entities/norsemenarcher"
 }

--- a/src/datagen/generated/minecolonies/data/minecolonies/loot_tables/entities/norsemenchief.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/loot_tables/entities/norsemenchief.json
@@ -25,8 +25,8 @@
           "weight": 50
         }
       ],
-      "name": "minecolonies:norsemenchief",
       "rolls": 2.0
     }
-  ]
+  ],
+  "random_sequence": "minecolonies:entities/norsemenchief"
 }

--- a/src/datagen/generated/minecolonies/data/minecolonies/loot_tables/entities/pharao.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/loot_tables/entities/pharao.json
@@ -67,8 +67,8 @@
           "weight": 30
         }
       ],
-      "name": "minecolonies:pharao",
       "rolls": 1.0
     }
-  ]
+  ],
+  "random_sequence": "minecolonies:entities/pharao"
 }

--- a/src/datagen/generated/minecolonies/data/minecolonies/loot_tables/entities/pirate.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/loot_tables/entities/pirate.json
@@ -18,8 +18,8 @@
           "weight": 4
         }
       ],
-      "name": "minecolonies:pirate",
       "rolls": 1.0
     }
-  ]
+  ],
+  "random_sequence": "minecolonies:entities/pirate"
 }

--- a/src/datagen/generated/minecolonies/data/minecolonies/loot_tables/entities/shieldmaiden.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/loot_tables/entities/shieldmaiden.json
@@ -18,8 +18,8 @@
           "weight": 5
         }
       ],
-      "name": "minecolonies:shieldmaiden",
       "rolls": 1.0
     }
-  ]
+  ],
+  "random_sequence": "minecolonies:entities/shieldmaiden"
 }

--- a/src/datagen/generated/minecolonies/data/minecolonies/loot_tables/fisherman.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/loot_tables/fisherman.json
@@ -40,5 +40,6 @@
       ],
       "rolls": 1.0
     }
-  ]
+  ],
+  "random_sequence": "minecolonies:fisherman"
 }

--- a/src/datagen/generated/minecolonies/data/minecolonies/loot_tables/fisherman/bonus1.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/loot_tables/fisherman/bonus1.json
@@ -1,3 +1,4 @@
 {
-  "type": "minecraft:empty"
+  "type": "minecraft:empty",
+  "random_sequence": "minecolonies:fisherman/bonus1"
 }

--- a/src/datagen/generated/minecolonies/data/minecolonies/loot_tables/fisherman/bonus2.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/loot_tables/fisherman/bonus2.json
@@ -1,3 +1,4 @@
 {
-  "type": "minecraft:empty"
+  "type": "minecraft:empty",
+  "random_sequence": "minecolonies:fisherman/bonus2"
 }

--- a/src/datagen/generated/minecolonies/data/minecolonies/loot_tables/fisherman/bonus3.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/loot_tables/fisherman/bonus3.json
@@ -22,5 +22,6 @@
       ],
       "rolls": 1.0
     }
-  ]
+  ],
+  "random_sequence": "minecolonies:fisherman/bonus3"
 }

--- a/src/datagen/generated/minecolonies/data/minecolonies/loot_tables/fisherman/bonus4.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/loot_tables/fisherman/bonus4.json
@@ -27,5 +27,6 @@
       ],
       "rolls": 1.0
     }
-  ]
+  ],
+  "random_sequence": "minecolonies:fisherman/bonus4"
 }

--- a/src/datagen/generated/minecolonies/data/minecolonies/loot_tables/fisherman/bonus5.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/loot_tables/fisherman/bonus5.json
@@ -27,5 +27,6 @@
       ],
       "rolls": 1.0
     }
-  ]
+  ],
+  "random_sequence": "minecolonies:fisherman/bonus5"
 }

--- a/src/datagen/generated/minecolonies/data/minecolonies/loot_tables/fisherman/fish.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/loot_tables/fisherman/fish.json
@@ -11,5 +11,6 @@
       ],
       "rolls": 1.0
     }
-  ]
+  ],
+  "random_sequence": "minecolonies:fisherman/fish"
 }

--- a/src/datagen/generated/minecolonies/data/minecolonies/loot_tables/fisherman/junk.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/loot_tables/fisherman/junk.json
@@ -11,5 +11,6 @@
       ],
       "rolls": 1.0
     }
-  ]
+  ],
+  "random_sequence": "minecolonies:fisherman/junk"
 }

--- a/src/datagen/generated/minecolonies/data/minecolonies/loot_tables/fisherman/treasure.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/loot_tables/fisherman/treasure.json
@@ -11,5 +11,6 @@
       ],
       "rolls": 1.0
     }
-  ]
+  ],
+  "random_sequence": "minecolonies:fisherman/treasure"
 }

--- a/src/datagen/generated/minecolonies/data/minecolonies/loot_tables/recipes/diamond/dirt.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/loot_tables/recipes/diamond/dirt.json
@@ -70,5 +70,6 @@
       ],
       "rolls": 1.0
     }
-  ]
+  ],
+  "random_sequence": "minecolonies:recipes/diamond/dirt"
 }

--- a/src/datagen/generated/minecolonies/data/minecolonies/loot_tables/recipes/diamond/gravel.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/loot_tables/recipes/diamond/gravel.json
@@ -50,5 +50,6 @@
       ],
       "rolls": 1.0
     }
-  ]
+  ],
+  "random_sequence": "minecolonies:recipes/diamond/gravel"
 }

--- a/src/datagen/generated/minecolonies/data/minecolonies/loot_tables/recipes/diamond/sand.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/loot_tables/recipes/diamond/sand.json
@@ -30,5 +30,6 @@
       ],
       "rolls": 1.0
     }
-  ]
+  ],
+  "random_sequence": "minecolonies:recipes/diamond/sand"
 }

--- a/src/datagen/generated/minecolonies/data/minecolonies/loot_tables/recipes/diamond/soul_sand.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/loot_tables/recipes/diamond/soul_sand.json
@@ -40,5 +40,6 @@
       ],
       "rolls": 1.0
     }
-  ]
+  ],
+  "random_sequence": "minecolonies:recipes/diamond/soul_sand"
 }

--- a/src/datagen/generated/minecolonies/data/minecolonies/loot_tables/recipes/enchanter1.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/loot_tables/recipes/enchanter1.json
@@ -248,5 +248,6 @@
       ],
       "rolls": 1.0
     }
-  ]
+  ],
+  "random_sequence": "minecolonies:recipes/enchanter1"
 }

--- a/src/datagen/generated/minecolonies/data/minecolonies/loot_tables/recipes/enchanter2.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/loot_tables/recipes/enchanter2.json
@@ -490,5 +490,6 @@
       ],
       "rolls": 1.0
     }
-  ]
+  ],
+  "random_sequence": "minecolonies:recipes/enchanter2"
 }

--- a/src/datagen/generated/minecolonies/data/minecolonies/loot_tables/recipes/enchanter3.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/loot_tables/recipes/enchanter3.json
@@ -753,5 +753,6 @@
       ],
       "rolls": 1.0
     }
-  ]
+  ],
+  "random_sequence": "minecolonies:recipes/enchanter3"
 }

--- a/src/datagen/generated/minecolonies/data/minecolonies/loot_tables/recipes/enchanter4.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/loot_tables/recipes/enchanter4.json
@@ -763,5 +763,6 @@
       ],
       "rolls": 1.0
     }
-  ]
+  ],
+  "random_sequence": "minecolonies:recipes/enchanter4"
 }

--- a/src/datagen/generated/minecolonies/data/minecolonies/loot_tables/recipes/enchanter5.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/loot_tables/recipes/enchanter5.json
@@ -801,5 +801,6 @@
       ],
       "rolls": 1.0
     }
-  ]
+  ],
+  "random_sequence": "minecolonies:recipes/enchanter5"
 }

--- a/src/datagen/generated/minecolonies/data/minecolonies/loot_tables/recipes/flint/dirt.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/loot_tables/recipes/flint/dirt.json
@@ -43,5 +43,6 @@
       ],
       "rolls": 1.0
     }
-  ]
+  ],
+  "random_sequence": "minecolonies:recipes/flint/dirt"
 }

--- a/src/datagen/generated/minecolonies/data/minecolonies/loot_tables/recipes/flint/gravel.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/loot_tables/recipes/flint/gravel.json
@@ -30,5 +30,6 @@
       ],
       "rolls": 1.0
     }
-  ]
+  ],
+  "random_sequence": "minecolonies:recipes/flint/gravel"
 }

--- a/src/datagen/generated/minecolonies/data/minecolonies/loot_tables/recipes/flint/sand.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/loot_tables/recipes/flint/sand.json
@@ -25,5 +25,6 @@
       ],
       "rolls": 1.0
     }
-  ]
+  ],
+  "random_sequence": "minecolonies:recipes/flint/sand"
 }

--- a/src/datagen/generated/minecolonies/data/minecolonies/loot_tables/recipes/flint/soul_sand.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/loot_tables/recipes/flint/soul_sand.json
@@ -25,5 +25,6 @@
       ],
       "rolls": 1.0
     }
-  ]
+  ],
+  "random_sequence": "minecolonies:recipes/flint/soul_sand"
 }

--- a/src/datagen/generated/minecolonies/data/minecolonies/loot_tables/recipes/glass_bottle.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/loot_tables/recipes/glass_bottle.json
@@ -15,8 +15,8 @@
           "weight": 0
         }
       ],
-      "name": "minecolonies:recipes/glass_bottle",
       "rolls": 1.0
     }
-  ]
+  ],
+  "random_sequence": "minecolonies:recipes/glass_bottle"
 }

--- a/src/datagen/generated/minecolonies/data/minecolonies/loot_tables/recipes/gravel.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/loot_tables/recipes/gravel.json
@@ -13,8 +13,8 @@
           "weight": 10
         }
       ],
-      "name": "minecolonies:recipes/gravel",
       "rolls": 1.0
     }
-  ]
+  ],
+  "random_sequence": "minecolonies:recipes/gravel"
 }

--- a/src/datagen/generated/minecolonies/data/minecolonies/loot_tables/recipes/iron/dirt.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/loot_tables/recipes/iron/dirt.json
@@ -63,5 +63,6 @@
       ],
       "rolls": 1.0
     }
-  ]
+  ],
+  "random_sequence": "minecolonies:recipes/iron/dirt"
 }

--- a/src/datagen/generated/minecolonies/data/minecolonies/loot_tables/recipes/iron/gravel.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/loot_tables/recipes/iron/gravel.json
@@ -46,5 +46,6 @@
       ],
       "rolls": 1.0
     }
-  ]
+  ],
+  "random_sequence": "minecolonies:recipes/iron/gravel"
 }

--- a/src/datagen/generated/minecolonies/data/minecolonies/loot_tables/recipes/iron/sand.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/loot_tables/recipes/iron/sand.json
@@ -30,5 +30,6 @@
       ],
       "rolls": 1.0
     }
-  ]
+  ],
+  "random_sequence": "minecolonies:recipes/iron/sand"
 }

--- a/src/datagen/generated/minecolonies/data/minecolonies/loot_tables/recipes/iron/soul_sand.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/loot_tables/recipes/iron/soul_sand.json
@@ -33,5 +33,6 @@
       ],
       "rolls": 1.0
     }
-  ]
+  ],
+  "random_sequence": "minecolonies:recipes/iron/soul_sand"
 }

--- a/src/datagen/generated/minecolonies/data/minecolonies/loot_tables/recipes/netherworker/trip1.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/loot_tables/recipes/netherworker/trip1.json
@@ -88,7 +88,6 @@
           "weight": 15
         }
       ],
-      "name": "blocks",
       "rolls": {
         "type": "minecraft:uniform",
         "max": 10.0,
@@ -175,12 +174,12 @@
           "weight": 100
         }
       ],
-      "name": "mobs",
       "rolls": {
         "type": "minecraft:uniform",
         "max": 6.0,
         "min": 2.0
       }
     }
-  ]
+  ],
+  "random_sequence": "minecolonies:recipes/netherworker/trip1"
 }

--- a/src/datagen/generated/minecolonies/data/minecolonies/loot_tables/recipes/netherworker/trip2.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/loot_tables/recipes/netherworker/trip2.json
@@ -200,7 +200,6 @@
           "weight": 5
         }
       ],
-      "name": "blocks",
       "rolls": {
         "type": "minecraft:uniform",
         "max": 10.0,
@@ -287,12 +286,12 @@
           "weight": 100
         }
       ],
-      "name": "mobs",
       "rolls": {
         "type": "minecraft:uniform",
         "max": 6.0,
         "min": 2.0
       }
     }
-  ]
+  ],
+  "random_sequence": "minecolonies:recipes/netherworker/trip2"
 }

--- a/src/datagen/generated/minecolonies/data/minecolonies/loot_tables/recipes/netherworker/trip3.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/loot_tables/recipes/netherworker/trip3.json
@@ -264,7 +264,6 @@
           "weight": 5
         }
       ],
-      "name": "blocks",
       "rolls": {
         "type": "minecraft:uniform",
         "max": 10.0,
@@ -351,12 +350,12 @@
           "weight": 100
         }
       ],
-      "name": "mobs",
       "rolls": {
         "type": "minecraft:uniform",
         "max": 6.0,
         "min": 2.0
       }
     }
-  ]
+  ],
+  "random_sequence": "minecolonies:recipes/netherworker/trip3"
 }

--- a/src/datagen/generated/minecolonies/data/minecolonies/loot_tables/recipes/netherworker/trip4.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/loot_tables/recipes/netherworker/trip4.json
@@ -296,7 +296,6 @@
           "weight": 5
         }
       ],
-      "name": "blocks",
       "rolls": {
         "type": "minecraft:uniform",
         "max": 10.0,
@@ -383,12 +382,12 @@
           "weight": 100
         }
       ],
-      "name": "mobs",
       "rolls": {
         "type": "minecraft:uniform",
         "max": 6.0,
         "min": 2.0
       }
     }
-  ]
+  ],
+  "random_sequence": "minecolonies:recipes/netherworker/trip4"
 }

--- a/src/datagen/generated/minecolonies/data/minecolonies/loot_tables/recipes/netherworker/trip5.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/loot_tables/recipes/netherworker/trip5.json
@@ -311,7 +311,6 @@
           "name": "minecraft:ancient_debris"
         }
       ],
-      "name": "blocks",
       "rolls": {
         "type": "minecraft:uniform",
         "max": 10.0,
@@ -398,12 +397,12 @@
           "weight": 100
         }
       ],
-      "name": "mobs",
       "rolls": {
         "type": "minecraft:uniform",
         "max": 6.0,
         "min": 2.0
       }
     }
-  ]
+  ],
+  "random_sequence": "minecolonies:recipes/netherworker/trip5"
 }

--- a/src/datagen/generated/minecolonies/data/minecolonies/loot_tables/recipes/string/dirt.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/loot_tables/recipes/string/dirt.json
@@ -31,5 +31,6 @@
       ],
       "rolls": 1.0
     }
-  ]
+  ],
+  "random_sequence": "minecolonies:recipes/string/dirt"
 }

--- a/src/datagen/generated/minecolonies/data/minecolonies/loot_tables/recipes/string/gravel.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/loot_tables/recipes/string/gravel.json
@@ -25,5 +25,6 @@
       ],
       "rolls": 1.0
     }
-  ]
+  ],
+  "random_sequence": "minecolonies:recipes/string/gravel"
 }

--- a/src/datagen/generated/minecolonies/data/minecolonies/loot_tables/recipes/string/sand.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/loot_tables/recipes/string/sand.json
@@ -20,5 +20,6 @@
       ],
       "rolls": 1.0
     }
-  ]
+  ],
+  "random_sequence": "minecolonies:recipes/string/sand"
 }

--- a/src/datagen/generated/minecolonies/data/minecolonies/loot_tables/recipes/string/soul_sand.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/loot_tables/recipes/string/soul_sand.json
@@ -20,5 +20,6 @@
       ],
       "rolls": 1.0
     }
-  ]
+  ],
+  "random_sequence": "minecolonies:recipes/string/soul_sand"
 }

--- a/src/datagen/generated/minecolonies/data/minecolonies/tags/items/stonemason_product_excluded.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/tags/items/stonemason_product_excluded.json
@@ -3,8 +3,10 @@
     "#minecolonies:mechanic_product",
     "#minecraft:wooden_slabs",
     "#minecraft:wooden_stairs",
+    "#minecraft:trim_templates",
     "minecraft:lectern",
     "minecraft:piston",
+    "minecraft:netherite_upgrade_smithing_template",
     "domum_ornamentum:paper_extra",
     "domum_ornamentum:white_paper_extra"
   ]

--- a/src/datagen/generated/minecolonies/data/minecraft/loot_tables/blocks/black_banner.json
+++ b/src/datagen/generated/minecolonies/data/minecraft/loot_tables/blocks/black_banner.json
@@ -38,5 +38,6 @@
       ],
       "rolls": 1.0
     }
-  ]
+  ],
+  "random_sequence": "minecraft:blocks/black_banner"
 }

--- a/src/datagen/generated/minecolonies/data/minecraft/loot_tables/blocks/black_wall_banner.json
+++ b/src/datagen/generated/minecolonies/data/minecraft/loot_tables/blocks/black_wall_banner.json
@@ -38,5 +38,6 @@
       ],
       "rolls": 1.0
     }
-  ]
+  ],
+  "random_sequence": "minecraft:blocks/black_wall_banner"
 }

--- a/src/datagen/generated/minecolonies/data/minecraft/loot_tables/blocks/blue_banner.json
+++ b/src/datagen/generated/minecolonies/data/minecraft/loot_tables/blocks/blue_banner.json
@@ -38,5 +38,6 @@
       ],
       "rolls": 1.0
     }
-  ]
+  ],
+  "random_sequence": "minecraft:blocks/blue_banner"
 }

--- a/src/datagen/generated/minecolonies/data/minecraft/loot_tables/blocks/blue_wall_banner.json
+++ b/src/datagen/generated/minecolonies/data/minecraft/loot_tables/blocks/blue_wall_banner.json
@@ -38,5 +38,6 @@
       ],
       "rolls": 1.0
     }
-  ]
+  ],
+  "random_sequence": "minecraft:blocks/blue_wall_banner"
 }

--- a/src/datagen/generated/minecolonies/data/minecraft/loot_tables/blocks/brown_banner.json
+++ b/src/datagen/generated/minecolonies/data/minecraft/loot_tables/blocks/brown_banner.json
@@ -38,5 +38,6 @@
       ],
       "rolls": 1.0
     }
-  ]
+  ],
+  "random_sequence": "minecraft:blocks/brown_banner"
 }

--- a/src/datagen/generated/minecolonies/data/minecraft/loot_tables/blocks/brown_wall_banner.json
+++ b/src/datagen/generated/minecolonies/data/minecraft/loot_tables/blocks/brown_wall_banner.json
@@ -38,5 +38,6 @@
       ],
       "rolls": 1.0
     }
-  ]
+  ],
+  "random_sequence": "minecraft:blocks/brown_wall_banner"
 }

--- a/src/datagen/generated/minecolonies/data/minecraft/loot_tables/blocks/cyan_banner.json
+++ b/src/datagen/generated/minecolonies/data/minecraft/loot_tables/blocks/cyan_banner.json
@@ -38,5 +38,6 @@
       ],
       "rolls": 1.0
     }
-  ]
+  ],
+  "random_sequence": "minecraft:blocks/cyan_banner"
 }

--- a/src/datagen/generated/minecolonies/data/minecraft/loot_tables/blocks/cyan_wall_banner.json
+++ b/src/datagen/generated/minecolonies/data/minecraft/loot_tables/blocks/cyan_wall_banner.json
@@ -38,5 +38,6 @@
       ],
       "rolls": 1.0
     }
-  ]
+  ],
+  "random_sequence": "minecraft:blocks/cyan_wall_banner"
 }

--- a/src/datagen/generated/minecolonies/data/minecraft/loot_tables/blocks/gray_banner.json
+++ b/src/datagen/generated/minecolonies/data/minecraft/loot_tables/blocks/gray_banner.json
@@ -38,5 +38,6 @@
       ],
       "rolls": 1.0
     }
-  ]
+  ],
+  "random_sequence": "minecraft:blocks/gray_banner"
 }

--- a/src/datagen/generated/minecolonies/data/minecraft/loot_tables/blocks/gray_wall_banner.json
+++ b/src/datagen/generated/minecolonies/data/minecraft/loot_tables/blocks/gray_wall_banner.json
@@ -38,5 +38,6 @@
       ],
       "rolls": 1.0
     }
-  ]
+  ],
+  "random_sequence": "minecraft:blocks/gray_wall_banner"
 }

--- a/src/datagen/generated/minecolonies/data/minecraft/loot_tables/blocks/green_banner.json
+++ b/src/datagen/generated/minecolonies/data/minecraft/loot_tables/blocks/green_banner.json
@@ -38,5 +38,6 @@
       ],
       "rolls": 1.0
     }
-  ]
+  ],
+  "random_sequence": "minecraft:blocks/green_banner"
 }

--- a/src/datagen/generated/minecolonies/data/minecraft/loot_tables/blocks/green_wall_banner.json
+++ b/src/datagen/generated/minecolonies/data/minecraft/loot_tables/blocks/green_wall_banner.json
@@ -38,5 +38,6 @@
       ],
       "rolls": 1.0
     }
-  ]
+  ],
+  "random_sequence": "minecraft:blocks/green_wall_banner"
 }

--- a/src/datagen/generated/minecolonies/data/minecraft/loot_tables/blocks/light_blue_banner.json
+++ b/src/datagen/generated/minecolonies/data/minecraft/loot_tables/blocks/light_blue_banner.json
@@ -38,5 +38,6 @@
       ],
       "rolls": 1.0
     }
-  ]
+  ],
+  "random_sequence": "minecraft:blocks/light_blue_banner"
 }

--- a/src/datagen/generated/minecolonies/data/minecraft/loot_tables/blocks/light_blue_wall_banner.json
+++ b/src/datagen/generated/minecolonies/data/minecraft/loot_tables/blocks/light_blue_wall_banner.json
@@ -38,5 +38,6 @@
       ],
       "rolls": 1.0
     }
-  ]
+  ],
+  "random_sequence": "minecraft:blocks/light_blue_wall_banner"
 }

--- a/src/datagen/generated/minecolonies/data/minecraft/loot_tables/blocks/light_gray_banner.json
+++ b/src/datagen/generated/minecolonies/data/minecraft/loot_tables/blocks/light_gray_banner.json
@@ -38,5 +38,6 @@
       ],
       "rolls": 1.0
     }
-  ]
+  ],
+  "random_sequence": "minecraft:blocks/light_gray_banner"
 }

--- a/src/datagen/generated/minecolonies/data/minecraft/loot_tables/blocks/light_gray_wall_banner.json
+++ b/src/datagen/generated/minecolonies/data/minecraft/loot_tables/blocks/light_gray_wall_banner.json
@@ -38,5 +38,6 @@
       ],
       "rolls": 1.0
     }
-  ]
+  ],
+  "random_sequence": "minecraft:blocks/light_gray_wall_banner"
 }

--- a/src/datagen/generated/minecolonies/data/minecraft/loot_tables/blocks/lime_banner.json
+++ b/src/datagen/generated/minecolonies/data/minecraft/loot_tables/blocks/lime_banner.json
@@ -38,5 +38,6 @@
       ],
       "rolls": 1.0
     }
-  ]
+  ],
+  "random_sequence": "minecraft:blocks/lime_banner"
 }

--- a/src/datagen/generated/minecolonies/data/minecraft/loot_tables/blocks/lime_wall_banner.json
+++ b/src/datagen/generated/minecolonies/data/minecraft/loot_tables/blocks/lime_wall_banner.json
@@ -38,5 +38,6 @@
       ],
       "rolls": 1.0
     }
-  ]
+  ],
+  "random_sequence": "minecraft:blocks/lime_wall_banner"
 }

--- a/src/datagen/generated/minecolonies/data/minecraft/loot_tables/blocks/magenta_banner.json
+++ b/src/datagen/generated/minecolonies/data/minecraft/loot_tables/blocks/magenta_banner.json
@@ -38,5 +38,6 @@
       ],
       "rolls": 1.0
     }
-  ]
+  ],
+  "random_sequence": "minecraft:blocks/magenta_banner"
 }

--- a/src/datagen/generated/minecolonies/data/minecraft/loot_tables/blocks/magenta_wall_banner.json
+++ b/src/datagen/generated/minecolonies/data/minecraft/loot_tables/blocks/magenta_wall_banner.json
@@ -38,5 +38,6 @@
       ],
       "rolls": 1.0
     }
-  ]
+  ],
+  "random_sequence": "minecraft:blocks/magenta_wall_banner"
 }

--- a/src/datagen/generated/minecolonies/data/minecraft/loot_tables/blocks/orange_banner.json
+++ b/src/datagen/generated/minecolonies/data/minecraft/loot_tables/blocks/orange_banner.json
@@ -38,5 +38,6 @@
       ],
       "rolls": 1.0
     }
-  ]
+  ],
+  "random_sequence": "minecraft:blocks/orange_banner"
 }

--- a/src/datagen/generated/minecolonies/data/minecraft/loot_tables/blocks/orange_wall_banner.json
+++ b/src/datagen/generated/minecolonies/data/minecraft/loot_tables/blocks/orange_wall_banner.json
@@ -38,5 +38,6 @@
       ],
       "rolls": 1.0
     }
-  ]
+  ],
+  "random_sequence": "minecraft:blocks/orange_wall_banner"
 }

--- a/src/datagen/generated/minecolonies/data/minecraft/loot_tables/blocks/pink_banner.json
+++ b/src/datagen/generated/minecolonies/data/minecraft/loot_tables/blocks/pink_banner.json
@@ -38,5 +38,6 @@
       ],
       "rolls": 1.0
     }
-  ]
+  ],
+  "random_sequence": "minecraft:blocks/pink_banner"
 }

--- a/src/datagen/generated/minecolonies/data/minecraft/loot_tables/blocks/pink_wall_banner.json
+++ b/src/datagen/generated/minecolonies/data/minecraft/loot_tables/blocks/pink_wall_banner.json
@@ -38,5 +38,6 @@
       ],
       "rolls": 1.0
     }
-  ]
+  ],
+  "random_sequence": "minecraft:blocks/pink_wall_banner"
 }

--- a/src/datagen/generated/minecolonies/data/minecraft/loot_tables/blocks/purple_banner.json
+++ b/src/datagen/generated/minecolonies/data/minecraft/loot_tables/blocks/purple_banner.json
@@ -38,5 +38,6 @@
       ],
       "rolls": 1.0
     }
-  ]
+  ],
+  "random_sequence": "minecraft:blocks/purple_banner"
 }

--- a/src/datagen/generated/minecolonies/data/minecraft/loot_tables/blocks/purple_wall_banner.json
+++ b/src/datagen/generated/minecolonies/data/minecraft/loot_tables/blocks/purple_wall_banner.json
@@ -38,5 +38,6 @@
       ],
       "rolls": 1.0
     }
-  ]
+  ],
+  "random_sequence": "minecraft:blocks/purple_wall_banner"
 }

--- a/src/datagen/generated/minecolonies/data/minecraft/loot_tables/blocks/red_banner.json
+++ b/src/datagen/generated/minecolonies/data/minecraft/loot_tables/blocks/red_banner.json
@@ -38,5 +38,6 @@
       ],
       "rolls": 1.0
     }
-  ]
+  ],
+  "random_sequence": "minecraft:blocks/red_banner"
 }

--- a/src/datagen/generated/minecolonies/data/minecraft/loot_tables/blocks/red_wall_banner.json
+++ b/src/datagen/generated/minecolonies/data/minecraft/loot_tables/blocks/red_wall_banner.json
@@ -38,5 +38,6 @@
       ],
       "rolls": 1.0
     }
-  ]
+  ],
+  "random_sequence": "minecraft:blocks/red_wall_banner"
 }

--- a/src/datagen/generated/minecolonies/data/minecraft/loot_tables/blocks/white_banner.json
+++ b/src/datagen/generated/minecolonies/data/minecraft/loot_tables/blocks/white_banner.json
@@ -38,5 +38,6 @@
       ],
       "rolls": 1.0
     }
-  ]
+  ],
+  "random_sequence": "minecraft:blocks/white_banner"
 }

--- a/src/datagen/generated/minecolonies/data/minecraft/loot_tables/blocks/white_wall_banner.json
+++ b/src/datagen/generated/minecolonies/data/minecraft/loot_tables/blocks/white_wall_banner.json
@@ -38,5 +38,6 @@
       ],
       "rolls": 1.0
     }
-  ]
+  ],
+  "random_sequence": "minecraft:blocks/white_wall_banner"
 }

--- a/src/datagen/generated/minecolonies/data/minecraft/loot_tables/blocks/yellow_banner.json
+++ b/src/datagen/generated/minecolonies/data/minecraft/loot_tables/blocks/yellow_banner.json
@@ -38,5 +38,6 @@
       ],
       "rolls": 1.0
     }
-  ]
+  ],
+  "random_sequence": "minecraft:blocks/yellow_banner"
 }

--- a/src/datagen/generated/minecolonies/data/minecraft/loot_tables/blocks/yellow_wall_banner.json
+++ b/src/datagen/generated/minecolonies/data/minecraft/loot_tables/blocks/yellow_wall_banner.json
@@ -38,5 +38,6 @@
       ],
       "rolls": 1.0
     }
-  ]
+  ],
+  "random_sequence": "minecraft:blocks/yellow_wall_banner"
 }

--- a/src/main/java/com/minecolonies/coremod/generation/DatagenLootTableManager.java
+++ b/src/main/java/com/minecolonies/coremod/generation/DatagenLootTableManager.java
@@ -47,7 +47,7 @@ public class DatagenLootTableManager extends LootDataManager
 
         try
         {
-            final Resource resource = existingFileHelper.getResource(location, PackType.SERVER_DATA);
+            final Resource resource = existingFileHelper.getResource(location, PackType.SERVER_DATA, ".json", "loot_tables");
             try (final InputStream inputstream = resource.open();
                  final Reader reader = new BufferedReader(new InputStreamReader(inputstream, StandardCharsets.UTF_8));
             )

--- a/src/main/java/com/minecolonies/coremod/generation/defaults/DefaultItemTagsProvider.java
+++ b/src/main/java/com/minecolonies/coremod/generation/defaults/DefaultItemTagsProvider.java
@@ -400,7 +400,8 @@ public class DefaultItemTagsProvider extends ItemTagsProvider
           .addTag(ModTags.crafterProduct.get(TagConstants.CRAFTING_MECHANIC))
           .addTag(ItemTags.WOODEN_SLABS)
           .addTag(ItemTags.WOODEN_STAIRS)
-          .add(Items.LECTERN, Items.PISTON)
+          .addTag(ItemTags.TRIM_TEMPLATES)
+          .add(Items.LECTERN, Items.PISTON, Items.NETHERITE_UPGRADE_SMITHING_TEMPLATE)
           .add(paperExtras);
 
         tag(ModTags.crafterIngredient.get(TagConstants.CRAFTING_STONE_SMELTERY))

--- a/src/main/java/com/minecolonies/coremod/generation/defaults/workers/DefaultBlacksmithCraftingProvider.java
+++ b/src/main/java/com/minecolonies/coremod/generation/defaults/workers/DefaultBlacksmithCraftingProvider.java
@@ -13,6 +13,7 @@ import net.minecraft.world.level.ItemLike;
 import net.minecraftforge.registries.ForgeRegistries;
 import org.jetbrains.annotations.NotNull;
 
+import java.util.Collections;
 import java.util.List;
 import java.util.function.Consumer;
 
@@ -79,9 +80,13 @@ public class DefaultBlacksmithCraftingProvider extends CustomRecipeProvider
         CustomRecipeBuilder.create(BLACKSMITH, MODULE_CRAFTING,
                         ForgeRegistries.ITEMS.getKey(output.asItem()).getPath())
                 .inputs(List.of(new ItemStorage(new ItemStack(input)),
-                        new ItemStorage(new ItemStack(Items.NETHERITE_INGOT))))
+                        new ItemStorage(new ItemStack(Items.NETHERITE_UPGRADE_SMITHING_TEMPLATE)),
+                        new ItemStorage(new ItemStack(Items.NETHERITE_INGOT)),
+                        new ItemStorage(new ItemStack(Items.DIAMOND, 7)),
+                        new ItemStorage(new ItemStack(Items.NETHERRACK))))
                 .result(new ItemStack(output))
-                .minBuildingLevel(5)
+                .secondaryOutputs(Collections.singletonList(new ItemStack(Items.NETHERITE_UPGRADE_SMITHING_TEMPLATE)))
+                .minBuildingLevel(4)
                 .build(consumer);
     }
 }


### PR DESCRIPTION
Closes [discord report](https://discord.com/channels/472875599422291968/1118076117681700924/1120108972775592047)

# Changes proposed in this pull request:
- General `runData` for 1.20
- Stops the stonemason from being able to craft smithing templates.
    - The blacksmith can still learn the recipe, but while I haven't tested it I'm dubious that it would work well, since it's a duplication recipe (same input and output), which I suspect would upset the request system.
- Changes the blacksmith's netherite tools recipe to require a netherite smithing template.
        ![image](https://github.com/ldtteam/minecolonies/assets/539951/d0d06587-5468-469b-abb7-4c2b3ef90eaa)
    - Due to the above, instead of directly consuming the template they require the components for duplicating the smithing template itself and output one along with the tool -- i.e. it acts kind of like a catalyst.
        - The good: you only need to find one to produce all the tools, same as vanilla.
        - The bad: you don't get any benefit from finding more than one.  (Though you can still use the extras for manual crafting.)
        - The compensation: the diamond cost is reduceable.
    - Due to the higher ingredient requirements (and that from 1.18 workers could use netherite tools earlier anyway), the blacksmith now learns how to do this at level 4 rather than 5.
- Fixes datagen loot table evaluation (netherminer non-JEI "recipe" hinting)

Review please (do not port)

[The 1.20 spreadsheet](https://docs.google.com/spreadsheets/d/1i6EQuPuxVWDmH2Z9_CHiXOmDG5sXVF2cscHg6lwXs9o/edit?usp=sharing), in case anyone wants to look for other oddities.  (One oddity that I've noticed, but is not addressed here, is that the DO doors/trapdoors/panels don't seem to be craftable any more.  Though note that this is with the current dep (1.20-1.0.93-ALPHA); I have not checked if this is fixed in a later version.)