### PR TITLE
Add colony chunk status command

### DIFF
--- a/src/api/java/com/minecolonies/api/colony/IColony.java
+++ b/src/api/java/com/minecolonies/api/colony/IColony.java
@@ -416,6 +416,8 @@ public interface IColony
      */
     int getLoadedChunkCount();
 
+    Set<Long> getLoadedChunks();
+
     /**
      * Returns the colonies current state.
      *

--- a/src/main/java/com/minecolonies/coremod/colony/Colony.java
+++ b/src/main/java/com/minecolonies/coremod/colony/Colony.java
@@ -15,6 +15,7 @@ import com.minecolonies.api.entity.ai.statemachine.tickratestatemachine.ITickRat
 import com.minecolonies.api.entity.ai.statemachine.tickratestatemachine.TickRateStateMachine;
 import com.minecolonies.api.entity.ai.statemachine.tickratestatemachine.TickingTransition;
 import com.minecolonies.api.entity.citizen.AbstractEntityCitizen;
+import com.minecolonies.api.quests.IQuestManager;
 import com.minecolonies.api.research.IResearchManager;
 import com.minecolonies.api.util.BlockPosUtil;
 import com.minecolonies.api.util.Log;
@@ -26,14 +27,13 @@ import com.minecolonies.api.util.constant.Suppression;
 import com.minecolonies.coremod.MineColonies;
 import com.minecolonies.coremod.Network;
 import com.minecolonies.coremod.colony.managers.*;
+import com.minecolonies.coremod.colony.permissions.ColonyPermissionEventHandler;
 import com.minecolonies.coremod.colony.permissions.Permissions;
 import com.minecolonies.coremod.colony.pvp.AttackingPlayer;
 import com.minecolonies.coremod.colony.requestsystem.management.manager.StandardRequestManager;
 import com.minecolonies.coremod.colony.workorders.WorkManager;
 import com.minecolonies.coremod.datalistener.CitizenNameListener;
 import com.minecolonies.coremod.network.messages.client.colony.ColonyViewRemoveWorkOrderMessage;
-import com.minecolonies.coremod.colony.permissions.ColonyPermissionEventHandler;
-import com.minecolonies.api.quests.IQuestManager;
 import com.minecolonies.coremod.quests.QuestManager;
 import net.minecraft.ChatFormatting;
 import net.minecraft.core.BlockPos;
@@ -66,7 +66,8 @@ import java.util.*;
 import static com.minecolonies.api.colony.ColonyState.*;
 import static com.minecolonies.api.entity.ai.statemachine.tickratestatemachine.TickRateConstants.MAX_TICKRATE;
 import static com.minecolonies.api.util.constant.ColonyConstants.*;
-import static com.minecolonies.api.util.constant.Constants.*;
+import static com.minecolonies.api.util.constant.Constants.DEFAULT_STYLE;
+import static com.minecolonies.api.util.constant.Constants.TICKS_SECOND;
 import static com.minecolonies.api.util.constant.NbtTagConstants.*;
 import static com.minecolonies.api.util.constant.TranslationConstants.*;
 import static com.minecolonies.coremod.MineColonies.getConfig;
@@ -1884,6 +1885,12 @@ public class Colony implements IColony
     public int getLoadedChunkCount()
     {
         return loadedChunks.size();
+    }
+
+    @Override
+    public Set<Long> getLoadedChunks()
+    {
+        return loadedChunks;
     }
 
     @Override

--- a/src/main/java/com/minecolonies/coremod/colony/ColonyView.java
+++ b/src/main/java/com/minecolonies/coremod/colony/ColonyView.java
@@ -648,6 +648,12 @@ public final class ColonyView implements IColonyView
     }
 
     @Override
+    public Set<Long> getLoadedChunks()
+    {
+        return null;
+    }
+
+    @Override
     public ColonyState getState()
     {
         return null;

--- a/src/main/java/com/minecolonies/coremod/colony/requestsystem/management/handlers/RequestHandler.java
+++ b/src/main/java/com/minecolonies/coremod/colony/requestsystem/management/handlers/RequestHandler.java
@@ -48,8 +48,8 @@ public class RequestHandler implements IRequestHandler
         final IToken<?> token = manager.getTokenHandler().generateNewToken();
 
         final IRequest<Request> constructedRequest = manager.getFactoryController()
-                                                       .getNewInstance(TypeToken.of((Class<? extends IRequest<Request>>) RequestMappingHandler.getRequestableMappings()
-                                                                                                                           .get(request.getClass())), request, token, requester);
+          .getNewInstance(TypeToken.of((Class<? extends IRequest<Request>>) RequestMappingHandler.getRequestableMappings()
+            .get(request.getClass())), request, token, requester);
 
         manager.getLogger().debug("Creating request for: " + request + ", token: " + token + " and output: " + constructedRequest);
 
@@ -133,17 +133,32 @@ public class RequestHandler implements IRequestHandler
 
         final List<TypeToken<?>> typeIndexList = new LinkedList<>(requestTypes);
 
-        final Set<IRequestResolver<?>> resolvers = requestTypes.stream()
-                                                     .filter(typeToken -> manager.getRequestableTypeRequestResolverAssignmentDataStore().getAssignments().containsKey(typeToken))
-                                                     .flatMap(type -> manager.getRequestableTypeRequestResolverAssignmentDataStore()
-                                                                        .getAssignments()
-                                                                        .get(type)
-                                                                        .stream()
-                                                                        .map(iToken -> manager.getResolverHandler().getResolver(iToken)))
-                                                     .filter(iRequestResolver -> typeIndexList.contains(iRequestResolver.getRequestType()))
-                                                     .sorted(Comparator.comparingInt((IRequestResolver<?> r) -> -1 * r.getPriority())
-                                                               .thenComparingInt((IRequestResolver<?> r) -> typeIndexList.indexOf(r.getRequestType())))
-                                                     .collect(Collectors.toCollection(LinkedHashSet::new));
+        List<IRequestResolver<? extends IRequestable>> resolverList = new ArrayList<>();
+        for (final TypeToken<?> requestTypeToken : requestTypes)
+        {
+            final Collection<IToken<?>> resolverTokens = manager.getRequestableTypeRequestResolverAssignmentDataStore()
+              .getAssignments()
+              .get(requestTypeToken);
+
+            if (resolverTokens == null)
+            {
+                continue;
+            }
+
+            for (IToken<?> iToken : resolverTokens)
+            {
+                final IRequestResolver<? extends IRequestable> iRequestResolver = manager.getResolverHandler().getResolver(iToken);
+                if (requestTypes.contains(iRequestResolver.getRequestType()))
+                {
+                    resolverList.add(iRequestResolver);
+                }
+            }
+        }
+
+        resolverList.sort(Comparator.comparingInt((IRequestResolver<?> r) -> -1 * r.getPriority())
+          .thenComparingInt((IRequestResolver<?> r) -> typeIndexList.indexOf(r.getRequestType())));
+
+        final Set<IRequestResolver<?>> resolvers = new LinkedHashSet<>(resolverList);
 
         IRequestResolver previousResolver = null;
         int previousMetric = Integer.MAX_VALUE;
@@ -182,7 +197,8 @@ public class RequestHandler implements IRequestHandler
                 final int currentResolverMetric = resolver.getSuitabilityMetric(request);
                 if (currentResolverMetric < previousMetric)
                 {
-                    @Nullable List<IToken<?>> tempAttemptResolveRequest = resolver.attemptResolveRequest(new WrappedBlacklistAssignmentRequestManager(manager, resolverTokenBlackList), request);
+                    @Nullable List<IToken<?>> tempAttemptResolveRequest =
+                      resolver.attemptResolveRequest(new WrappedBlacklistAssignmentRequestManager(manager, resolverTokenBlackList), request);
                     if (tempAttemptResolveRequest != null)
                     {
                         previousResolver = resolver;
@@ -203,12 +219,17 @@ public class RequestHandler implements IRequestHandler
 
     /**
      * Attempt to resolve a given request with a set resolver.
-     * @param request the request to fulfill.
-     * @param resolver the resolver to use.
+     *
+     * @param request                the request to fulfill.
+     * @param resolver               the resolver to use.
      * @param resolverTokenBlackList the black list.
      * @return the resolver token.
      */
-    private IToken<?> resolve(final IRequest<?> request, final IRequestResolver resolver, final Collection<IToken<?>> resolverTokenBlackList, @Nullable final List<IToken<?>> attemptResult)
+    private IToken<?> resolve(
+      final IRequest<?> request,
+      final IRequestResolver resolver,
+      final Collection<IToken<?>> resolverTokenBlackList,
+      @Nullable final List<IToken<?>> attemptResult)
     {
         //Successfully found a resolver. Registering
         manager.getLogger().debug("Finished resolver assignment search for request: " + request + " successfully");
@@ -484,7 +505,7 @@ public class RequestHandler implements IRequestHandler
             }
         }
 
-                if (request.hasParent())
+        if (request.hasParent())
         {
             getRequest(request.getParent()).removeChild(request.getId());
         }
@@ -608,10 +629,10 @@ public class RequestHandler implements IRequestHandler
     public Collection<IRequest<?>> getRequestsMadeByRequester(final IRequester requester)
     {
         return manager.getRequestIdentitiesDataStore()
-                 .getIdentities()
-                 .values()
-                 .stream()
-                 .filter(iRequest -> iRequest.getRequester().getId().equals(requester.getId()))
-                 .collect(Collectors.toList());
+          .getIdentities()
+          .values()
+          .stream()
+          .filter(iRequest -> iRequest.getRequester().getId().equals(requester.getId()))
+          .collect(Collectors.toList());
     }
 }

--- a/src/main/java/com/minecolonies/coremod/commands/EntryPoint.java
+++ b/src/main/java/com/minecolonies/coremod/commands/EntryPoint.java
@@ -54,6 +54,7 @@ public class EntryPoint
           .addNode(new CommandLoadBackup().build())
           .addNode(new CommandLoadAllBackups().build())
           .addNode(new CommandColonyInfo().build())
+          .addNode(new CommandColonyChunks().build())
           .addNode(new CommandRSReset().build())
           .addNode(new CommandRSResetAll().build())
           .addNode(new CommandSetAbandoned().build())

--- a/src/main/java/com/minecolonies/coremod/commands/colonycommands/CommandColonyChunks.java
+++ b/src/main/java/com/minecolonies/coremod/commands/colonycommands/CommandColonyChunks.java
@@ -1,0 +1,91 @@
+package com.minecolonies.coremod.commands.colonycommands;
+
+import com.minecolonies.api.colony.IColony;
+import com.minecolonies.api.colony.IColonyManager;
+import com.minecolonies.coremod.commands.commandTypes.IMCColonyOfficerCommand;
+import com.minecolonies.coremod.commands.commandTypes.IMCCommand;
+import com.mojang.brigadier.arguments.IntegerArgumentType;
+import com.mojang.brigadier.builder.LiteralArgumentBuilder;
+import com.mojang.brigadier.context.CommandContext;
+import net.minecraft.ChatFormatting;
+import net.minecraft.commands.CommandSourceStack;
+import net.minecraft.network.chat.Component;
+import net.minecraft.server.level.Ticket;
+import net.minecraft.server.level.TicketType;
+import net.minecraft.util.SortedArraySet;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import static com.minecolonies.api.util.constant.translation.CommandTranslationConstants.COMMAND_COLONY_ID_NOT_FOUND;
+import static com.minecolonies.coremod.commands.CommandArgumentNames.COLONYID_ARG;
+import static com.minecolonies.coremod.commands.colonycommands.CommandColonyInfo.ID_TEXT;
+import static com.minecolonies.coremod.commands.colonycommands.CommandColonyInfo.NAME_TEXT;
+
+public class CommandColonyChunks implements IMCColonyOfficerCommand
+{
+    /**
+     * What happens when the command is executed after preConditions are successful.
+     *
+     * @param context the context of the command execution
+     */
+    @Override
+    public int onExecute(final CommandContext<CommandSourceStack> context)
+    {
+        // Colony
+        final int colonyID = IntegerArgumentType.getInteger(context, COLONYID_ARG);
+        final IColony colony = IColonyManager.getInstance().getColonyByDimension(colonyID, context.getSource().getLevel().dimension());
+        if (colony == null)
+        {
+            context.getSource().sendSuccess(Component.translatable(COMMAND_COLONY_ID_NOT_FOUND, colonyID), true);
+            return 0;
+        }
+
+
+        Set<TicketType> types = new HashSet<>();
+
+        for (final Long chunkLong : colony.getLoadedChunks())
+        {
+            final SortedArraySet<Ticket<?>> tickets = context.getSource().getLevel().getChunkSource().chunkMap.getDistanceManager().tickets.get((long) chunkLong);
+            if (tickets != null)
+            {
+                for (final Ticket<?> ticket : tickets)
+                {
+                    types.add(ticket.getType());
+                }
+            }
+        }
+
+        StringBuilder ticketString = new StringBuilder();
+        for (final TicketType type : types)
+        {
+            ticketString.append("[").append(type).append("]");
+        }
+
+        context.getSource()
+          .sendSuccess(Component.literal(ID_TEXT)
+            .append(Component.literal("" + colony.getID()).withStyle(ChatFormatting.YELLOW))
+            .append(Component.literal(" " + NAME_TEXT))
+            .append(Component.literal("" + colony.getName()).withStyle(ChatFormatting.YELLOW)), true);
+        context.getSource().sendSuccess(Component.literal("Loaded chunks:").append(Component.literal(" " + colony.getLoadedChunkCount()).withStyle(ChatFormatting.YELLOW)), true);
+        context.getSource().sendSuccess(Component.translatable("Ticket types: ").append(Component.literal(ticketString.toString()).withStyle(ChatFormatting.YELLOW)), true);
+
+        return 1;
+    }
+
+    /**
+     * Name string of the command.
+     */
+    @Override
+    public String getName()
+    {
+        return "chunkstatus";
+    }
+
+    @Override
+    public LiteralArgumentBuilder<CommandSourceStack> build()
+    {
+        return IMCCommand.newLiteral(getName())
+          .then(IMCCommand.newArgument(COLONYID_ARG, IntegerArgumentType.integer(1)).executes(this::checkPreConditionAndExecute));
+    }
+}

--- a/src/main/java/com/minecolonies/coremod/commands/colonycommands/CommandColonyInfo.java
+++ b/src/main/java/com/minecolonies/coremod/commands/colonycommands/CommandColonyInfo.java
@@ -7,11 +7,11 @@ import com.minecolonies.coremod.commands.commandTypes.IMCCommand;
 import com.mojang.brigadier.arguments.IntegerArgumentType;
 import com.mojang.brigadier.builder.LiteralArgumentBuilder;
 import com.mojang.brigadier.context.CommandContext;
+import net.minecraft.ChatFormatting;
 import net.minecraft.commands.CommandSourceStack;
 import net.minecraft.core.BlockPos;
-import net.minecraft.network.chat.Style;
-import net.minecraft.ChatFormatting;
 import net.minecraft.network.chat.Component;
+import net.minecraft.network.chat.Style;
 
 import static com.minecolonies.api.util.constant.translation.CommandTranslationConstants.COMMAND_COLONY_ID_NOT_FOUND;
 import static com.minecolonies.api.util.constant.translation.CommandTranslationConstants.COMMAND_DISABLED_IN_CONFIG;
@@ -19,8 +19,8 @@ import static com.minecolonies.coremod.commands.CommandArgumentNames.COLONYID_AR
 
 public class CommandColonyInfo implements IMCCommand
 {
-    private static final String ID_TEXT           = "ID: ";
-    private static final String NAME_TEXT         = "Name: ";
+    public static final  String ID_TEXT           = "ID: ";
+    public static final  String NAME_TEXT         = "Name: ";
     private static final String MAYOR_TEXT        = "Mayor: ";
     private static final String COORDINATES_TEXT  = "Coordinates: ";
     private static final String COORDINATES_XYZ   = "x=%s y=%s z=%s";

--- a/src/main/resources/META-INF/accesstransformer.cfg
+++ b/src/main/resources/META-INF/accesstransformer.cfg
@@ -95,3 +95,5 @@ public net.minecraft.world.level.block.state.BlockBehaviour f_60439_ # propertie
 public net.minecraft.world.level.block.state.BlockBehaviour$Properties f_60884_ # hasCollision
 
 public net.minecraft.client.gui.MapRenderer f_93255_ # textureManager
+
+public net.minecraft.server.level.DistanceManager f_140761_ # tickets


### PR DESCRIPTION
# Changes proposed in this pull request:
- Add a command to display a colonies loaded chunks and the tickets keeping them loaded
- Improved rs hotspot a bit

`/mc colony chunkstatus <id>`
![image](https://github.com/ldtteam/minecolonies/assets/38401808/ed7ad73b-2daf-4ef8-a04c-800b98302b91)

Review please
