### PR TITLE
Fix AI errors for jobs not assigned to buildings

### DIFF
--- a/src/main/java/com/minecolonies/coremod/colony/CitizenData.java
+++ b/src/main/java/com/minecolonies/coremod/colony/CitizenData.java
@@ -527,6 +527,11 @@ public class CitizenData implements ICitizenData
 
         setLastPosition(citizen.blockPosition());
 
+        if (workBuilding == null)
+        {
+            setJob(null);
+        }
+
         citizen.getCitizenJobHandler().onJobChanged(citizen.getCitizenJobHandler().getColonyJob());
 
         applyResearchEffects();


### PR DESCRIPTION
Closes #9376

# Changes proposed in this pull request:
- Jobs require a building to work, if a citizen is loaded with a job but without the building the job is removed


[x ] Yes I tested this before submitting it.
[ ] I also did a multiplayer test.

Review please
