### PR TITLE
Support for lucky ores by mine level

### DIFF
--- a/src/api/java/com/minecolonies/api/compatibility/CompatibilityManager.java
+++ b/src/api/java/com/minecolonies/api/compatibility/CompatibilityManager.java
@@ -561,7 +561,8 @@ public class CompatibilityManager implements ICompatibilityManager
             // fetch default config for all level
             // override it if specific config for this level is available.
             List<ItemStorage> luckyOresInLevel = luckyOres.get(0);
-            if (luckyOres.containsKey(buildingLevel)) {
+            if (luckyOres.containsKey(buildingLevel))
+            {
                 luckyOresInLevel = luckyOres.get(buildingLevel);
             }
 
@@ -802,7 +803,8 @@ public class CompatibilityManager implements ICompatibilityManager
                 }
 
                 final Item item = ForgeRegistries.ITEMS.getValue(new ResourceLocation(split[0]));
-                if (item == null || item == Items.AIR) {
+                if (item == null || item == Items.AIR)
+                {
                     Log.getLogger().warn("Invalid lucky block: " + ore);
                     continue;
                 }
@@ -810,8 +812,10 @@ public class CompatibilityManager implements ICompatibilityManager
                 final int defaultMineLevel = 0;
                 int buildingLevel = defaultMineLevel;
                 final ItemStack stack = new ItemStack(item, 1);
-                try {
-                    if (split.length == 3) {
+                try
+                {
+                    if (split.length == 3)
+                    {
                         buildingLevel = Integer.parseInt(split[2]);
                     }
 
@@ -819,27 +823,32 @@ public class CompatibilityManager implements ICompatibilityManager
 
                     luckyOres.putIfAbsent(buildingLevel, new ArrayList<>());
 
-                    for (int i = 0; i < rarity; i++) {
+                    for (int i = 0; i < rarity; i++)
+                    {
                         List<ItemStorage> luckyOreOnLevel = luckyOres.get(buildingLevel);
                         luckyOreOnLevel.add(new ItemStorage(stack));
                     }
-                } catch (final NumberFormatException ex) {
+                }
+                catch (final NumberFormatException ex)
+                {
                     Log.getLogger().warn("Ore has invalid rarity or building level: " + ore);
                 }
             }
 
             List<ItemStorage> alternative = null;
             int mineMaxLevel = ModBuildings.miner.get().produceBuilding(BlockPos.ZERO, null).getMaxBuildingLevel();
-            for (int levelToTest = 0; levelToTest <= mineMaxLevel; levelToTest++) {
-                if (luckyOres.containsKey(levelToTest) && !luckyOres.get(levelToTest).isEmpty()) {
+            for (int levelToTest = 0; levelToTest <= mineMaxLevel; levelToTest++)
+            {
+                if (luckyOres.containsKey(levelToTest) && !luckyOres.get(levelToTest).isEmpty())
+                {
                     alternative = luckyOres.get(levelToTest);
                 }
             }
 
-            for (int levelToReplace = 0; levelToReplace <= mineMaxLevel; levelToReplace++) {
+            for (int levelToReplace = 0; levelToReplace <= mineMaxLevel; levelToReplace++)
+            {
                 luckyOres.putIfAbsent(levelToReplace, alternative);
             }
-
         }
         Log.getLogger().info("Finished discovering lucky oreBlocks " + luckyOres.size());
     }

--- a/src/api/java/com/minecolonies/api/compatibility/CompatibilityManager.java
+++ b/src/api/java/com/minecolonies/api/compatibility/CompatibilityManager.java
@@ -795,8 +795,8 @@ public class CompatibilityManager implements ICompatibilityManager
             for (final String ore : MinecoloniesAPIProxy.getInstance().getConfig().getServer().luckyOres.get())
             {
                 final String pattern = "([\\w:]+)!(\\d+)(?:#(\\d+))?";
-                Pattern r = Pattern.compile(pattern);
-                Matcher m = r.matcher(ore);
+                final Pattern r = Pattern.compile(pattern);
+                final Matcher m = r.matcher(ore);
                 if (!m.find())
                 {
                     Log.getLogger().warn("Wrong configured ore: " + ore);
@@ -805,8 +805,9 @@ public class CompatibilityManager implements ICompatibilityManager
 
                 final String oreName = m.group(1);
                 final String chance = m.group(2);
+                final String detectedLevelName = m.group(3);
+
                 String mineLevelName = defaultMineLevelName + "";
-                String detectedLevelName = m.group(3);
                 if (m.groupCount() == 3 && null != detectedLevelName) {
                     mineLevelName = m.group(3);
                 }

--- a/src/api/java/com/minecolonies/api/compatibility/CompatibilityManager.java
+++ b/src/api/java/com/minecolonies/api/compatibility/CompatibilityManager.java
@@ -4,6 +4,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.minecolonies.api.MinecoloniesAPIProxy;
+import com.minecolonies.api.colony.buildings.ModBuildings;
 import com.minecolonies.api.colony.requestsystem.StandardFactoryController;
 import com.minecolonies.api.compatibility.dynamictrees.DynamicTreeCompat;
 import com.minecolonies.api.compatibility.resourcefulbees.ResourcefulBeesCompat;
@@ -816,7 +817,7 @@ public class CompatibilityManager implements ICompatibilityManager
             }
 
             List<ItemStorage> alternative = null;
-            int mineMaxLevel = 5;
+            int mineMaxLevel = ModBuildings.miner.get().produceBuilding(BlockPos.ZERO, null).getMaxBuildingLevel();
             for (int levelToTest = 0; levelToTest <= mineMaxLevel; levelToTest++) {
                 if (luckyOres.containsKey(levelToTest) && !luckyOres.get(levelToTest).isEmpty()) {
                     alternative = luckyOres.get(levelToTest);

--- a/src/api/java/com/minecolonies/api/compatibility/ICompatibilityManager.java
+++ b/src/api/java/com/minecolonies/api/compatibility/ICompatibilityManager.java
@@ -235,11 +235,13 @@ public interface ICompatibilityManager
 
     /**
      * Get a random lucky ore from a luckyblock.
+     * Loot may change depending on the mine level
      *
      * @param chanceBonus the chance bonus.
+     * @param buildingLevel level of the mine
      * @return the lucky ore.
      */
-    ItemStack getRandomLuckyOre(final double chanceBonus);
+    ItemStack getRandomLuckyOre(final double chanceBonus, final int buildingLevel);
 
     /**
      * Check if the block is configured to bypass the colony restrictions.

--- a/src/main/java/com/minecolonies/coremod/entity/ai/citizen/miner/EntityAIStructureMiner.java
+++ b/src/main/java/com/minecolonies/coremod/entity/ai/citizen/miner/EntityAIStructureMiner.java
@@ -954,7 +954,8 @@ public class EntityAIStructureMiner extends AbstractEntityAIStructureWithWorkOrd
 
         if (IColonyManager.getInstance().getCompatibilityManager().isLuckyBlock(blockToMine.getBlock()))
         {
-            InventoryUtils.transferItemStackIntoNextBestSlotInItemHandler(IColonyManager.getInstance().getCompatibilityManager().getRandomLuckyOre(chance),
+            int level = building.getBuildingLevel();
+            InventoryUtils.transferItemStackIntoNextBestSlotInItemHandler(IColonyManager.getInstance().getCompatibilityManager().getRandomLuckyOre(chance, level),
               worker.getInventoryCitizen());
         }
 

--- a/src/main/java/com/minecolonies/coremod/entity/ai/citizen/miner/EntityAIStructureMiner.java
+++ b/src/main/java/com/minecolonies/coremod/entity/ai/citizen/miner/EntityAIStructureMiner.java
@@ -954,7 +954,7 @@ public class EntityAIStructureMiner extends AbstractEntityAIStructureWithWorkOrd
 
         if (IColonyManager.getInstance().getCompatibilityManager().isLuckyBlock(blockToMine.getBlock()))
         {
-            int level = building.getBuildingLevel();
+            final int level = building.getBuildingLevel();
             InventoryUtils.transferItemStackIntoNextBestSlotInItemHandler(IColonyManager.getInstance().getCompatibilityManager().getRandomLuckyOre(chance, level),
               worker.getInventoryCitizen());
         }


### PR DESCRIPTION
Closes ldtteam/minecolonies-features#784

# Changes proposed in this pull request:
- Added Option to append hashtag followed the mine level to luckyOres
- If present only the blocks with the Level of the mine are created
- When a level has no configuration the first configured level is taken (first any block without. If there is no default config, the next higher level is used)


[x] Yes I tested this before submitting it.
[x] I also did a multiplayer test.

Review please
