### PR TITLE
Froglights

### DIFF
--- a/src/datagen/generated/minecolonies/data/minecolonies/crafterrecipes/netherworker/ochre_froglight.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/crafterrecipes/netherworker/ochre_froglight.json
@@ -10,7 +10,7 @@
     },
     {
       "count": 4,
-      "item": "minecraft:magma_block"
+      "item": "minecraft:lily_pad"
     }
   ],
   "intermediate": "minecraft:air",

--- a/src/datagen/generated/minecolonies/data/minecolonies/crafterrecipes/netherworker/ochre_froglight.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/crafterrecipes/netherworker/ochre_froglight.json
@@ -1,0 +1,19 @@
+{
+  "type": "recipe",
+  "crafter": "netherworker_custom",
+  "inputs": [
+    {
+      "item": "minecraft:slime_block"
+    },
+    {
+      "item": "minecraft:magma_cream"
+    },
+    {
+      "count": 4,
+      "item": "minecraft:magma_block"
+    }
+  ],
+  "intermediate": "minecraft:air",
+  "min-building-level": 3,
+  "result": "minecraft:ochre_froglight"
+}

--- a/src/datagen/generated/minecolonies/data/minecolonies/crafterrecipes/netherworker/pearlescent_froglight.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/crafterrecipes/netherworker/pearlescent_froglight.json
@@ -10,7 +10,7 @@
     },
     {
       "count": 4,
-      "item": "minecraft:lily_pad"
+      "item": "minecraft:magma_block"
     }
   ],
   "intermediate": "minecraft:air",

--- a/src/datagen/generated/minecolonies/data/minecolonies/crafterrecipes/netherworker/pearlescent_froglight.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/crafterrecipes/netherworker/pearlescent_froglight.json
@@ -1,0 +1,19 @@
+{
+  "type": "recipe",
+  "crafter": "netherworker_custom",
+  "inputs": [
+    {
+      "item": "minecraft:slime_block"
+    },
+    {
+      "item": "minecraft:magma_cream"
+    },
+    {
+      "count": 4,
+      "item": "minecraft:lily_pad"
+    }
+  ],
+  "intermediate": "minecraft:air",
+  "min-building-level": 3,
+  "result": "minecraft:pearlescent_froglight"
+}

--- a/src/datagen/generated/minecolonies/data/minecolonies/crafterrecipes/netherworker/trip1.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/crafterrecipes/netherworker/trip1.json
@@ -44,15 +44,6 @@
       "item": "minecraft:magma_cream"
     },
     {
-      "item": "minecraft:pearlescent_froglight"
-    },
-    {
-      "item": "minecraft:verdant_froglight"
-    },
-    {
-      "item": "minecraft:ochre_froglight"
-    },
-    {
       "item": "minecraft:blaze_rod"
     }
   ],

--- a/src/datagen/generated/minecolonies/data/minecolonies/crafterrecipes/netherworker/trip2.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/crafterrecipes/netherworker/trip2.json
@@ -65,15 +65,6 @@
       "item": "minecraft:magma_cream"
     },
     {
-      "item": "minecraft:pearlescent_froglight"
-    },
-    {
-      "item": "minecraft:verdant_froglight"
-    },
-    {
-      "item": "minecraft:ochre_froglight"
-    },
-    {
       "item": "minecraft:blaze_rod"
     }
   ],

--- a/src/datagen/generated/minecolonies/data/minecolonies/crafterrecipes/netherworker/trip3.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/crafterrecipes/netherworker/trip3.json
@@ -77,15 +77,6 @@
       "item": "minecraft:magma_cream"
     },
     {
-      "item": "minecraft:pearlescent_froglight"
-    },
-    {
-      "item": "minecraft:verdant_froglight"
-    },
-    {
-      "item": "minecraft:ochre_froglight"
-    },
-    {
       "item": "minecraft:blaze_rod"
     }
   ],

--- a/src/datagen/generated/minecolonies/data/minecolonies/crafterrecipes/netherworker/trip4.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/crafterrecipes/netherworker/trip4.json
@@ -83,15 +83,6 @@
       "item": "minecraft:magma_cream"
     },
     {
-      "item": "minecraft:pearlescent_froglight"
-    },
-    {
-      "item": "minecraft:verdant_froglight"
-    },
-    {
-      "item": "minecraft:ochre_froglight"
-    },
-    {
       "item": "minecraft:blaze_rod"
     }
   ],

--- a/src/datagen/generated/minecolonies/data/minecolonies/crafterrecipes/netherworker/trip5.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/crafterrecipes/netherworker/trip5.json
@@ -83,15 +83,6 @@
       "item": "minecraft:magma_cream"
     },
     {
-      "item": "minecraft:pearlescent_froglight"
-    },
-    {
-      "item": "minecraft:verdant_froglight"
-    },
-    {
-      "item": "minecraft:ochre_froglight"
-    },
-    {
       "item": "minecraft:blaze_rod"
     },
     {

--- a/src/datagen/generated/minecolonies/data/minecolonies/crafterrecipes/netherworker/verdant_froglight.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/crafterrecipes/netherworker/verdant_froglight.json
@@ -1,0 +1,19 @@
+{
+  "type": "recipe",
+  "crafter": "netherworker_custom",
+  "inputs": [
+    {
+      "item": "minecraft:slime_block"
+    },
+    {
+      "item": "minecraft:magma_cream"
+    },
+    {
+      "count": 4,
+      "item": "minecraft:snow_block"
+    }
+  ],
+  "intermediate": "minecraft:air",
+  "min-building-level": 3,
+  "result": "minecraft:verdant_froglight"
+}

--- a/src/main/java/com/minecolonies/coremod/generation/defaults/workers/DefaultNetherWorkerLootProvider.java
+++ b/src/main/java/com/minecolonies/coremod/generation/defaults/workers/DefaultNetherWorkerLootProvider.java
@@ -26,7 +26,6 @@ import net.minecraft.world.level.storage.loot.providers.number.UniformGenerator;
 import net.minecraftforge.registries.ForgeRegistries;
 import org.jetbrains.annotations.NotNull;
 
-import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -248,6 +247,24 @@ public class DefaultNetherWorkerLootProvider extends CustomRecipeAndLootTablePro
         CustomRecipeProvider.CustomRecipeBuilder.create(NETHERWORKER, MODULE_CUSTOM, "lava")
                 .inputs(Collections.singletonList(new ItemStorage(new ItemStack(Items.BUCKET))))
                 .result(new ItemStack(Items.LAVA_BUCKET))
+                .build(consumer);
+
+        // and some froglights, because why not
+        frogLight(consumer, Items.OCHRE_FROGLIGHT, Items.MAGMA_BLOCK);
+        frogLight(consumer, Items.PEARLESCENT_FROGLIGHT, Items.LILY_PAD);
+        frogLight(consumer, Items.VERDANT_FROGLIGHT, Items.SNOW_BLOCK);
+    }
+
+    private void frogLight(@NotNull final Consumer<FinishedRecipe> consumer,
+                           @NotNull final Item frogLight,
+                           @NotNull final Item flavour)
+    {
+        CustomRecipeProvider.CustomRecipeBuilder.create(NETHERWORKER, MODULE_CUSTOM, ForgeRegistries.ITEMS.getKey(frogLight).getPath())
+                .inputs(List.of(new ItemStorage(new ItemStack(Items.SLIME_BLOCK)),
+                        new ItemStorage(new ItemStack(Items.MAGMA_CREAM)),
+                        new ItemStorage(new ItemStack(flavour, 4))))
+                .result(new ItemStack(frogLight))
+                .minBuildingLevel(3)
                 .build(consumer);
     }
 

--- a/src/main/java/com/minecolonies/coremod/generation/defaults/workers/DefaultNetherWorkerLootProvider.java
+++ b/src/main/java/com/minecolonies/coremod/generation/defaults/workers/DefaultNetherWorkerLootProvider.java
@@ -250,8 +250,8 @@ public class DefaultNetherWorkerLootProvider extends CustomRecipeAndLootTablePro
                 .build(consumer);
 
         // and some froglights, because why not
-        frogLight(consumer, Items.OCHRE_FROGLIGHT, Items.MAGMA_BLOCK);
-        frogLight(consumer, Items.PEARLESCENT_FROGLIGHT, Items.LILY_PAD);
+        frogLight(consumer, Items.OCHRE_FROGLIGHT, Items.LILY_PAD);
+        frogLight(consumer, Items.PEARLESCENT_FROGLIGHT, Items.MAGMA_BLOCK);
         frogLight(consumer, Items.VERDANT_FROGLIGHT, Items.SNOW_BLOCK);
     }
 


### PR DESCRIPTION
Closes [discord request](https://discord.com/channels/472875599422291968/473575384445878273/1129239041531969566)

# Changes proposed in this pull request:
- Makes JEI realise that froglights aren't actually a real drop from magma cubes, at least during nether expeditions.
- Adds a custom crafting recipe for froglights to the netherworker (unlocked at level 3).
    - This is somewhat deliberately a bit more complicated/expensive than it might be to actually go find a frog and magma cube yourself, but is perhaps more easily mass-producible.
    - All recipes require a slime block and a magma cream.
    - Sadly there aren't really any "frog" items that could be used, so it instead uses a representative block from typical frog biomes:
        - Lily pad for ochre
            ![image](https://github.com/ldtteam/minecolonies/assets/539951/704fec5a-d295-48d2-ae7e-22ce6c466dce)
        - Magma block for pearlescent
            ![image](https://github.com/ldtteam/minecolonies/assets/539951/eabb638e-a26d-4201-9ed3-bc8b6e4e4d68)
        - Snow block for verdant
            ![image](https://github.com/ldtteam/minecolonies/assets/539951/83262739-40e5-4fb0-9d15-ed406ed2bfb4)

Review please (could port either way)

Alternative recipe suggestions welcome.