### PR TITLE
Accept modded bookshelves too

### DIFF
--- a/src/main/java/com/minecolonies/coremod/colony/buildings/workerbuildings/BuildingLibrary.java
+++ b/src/main/java/com/minecolonies/coremod/colony/buildings/workerbuildings/BuildingLibrary.java
@@ -1,14 +1,10 @@
 package com.minecolonies.coremod.colony.buildings.workerbuildings;
 
-import com.ldtteam.blockui.views.BOWindow;
 import com.minecolonies.api.colony.IColony;
-import com.minecolonies.api.colony.IColonyView;
 import com.minecolonies.api.entity.ai.util.StudyItem;
 import com.minecolonies.api.util.Log;
 import com.minecolonies.coremod.MineColonies;
-import com.minecolonies.coremod.client.gui.huts.WindowHutWorkerModulePlaceholder;
 import com.minecolonies.coremod.colony.buildings.AbstractBuilding;
-import com.minecolonies.coremod.colony.buildings.views.AbstractBuildingView;
 import net.minecraft.core.BlockPos;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.nbt.ListTag;
@@ -19,8 +15,7 @@ import net.minecraft.util.Tuple;
 import net.minecraft.world.item.Item;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.Block;
-import net.minecraft.world.level.block.Blocks;
-
+import net.minecraftforge.common.Tags;
 import net.minecraftforge.registries.ForgeRegistries;
 import org.jetbrains.annotations.NotNull;
 
@@ -160,8 +155,7 @@ public class BuildingLibrary extends AbstractBuilding
     public void registerBlockPosition(@NotNull final Block block, @NotNull final BlockPos pos, @NotNull final Level world)
     {
         super.registerBlockPosition(block, pos, world);
-        //todo we might in the future want to add our own oredict tag to this.
-        if (block == Blocks.BOOKSHELF)
+        if (block.defaultBlockState().is(Tags.Blocks.BOOKSHELVES))
         {
             bookCases.add(pos);
         }
@@ -179,7 +173,7 @@ public class BuildingLibrary extends AbstractBuilding
             return getPosition();
         }
         final BlockPos returnPos = bookCases.get(random.nextInt(bookCases.size()));
-        if (colony.getWorld().getBlockState(returnPos).getBlock() == Blocks.BOOKSHELF)
+        if (colony.getWorld().getBlockState(returnPos).is(Tags.Blocks.BOOKSHELVES))
         {
             return returnPos;
         }

--- a/src/main/java/com/minecolonies/coremod/colony/buildings/workerbuildings/BuildingUniversity.java
+++ b/src/main/java/com/minecolonies/coremod/colony/buildings/workerbuildings/BuildingUniversity.java
@@ -1,6 +1,5 @@
 package com.minecolonies.coremod.colony.buildings.workerbuildings;
 
-import com.ldtteam.blockui.views.BOWindow;
 import com.minecolonies.api.colony.ICitizenData;
 import com.minecolonies.api.colony.IColony;
 import com.minecolonies.api.colony.jobs.ModJobs;
@@ -9,7 +8,6 @@ import com.minecolonies.api.research.ILocalResearch;
 import com.minecolonies.api.util.MessageUtils;
 import com.minecolonies.coremod.colony.buildings.AbstractBuilding;
 import com.minecolonies.coremod.colony.buildings.modules.WorkerBuildingModule;
-import com.minecolonies.coremod.colony.buildings.views.AbstractBuildingView;
 import net.minecraft.core.BlockPos;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.nbt.ListTag;
@@ -17,11 +15,9 @@ import net.minecraft.nbt.NbtUtils;
 import net.minecraft.nbt.Tag;
 import net.minecraft.network.chat.Component;
 import net.minecraft.network.chat.MutableComponent;
-import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.Block;
-import net.minecraft.world.level.block.Blocks;
-
+import net.minecraftforge.common.Tags;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.ArrayList;
@@ -108,8 +104,7 @@ public class BuildingUniversity extends AbstractBuilding
     public void registerBlockPosition(@NotNull final Block block, @NotNull final BlockPos pos, @NotNull final Level world)
     {
         super.registerBlockPosition(block, pos, world);
-        //todo we might in the future want to add our own oredict tag to this.
-        if (block == Blocks.BOOKSHELF)
+        if (block.defaultBlockState().is(Tags.Blocks.BOOKSHELVES))
         {
             bookCases.add(pos);
         }
@@ -127,7 +122,7 @@ public class BuildingUniversity extends AbstractBuilding
             return getPosition();
         }
         final BlockPos returnPos = bookCases.get(random.nextInt(bookCases.size()));
-        if (colony.getWorld().getBlockState(returnPos).getBlock() == Blocks.BOOKSHELF)
+        if (colony.getWorld().getBlockState(returnPos).is(Tags.Blocks.BOOKSHELVES))
         {
             return returnPos;
         }

--- a/src/main/java/com/minecolonies/coremod/util/SchemAnalyzerUtil.java
+++ b/src/main/java/com/minecolonies/coremod/util/SchemAnalyzerUtil.java
@@ -11,7 +11,6 @@ import com.minecolonies.api.items.ModTags;
 import net.minecraft.tags.BlockTags;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.level.block.Block;
-import net.minecraft.world.level.block.Blocks;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraftforge.common.Tags;
 
@@ -108,7 +107,7 @@ public class SchemAnalyzerUtil
         {
             score *= 31;
         }
-        else if (block == Blocks.BOOKSHELF)
+        else if (state.is(Tags.Blocks.BOOKSHELVES))
         {
             score *= 3;
         }


### PR DESCRIPTION
Closes [discord request](https://discord.com/channels/472875599422291968/1147271162716504125/1147271162716504125)

# Changes proposed in this pull request:
- Allows library and university to use modded bookshelves, not just vanilla ones.
    - Not including the vanilla Chiseled Bookshelf, though #blame-forge
    - As usual, the builder will have to place the block in order for it to register, so it may not affect existing buildings until you at least repair them.

- [x] Yes I compiled this
- [ ] Yes I tested this before submitting it.
- [ ] I also did a multiplayer test.

Review please (could port)
