### PR TITLE
Fix visitor entity no longer ticking

### DIFF
--- a/src/main/java/com/minecolonies/coremod/entity/ai/visitor/EntityAIVisitor.java
+++ b/src/main/java/com/minecolonies/coremod/entity/ai/visitor/EntityAIVisitor.java
@@ -4,7 +4,6 @@ import com.minecolonies.api.colony.buildings.IBuilding;
 import com.minecolonies.api.entity.ai.statemachine.states.EntityState;
 import com.minecolonies.api.entity.ai.statemachine.states.IState;
 import com.minecolonies.api.entity.ai.statemachine.tickratestatemachine.ITickRateStateMachine;
-import com.minecolonies.api.entity.ai.statemachine.tickratestatemachine.TickRateStateMachine;
 import com.minecolonies.api.entity.ai.statemachine.tickratestatemachine.TickingTransition;
 import com.minecolonies.api.entity.citizen.AbstractEntityCitizen;
 import com.minecolonies.api.util.Log;
@@ -35,7 +34,6 @@ public class EntityAIVisitor implements IState
      */
     public enum VisitorState implements IState
     {
-        INIT,
         IDLE,
         SLEEPING,
         SITTING,
@@ -47,11 +45,6 @@ public class EntityAIVisitor implements IState
      * The visitor entity we are attached to.
      */
     private final VisitorCitizen citizen;
-
-    /**
-     * This AI's state changer.
-     */
-    private final ITickRateStateMachine<VisitorState> stateMachine;
 
     /**
      * The tavern building for the citizen
@@ -78,13 +71,8 @@ public class EntityAIVisitor implements IState
         super();
         this.citizen = (VisitorCitizen) entity;
 
-        stateMachine = new TickRateStateMachine<>(VisitorState.INIT, this::onException);
-        entity.getEntityStateController().addTransition(new TickingTransition<>(EntityState.ACTIVE_SERVER, () -> {
-            stateMachine.tick();
-            return false;
-        }, () -> null, 1));
-
-        stateMachine.addTransition(new TickingTransition<>(VisitorState.INIT, this::isEntityLoaded, () -> VisitorState.IDLE, 50));
+        ITickRateStateMachine<IState> stateMachine = entity.getEntityStateController();
+        stateMachine.addTransition(new TickingTransition<>(EntityState.INIT, this::isEntityLoaded, () -> VisitorState.IDLE, 50));
         stateMachine.addTransition(new TickingTransition<>(VisitorState.IDLE, () -> true, this::decide, 50));
         stateMachine.addTransition(new TickingTransition<>(VisitorState.WANDERING, this::wander, () -> VisitorState.IDLE, 200));
         stateMachine.addTransition(new TickingTransition<>(VisitorState.WANDERING, this::shouldFight, () -> VisitorState.COMBAT, 200));
@@ -291,7 +279,6 @@ public class EntityAIVisitor implements IState
      */
     public void stop()
     {
-        stateMachine.reset();
         resetLogic();
     }
 }

--- a/src/main/java/com/minecolonies/coremod/entity/citizen/VisitorCitizen.java
+++ b/src/main/java/com/minecolonies/coremod/entity/citizen/VisitorCitizen.java
@@ -7,6 +7,8 @@ import com.minecolonies.api.colony.requestsystem.StandardFactoryController;
 import com.minecolonies.api.colony.requestsystem.location.ILocation;
 import com.minecolonies.api.entity.CustomGoalSelector;
 import com.minecolonies.api.entity.ai.pathfinding.IWalkToProxy;
+import com.minecolonies.api.entity.ai.statemachine.states.EntityState;
+import com.minecolonies.api.entity.ai.statemachine.tickratestatemachine.TickingTransition;
 import com.minecolonies.api.entity.citizen.AbstractEntityCitizen;
 import com.minecolonies.api.entity.citizen.citizenhandlers.*;
 import com.minecolonies.api.inventory.InventoryCitizen;

--- a/src/main/java/com/minecolonies/coremod/entity/citizen/VisitorCitizen.java
+++ b/src/main/java/com/minecolonies/coremod/entity/citizen/VisitorCitizen.java
@@ -7,8 +7,6 @@ import com.minecolonies.api.colony.requestsystem.StandardFactoryController;
 import com.minecolonies.api.colony.requestsystem.location.ILocation;
 import com.minecolonies.api.entity.CustomGoalSelector;
 import com.minecolonies.api.entity.ai.pathfinding.IWalkToProxy;
-import com.minecolonies.api.entity.ai.statemachine.states.EntityState;
-import com.minecolonies.api.entity.ai.statemachine.tickratestatemachine.TickingTransition;
 import com.minecolonies.api.entity.citizen.AbstractEntityCitizen;
 import com.minecolonies.api.entity.citizen.citizenhandlers.*;
 import com.minecolonies.api.inventory.InventoryCitizen;


### PR DESCRIPTION
# Changes proposed in this pull request:
- Visitors their state machines were no longer ticking, causing them to idle indefinitely. State machine of the overarching entity is now used, whilst also implementing the EntityState.INIT state correctly now.

Review please
