### PR TITLE
Better nbt matching

### DIFF
--- a/src/api/java/com/minecolonies/api/compatibility/CompatibilityManager.java
+++ b/src/api/java/com/minecolonies/api/compatibility/CompatibilityManager.java
@@ -623,7 +623,6 @@ public class CompatibilityManager implements ICompatibilityManager
         final CreativeModeTab.ItemDisplayParameters tempDisplayParams = new CreativeModeTab.ItemDisplayParameters(level.enabledFeatures(), true, level.registryAccess());
 
         final ImmutableList.Builder<ItemStack> listBuilder = new ImmutableList.Builder<>();
-        final ImmutableSet.Builder<ItemStorage> setBuilder = new ImmutableSet.Builder<>();
         final Registry<CreativeModeTab> registry = level.registryAccess().registryOrThrow(Registries.CREATIVE_MODE_TAB);
 
         for (CreativeModeTab tab : CreativeModeTabs.allTabs())

--- a/src/api/java/com/minecolonies/api/items/CheckedNbtKey.java
+++ b/src/api/java/com/minecolonies/api/items/CheckedNbtKey.java
@@ -1,0 +1,84 @@
+package com.minecolonies.api.items;
+
+import net.minecraft.nbt.CompoundTag;
+import net.minecraft.nbt.Tag;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.Objects;
+import java.util.Set;
+
+/**
+ * Representation of a nbt key to match two item stacks.
+ */
+public class CheckedNbtKey
+{
+    @NotNull
+    public String key;
+
+    @NotNull
+    public Set<CheckedNbtKey> children;
+
+    public CheckedNbtKey(@NotNull final String key, @NotNull final Set<CheckedNbtKey> children)
+    {
+        this.key = key;
+        this.children = children;
+    }
+
+    @Override
+    public boolean equals(final Object o)
+    {
+        if (this == o)
+        {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass())
+        {
+            return false;
+        }
+        final CheckedNbtKey keyObject = (CheckedNbtKey) o;
+        return key.equals(keyObject.key) && children.equals(keyObject.children);
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return Objects.hash(key, children);
+    }
+
+    /**
+     * Check if two nbt match according to this checked nbt keys rules.
+     * @param nbt1 the first nbt.
+     * @param nbt2 the second nbt.
+     * @return true if they match.
+     */
+    public boolean matches(final CompoundTag nbt1, final CompoundTag nbt2)
+    {
+        final Tag tag1 = nbt1.get(key);
+        final Tag tag2 = nbt2.get(key);
+
+        if (tag1 == null || tag2 == null)
+        {
+            return (tag1 == null) == (tag2 == null);
+        }
+        else
+        {
+            if (children.isEmpty())
+            {
+                return tag1.equals(tag2);
+            }
+
+            if (tag1 instanceof CompoundTag && tag2 instanceof CompoundTag)
+            {
+                for (final CheckedNbtKey key : children)
+                {
+                    if (!key.matches((CompoundTag) tag1, (CompoundTag) tag2))
+                    {
+                        return false;
+                    }
+                }
+                return true;
+            }
+            return false;
+        }
+    }
+}

--- a/src/api/java/com/minecolonies/api/items/ModTags.java
+++ b/src/api/java/com/minecolonies/api/items/ModTags.java
@@ -59,11 +59,14 @@ public class ModTags
     public static final TagKey<EntityType<?>> hostile = TagKey.create(Registries.ENTITY_TYPE, TagConstants.HOSTILE);
     public static final TagKey<EntityType<?>> mobAttackBlacklist = TagKey.create(Registries.ENTITY_TYPE, TagConstants.MOB_ATTACK_BLACKLIST);
 
+    public static final TagKey<Item> ignoreNBT = ItemTags.create(TagConstants.IGNORE_NBT);
+
     public static final Map<String, TagKey<Item>> crafterProduct              = new HashMap<>();
     public static final Map<String, TagKey<Item>> crafterProductExclusions    = new HashMap<>();
     public static final Map<String, TagKey<Item>> crafterIngredient           = new HashMap<>();
     public static final Map<String, TagKey<Item>> crafterIngredientExclusions = new HashMap<>();
     public static final Map<String, TagKey<Item>> crafterDoIngredient         = new HashMap<>();
+
 
     /**
      * Tag specifier for Products to Include

--- a/src/api/java/com/minecolonies/api/util/constant/TagConstants.java
+++ b/src/api/java/com/minecolonies/api/util/constant/TagConstants.java
@@ -39,6 +39,7 @@ public final class TagConstants
     public static final ResourceLocation BREAKABLE_ORE             = new ResourceLocation(MOD_ID, "breakable_ore");
     public static final ResourceLocation RAW_ORE                   = new ResourceLocation(MOD_ID, "raw_ore");
     public static final ResourceLocation MOB_ATTACK_BLACKLIST      = new ResourceLocation(MOD_ID, "mob_attack_blacklist");
+    public static final ResourceLocation IGNORE_NBT                = new ResourceLocation(MOD_ID, "ignore_nbt");
 
     public static final String CRAFTING_BAKER                = ModJobs.BAKER_ID.getPath();
     public static final String CRAFTING_BLACKSMITH           = ModJobs.BLACKSMITH_ID.getPath();

--- a/src/datagen/generated/minecolonies/data/minecolonies/compatibility/itemnbtmatching.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/compatibility/itemnbtmatching.json
@@ -1,0 +1,4866 @@
+[
+  {
+    "item": "minecraft:cod_bucket"
+  },
+  {
+    "item": "minecraft:iron_leggings"
+  },
+  {
+    "item": "minecraft:burn_pottery_sherd"
+  },
+  {
+    "item": "minecraft:name_tag"
+  },
+  {
+    "item": "minecraft:ghast_spawn_egg"
+  },
+  {
+    "item": "minecraft:archer_pottery_sherd"
+  },
+  {
+    "item": "minecraft:andesite_wall"
+  },
+  {
+    "item": "minecraft:gray_bed"
+  },
+  {
+    "item": "minecraft:golden_horse_armor"
+  },
+  {
+    "item": "minecraft:flower_banner_pattern"
+  },
+  {
+    "item": "minecolonies:blockhuthospital"
+  },
+  {
+    "checkednbtkeys": [
+      {
+        "children": [
+          {
+            "key": "minecraft:block/oak_planks"
+          }
+        ],
+        "key": "textureData"
+      },
+      {
+        "key": "type"
+      }
+    ],
+    "item": "domum_ornamentum:panel"
+  },
+  {
+    "item": "minecraft:warped_slab"
+  },
+  {
+    "item": "minecraft:golden_hoe"
+  },
+  {
+    "item": "minecraft:stone_shovel"
+  },
+  {
+    "item": "minecraft:jungle_slab"
+  },
+  {
+    "item": "minecraft:beetroot"
+  },
+  {
+    "item": "minecraft:chainmail_leggings"
+  },
+  {
+    "item": "minecraft:crimson_stairs"
+  },
+  {
+    "item": "minecraft:saddle"
+  },
+  {
+    "item": "minecolonies:blockhutcrusher"
+  },
+  {
+    "item": "minecraft:lily_pad"
+  },
+  {
+    "item": "minecraft:deepslate_tiles"
+  },
+  {
+    "item": "minecraft:deepslate_tile_stairs"
+  },
+  {
+    "item": "minecraft:apple"
+  },
+  {
+    "item": "minecraft:zoglin_spawn_egg"
+  },
+  {
+    "item": "minecraft:blackstone_stairs"
+  },
+  {
+    "item": "minecraft:observer"
+  },
+  {
+    "item": "minecolonies:blockhutfield"
+  },
+  {
+    "item": "minecraft:warped_fence"
+  },
+  {
+    "item": "minecraft:polished_blackstone_brick_stairs"
+  },
+  {
+    "item": "minecraft:bubble_coral_fan"
+  },
+  {
+    "item": "minecraft:blue_dye"
+  },
+  {
+    "item": "minecraft:pink_wool"
+  },
+  {
+    "item": "minecolonies:blockhutlumberjack"
+  },
+  {
+    "item": "minecraft:light_gray_shulker_box"
+  },
+  {
+    "item": "minecraft:mangrove_pressure_plate"
+  },
+  {
+    "item": "minecraft:bamboo_raft"
+  },
+  {
+    "item": "minecraft:green_banner"
+  },
+  {
+    "item": "minecraft:sculk"
+  },
+  {
+    "item": "minecraft:orange_stained_glass_pane"
+  },
+  {
+    "item": "minecraft:mangrove_fence"
+  },
+  {
+    "item": "minecraft:skull_banner_pattern"
+  },
+  {
+    "item": "minecraft:granite_stairs"
+  },
+  {
+    "item": "minecraft:melon_seeds"
+  },
+  {
+    "item": "minecraft:fire_coral_block"
+  },
+  {
+    "item": "minecraft:endermite_spawn_egg"
+  },
+  {
+    "item": "minecraft:blue_ice"
+  },
+  {
+    "item": "minecraft:piglin_head"
+  },
+  {
+    "item": "minecraft:cherry_planks"
+  },
+  {
+    "item": "minecraft:light_blue_stained_glass"
+  },
+  {
+    "item": "minecraft:polar_bear_spawn_egg"
+  },
+  {
+    "item": "minecraft:music_disc_otherside"
+  },
+  {
+    "item": "minecraft:dead_horn_coral_fan"
+  },
+  {
+    "item": "minecraft:iron_sword"
+  },
+  {
+    "item": "minecraft:loom"
+  },
+  {
+    "item": "minecraft:golden_carrot"
+  },
+  {
+    "item": "minecolonies:blockhutblacksmith"
+  },
+  {
+    "item": "minecraft:lime_shulker_box"
+  },
+  {
+    "item": "minecraft:firework_star"
+  },
+  {
+    "item": "minecraft:stripped_crimson_stem"
+  },
+  {
+    "item": "minecraft:beacon"
+  },
+  {
+    "item": "minecraft:quartz"
+  },
+  {
+    "item": "structurize:blockfluidsubstitution"
+  },
+  {
+    "item": "minecraft:honey_bottle"
+  },
+  {
+    "item": "minecraft:diorite_stairs"
+  },
+  {
+    "item": "minecraft:dead_brain_coral"
+  },
+  {
+    "checkednbtkeys": [
+      {
+        "children": [
+          {
+            "key": "minecraft:block/oak_planks"
+          },
+          {
+            "key": "minecraft:block/glowstone"
+          }
+        ],
+        "key": "textureData"
+      }
+    ],
+    "item": "domum_ornamentum:crossed_light"
+  },
+  {
+    "item": "domum_ornamentum:magenta_floating_carpet"
+  },
+  {
+    "item": "minecolonies:build_goggles"
+  },
+  {
+    "item": "minecraft:stripped_mangrove_log"
+  },
+  {
+    "item": "minecraft:yellow_candle"
+  },
+  {
+    "item": "minecraft:calibrated_sculk_sensor"
+  },
+  {
+    "item": "minecraft:green_carpet"
+  },
+  {
+    "item": "minecraft:zombie_head"
+  },
+  {
+    "item": "minecraft:rabbit_stew"
+  },
+  {
+    "checkednbtkeys": [
+      {
+        "key": "Potion"
+      }
+    ],
+    "item": "minecraft:tipped_arrow"
+  },
+  {
+    "item": "minecolonies:decorationcontroller"
+  },
+  {
+    "item": "minecraft:pumpkin_seeds"
+  },
+  {
+    "item": "minecraft:white_dye"
+  },
+  {
+    "item": "minecraft:gray_banner"
+  },
+  {
+    "item": "minecraft:oak_hanging_sign"
+  },
+  {
+    "item": "minecraft:stripped_acacia_log"
+  },
+  {
+    "item": "minecraft:tropical_fish_bucket"
+  },
+  {
+    "item": "minecraft:chiseled_quartz_block"
+  },
+  {
+    "item": "minecraft:diorite_wall"
+  },
+  {
+    "item": "minecraft:exposed_cut_copper_slab"
+  },
+  {
+    "item": "minecraft:netherite_hoe"
+  },
+  {
+    "item": "minecraft:lever"
+  },
+  {
+    "item": "minecraft:cyan_dye"
+  },
+  {
+    "item": "minecraft:mossy_stone_bricks"
+  },
+  {
+    "item": "minecraft:tnt"
+  },
+  {
+    "item": "minecraft:crimson_sign"
+  },
+  {
+    "item": "minecraft:black_carpet"
+  },
+  {
+    "item": "minecraft:blade_pottery_sherd"
+  },
+  {
+    "checkednbtkeys": [
+      {
+        "children": [
+          {
+            "key": "minecraft:block/acacia_planks"
+          },
+          {
+            "key": "minecraft:block/oak_planks"
+          }
+        ],
+        "key": "textureData"
+      },
+      {
+        "key": "type"
+      }
+    ],
+    "item": "domum_ornamentum:fancy_trapdoors"
+  },
+  {
+    "item": "minecolonies:sifter_mesh_flint"
+  },
+  {
+    "item": "minecraft:white_carpet"
+  },
+  {
+    "item": "minecraft:gray_terracotta"
+  },
+  {
+    "item": "minecraft:end_stone_bricks"
+  },
+  {
+    "item": "minecraft:sandstone_slab"
+  },
+  {
+    "item": "minecraft:iron_horse_armor"
+  },
+  {
+    "item": "minecraft:birch_trapdoor"
+  },
+  {
+    "item": "minecraft:jungle_fence"
+  },
+  {
+    "item": "minecraft:smooth_stone_slab"
+  },
+  {
+    "item": "minecraft:arrow"
+  },
+  {
+    "item": "minecraft:end_stone_brick_slab"
+  },
+  {
+    "item": "minecraft:stripped_birch_wood"
+  },
+  {
+    "item": "minecraft:chest_minecart"
+  },
+  {
+    "item": "minecraft:warped_nylium"
+  },
+  {
+    "item": "minecraft:red_sandstone"
+  },
+  {
+    "item": "minecraft:dark_oak_leaves"
+  },
+  {
+    "item": "minecraft:light_blue_dye"
+  },
+  {
+    "item": "minecraft:crimson_hanging_sign"
+  },
+  {
+    "item": "minecraft:waxed_oxidized_cut_copper_stairs"
+  },
+  {
+    "item": "minecraft:deepslate_copper_ore"
+  },
+  {
+    "item": "minecraft:bamboo_door"
+  },
+  {
+    "item": "minecraft:bubble_coral"
+  },
+  {
+    "item": "minecraft:wither_skeleton_skull"
+  },
+  {
+    "item": "minecraft:iron_axe"
+  },
+  {
+    "item": "minecraft:light_weighted_pressure_plate"
+  },
+  {
+    "item": "minecraft:orange_glazed_terracotta"
+  },
+  {
+    "item": "minecraft:mangrove_leaves"
+  },
+  {
+    "item": "minecraft:suspicious_gravel"
+  },
+  {
+    "item": "minecraft:tuff"
+  },
+  {
+    "item": "minecraft:end_portal_frame"
+  },
+  {
+    "item": "minecraft:netherite_boots"
+  },
+  {
+    "item": "minecraft:purpur_stairs"
+  },
+  {
+    "item": "minecraft:magma_block"
+  },
+  {
+    "item": "minecraft:cobblestone_slab"
+  },
+  {
+    "item": "minecraft:waxed_oxidized_copper"
+  },
+  {
+    "item": "minecraft:red_nether_bricks"
+  },
+  {
+    "item": "minecraft:lime_dye"
+  },
+  {
+    "item": "minecraft:sheaf_pottery_sherd"
+  },
+  {
+    "item": "minecraft:terracotta"
+  },
+  {
+    "item": "minecraft:coal"
+  },
+  {
+    "item": "minecraft:zombie_villager_spawn_egg"
+  },
+  {
+    "item": "domum_ornamentum:brick_extra"
+  },
+  {
+    "item": "minecolonies:simplequarry"
+  },
+  {
+    "item": "minecraft:dead_fire_coral_block"
+  },
+  {
+    "item": "minecraft:crimson_fungus"
+  },
+  {
+    "item": "minecraft:repeating_command_block"
+  },
+  {
+    "item": "domum_ornamentum:light_gray_brick_extra"
+  },
+  {
+    "item": "minecraft:dirt"
+  },
+  {
+    "item": "minecraft:stripped_dark_oak_log"
+  },
+  {
+    "item": "minecolonies:colony_banner"
+  },
+  {
+    "item": "minecraft:stray_spawn_egg"
+  },
+  {
+    "item": "minecraft:armor_stand"
+  },
+  {
+    "item": "minecraft:green_dye"
+  },
+  {
+    "item": "domum_ornamentum:lime_floating_carpet"
+  },
+  {
+    "item": "domum_ornamentum:purple_brick_extra"
+  },
+  {
+    "item": "minecraft:pink_concrete_powder"
+  },
+  {
+    "item": "minecraft:suspicious_sand"
+  },
+  {
+    "item": "minecraft:dark_oak_chest_boat"
+  },
+  {
+    "item": "minecraft:oak_planks"
+  },
+  {
+    "item": "minecraft:cut_sandstone"
+  },
+  {
+    "item": "minecraft:music_disc_pigstep"
+  },
+  {
+    "item": "minecraft:evoker_spawn_egg"
+  },
+  {
+    "item": "minecraft:black_terracotta"
+  },
+  {
+    "item": "minecraft:spruce_leaves"
+  },
+  {
+    "item": "minecraft:porkchop"
+  },
+  {
+    "item": "minecraft:end_stone"
+  },
+  {
+    "item": "minecraft:birch_hanging_sign"
+  },
+  {
+    "item": "minecraft:jungle_log"
+  },
+  {
+    "item": "minecraft:wither_skeleton_spawn_egg"
+  },
+  {
+    "item": "minecraft:yellow_terracotta"
+  },
+  {
+    "item": "minecraft:vex_armor_trim_smithing_template"
+  },
+  {
+    "item": "minecraft:mud_bricks"
+  },
+  {
+    "item": "minecraft:red_sandstone_stairs"
+  },
+  {
+    "item": "minecraft:ward_armor_trim_smithing_template"
+  },
+  {
+    "checkednbtkeys": [
+      {
+        "children": [
+          {
+            "key": "minecraft:block/oak_planks"
+          }
+        ],
+        "key": "textureData"
+      }
+    ],
+    "item": "domum_ornamentum:vanilla_fence_gate_compat"
+  },
+  {
+    "item": "minecraft:chicken"
+  },
+  {
+    "item": "minecraft:salmon_bucket"
+  },
+  {
+    "item": "minecolonies:firearrow"
+  },
+  {
+    "item": "minecraft:yellow_bed"
+  },
+  {
+    "item": "minecraft:pink_candle"
+  },
+  {
+    "item": "minecraft:dead_bubble_coral"
+  },
+  {
+    "item": "minecraft:oak_log"
+  },
+  {
+    "item": "minecraft:carved_pumpkin"
+  },
+  {
+    "item": "minecraft:redstone_torch"
+  },
+  {
+    "item": "minecraft:diamond_hoe"
+  },
+  {
+    "item": "minecraft:mud"
+  },
+  {
+    "checkednbtkeys": [
+      {
+        "children": [
+          {
+            "key": "minecraft:block/oak_planks"
+          },
+          {
+            "key": "minecraft:block/glowstone"
+          }
+        ],
+        "key": "textureData"
+      }
+    ],
+    "item": "domum_ornamentum:vertical_light"
+  },
+  {
+    "item": "minecraft:end_stone_brick_wall"
+  },
+  {
+    "item": "minecraft:magenta_banner"
+  },
+  {
+    "checkednbtkeys": [
+      {
+        "key": "textureData"
+      }
+    ],
+    "item": "minecolonies:blockminecoloniesrack"
+  },
+  {
+    "item": "minecraft:jungle_boat"
+  },
+  {
+    "item": "minecolonies:scroll_highlight"
+  },
+  {
+    "checkednbtkeys": [
+      {
+        "children": [
+          {
+            "key": "level"
+          }
+        ],
+        "key": "BlockStateTag"
+      }
+    ],
+    "item": "minecraft:light"
+  },
+  {
+    "item": "minecraft:black_dye"
+  },
+  {
+    "item": "minecraft:soul_torch"
+  },
+  {
+    "item": "minecraft:mossy_cobblestone"
+  },
+  {
+    "checkednbtkeys": [
+      {
+        "children": [
+          {
+            "key": "minecraft:block/oak_planks"
+          }
+        ],
+        "key": "textureData"
+      }
+    ],
+    "item": "domum_ornamentum:vanilla_slab_compat"
+  },
+  {
+    "item": "minecraft:calcite"
+  },
+  {
+    "item": "minecraft:orange_banner"
+  },
+  {
+    "item": "minecraft:trident"
+  },
+  {
+    "item": "minecraft:cherry_trapdoor"
+  },
+  {
+    "item": "minecraft:golden_axe"
+  },
+  {
+    "item": "minecraft:prismarine_shard"
+  },
+  {
+    "item": "minecraft:jungle_pressure_plate"
+  },
+  {
+    "item": "minecraft:magma_cube_spawn_egg"
+  },
+  {
+    "item": "minecraft:barrier"
+  },
+  {
+    "item": "minecraft:scute"
+  },
+  {
+    "item": "minecraft:dark_oak_door"
+  },
+  {
+    "item": "minecraft:cherry_chest_boat"
+  },
+  {
+    "item": "minecraft:spruce_sapling"
+  },
+  {
+    "item": "minecraft:acacia_pressure_plate"
+  },
+  {
+    "item": "minecraft:exposed_cut_copper"
+  },
+  {
+    "item": "minecraft:cooked_beef"
+  },
+  {
+    "item": "minecraft:magenta_carpet"
+  },
+  {
+    "item": "minecraft:crimson_roots"
+  },
+  {
+    "item": "minecraft:frogspawn"
+  },
+  {
+    "item": "minecraft:stripped_jungle_wood"
+  },
+  {
+    "item": "minecraft:acacia_log"
+  },
+  {
+    "item": "minecraft:jungle_button"
+  },
+  {
+    "item": "minecraft:ladder"
+  },
+  {
+    "item": "minecraft:nautilus_shell"
+  },
+  {
+    "item": "minecraft:basalt"
+  },
+  {
+    "item": "minecraft:item_frame"
+  },
+  {
+    "item": "minecraft:slime_block"
+  },
+  {
+    "item": "minecraft:silence_armor_trim_smithing_template"
+  },
+  {
+    "item": "minecraft:tropical_fish_spawn_egg"
+  },
+  {
+    "item": "minecraft:minecart"
+  },
+  {
+    "item": "minecraft:clay_ball"
+  },
+  {
+    "item": "minecraft:sugar"
+  },
+  {
+    "item": "minecraft:lapis_block"
+  },
+  {
+    "item": "minecraft:prismarine"
+  },
+  {
+    "item": "minecraft:iron_block"
+  },
+  {
+    "item": "minecraft:glow_ink_sac"
+  },
+  {
+    "item": "minecraft:reinforced_deepslate"
+  },
+  {
+    "item": "minecraft:bell"
+  },
+  {
+    "item": "domum_ornamentum:pink_floating_carpet"
+  },
+  {
+    "item": "minecraft:brick_slab"
+  },
+  {
+    "item": "minecraft:gravel"
+  },
+  {
+    "item": "minecraft:music_disc_strad"
+  },
+  {
+    "item": "minecraft:light_gray_stained_glass_pane"
+  },
+  {
+    "item": "minecraft:light_gray_concrete_powder"
+  },
+  {
+    "item": "minecraft:birch_wood"
+  },
+  {
+    "item": "minecraft:vex_spawn_egg"
+  },
+  {
+    "item": "minecraft:dark_prismarine_stairs"
+  },
+  {
+    "item": "minecraft:lime_banner"
+  },
+  {
+    "item": "minecraft:golden_pickaxe"
+  },
+  {
+    "item": "minecraft:eye_armor_trim_smithing_template"
+  },
+  {
+    "item": "minecraft:orange_terracotta"
+  },
+  {
+    "item": "minecraft:pink_stained_glass"
+  },
+  {
+    "item": "minecraft:glow_lichen"
+  },
+  {
+    "checkednbtkeys": [
+      {
+        "children": [
+          {
+            "key": "minecraft:block/oak_planks"
+          }
+        ],
+        "key": "textureData"
+      }
+    ],
+    "item": "domum_ornamentum:squarepillar"
+  },
+  {
+    "item": "minecraft:black_concrete"
+  },
+  {
+    "item": "minecraft:brown_candle"
+  },
+  {
+    "item": "minecraft:dark_oak_sapling"
+  },
+  {
+    "item": "minecraft:conduit"
+  },
+  {
+    "item": "minecraft:black_wool"
+  },
+  {
+    "item": "minecraft:wandering_trader_spawn_egg"
+  },
+  {
+    "item": "minecraft:brain_coral_fan"
+  },
+  {
+    "item": "minecraft:light_gray_carpet"
+  },
+  {
+    "item": "minecraft:flowering_azalea_leaves"
+  },
+  {
+    "item": "minecraft:hopper_minecart"
+  },
+  {
+    "item": "domum_ornamentum:white_paper_extra"
+  },
+  {
+    "item": "minecraft:coarse_dirt"
+  },
+  {
+    "item": "minecolonies:blockhutshepherd"
+  },
+  {
+    "item": "minecraft:dark_oak_log"
+  },
+  {
+    "item": "minecraft:cyan_glazed_terracotta"
+  },
+  {
+    "item": "minecraft:brown_mushroom"
+  },
+  {
+    "item": "minecraft:wild_armor_trim_smithing_template"
+  },
+  {
+    "item": "minecraft:stripped_warped_stem"
+  },
+  {
+    "item": "minecraft:waxed_oxidized_cut_copper_slab"
+  },
+  {
+    "checkednbtkeys": [
+      {
+        "children": [
+          {
+            "key": "minecraft:block/acacia_planks"
+          },
+          {
+            "key": "minecraft:block/oak_planks"
+          },
+          {
+            "key": "minecraft:block/dark_oak_planks"
+          }
+        ],
+        "key": "textureData"
+      }
+    ],
+    "item": "domum_ornamentum:shingle_slab"
+  },
+  {
+    "item": "minecolonies:blockhutmechanic"
+  },
+  {
+    "item": "minecolonies:blockhutfletcher"
+  },
+  {
+    "checkednbtkeys": [
+      {
+        "children": [
+          {
+            "key": "minecraft:block/oak_planks"
+          },
+          {
+            "key": "minecraft:block/clay"
+          }
+        ],
+        "key": "textureData"
+      }
+    ],
+    "item": "domum_ornamentum:shingle"
+  },
+  {
+    "item": "domum_ornamentum:beige_stone_bricks"
+  },
+  {
+    "item": "minecolonies:blockhutsawmill"
+  },
+  {
+    "item": "minecraft:crimson_trapdoor"
+  },
+  {
+    "item": "minecraft:bamboo_block"
+  },
+  {
+    "item": "domum_ornamentum:light_gray_floating_carpet"
+  },
+  {
+    "item": "minecraft:dark_oak_fence_gate"
+  },
+  {
+    "item": "minecolonies:blockhutlibrary"
+  },
+  {
+    "item": "minecolonies:blockhutbarracks"
+  },
+  {
+    "item": "minecraft:dark_oak_stairs"
+  },
+  {
+    "item": "minecraft:glistering_melon_slice"
+  },
+  {
+    "item": "minecraft:brown_dye"
+  },
+  {
+    "item": "minecraft:waxed_copper_block"
+  },
+  {
+    "item": "minecraft:lime_stained_glass_pane"
+  },
+  {
+    "item": "minecraft:waxed_oxidized_cut_copper"
+  },
+  {
+    "item": "minecraft:dead_brain_coral_block"
+  },
+  {
+    "item": "minecraft:grass_block"
+  },
+  {
+    "item": "minecraft:magenta_concrete_powder"
+  },
+  {
+    "item": "minecraft:green_terracotta"
+  },
+  {
+    "item": "minecraft:bamboo_planks"
+  },
+  {
+    "item": "minecolonies:barrel_block"
+  },
+  {
+    "item": "minecraft:netherite_block"
+  },
+  {
+    "item": "minecraft:iron_ingot"
+  },
+  {
+    "item": "minecraft:tnt_minecart"
+  },
+  {
+    "item": "minecraft:rotten_flesh"
+  },
+  {
+    "item": "minecraft:iron_hoe"
+  },
+  {
+    "item": "minecraft:leather_horse_armor"
+  },
+  {
+    "item": "minecraft:smooth_red_sandstone_stairs"
+  },
+  {
+    "item": "minecraft:polished_andesite"
+  },
+  {
+    "item": "minecraft:acacia_leaves"
+  },
+  {
+    "item": "domum_ornamentum:cyan_brick_extra"
+  },
+  {
+    "item": "minecraft:acacia_door"
+  },
+  {
+    "item": "minecraft:flower_pot"
+  },
+  {
+    "item": "minecraft:quartz_slab"
+  },
+  {
+    "item": "minecraft:lime_carpet"
+  },
+  {
+    "checkednbtkeys": [
+      {
+        "children": [
+          {
+            "key": "Patterns"
+          },
+          {
+            "key": "id"
+          }
+        ],
+        "key": "BlockEntityTag"
+      },
+      {
+        "children": [
+          {
+            "key": "Name"
+          }
+        ],
+        "key": "display"
+      },
+      {
+        "key": "HideFlags"
+      }
+    ],
+    "item": "minecraft:white_banner"
+  },
+  {
+    "item": "minecolonies:chorus_bread"
+  },
+  {
+    "item": "minecraft:shroomlight"
+  },
+  {
+    "item": "minecraft:diamond_chestplate"
+  },
+  {
+    "item": "minecraft:smooth_quartz_stairs"
+  },
+  {
+    "item": "minecraft:furnace_minecart"
+  },
+  {
+    "item": "minecraft:cobweb"
+  },
+  {
+    "item": "minecraft:weeping_vines"
+  },
+  {
+    "item": "minecolonies:mediumquarry"
+  },
+  {
+    "item": "minecraft:stripped_spruce_log"
+  },
+  {
+    "item": "minecraft:echo_shard"
+  },
+  {
+    "item": "minecraft:raiser_armor_trim_smithing_template"
+  },
+  {
+    "item": "minecolonies:blockhutdeliveryman"
+  },
+  {
+    "item": "minecraft:sandstone"
+  },
+  {
+    "item": "minecraft:oak_door"
+  },
+  {
+    "item": "minecraft:tadpole_bucket"
+  },
+  {
+    "item": "minecraft:warped_hyphae"
+  },
+  {
+    "item": "minecraft:pointed_dripstone"
+  },
+  {
+    "item": "minecraft:shelter_pottery_sherd"
+  },
+  {
+    "item": "minecraft:scaffolding"
+  },
+  {
+    "item": "minecraft:large_amethyst_bud"
+  },
+  {
+    "item": "minecraft:cartography_table"
+  },
+  {
+    "item": "minecraft:amethyst_shard"
+  },
+  {
+    "item": "minecraft:potato"
+  },
+  {
+    "item": "minecolonies:gate_iron"
+  },
+  {
+    "item": "minecraft:lime_concrete_powder"
+  },
+  {
+    "item": "minecraft:birch_pressure_plate"
+  },
+  {
+    "item": "minecraft:panda_spawn_egg"
+  },
+  {
+    "item": "minecolonies:pirate_cap"
+  },
+  {
+    "item": "minecraft:spruce_sign"
+  },
+  {
+    "item": "domum_ornamentum:blue_brick_extra"
+  },
+  {
+    "item": "minecraft:egg"
+  },
+  {
+    "item": "minecraft:crimson_fence_gate"
+  },
+  {
+    "item": "minecraft:pink_petals"
+  },
+  {
+    "checkednbtkeys": [
+      {
+        "key": "Potion"
+      }
+    ],
+    "item": "minecraft:splash_potion"
+  },
+  {
+    "item": "minecraft:mangrove_wood"
+  },
+  {
+    "item": "minecraft:stone_brick_wall"
+  },
+  {
+    "item": "minecraft:stripped_oak_log"
+  },
+  {
+    "item": "minecraft:silverfish_spawn_egg"
+  },
+  {
+    "item": "minecraft:red_shulker_box"
+  },
+  {
+    "item": "minecraft:damaged_anvil"
+  },
+  {
+    "checkednbtkeys": [
+      {
+        "key": "StoredEnchantments"
+      }
+    ],
+    "item": "minecraft:enchanted_book"
+  },
+  {
+    "item": "minecraft:shaper_armor_trim_smithing_template"
+  },
+  {
+    "item": "minecraft:lily_of_the_valley"
+  },
+  {
+    "item": "minecraft:honeycomb"
+  },
+  {
+    "item": "minecolonies:blockhutswineherder"
+  },
+  {
+    "item": "minecolonies:plate_armor_helmet"
+  },
+  {
+    "item": "minecraft:end_stone_brick_stairs"
+  },
+  {
+    "item": "minecraft:cooked_rabbit"
+  },
+  {
+    "item": "minecraft:purple_glazed_terracotta"
+  },
+  {
+    "item": "minecraft:music_disc_11"
+  },
+  {
+    "item": "minecraft:spider_eye"
+  },
+  {
+    "item": "minecraft:iron_pickaxe"
+  },
+  {
+    "item": "minecraft:tropical_fish"
+  },
+  {
+    "item": "minecraft:music_disc_13"
+  },
+  {
+    "item": "minecraft:bubble_coral_block"
+  },
+  {
+    "item": "minecraft:gold_ingot"
+  },
+  {
+    "item": "minecraft:brown_terracotta"
+  },
+  {
+    "item": "minecraft:leather"
+  },
+  {
+    "item": "minecraft:kelp"
+  },
+  {
+    "checkednbtkeys": [
+      {
+        "children": [
+          {
+            "key": "minecraft:block/oak_planks"
+          },
+          {
+            "key": "minecraft:block/dark_oak_planks"
+          }
+        ],
+        "key": "textureData"
+      }
+    ],
+    "item": "domum_ornamentum:side_framed"
+  },
+  {
+    "item": "minecraft:light_gray_bed"
+  },
+  {
+    "item": "minecraft:weathered_cut_copper_stairs"
+  },
+  {
+    "item": "minecraft:sandstone_wall"
+  },
+  {
+    "item": "minecraft:polished_blackstone_wall"
+  },
+  {
+    "item": "minecraft:music_disc_stal"
+  },
+  {
+    "item": "minecraft:waxed_exposed_cut_copper_stairs"
+  },
+  {
+    "item": "minecraft:smooth_stone"
+  },
+  {
+    "item": "minecraft:quartz_bricks"
+  },
+  {
+    "item": "minecraft:end_crystal"
+  },
+  {
+    "item": "minecraft:bamboo_fence"
+  },
+  {
+    "item": "structurize:sceptertag"
+  },
+  {
+    "item": "minecraft:polished_diorite_stairs"
+  },
+  {
+    "item": "minecraft:experience_bottle"
+  },
+  {
+    "item": "minecraft:black_shulker_box"
+  },
+  {
+    "item": "minecraft:comparator"
+  },
+  {
+    "item": "minecraft:powder_snow_bucket"
+  },
+  {
+    "item": "minecraft:explorer_pottery_sherd"
+  },
+  {
+    "item": "minecraft:ender_eye"
+  },
+  {
+    "item": "minecraft:oak_stairs"
+  },
+  {
+    "item": "minecraft:gray_candle"
+  },
+  {
+    "item": "minecraft:grass"
+  },
+  {
+    "item": "minecraft:chain_command_block"
+  },
+  {
+    "item": "minecolonies:spear"
+  },
+  {
+    "item": "domum_ornamentum:blue_floating_carpet"
+  },
+  {
+    "item": "minecraft:white_stained_glass"
+  },
+  {
+    "item": "minecraft:bamboo_mosaic_stairs"
+  },
+  {
+    "item": "minecraft:warped_wart_block"
+  },
+  {
+    "item": "minecraft:small_dripleaf"
+  },
+  {
+    "item": "minecraft:moss_block"
+  },
+  {
+    "item": "minecraft:raw_gold"
+  },
+  {
+    "item": "domum_ornamentum:pink_brick_extra"
+  },
+  {
+    "item": "minecraft:polished_blackstone_bricks"
+  },
+  {
+    "item": "minecraft:tube_coral"
+  },
+  {
+    "item": "minecraft:zombified_piglin_spawn_egg"
+  },
+  {
+    "item": "minecolonies:pirate_boots"
+  },
+  {
+    "item": "minecraft:birch_fence"
+  },
+  {
+    "item": "minecraft:light_gray_wool"
+  },
+  {
+    "item": "minecraft:heart_of_the_sea"
+  },
+  {
+    "item": "minecraft:beef"
+  },
+  {
+    "item": "minecraft:green_stained_glass"
+  },
+  {
+    "item": "minecraft:dark_oak_hanging_sign"
+  },
+  {
+    "item": "minecraft:netherite_upgrade_smithing_template"
+  },
+  {
+    "item": "minecraft:sand"
+  },
+  {
+    "item": "minecraft:cut_copper"
+  },
+  {
+    "item": "minecraft:purpur_slab"
+  },
+  {
+    "item": "minecraft:light_blue_carpet"
+  },
+  {
+    "item": "minecraft:spire_armor_trim_smithing_template"
+  },
+  {
+    "item": "minecraft:mangrove_button"
+  },
+  {
+    "item": "minecraft:warped_button"
+  },
+  {
+    "item": "minecraft:globe_banner_pattern"
+  },
+  {
+    "item": "minecolonies:resourcescroll"
+  },
+  {
+    "item": "minecolonies:blockwaypoint"
+  },
+  {
+    "item": "minecraft:warped_planks"
+  },
+  {
+    "item": "minecraft:cyan_wool"
+  },
+  {
+    "item": "minecraft:decorated_pot"
+  },
+  {
+    "item": "domum_ornamentum:cream_bricks"
+  },
+  {
+    "item": "minecraft:fletching_table"
+  },
+  {
+    "checkednbtkeys": [
+      {
+        "children": [
+          {
+            "key": "minecraft:block/oak_planks"
+          },
+          {
+            "key": "minecraft:block/dark_oak_planks"
+          }
+        ],
+        "key": "textureData"
+      }
+    ],
+    "item": "domum_ornamentum:double_crossed"
+  },
+  {
+    "item": "minecraft:light_blue_glazed_terracotta"
+  },
+  {
+    "item": "minecraft:smooth_quartz_slab"
+  },
+  {
+    "item": "minecolonies:blockhuttownhall"
+  },
+  {
+    "item": "minecraft:polished_granite_stairs"
+  },
+  {
+    "item": "minecraft:ocelot_spawn_egg"
+  },
+  {
+    "item": "minecraft:lime_stained_glass"
+  },
+  {
+    "item": "minecraft:composter"
+  },
+  {
+    "item": "minecraft:cyan_terracotta"
+  },
+  {
+    "item": "minecolonies:blockhutrabbithutch"
+  },
+  {
+    "item": "minecraft:waxed_weathered_copper"
+  },
+  {
+    "item": "minecraft:pink_terracotta"
+  },
+  {
+    "item": "minecraft:chorus_flower"
+  },
+  {
+    "item": "minecraft:birch_sign"
+  },
+  {
+    "item": "minecraft:acacia_fence"
+  },
+  {
+    "item": "minecraft:wooden_pickaxe"
+  },
+  {
+    "item": "domum_ornamentum:brown_brick_extra"
+  },
+  {
+    "item": "minecraft:magenta_concrete"
+  },
+  {
+    "item": "minecraft:lava_bucket"
+  },
+  {
+    "item": "minecolonies:blockhutwarehouse"
+  },
+  {
+    "item": "minecraft:music_disc_mall"
+  },
+  {
+    "item": "minecolonies:sugary_bread"
+  },
+  {
+    "item": "minecraft:lectern"
+  },
+  {
+    "item": "minecraft:gunpowder"
+  },
+  {
+    "item": "minecraft:dark_prismarine_slab"
+  },
+  {
+    "item": "minecraft:snow_golem_spawn_egg"
+  },
+  {
+    "item": "minecraft:oxidized_cut_copper_slab"
+  },
+  {
+    "item": "minecraft:dark_oak_button"
+  },
+  {
+    "item": "minecraft:campfire"
+  },
+  {
+    "item": "minecraft:elytra"
+  },
+  {
+    "item": "domum_ornamentum:blockbarreldeco_onside"
+  },
+  {
+    "item": "minecraft:iron_boots"
+  },
+  {
+    "item": "minecraft:bowl"
+  },
+  {
+    "item": "minecraft:skeleton_spawn_egg"
+  },
+  {
+    "item": "minecolonies:scepterlumberjack"
+  },
+  {
+    "item": "minecraft:azalea"
+  },
+  {
+    "item": "minecraft:andesite_slab"
+  },
+  {
+    "item": "minecraft:light_gray_stained_glass"
+  },
+  {
+    "item": "minecraft:white_bed"
+  },
+  {
+    "item": "minecraft:warped_stem"
+  },
+  {
+    "item": "minecraft:red_concrete_powder"
+  },
+  {
+    "item": "minecraft:green_concrete"
+  },
+  {
+    "item": "minecraft:red_tulip"
+  },
+  {
+    "item": "minecraft:jigsaw"
+  },
+  {
+    "item": "minecraft:podzol"
+  },
+  {
+    "item": "minecraft:white_concrete_powder"
+  },
+  {
+    "item": "minecraft:light_blue_bed"
+  },
+  {
+    "item": "minecraft:lightning_rod"
+  },
+  {
+    "item": "minecraft:stripped_crimson_hyphae"
+  },
+  {
+    "item": "minecraft:birch_log"
+  },
+  {
+    "item": "minecraft:orange_shulker_box"
+  },
+  {
+    "item": "minecraft:cyan_candle"
+  },
+  {
+    "item": "minecraft:cyan_bed"
+  },
+  {
+    "item": "minecraft:cherry_log"
+  },
+  {
+    "item": "minecraft:brown_mushroom_block"
+  },
+  {
+    "item": "minecraft:azure_bluet"
+  },
+  {
+    "item": "minecraft:polished_deepslate_wall"
+  },
+  {
+    "item": "minecraft:red_stained_glass"
+  },
+  {
+    "item": "minecolonies:blockhutplantationfield"
+  },
+  {
+    "item": "minecraft:feather"
+  },
+  {
+    "item": "minecraft:purple_wool"
+  },
+  {
+    "item": "minecraft:waxed_exposed_cut_copper_slab"
+  },
+  {
+    "item": "minecraft:red_nether_brick_stairs"
+  },
+  {
+    "item": "minecolonies:blockhutguardtower"
+  },
+  {
+    "item": "minecolonies:mistletoe"
+  },
+  {
+    "item": "minecraft:polished_andesite_slab"
+  },
+  {
+    "item": "minecraft:melon"
+  },
+  {
+    "item": "domum_ornamentum:green_floating_carpet"
+  },
+  {
+    "item": "minecraft:mossy_stone_brick_stairs"
+  },
+  {
+    "item": "minecolonies:blockhutnetherworker"
+  },
+  {
+    "item": "minecraft:diamond_ore"
+  },
+  {
+    "item": "minecraft:dragon_head"
+  },
+  {
+    "item": "minecraft:diorite"
+  },
+  {
+    "item": "minecraft:waxed_weathered_cut_copper_slab"
+  },
+  {
+    "item": "minecraft:light_gray_banner"
+  },
+  {
+    "item": "minecraft:infested_chiseled_stone_bricks"
+  },
+  {
+    "item": "minecraft:polished_andesite_stairs"
+  },
+  {
+    "item": "minecolonies:blockhutenchanter"
+  },
+  {
+    "item": "minecraft:iron_door"
+  },
+  {
+    "item": "minecraft:lime_bed"
+  },
+  {
+    "item": "minecraft:arms_up_pottery_sherd"
+  },
+  {
+    "item": "minecraft:polished_basalt"
+  },
+  {
+    "item": "minecraft:diamond"
+  },
+  {
+    "item": "minecolonies:blockhutcitizen"
+  },
+  {
+    "item": "minecraft:mangrove_sign"
+  },
+  {
+    "item": "minecraft:black_glazed_terracotta"
+  },
+  {
+    "item": "minecraft:ender_chest"
+  },
+  {
+    "item": "minecraft:dark_oak_trapdoor"
+  },
+  {
+    "item": "minecraft:iron_helmet"
+  },
+  {
+    "item": "structurize:blocktagsubstitution"
+  },
+  {
+    "item": "minecraft:cherry_stairs"
+  },
+  {
+    "item": "minecraft:black_candle"
+  },
+  {
+    "item": "minecraft:infested_deepslate"
+  },
+  {
+    "item": "minecraft:raw_copper"
+  },
+  {
+    "item": "minecraft:mud_brick_slab"
+  },
+  {
+    "item": "minecraft:brick_wall"
+  },
+  {
+    "item": "minecraft:cherry_slab"
+  },
+  {
+    "item": "minecolonies:blockminecoloniesnamedgrave"
+  },
+  {
+    "item": "minecraft:black_stained_glass_pane"
+  },
+  {
+    "item": "minecraft:villager_spawn_egg"
+  },
+  {
+    "item": "minecraft:mutton"
+  },
+  {
+    "item": "minecraft:stone_axe"
+  },
+  {
+    "item": "minecraft:orange_bed"
+  },
+  {
+    "item": "minecraft:lilac"
+  },
+  {
+    "item": "minecolonies:supplychestdeployer"
+  },
+  {
+    "item": "minecraft:pitcher_plant"
+  },
+  {
+    "item": "minecraft:respawn_anchor"
+  },
+  {
+    "item": "minecraft:nether_brick_wall"
+  },
+  {
+    "item": "minecraft:acacia_slab"
+  },
+  {
+    "item": "domum_ornamentum:white_brick_extra"
+  },
+  {
+    "item": "minecraft:polished_diorite_slab"
+  },
+  {
+    "item": "minecraft:jack_o_lantern"
+  },
+  {
+    "item": "minecraft:mangrove_roots"
+  },
+  {
+    "item": "minecraft:jungle_chest_boat"
+  },
+  {
+    "checkednbtkeys": [
+      {
+        "children": [
+          {
+            "key": "Flight"
+          }
+        ],
+        "key": "Fireworks"
+      }
+    ],
+    "item": "minecraft:firework_rocket"
+  },
+  {
+    "item": "minecraft:cactus"
+  },
+  {
+    "item": "minecraft:purple_stained_glass_pane"
+  },
+  {
+    "item": "minecraft:pink_shulker_box"
+  },
+  {
+    "item": "minecraft:crimson_door"
+  },
+  {
+    "item": "minecraft:shulker_shell"
+  },
+  {
+    "item": "minecraft:twisting_vines"
+  },
+  {
+    "item": "minecraft:iron_chestplate"
+  },
+  {
+    "item": "minecolonies:blockhutfarmer"
+  },
+  {
+    "item": "minecraft:elder_guardian_spawn_egg"
+  },
+  {
+    "item": "minecraft:weathered_cut_copper_slab"
+  },
+  {
+    "item": "minecraft:blue_glazed_terracotta"
+  },
+  {
+    "item": "minecraft:brain_coral_block"
+  },
+  {
+    "checkednbtkeys": [
+      {
+        "children": [
+          {
+            "key": "minecraft:block/acacia_planks"
+          },
+          {
+            "key": "minecraft:block/oak_planks"
+          }
+        ],
+        "key": "textureData"
+      },
+      {
+        "key": "type"
+      }
+    ],
+    "item": "domum_ornamentum:fancy_door"
+  },
+  {
+    "item": "minecraft:sandstone_stairs"
+  },
+  {
+    "item": "minecraft:white_glazed_terracotta"
+  },
+  {
+    "item": "minecraft:player_head"
+  },
+  {
+    "item": "minecraft:smoker"
+  },
+  {
+    "item": "domum_ornamentum:roan_bricks"
+  },
+  {
+    "item": "minecraft:acacia_boat"
+  },
+  {
+    "item": "minecolonies:blockhutminer"
+  },
+  {
+    "item": "minecraft:magenta_stained_glass"
+  },
+  {
+    "item": "minecraft:purple_terracotta"
+  },
+  {
+    "item": "minecraft:large_fern"
+  },
+  {
+    "item": "minecraft:nether_brick_fence"
+  },
+  {
+    "item": "minecraft:emerald"
+  },
+  {
+    "item": "domum_ornamentum:paper_extra"
+  },
+  {
+    "item": "minecraft:nether_star"
+  },
+  {
+    "item": "domum_ornamentum:sand_bricks"
+  },
+  {
+    "item": "minecraft:light_blue_concrete"
+  },
+  {
+    "item": "minecraft:note_block"
+  },
+  {
+    "item": "minecraft:dead_bubble_coral_fan"
+  },
+  {
+    "item": "minecolonies:scroll_buff"
+  },
+  {
+    "item": "domum_ornamentum:lime_brick_extra"
+  },
+  {
+    "item": "minecraft:bamboo_slab"
+  },
+  {
+    "item": "minecraft:oak_boat"
+  },
+  {
+    "item": "minecraft:slime_ball"
+  },
+  {
+    "item": "minecraft:brown_carpet"
+  },
+  {
+    "item": "minecraft:cooked_cod"
+  },
+  {
+    "item": "minecraft:soul_soil"
+  },
+  {
+    "item": "minecraft:acacia_hanging_sign"
+  },
+  {
+    "item": "minecraft:stone_stairs"
+  },
+  {
+    "item": "minecolonies:sifter_mesh_iron"
+  },
+  {
+    "item": "minecraft:granite_wall"
+  },
+  {
+    "item": "minecraft:sticky_piston"
+  },
+  {
+    "item": "minecraft:red_bed"
+  },
+  {
+    "item": "minecraft:snow"
+  },
+  {
+    "item": "minecraft:cyan_stained_glass"
+  },
+  {
+    "item": "minecraft:glass_pane"
+  },
+  {
+    "item": "minecraft:iron_shovel"
+  },
+  {
+    "item": "minecraft:sculk_sensor"
+  },
+  {
+    "item": "minecraft:iron_golem_spawn_egg"
+  },
+  {
+    "item": "minecraft:oak_trapdoor"
+  },
+  {
+    "item": "minecraft:crimson_nylium"
+  },
+  {
+    "item": "minecraft:diamond_block"
+  },
+  {
+    "item": "minecraft:birch_sapling"
+  },
+  {
+    "item": "minecraft:cod"
+  },
+  {
+    "item": "minecraft:acacia_button"
+  },
+  {
+    "item": "minecraft:dead_bush"
+  },
+  {
+    "item": "minecraft:stone_slab"
+  },
+  {
+    "item": "minecraft:farmland"
+  },
+  {
+    "item": "minecraft:bedrock"
+  },
+  {
+    "item": "minecraft:phantom_spawn_egg"
+  },
+  {
+    "item": "minecraft:glow_squid_spawn_egg"
+  },
+  {
+    "item": "minecraft:infested_mossy_stone_bricks"
+  },
+  {
+    "item": "minecraft:cherry_pressure_plate"
+  },
+  {
+    "item": "minecraft:hoglin_spawn_egg"
+  },
+  {
+    "item": "minecraft:purple_candle"
+  },
+  {
+    "item": "minecraft:brick"
+  },
+  {
+    "item": "minecraft:wooden_axe"
+  },
+  {
+    "item": "minecraft:activator_rail"
+  },
+  {
+    "item": "minecraft:nether_brick"
+  },
+  {
+    "item": "minecraft:smooth_quartz"
+  },
+  {
+    "item": "minecraft:oak_pressure_plate"
+  },
+  {
+    "item": "minecraft:glowstone"
+  },
+  {
+    "item": "minecraft:spawner"
+  },
+  {
+    "item": "minecraft:light_gray_glazed_terracotta"
+  },
+  {
+    "item": "minecraft:white_tulip"
+  },
+  {
+    "item": "minecraft:dark_oak_boat"
+  },
+  {
+    "item": "minecraft:tube_coral_fan"
+  },
+  {
+    "item": "minecraft:wooden_sword"
+  },
+  {
+    "checkednbtkeys": [
+      {
+        "key": "Potion"
+      }
+    ],
+    "item": "minecraft:potion"
+  },
+  {
+    "item": "minecraft:music_disc_blocks"
+  },
+  {
+    "item": "minecraft:husk_spawn_egg"
+  },
+  {
+    "item": "minecraft:blaze_spawn_egg"
+  },
+  {
+    "item": "minecolonies:chiefsword"
+  },
+  {
+    "item": "minecraft:purple_concrete"
+  },
+  {
+    "item": "minecraft:light_blue_stained_glass_pane"
+  },
+  {
+    "item": "minecraft:oak_fence_gate"
+  },
+  {
+    "item": "minecraft:tripwire_hook"
+  },
+  {
+    "item": "minecraft:black_concrete_powder"
+  },
+  {
+    "item": "minecraft:salmon"
+  },
+  {
+    "item": "minecolonies:pirate_legs"
+  },
+  {
+    "item": "minecraft:spruce_button"
+  },
+  {
+    "item": "minecraft:prismarine_wall"
+  },
+  {
+    "item": "minecraft:cracked_deepslate_tiles"
+  },
+  {
+    "item": "minecraft:chipped_anvil"
+  },
+  {
+    "item": "minecraft:book"
+  },
+  {
+    "item": "minecolonies:milky_bread"
+  },
+  {
+    "item": "minecraft:stone_brick_stairs"
+  },
+  {
+    "item": "minecraft:gold_ore"
+  },
+  {
+    "item": "minecraft:light_blue_wool"
+  },
+  {
+    "item": "minecraft:birch_stairs"
+  },
+  {
+    "item": "minecraft:blue_shulker_box"
+  },
+  {
+    "item": "minecraft:tinted_glass"
+  },
+  {
+    "item": "minecraft:baked_potato"
+  },
+  {
+    "item": "minecraft:polished_blackstone_brick_slab"
+  },
+  {
+    "item": "minecolonies:santa_hat"
+  },
+  {
+    "item": "minecraft:rabbit"
+  },
+  {
+    "item": "minecraft:daylight_detector"
+  },
+  {
+    "item": "minecraft:pink_concrete"
+  },
+  {
+    "item": "minecraft:cooked_porkchop"
+  },
+  {
+    "item": "minecraft:mule_spawn_egg"
+  },
+  {
+    "item": "minecraft:quartz_block"
+  },
+  {
+    "item": "minecraft:fire_coral"
+  },
+  {
+    "item": "minecraft:skull_pottery_sherd"
+  },
+  {
+    "item": "minecraft:bone"
+  },
+  {
+    "item": "minecraft:polished_deepslate"
+  },
+  {
+    "item": "minecraft:coal_ore"
+  },
+  {
+    "item": "minecraft:creeper_banner_pattern"
+  },
+  {
+    "item": "domum_ornamentum:orange_brick_extra"
+  },
+  {
+    "item": "minecraft:jungle_door"
+  },
+  {
+    "item": "minecolonies:plate_armor_boots"
+  },
+  {
+    "item": "minecraft:stone_hoe"
+  },
+  {
+    "item": "minecraft:bucket"
+  },
+  {
+    "item": "minecolonies:ancienttome"
+  },
+  {
+    "item": "minecraft:bread"
+  },
+  {
+    "item": "domum_ornamentum:yellow_floating_carpet"
+  },
+  {
+    "item": "minecraft:carrot"
+  },
+  {
+    "item": "minecraft:goat_spawn_egg"
+  },
+  {
+    "item": "minecraft:deepslate_iron_ore"
+  },
+  {
+    "item": "minecraft:blue_carpet"
+  },
+  {
+    "item": "minecraft:diamond_boots"
+  },
+  {
+    "item": "minecraft:diamond_horse_armor"
+  },
+  {
+    "item": "minecraft:zombie_horse_spawn_egg"
+  },
+  {
+    "item": "minecraft:spruce_door"
+  },
+  {
+    "item": "minecraft:polished_deepslate_stairs"
+  },
+  {
+    "item": "minecraft:bee_spawn_egg"
+  },
+  {
+    "item": "minecolonies:blockpostbox"
+  },
+  {
+    "item": "minecraft:acacia_chest_boat"
+  },
+  {
+    "item": "minecraft:cobblestone"
+  },
+  {
+    "item": "minecraft:glow_berries"
+  },
+  {
+    "item": "minecraft:jungle_leaves"
+  },
+  {
+    "item": "minecraft:powered_rail"
+  },
+  {
+    "item": "minecraft:writable_book"
+  },
+  {
+    "item": "minecraft:cod_spawn_egg"
+  },
+  {
+    "item": "minecraft:stripped_dark_oak_wood"
+  },
+  {
+    "item": "minecraft:exposed_cut_copper_stairs"
+  },
+  {
+    "item": "minecraft:waxed_cut_copper_stairs"
+  },
+  {
+    "item": "minecraft:brown_bed"
+  },
+  {
+    "item": "minecraft:snowball"
+  },
+  {
+    "item": "minecraft:llama_spawn_egg"
+  },
+  {
+    "item": "minecraft:command_block"
+  },
+  {
+    "item": "minecraft:bamboo_mosaic"
+  },
+  {
+    "item": "minecraft:honeycomb_block"
+  },
+  {
+    "item": "minecraft:light_blue_terracotta"
+  },
+  {
+    "item": "minecraft:gray_concrete"
+  },
+  {
+    "item": "minecraft:smooth_sandstone_slab"
+  },
+  {
+    "item": "minecraft:chainmail_boots"
+  },
+  {
+    "item": "minecraft:blast_furnace"
+  },
+  {
+    "item": "minecraft:horn_coral"
+  },
+  {
+    "item": "minecraft:beehive"
+  },
+  {
+    "item": "minecraft:fox_spawn_egg"
+  },
+  {
+    "item": "minecraft:piglin_brute_spawn_egg"
+  },
+  {
+    "checkednbtkeys": [
+      {
+        "children": [
+          {
+            "key": "minecraft:block/oak_planks"
+          },
+          {
+            "key": "minecraft:block/dark_oak_planks"
+          }
+        ],
+        "key": "textureData"
+      }
+    ],
+    "item": "domum_ornamentum:horizontal_plain"
+  },
+  {
+    "item": "minecraft:bamboo_mosaic_slab"
+  },
+  {
+    "item": "minecraft:pink_carpet"
+  },
+  {
+    "item": "minecraft:moss_carpet"
+  },
+  {
+    "item": "minecraft:lapis_ore"
+  },
+  {
+    "item": "minecolonies:blockhutconcretemixer"
+  },
+  {
+    "item": "minecolonies:blockminecoloniesgrave"
+  },
+  {
+    "item": "minecraft:cut_red_sandstone"
+  },
+  {
+    "item": "domum_ornamentum:blue_cobblestone_extra"
+  },
+  {
+    "item": "minecraft:anvil"
+  },
+  {
+    "item": "minecraft:cherry_boat"
+  },
+  {
+    "item": "minecraft:brown_stained_glass_pane"
+  },
+  {
+    "item": "minecraft:obsidian"
+  },
+  {
+    "item": "minecolonies:blockhutsifter"
+  },
+  {
+    "item": "minecraft:red_sandstone_wall"
+  },
+  {
+    "item": "minecraft:purple_concrete_powder"
+  },
+  {
+    "item": "minecraft:cobbled_deepslate_stairs"
+  },
+  {
+    "item": "minecraft:chiseled_stone_bricks"
+  },
+  {
+    "item": "minecraft:chiseled_deepslate"
+  },
+  {
+    "item": "minecraft:bamboo_button"
+  },
+  {
+    "item": "minecraft:clay"
+  },
+  {
+    "item": "minecraft:beetroot_seeds"
+  },
+  {
+    "item": "minecraft:soul_campfire"
+  },
+  {
+    "checkednbtkeys": [
+      {
+        "children": [
+          {
+            "key": "minecraft:block/oak_planks"
+          },
+          {
+            "key": "minecraft:block/dark_oak_planks"
+          }
+        ],
+        "key": "textureData"
+      }
+    ],
+    "item": "domum_ornamentum:plain"
+  },
+  {
+    "item": "minecraft:gray_concrete_powder"
+  },
+  {
+    "item": "minecraft:warped_roots"
+  },
+  {
+    "item": "structurize:sceptergold"
+  },
+  {
+    "item": "minecolonies:blockhutcowboy"
+  },
+  {
+    "item": "minecraft:yellow_glazed_terracotta"
+  },
+  {
+    "item": "minecolonies:bread_dough"
+  },
+  {
+    "item": "minecraft:yellow_wool"
+  },
+  {
+    "item": "minecraft:hanging_roots"
+  },
+  {
+    "item": "domum_ornamentum:cactus_extra"
+  },
+  {
+    "item": "minecraft:cherry_button"
+  },
+  {
+    "item": "minecraft:bamboo_pressure_plate"
+  },
+  {
+    "item": "minecraft:polished_deepslate_slab"
+  },
+  {
+    "item": "minecraft:pig_spawn_egg"
+  },
+  {
+    "item": "domum_ornamentum:gray_floating_carpet"
+  },
+  {
+    "item": "minecraft:compass"
+  },
+  {
+    "item": "minecraft:chainmail_helmet"
+  },
+  {
+    "item": "minecolonies:clipboard"
+  },
+  {
+    "item": "minecraft:dead_tube_coral"
+  },
+  {
+    "item": "minecraft:brown_concrete_powder"
+  },
+  {
+    "item": "minecraft:acacia_fence_gate"
+  },
+  {
+    "item": "minecraft:red_sand"
+  },
+  {
+    "item": "minecraft:pearlescent_froglight"
+  },
+  {
+    "item": "minecraft:cow_spawn_egg"
+  },
+  {
+    "item": "minecraft:oak_button"
+  },
+  {
+    "item": "minecraft:ochre_froglight"
+  },
+  {
+    "item": "minecraft:sunflower"
+  },
+  {
+    "item": "minecraft:cake"
+  },
+  {
+    "item": "minecraft:stone_bricks"
+  },
+  {
+    "item": "minecraft:crimson_pressure_plate"
+  },
+  {
+    "item": "minecraft:enchanting_table"
+  },
+  {
+    "item": "minecraft:friend_pottery_sherd"
+  },
+  {
+    "item": "minecolonies:pirate_shoes"
+  },
+  {
+    "item": "minecraft:cut_sandstone_slab"
+  },
+  {
+    "item": "minecraft:lantern"
+  },
+  {
+    "item": "minecolonies:scepterguard"
+  },
+  {
+    "item": "minecraft:cobblestone_stairs"
+  },
+  {
+    "item": "minecraft:stone"
+  },
+  {
+    "item": "minecraft:poppy"
+  },
+  {
+    "item": "minecraft:white_shulker_box"
+  },
+  {
+    "item": "minecraft:redstone_ore"
+  },
+  {
+    "item": "minecraft:seagrass"
+  },
+  {
+    "item": "minecraft:jungle_sapling"
+  },
+  {
+    "item": "minecraft:amethyst_block"
+  },
+  {
+    "item": "minecraft:turtle_egg"
+  },
+  {
+    "checkednbtkeys": [
+      {
+        "children": [
+          {
+            "key": "minecraft:block/oak_planks"
+          },
+          {
+            "key": "minecraft:block/glowstone"
+          }
+        ],
+        "key": "textureData"
+      }
+    ],
+    "item": "domum_ornamentum:fancy_light"
+  },
+  {
+    "item": "minecraft:big_dripleaf"
+  },
+  {
+    "item": "minecraft:cooked_chicken"
+  },
+  {
+    "item": "minecraft:waxed_weathered_cut_copper"
+  },
+  {
+    "item": "minecraft:cut_red_sandstone_slab"
+  },
+  {
+    "item": "minecraft:birch_door"
+  },
+  {
+    "item": "minecraft:leather_leggings"
+  },
+  {
+    "item": "minecraft:jungle_fence_gate"
+  },
+  {
+    "item": "minecraft:oak_slab"
+  },
+  {
+    "item": "minecraft:oxidized_cut_copper_stairs"
+  },
+  {
+    "item": "minecraft:dark_prismarine"
+  },
+  {
+    "item": "minecraft:ancient_debris"
+  },
+  {
+    "item": "minecraft:spruce_slab"
+  },
+  {
+    "item": "minecraft:brush"
+  },
+  {
+    "item": "minecraft:white_terracotta"
+  },
+  {
+    "item": "minecraft:stripped_cherry_log"
+  },
+  {
+    "item": "minecraft:golden_shovel"
+  },
+  {
+    "item": "domum_ornamentum:brown_stone_bricks"
+  },
+  {
+    "item": "minecraft:cherry_sign"
+  },
+  {
+    "item": "minecraft:acacia_wood"
+  },
+  {
+    "item": "minecraft:peony"
+  },
+  {
+    "item": "minecraft:sweet_berries"
+  },
+  {
+    "item": "minecraft:sea_lantern"
+  },
+  {
+    "item": "minecraft:skeleton_skull"
+  },
+  {
+    "item": "minecraft:ghast_tear"
+  },
+  {
+    "item": "minecraft:dirt_path"
+  },
+  {
+    "item": "domum_ornamentum:purple_cobblestone_extra"
+  },
+  {
+    "item": "minecraft:mossy_cobblestone_wall"
+  },
+  {
+    "item": "minecraft:white_wool"
+  },
+  {
+    "item": "minecraft:squid_spawn_egg"
+  },
+  {
+    "item": "minecraft:blue_stained_glass_pane"
+  },
+  {
+    "item": "minecraft:purple_stained_glass"
+  },
+  {
+    "item": "minecraft:deepslate_emerald_ore"
+  },
+  {
+    "item": "minecraft:small_amethyst_bud"
+  },
+  {
+    "item": "minecraft:polished_blackstone_slab"
+  },
+  {
+    "item": "minecraft:light_blue_candle"
+  },
+  {
+    "item": "minecraft:deepslate_brick_slab"
+  },
+  {
+    "item": "minecraft:golden_apple"
+  },
+  {
+    "item": "minecraft:cooked_mutton"
+  },
+  {
+    "item": "minecraft:end_rod"
+  },
+  {
+    "item": "domum_ornamentum:beige_bricks"
+  },
+  {
+    "item": "minecraft:smooth_basalt"
+  },
+  {
+    "item": "minecraft:allium"
+  },
+  {
+    "item": "minecraft:magenta_wool"
+  },
+  {
+    "item": "minecraft:prismarine_bricks"
+  },
+  {
+    "item": "minecraft:chainmail_chestplate"
+  },
+  {
+    "item": "minecraft:mud_brick_stairs"
+  },
+  {
+    "item": "minecraft:crafting_table"
+  },
+  {
+    "item": "minecraft:warped_pressure_plate"
+  },
+  {
+    "item": "minecraft:green_shulker_box"
+  },
+  {
+    "item": "minecraft:blaze_powder"
+  },
+  {
+    "item": "minecraft:sculk_catalyst"
+  },
+  {
+    "item": "minecolonies:blockstash"
+  },
+  {
+    "item": "minecraft:cut_copper_stairs"
+  },
+  {
+    "item": "minecraft:golden_boots"
+  },
+  {
+    "item": "minecraft:magenta_dye"
+  },
+  {
+    "item": "minecraft:dried_kelp_block"
+  },
+  {
+    "item": "minecraft:creeper_head"
+  },
+  {
+    "item": "minecraft:birch_chest_boat"
+  },
+  {
+    "item": "minecraft:red_carpet"
+  },
+  {
+    "item": "minecraft:oak_chest_boat"
+  },
+  {
+    "item": "minecraft:dark_oak_slab"
+  },
+  {
+    "item": "minecraft:wooden_hoe"
+  },
+  {
+    "item": "minecraft:prismarine_brick_slab"
+  },
+  {
+    "item": "minecraft:bamboo_trapdoor"
+  },
+  {
+    "item": "minecraft:warped_fungus"
+  },
+  {
+    "item": "minecraft:pumpkin"
+  },
+  {
+    "item": "minecraft:oak_sapling"
+  },
+  {
+    "item": "minecraft:barrel"
+  },
+  {
+    "item": "minecraft:jungle_trapdoor"
+  },
+  {
+    "item": "minecraft:warden_spawn_egg"
+  },
+  {
+    "item": "minecraft:blue_stained_glass"
+  },
+  {
+    "item": "minecraft:bookshelf"
+  },
+  {
+    "item": "minecraft:stone_sword"
+  },
+  {
+    "item": "minecolonies:composted_dirt"
+  },
+  {
+    "item": "minecolonies:pirate_hat"
+  },
+  {
+    "item": "minecraft:light_gray_candle"
+  },
+  {
+    "item": "minecraft:spruce_hanging_sign"
+  },
+  {
+    "item": "minecraft:polished_blackstone_button"
+  },
+  {
+    "item": "minecraft:dead_fire_coral_fan"
+  },
+  {
+    "item": "minecraft:netherite_leggings"
+  },
+  {
+    "item": "minecraft:magma_cream"
+  },
+  {
+    "item": "minecolonies:scroll_guard_help"
+  },
+  {
+    "item": "minecolonies:golden_bread"
+  },
+  {
+    "item": "structurize:sceptersteel"
+  },
+  {
+    "item": "minecolonies:plate_armor_legs"
+  },
+  {
+    "item": "minecraft:red_dye"
+  },
+  {
+    "item": "minecraft:chiseled_red_sandstone"
+  },
+  {
+    "item": "minecraft:leather_chestplate"
+  },
+  {
+    "item": "minecraft:torchflower"
+  },
+  {
+    "item": "minecraft:orange_candle"
+  },
+  {
+    "item": "minecraft:sea_pickle"
+  },
+  {
+    "item": "domum_ornamentum:green_brick_extra"
+  },
+  {
+    "item": "minecraft:green_concrete_powder"
+  },
+  {
+    "item": "minecraft:copper_block"
+  },
+  {
+    "item": "minecraft:weathered_copper"
+  },
+  {
+    "item": "minecraft:brown_stained_glass"
+  },
+  {
+    "item": "minecraft:mangrove_door"
+  },
+  {
+    "item": "minecraft:witch_spawn_egg"
+  },
+  {
+    "item": "domum_ornamentum:green_cobblestone_extra"
+  },
+  {
+    "item": "minecraft:glass"
+  },
+  {
+    "item": "minecraft:cyan_carpet"
+  },
+  {
+    "item": "minecolonies:raw_pumpkin_pie"
+  },
+  {
+    "item": "minecraft:cherry_fence"
+  },
+  {
+    "item": "minecraft:blackstone_wall"
+  },
+  {
+    "item": "minecraft:popped_chorus_fruit"
+  },
+  {
+    "item": "minecraft:orange_wool"
+  },
+  {
+    "item": "minecraft:golden_leggings"
+  },
+  {
+    "item": "minecraft:polished_blackstone_pressure_plate"
+  },
+  {
+    "item": "minecraft:green_stained_glass_pane"
+  },
+  {
+    "item": "minecraft:pufferfish"
+  },
+  {
+    "item": "minecraft:disc_fragment_5"
+  },
+  {
+    "item": "minecraft:polished_blackstone_brick_wall"
+  },
+  {
+    "item": "minecraft:stick"
+  },
+  {
+    "item": "minecraft:allay_spawn_egg"
+  },
+  {
+    "item": "minecraft:piston"
+  },
+  {
+    "item": "minecraft:purple_bed"
+  },
+  {
+    "item": "minecraft:ink_sac"
+  },
+  {
+    "item": "minecraft:tube_coral_block"
+  },
+  {
+    "item": "minecraft:orange_dye"
+  },
+  {
+    "item": "minecraft:spruce_trapdoor"
+  },
+  {
+    "item": "minecraft:magenta_shulker_box"
+  },
+  {
+    "item": "minecraft:iron_ore"
+  },
+  {
+    "item": "minecraft:pillager_spawn_egg"
+  },
+  {
+    "item": "minecraft:smooth_sandstone_stairs"
+  },
+  {
+    "item": "minecraft:exposed_copper"
+  },
+  {
+    "item": "domum_ornamentum:orange_floating_carpet"
+  },
+  {
+    "item": "minecraft:gilded_blackstone"
+  },
+  {
+    "item": "minecraft:netherrack"
+  },
+  {
+    "item": "minecraft:nether_brick_slab"
+  },
+  {
+    "item": "minecraft:pitcher_pod"
+  },
+  {
+    "item": "minecraft:prismarine_crystals"
+  },
+  {
+    "item": "minecraft:yellow_shulker_box"
+  },
+  {
+    "item": "minecraft:frog_spawn_egg"
+  },
+  {
+    "item": "minecolonies:blockhutuniversity"
+  },
+  {
+    "item": "minecraft:cave_spider_spawn_egg"
+  },
+  {
+    "item": "minecraft:gray_stained_glass_pane"
+  },
+  {
+    "item": "minecraft:crimson_slab"
+  },
+  {
+    "item": "minecraft:purple_carpet"
+  },
+  {
+    "item": "minecraft:blue_concrete_powder"
+  },
+  {
+    "item": "minecraft:bee_nest"
+  },
+  {
+    "item": "minecraft:furnace"
+  },
+  {
+    "item": "minecraft:snort_pottery_sherd"
+  },
+  {
+    "item": "minecraft:smithing_table"
+  },
+  {
+    "checkednbtkeys": [
+      {
+        "children": [
+          {
+            "key": "minecraft:block/oak_planks"
+          }
+        ],
+        "key": "textureData"
+      },
+      {
+        "key": "type"
+      }
+    ],
+    "item": "domum_ornamentum:vanilla_doors_compat"
+  },
+  {
+    "item": "domum_ornamentum:sand_stone_bricks"
+  },
+  {
+    "item": "minecraft:iron_trapdoor"
+  },
+  {
+    "item": "minecraft:bone_meal"
+  },
+  {
+    "item": "minecraft:grindstone"
+  },
+  {
+    "item": "minecraft:mangrove_fence_gate"
+  },
+  {
+    "item": "minecraft:white_stained_glass_pane"
+  },
+  {
+    "item": "minecraft:lime_wool"
+  },
+  {
+    "item": "minecraft:candle"
+  },
+  {
+    "item": "minecraft:bricks"
+  },
+  {
+    "item": "minecraft:brewing_stand"
+  },
+  {
+    "item": "minecraft:stripped_spruce_wood"
+  },
+  {
+    "item": "minecraft:spruce_fence"
+  },
+  {
+    "item": "minecraft:red_sandstone_slab"
+  },
+  {
+    "item": "minecolonies:blockhutbaker"
+  },
+  {
+    "item": "minecraft:waxed_exposed_cut_copper"
+  },
+  {
+    "item": "minecraft:smooth_red_sandstone"
+  },
+  {
+    "item": "minecraft:bamboo_fence_gate"
+  },
+  {
+    "item": "minecraft:pink_stained_glass_pane"
+  },
+  {
+    "item": "minecraft:stripped_bamboo_block"
+  },
+  {
+    "item": "minecraft:cracked_polished_blackstone_bricks"
+  },
+  {
+    "item": "minecraft:jungle_planks"
+  },
+  {
+    "item": "minecraft:pufferfish_bucket"
+  },
+  {
+    "item": "minecraft:chain"
+  },
+  {
+    "item": "domum_ornamentum:red_brick_extra"
+  },
+  {
+    "item": "minecraft:bat_spawn_egg"
+  },
+  {
+    "item": "minecraft:dead_tube_coral_fan"
+  },
+  {
+    "item": "minecraft:jungle_stairs"
+  },
+  {
+    "item": "minecraft:rail"
+  },
+  {
+    "item": "minecolonies:blockconstructiontape"
+  },
+  {
+    "item": "minecraft:cobbled_deepslate_wall"
+  },
+  {
+    "item": "minecraft:purple_shulker_box"
+  },
+  {
+    "item": "minecraft:spruce_boat"
+  },
+  {
+    "item": "minecraft:trader_llama_spawn_egg"
+  },
+  {
+    "item": "minecraft:paper"
+  },
+  {
+    "item": "minecolonies:scroll_tp"
+  },
+  {
+    "item": "minecraft:prismarine_stairs"
+  },
+  {
+    "item": "minecraft:spider_spawn_egg"
+  },
+  {
+    "item": "minecraft:cherry_wood"
+  },
+  {
+    "item": "minecraft:sculk_vein"
+  },
+  {
+    "item": "minecolonies:blockhutschool"
+  },
+  {
+    "item": "minecraft:vine"
+  },
+  {
+    "item": "minecraft:red_mushroom_block"
+  },
+  {
+    "item": "minecraft:piglin_banner_pattern"
+  },
+  {
+    "item": "minecolonies:blockhutstonesmeltery"
+  },
+  {
+    "item": "minecraft:pink_tulip"
+  },
+  {
+    "item": "minecraft:flowering_azalea"
+  },
+  {
+    "item": "minecraft:light_blue_shulker_box"
+  },
+  {
+    "item": "minecraft:heart_pottery_sherd"
+  },
+  {
+    "checkednbtkeys": [
+      {
+        "children": [
+          {
+            "key": "minecraft:block/oak_planks"
+          },
+          {
+            "key": "minecraft:block/glowstone"
+          }
+        ],
+        "key": "textureData"
+      }
+    ],
+    "item": "domum_ornamentum:framed_light"
+  },
+  {
+    "item": "minecraft:rabbit_spawn_egg"
+  },
+  {
+    "item": "minecraft:weathered_cut_copper"
+  },
+  {
+    "item": "domum_ornamentum:cobblestone_extra"
+  },
+  {
+    "item": "minecraft:wooden_shovel"
+  },
+  {
+    "item": "minecraft:trapped_chest"
+  },
+  {
+    "item": "minecraft:pink_bed"
+  },
+  {
+    "item": "minecraft:dropper"
+  },
+  {
+    "item": "minecraft:fire_charge"
+  },
+  {
+    "item": "minecraft:music_disc_cat"
+  },
+  {
+    "item": "domum_ornamentum:brown_floating_carpet"
+  },
+  {
+    "item": "minecraft:spruce_log"
+  },
+  {
+    "item": "minecraft:chest"
+  },
+  {
+    "item": "minecraft:red_nether_brick_slab"
+  },
+  {
+    "item": "minecraft:mud_brick_wall"
+  },
+  {
+    "item": "minecraft:cauldron"
+  },
+  {
+    "item": "minecraft:infested_stone_bricks"
+  },
+  {
+    "checkednbtkeys": [
+      {
+        "children": [
+          {
+            "key": "variant"
+          }
+        ],
+        "key": "EntityTag"
+      }
+    ],
+    "item": "minecraft:painting"
+  },
+  {
+    "item": "minecraft:chiseled_sandstone"
+  },
+  {
+    "item": "structurize:caliper"
+  },
+  {
+    "item": "minecraft:polished_granite"
+  },
+  {
+    "item": "minecraft:dispenser"
+  },
+  {
+    "item": "minecolonies:pharaoscepter"
+  },
+  {
+    "item": "minecraft:polished_blackstone"
+  },
+  {
+    "item": "minecraft:jungle_sign"
+  },
+  {
+    "item": "minecraft:light_gray_concrete"
+  },
+  {
+    "item": "minecraft:copper_ingot"
+  },
+  {
+    "checkednbtkeys": [
+      {
+        "children": [
+          {
+            "key": "minecraft:block/oak_planks"
+          },
+          {
+            "key": "minecraft:block/dark_oak_planks"
+          }
+        ],
+        "key": "textureData"
+      }
+    ],
+    "item": "domum_ornamentum:side_framed_horizontal"
+  },
+  {
+    "item": "minecraft:acacia_sapling"
+  },
+  {
+    "item": "minecraft:infested_cobblestone"
+  },
+  {
+    "item": "minecraft:red_banner"
+  },
+  {
+    "item": "minecraft:warped_fence_gate"
+  },
+  {
+    "item": "minecraft:deepslate_redstone_ore"
+  },
+  {
+    "checkednbtkeys": [
+      {
+        "children": [
+          {
+            "key": "minecraft:block/oak_planks"
+          }
+        ],
+        "key": "textureData"
+      }
+    ],
+    "item": "domum_ornamentum:vanilla_stairs_compat"
+  },
+  {
+    "item": "domum_ornamentum:light_blue_brick_extra"
+  },
+  {
+    "item": "minecraft:warped_sign"
+  },
+  {
+    "item": "minecraft:brick_stairs"
+  },
+  {
+    "item": "minecraft:granite_slab"
+  },
+  {
+    "item": "minecraft:wet_sponge"
+  },
+  {
+    "item": "minecraft:cracked_stone_bricks"
+  },
+  {
+    "item": "minecraft:warped_stairs"
+  },
+  {
+    "item": "minecraft:yellow_carpet"
+  },
+  {
+    "item": "minecraft:azalea_leaves"
+  },
+  {
+    "item": "minecraft:leather_boots"
+  },
+  {
+    "item": "minecraft:sniffer_spawn_egg"
+  },
+  {
+    "item": "minecraft:blaze_rod"
+  },
+  {
+    "item": "minecraft:beetroot_soup"
+  },
+  {
+    "item": "minecraft:warped_trapdoor"
+  },
+  {
+    "item": "minecraft:heavy_weighted_pressure_plate"
+  },
+  {
+    "item": "minecraft:redstone_block"
+  },
+  {
+    "item": "minecraft:mojang_banner_pattern"
+  },
+  {
+    "item": "minecraft:dead_horn_coral_block"
+  },
+  {
+    "item": "minecraft:polished_granite_slab"
+  },
+  {
+    "item": "minecraft:yellow_stained_glass"
+  },
+  {
+    "item": "minecraft:mangrove_chest_boat"
+  },
+  {
+    "item": "minecraft:cracked_deepslate_bricks"
+  },
+  {
+    "item": "minecraft:piglin_spawn_egg"
+  },
+  {
+    "item": "minecolonies:scan_analyzer"
+  },
+  {
+    "item": "minecraft:shield"
+  },
+  {
+    "item": "minecraft:netherite_shovel"
+  },
+  {
+    "item": "minecraft:netherite_scrap"
+  },
+  {
+    "item": "minecraft:deepslate_lapis_ore"
+  },
+  {
+    "item": "minecraft:turtle_spawn_egg"
+  },
+  {
+    "item": "minecraft:red_stained_glass_pane"
+  },
+  {
+    "item": "minecraft:rose_bush"
+  },
+  {
+    "item": "minecraft:sponge"
+  },
+  {
+    "item": "minecraft:phantom_membrane"
+  },
+  {
+    "item": "minecraft:mooshroom_spawn_egg"
+  },
+  {
+    "item": "minecraft:golden_sword"
+  },
+  {
+    "item": "minecraft:mourner_pottery_sherd"
+  },
+  {
+    "item": "minecraft:fermented_spider_eye"
+  },
+  {
+    "item": "minecraft:diamond_helmet"
+  },
+  {
+    "item": "minecraft:crimson_button"
+  },
+  {
+    "item": "minecraft:stone_pickaxe"
+  },
+  {
+    "item": "minecraft:prismarine_slab"
+  },
+  {
+    "item": "minecraft:blue_candle"
+  },
+  {
+    "item": "minecraft:warped_hanging_sign"
+  },
+  {
+    "item": "minecraft:cyan_stained_glass_pane"
+  },
+  {
+    "item": "minecraft:jungle_hanging_sign"
+  },
+  {
+    "item": "minecraft:red_mushroom"
+  },
+  {
+    "item": "minecraft:spruce_planks"
+  },
+  {
+    "item": "minecraft:gray_stained_glass"
+  },
+  {
+    "item": "minecraft:torchflower_seeds"
+  },
+  {
+    "item": "minecolonies:scepterpermission"
+  },
+  {
+    "item": "minecraft:repeater"
+  },
+  {
+    "item": "minecraft:andesite"
+  },
+  {
+    "item": "minecraft:music_disc_mellohi"
+  },
+  {
+    "checkednbtkeys": [
+      {
+        "children": [
+          {
+            "key": "minecraft:block/oak_planks"
+          }
+        ],
+        "key": "textureData"
+      }
+    ],
+    "item": "domum_ornamentum:blockypillar"
+  },
+  {
+    "item": "minecraft:magenta_terracotta"
+  },
+  {
+    "item": "minecolonies:cake_batter"
+  },
+  {
+    "item": "minecraft:birch_planks"
+  },
+  {
+    "item": "minecraft:pufferfish_spawn_egg"
+  },
+  {
+    "item": "minecraft:crimson_hyphae"
+  },
+  {
+    "item": "minecraft:gray_glazed_terracotta"
+  },
+  {
+    "item": "minecraft:horn_coral_block"
+  },
+  {
+    "item": "minecraft:diamond_leggings"
+  },
+  {
+    "item": "minecraft:golden_chestplate"
+  },
+  {
+    "item": "minecraft:spruce_pressure_plate"
+  },
+  {
+    "item": "minecraft:raw_iron_block"
+  },
+  {
+    "item": "minecolonies:banner_rally_guards"
+  },
+  {
+    "item": "minecraft:mossy_cobblestone_slab"
+  },
+  {
+    "item": "minecraft:dandelion"
+  },
+  {
+    "item": "minecraft:cookie"
+  },
+  {
+    "item": "minecraft:parrot_spawn_egg"
+  },
+  {
+    "item": "minecraft:crying_obsidian"
+  },
+  {
+    "item": "minecraft:oxeye_daisy"
+  },
+  {
+    "item": "minecraft:cooked_salmon"
+  },
+  {
+    "item": "minecraft:zombie_spawn_egg"
+  },
+  {
+    "item": "minecraft:deepslate_brick_wall"
+  },
+  {
+    "item": "minecraft:shulker_box"
+  },
+  {
+    "item": "minecraft:brown_concrete"
+  },
+  {
+    "item": "minecraft:light_blue_banner"
+  },
+  {
+    "item": "minecolonies:blockhutcomposter"
+  },
+  {
+    "item": "minecraft:cyan_concrete"
+  },
+  {
+    "item": "minecraft:music_disc_chirp"
+  },
+  {
+    "item": "minecraft:redstone"
+  },
+  {
+    "item": "minecraft:wheat_seeds"
+  },
+  {
+    "item": "minecraft:stone_pressure_plate"
+  },
+  {
+    "item": "minecraft:wither_rose"
+  },
+  {
+    "item": "domum_ornamentum:purple_floating_carpet"
+  },
+  {
+    "item": "minecraft:dripstone_block"
+  },
+  {
+    "item": "minecraft:wolf_spawn_egg"
+  },
+  {
+    "item": "minecraft:shears"
+  },
+  {
+    "item": "minecraft:dark_oak_wood"
+  },
+  {
+    "item": "minecraft:coast_armor_trim_smithing_template"
+  },
+  {
+    "item": "minecraft:prismarine_brick_stairs"
+  },
+  {
+    "item": "minecraft:raw_gold_block"
+  },
+  {
+    "item": "minecraft:rabbit_hide"
+  },
+  {
+    "item": "minecraft:cyan_concrete_powder"
+  },
+  {
+    "item": "minecraft:lime_concrete"
+  },
+  {
+    "item": "minecraft:gray_dye"
+  },
+  {
+    "item": "minecraft:orange_stained_glass"
+  },
+  {
+    "item": "minecraft:cocoa_beans"
+  },
+  {
+    "item": "minecraft:structure_void"
+  },
+  {
+    "item": "minecolonies:blockhutstonemason"
+  },
+  {
+    "item": "minecolonies:blockhutflorist"
+  },
+  {
+    "item": "minecraft:stonecutter"
+  },
+  {
+    "item": "minecraft:iron_nugget"
+  },
+  {
+    "item": "minecraft:green_candle"
+  },
+  {
+    "item": "minecraft:light_gray_terracotta"
+  },
+  {
+    "item": "minecraft:skeleton_horse_spawn_egg"
+  },
+  {
+    "item": "minecraft:smooth_red_sandstone_slab"
+  },
+  {
+    "item": "minecraft:mangrove_planks"
+  },
+  {
+    "item": "minecraft:recovery_compass"
+  },
+  {
+    "checkednbtkeys": [
+      {
+        "children": [
+          {
+            "key": "minecraft:block/oak_planks"
+          }
+        ],
+        "key": "textureData"
+      }
+    ],
+    "item": "domum_ornamentum:blockpillar"
+  },
+  {
+    "item": "structurize:shapetool"
+  },
+  {
+    "item": "minecraft:granite"
+  },
+  {
+    "item": "minecraft:snout_armor_trim_smithing_template"
+  },
+  {
+    "item": "minecraft:sentry_armor_trim_smithing_template"
+  },
+  {
+    "checkednbtkeys": [
+      {
+        "key": "Effects"
+      }
+    ],
+    "item": "minecraft:suspicious_stew"
+  },
+  {
+    "item": "minecraft:brewer_pottery_sherd"
+  },
+  {
+    "item": "minecraft:waxed_cut_copper"
+  },
+  {
+    "item": "minecraft:diamond_pickaxe"
+  },
+  {
+    "item": "minecraft:cobblestone_wall"
+  },
+  {
+    "item": "minecraft:white_candle"
+  },
+  {
+    "item": "minecraft:sheep_spawn_egg"
+  },
+  {
+    "checkednbtkeys": [
+      {
+        "children": [
+          {
+            "key": "minecraft:block/oak_planks"
+          }
+        ],
+        "key": "textureData"
+      }
+    ],
+    "item": "domum_ornamentum:vanilla_fence_compat"
+  },
+  {
+    "item": "minecraft:polished_diorite"
+  },
+  {
+    "item": "minecraft:orange_concrete_powder"
+  },
+  {
+    "item": "minecraft:music_disc_ward"
+  },
+  {
+    "item": "minecraft:mushroom_stew"
+  },
+  {
+    "item": "domum_ornamentum:cream_stone_bricks"
+  },
+  {
+    "item": "minecraft:white_concrete"
+  },
+  {
+    "item": "minecraft:chiseled_polished_blackstone"
+  },
+  {
+    "item": "minecraft:mushroom_stem"
+  },
+  {
+    "item": "domum_ornamentum:black_floating_carpet"
+  },
+  {
+    "item": "domum_ornamentum:magenta_brick_extra"
+  },
+  {
+    "item": "minecraft:nether_brick_stairs"
+  },
+  {
+    "item": "domum_ornamentum:mossy_cobblestone_extra"
+  },
+  {
+    "item": "minecraft:hay_block"
+  },
+  {
+    "item": "minecraft:purpur_pillar"
+  },
+  {
+    "item": "minecraft:netherite_pickaxe"
+  },
+  {
+    "item": "minecraft:carrot_on_a_stick"
+  },
+  {
+    "item": "minecraft:cherry_door"
+  },
+  {
+    "item": "minecraft:wheat"
+  },
+  {
+    "item": "minecraft:netherite_ingot"
+  },
+  {
+    "item": "minecraft:slime_spawn_egg"
+  },
+  {
+    "item": "minecraft:cherry_fence_gate"
+  },
+  {
+    "item": "minecraft:dark_oak_fence"
+  },
+  {
+    "item": "minecraft:verdant_froglight"
+  },
+  {
+    "item": "minecolonies:blockhutcook"
+  },
+  {
+    "item": "minecraft:mossy_cobblestone_stairs"
+  },
+  {
+    "item": "minecraft:vindicator_spawn_egg"
+  },
+  {
+    "item": "minecraft:mangrove_boat"
+  },
+  {
+    "item": "minecraft:dead_brain_coral_fan"
+  },
+  {
+    "item": "minecraft:stripped_jungle_log"
+  },
+  {
+    "item": "minecraft:jukebox"
+  },
+  {
+    "item": "minecraft:orange_tulip"
+  },
+  {
+    "item": "minecraft:snow_block"
+  },
+  {
+    "item": "minecraft:ice"
+  },
+  {
+    "item": "minecolonies:pirate_top"
+  },
+  {
+    "item": "minecraft:camel_spawn_egg"
+  },
+  {
+    "item": "minecraft:crimson_fence"
+  },
+  {
+    "item": "minecraft:muddy_mangrove_roots"
+  },
+  {
+    "item": "minecolonies:scepterbeekeeper"
+  },
+  {
+    "item": "minecraft:blue_bed"
+  },
+  {
+    "item": "minecraft:glow_item_frame"
+  },
+  {
+    "item": "minecraft:infested_cracked_stone_bricks"
+  },
+  {
+    "item": "domum_ornamentum:roan_stone_bricks"
+  },
+  {
+    "item": "minecraft:red_wool"
+  },
+  {
+    "item": "minecraft:birch_fence_gate"
+  },
+  {
+    "item": "minecraft:crimson_planks"
+  },
+  {
+    "item": "minecolonies:compost"
+  },
+  {
+    "item": "domum_ornamentum:brown_bricks"
+  },
+  {
+    "item": "minecraft:dragon_breath"
+  },
+  {
+    "item": "minecraft:blue_concrete"
+  },
+  {
+    "checkednbtkeys": [
+      {
+        "children": [
+          {
+            "key": "minecraft:block/oak_planks"
+          }
+        ],
+        "key": "textureData"
+      },
+      {
+        "key": "type"
+      }
+    ],
+    "item": "domum_ornamentum:vanilla_trapdoors_compat"
+  },
+  {
+    "item": "minecolonies:blockhutchickenherder"
+  },
+  {
+    "item": "minecraft:horn_coral_fan"
+  },
+  {
+    "item": "minecraft:structure_block"
+  },
+  {
+    "item": "minecraft:axolotl_spawn_egg"
+  },
+  {
+    "item": "minecraft:spore_blossom"
+  },
+  {
+    "checkednbtkeys": [
+      {
+        "children": [
+          {
+            "key": "minecraft:block/oak_planks"
+          },
+          {
+            "key": "minecraft:block/dark_oak_planks"
+          }
+        ],
+        "key": "textureData"
+      }
+    ],
+    "item": "domum_ornamentum:up_gated"
+  },
+  {
+    "item": "minecraft:budding_amethyst"
+  },
+  {
+    "item": "minecraft:oxidized_copper"
+  },
+  {
+    "item": "domum_ornamentum:gray_brick_extra"
+  },
+  {
+    "item": "minecraft:nether_quartz_ore"
+  },
+  {
+    "item": "minecraft:lime_terracotta"
+  },
+  {
+    "item": "minecraft:acacia_trapdoor"
+  },
+  {
+    "item": "minecraft:magenta_stained_glass_pane"
+  },
+  {
+    "item": "minecraft:brown_glazed_terracotta"
+  },
+  {
+    "item": "minecraft:nether_gold_ore"
+  },
+  {
+    "item": "minecraft:wayfinder_armor_trim_smithing_template"
+  },
+  {
+    "item": "minecolonies:blockhutbarrackstower"
+  },
+  {
+    "item": "minecraft:mossy_stone_brick_wall"
+  },
+  {
+    "item": "minecraft:brown_wool"
+  },
+  {
+    "item": "minecraft:lodestone"
+  },
+  {
+    "item": "minecraft:yellow_concrete_powder"
+  },
+  {
+    "item": "minecraft:netherite_helmet"
+  },
+  {
+    "item": "minecraft:quartz_pillar"
+  },
+  {
+    "item": "minecraft:drowned_spawn_egg"
+  },
+  {
+    "item": "minecraft:milk_bucket"
+  },
+  {
+    "item": "minecraft:chiseled_bookshelf"
+  },
+  {
+    "item": "minecraft:acacia_stairs"
+  },
+  {
+    "item": "minecraft:target"
+  },
+  {
+    "item": "minecolonies:blockhutsmeltery"
+  },
+  {
+    "item": "minecraft:jungle_wood"
+  },
+  {
+    "item": "minecraft:glass_bottle"
+  },
+  {
+    "item": "minecraft:spruce_wood"
+  },
+  {
+    "item": "minecraft:deepslate_diamond_ore"
+  },
+  {
+    "item": "minecraft:magenta_bed"
+  },
+  {
+    "item": "minecraft:dolphin_spawn_egg"
+  },
+  {
+    "item": "minecraft:ender_pearl"
+  },
+  {
+    "item": "minecolonies:magicpotion"
+  },
+  {
+    "item": "minecraft:rib_armor_trim_smithing_template"
+  },
+  {
+    "item": "minecraft:soul_lantern"
+  },
+  {
+    "item": "minecraft:bamboo_sign"
+  },
+  {
+    "item": "minecraft:honey_block"
+  },
+  {
+    "item": "minecraft:diamond_shovel"
+  },
+  {
+    "item": "minecraft:leather_helmet"
+  },
+  {
+    "item": "minecraft:music_disc_far"
+  },
+  {
+    "item": "domum_ornamentum:architectscutter"
+  },
+  {
+    "item": "minecraft:cracked_nether_bricks"
+  },
+  {
+    "item": "minecraft:gray_wool"
+  },
+  {
+    "item": "minecraft:dune_armor_trim_smithing_template"
+  },
+  {
+    "item": "minecraft:donkey_spawn_egg"
+  },
+  {
+    "item": "minecraft:dead_tube_coral_block"
+  },
+  {
+    "item": "minecraft:deepslate_brick_stairs"
+  },
+  {
+    "item": "minecraft:string"
+  },
+  {
+    "checkednbtkeys": [
+      {
+        "children": [
+          {
+            "key": "minecraft:block/oak_planks"
+          },
+          {
+            "key": "minecraft:block/glowstone"
+          }
+        ],
+        "key": "textureData"
+      }
+    ],
+    "item": "domum_ornamentum:horizontal_light"
+  },
+  {
+    "item": "minecraft:rabbit_foot"
+  },
+  {
+    "item": "minecraft:nether_bricks"
+  },
+  {
+    "item": "minecraft:purple_dye"
+  },
+  {
+    "item": "minecraft:oak_wood"
+  },
+  {
+    "item": "minecraft:polished_blackstone_stairs"
+  },
+  {
+    "item": "minecraft:blue_terracotta"
+  },
+  {
+    "item": "minecraft:deepslate_coal_ore"
+  },
+  {
+    "item": "minecraft:gold_nugget"
+  },
+  {
+    "item": "minecraft:green_bed"
+  },
+  {
+    "item": "minecraft:magenta_glazed_terracotta"
+  },
+  {
+    "item": "minecraft:diorite_slab"
+  },
+  {
+    "item": "minecraft:stone_button"
+  },
+  {
+    "item": "minecraft:diamond_sword"
+  },
+  {
+    "item": "domum_ornamentum:blockbarreldeco_standing"
+  },
+  {
+    "item": "minecraft:diamond_axe"
+  },
+  {
+    "item": "minecraft:brown_banner"
+  },
+  {
+    "item": "minecraft:birch_boat"
+  },
+  {
+    "item": "minecraft:red_candle"
+  },
+  {
+    "item": "minecraft:mangrove_log"
+  },
+  {
+    "item": "minecraft:nether_sprouts"
+  },
+  {
+    "item": "minecolonies:pirate_leggins"
+  },
+  {
+    "item": "minecraft:music_disc_relic"
+  },
+  {
+    "item": "minecraft:gold_block"
+  },
+  {
+    "item": "minecraft:yellow_banner"
+  },
+  {
+    "item": "minecraft:amethyst_cluster"
+  },
+  {
+    "item": "minecraft:waxed_weathered_cut_copper_stairs"
+  },
+  {
+    "item": "minecraft:debug_stick"
+  },
+  {
+    "item": "domum_ornamentum:white_floating_carpet"
+  },
+  {
+    "item": "minecraft:detector_rail"
+  },
+  {
+    "item": "minecolonies:blockhutalchemist"
+  },
+  {
+    "item": "minecraft:packed_mud"
+  },
+  {
+    "item": "minecraft:deepslate_tile_slab"
+  },
+  {
+    "item": "minecraft:raw_iron"
+  },
+  {
+    "item": "minecraft:enderman_spawn_egg"
+  },
+  {
+    "item": "minecraft:flint"
+  },
+  {
+    "item": "minecraft:heartbreak_pottery_sherd"
+  },
+  {
+    "item": "minecolonies:blockhuttavern"
+  },
+  {
+    "item": "minecraft:birch_leaves"
+  },
+  {
+    "item": "minecraft:purple_banner"
+  },
+  {
+    "item": "minecraft:lead"
+  },
+  {
+    "item": "minecraft:chicken_spawn_egg"
+  },
+  {
+    "item": "minecraft:bamboo_chest_raft"
+  },
+  {
+    "item": "minecraft:shulker_spawn_egg"
+  },
+  {
+    "item": "minecraft:howl_pottery_sherd"
+  },
+  {
+    "item": "minecraft:spyglass"
+  },
+  {
+    "item": "minecraft:strider_spawn_egg"
+  },
+  {
+    "item": "minecraft:acacia_planks"
+  },
+  {
+    "item": "minecraft:bone_block"
+  },
+  {
+    "item": "minecraft:black_stained_glass"
+  },
+  {
+    "item": "minecraft:plenty_pottery_sherd"
+  },
+  {
+    "item": "minecraft:pink_glazed_terracotta"
+  },
+  {
+    "item": "minecraft:cobbled_deepslate"
+  },
+  {
+    "item": "minecraft:yellow_stained_glass_pane"
+  },
+  {
+    "item": "minecraft:red_glazed_terracotta"
+  },
+  {
+    "item": "minecraft:netherite_chestplate"
+  },
+  {
+    "item": "minecraft:blackstone"
+  },
+  {
+    "item": "minecraft:mangrove_propagule"
+  },
+  {
+    "item": "minecolonies:blockhutdyer"
+  },
+  {
+    "item": "minecraft:mangrove_hanging_sign"
+  },
+  {
+    "item": "minecraft:waxed_cut_copper_slab"
+  },
+  {
+    "item": "minecraft:hopper"
+  },
+  {
+    "item": "minecraft:mossy_stone_brick_slab"
+  },
+  {
+    "item": "minecraft:green_glazed_terracotta"
+  },
+  {
+    "item": "minecraft:orange_carpet"
+  },
+  {
+    "item": "minecraft:orange_concrete"
+  },
+  {
+    "item": "minecraft:fern"
+  },
+  {
+    "item": "minecolonies:blockhutgraveyard"
+  },
+  {
+    "item": "minecraft:bow"
+  },
+  {
+    "item": "minecraft:cut_copper_slab"
+  },
+  {
+    "item": "minecraft:chiseled_nether_bricks"
+  },
+  {
+    "item": "domum_ornamentum:yellow_brick_extra"
+  },
+  {
+    "item": "structurize:blocksolidsubstitution"
+  },
+  {
+    "item": "minecraft:pumpkin_pie"
+  },
+  {
+    "item": "minecraft:black_bed"
+  },
+  {
+    "item": "minecraft:brain_coral"
+  },
+  {
+    "item": "minecraft:redstone_lamp"
+  },
+  {
+    "checkednbtkeys": [
+      {
+        "children": [
+          {
+            "key": "minecraft:block/oak_planks"
+          },
+          {
+            "key": "minecraft:block/dark_oak_planks"
+          }
+        ],
+        "key": "textureData"
+      }
+    ],
+    "item": "domum_ornamentum:one_crossed_lr"
+  },
+  {
+    "item": "minecraft:quartz_stairs"
+  },
+  {
+    "item": "minecraft:dark_oak_sign"
+  },
+  {
+    "item": "minecraft:warped_fungus_on_a_stick"
+  },
+  {
+    "item": "minecraft:blue_orchid"
+  },
+  {
+    "item": "minecraft:chorus_plant"
+  },
+  {
+    "item": "minecraft:stone_brick_slab"
+  },
+  {
+    "item": "minecraft:oak_leaves"
+  },
+  {
+    "item": "minecraft:flint_and_steel"
+  },
+  {
+    "item": "minecraft:dragon_egg"
+  },
+  {
+    "checkednbtkeys": [
+      {
+        "children": [
+          {
+            "key": "minecraft:block/oak_planks"
+          }
+        ],
+        "key": "textureData"
+      },
+      {
+        "key": "type"
+      }
+    ],
+    "item": "domum_ornamentum:post"
+  },
+  {
+    "checkednbtkeys": [
+      {
+        "children": [
+          {
+            "key": "minecraft:block/oak_planks"
+          },
+          {
+            "key": "minecraft:block/dark_oak_planks"
+          }
+        ],
+        "key": "textureData"
+      }
+    ],
+    "item": "domum_ornamentum:framed"
+  },
+  {
+    "item": "minecraft:red_concrete"
+  },
+  {
+    "item": "minecraft:glowstone_dust"
+  },
+  {
+    "item": "minecraft:tadpole_spawn_egg"
+  },
+  {
+    "item": "minecraft:yellow_dye"
+  },
+  {
+    "item": "minecraft:bamboo_hanging_sign"
+  },
+  {
+    "item": "minecraft:music_disc_wait"
+  },
+  {
+    "item": "minecraft:dark_oak_pressure_plate"
+  },
+  {
+    "item": "minecraft:fishing_rod"
+  },
+  {
+    "item": "minecraft:cat_spawn_egg"
+  },
+  {
+    "item": "minecolonies:blockhutcombatacademy"
+  },
+  {
+    "item": "minecraft:pink_banner"
+  },
+  {
+    "item": "minecraft:guardian_spawn_egg"
+  },
+  {
+    "item": "minecraft:cyan_shulker_box"
+  },
+  {
+    "item": "domum_ornamentum:cyan_floating_carpet"
+  },
+  {
+    "item": "minecraft:stripped_acacia_wood"
+  },
+  {
+    "checkednbtkeys": [
+      {
+        "children": [
+          {
+            "key": "minecraft:block/oak_planks"
+          },
+          {
+            "key": "minecraft:block/dark_oak_planks"
+          }
+        ],
+        "key": "textureData"
+      }
+    ],
+    "item": "domum_ornamentum:blockpaperwall"
+  },
+  {
+    "item": "minecraft:spruce_fence_gate"
+  },
+  {
+    "item": "minecraft:totem_of_undying"
+  },
+  {
+    "item": "minecraft:pink_dye"
+  },
+  {
+    "item": "domum_ornamentum:red_floating_carpet"
+  },
+  {
+    "item": "minecolonies:scroll_area_tp"
+  },
+  {
+    "item": "minecraft:cherry_leaves"
+  },
+  {
+    "item": "multipiston:multipistonblock"
+  },
+  {
+    "item": "minecraft:blackstone_slab"
+  },
+  {
+    "item": "minecraft:enchanted_golden_apple"
+  },
+  {
+    "item": "minecraft:netherite_axe"
+  },
+  {
+    "item": "structurize:blocksubstitution"
+  },
+  {
+    "item": "minecraft:spruce_stairs"
+  },
+  {
+    "item": "minecraft:sculk_shrieker"
+  },
+  {
+    "item": "minecraft:mangrove_slab"
+  },
+  {
+    "item": "minecraft:magenta_candle"
+  },
+  {
+    "item": "minecraft:nether_wart"
+  },
+  {
+    "item": "minecraft:salmon_spawn_egg"
+  },
+  {
+    "item": "minecraft:light_blue_concrete_powder"
+  },
+  {
+    "item": "minecraft:soul_sand"
+  },
+  {
+    "item": "minecraft:dead_fire_coral"
+  },
+  {
+    "item": "minecraft:cornflower"
+  },
+  {
+    "item": "minecraft:deepslate_gold_ore"
+  },
+  {
+    "item": "minecolonies:blockhutglassblower"
+  },
+  {
+    "item": "minecraft:creeper_spawn_egg"
+  },
+  {
+    "item": "minecraft:nether_wart_block"
+  },
+  {
+    "item": "minecraft:turtle_helmet"
+  },
+  {
+    "item": "minecraft:crossbow"
+  },
+  {
+    "item": "minecraft:green_wool"
+  },
+  {
+    "item": "domum_ornamentum:black_brick_extra"
+  },
+  {
+    "item": "minecraft:lime_glazed_terracotta"
+  },
+  {
+    "item": "minecraft:deepslate_tile_wall"
+  },
+  {
+    "item": "minecraft:black_banner"
+  },
+  {
+    "item": "minecraft:map"
+  },
+  {
+    "item": "minecraft:dried_kelp"
+  },
+  {
+    "item": "minecraft:birch_button"
+  },
+  {
+    "item": "minecraft:cyan_banner"
+  },
+  {
+    "item": "minecolonies:plate_armor_chest"
+  },
+  {
+    "item": "minecraft:angler_pottery_sherd"
+  },
+  {
+    "item": "minecraft:waxed_exposed_copper"
+  },
+  {
+    "item": "minecraft:acacia_sign"
+  },
+  {
+    "item": "domum_ornamentum:wheat_extra"
+  },
+  {
+    "item": "minecolonies:supplycampdeployer"
+  },
+  {
+    "item": "minecraft:cherry_hanging_sign"
+  },
+  {
+    "item": "minecraft:warped_door"
+  },
+  {
+    "item": "minecraft:chorus_fruit"
+  },
+  {
+    "item": "minecraft:horse_spawn_egg"
+  },
+  {
+    "item": "minecraft:cherry_sapling"
+  },
+  {
+    "item": "minecraft:purpur_block"
+  },
+  {
+    "item": "minecraft:deepslate_bricks"
+  },
+  {
+    "item": "minecolonies:blockhutmysticalsite"
+  },
+  {
+    "item": "minecolonies:cookie_dough"
+  },
+  {
+    "item": "minecolonies:pirate_chest"
+  },
+  {
+    "item": "minecraft:oxidized_cut_copper"
+  },
+  {
+    "item": "minecraft:blue_banner"
+  },
+  {
+    "item": "minecolonies:blockhutbuilder"
+  },
+  {
+    "item": "minecraft:clock"
+  },
+  {
+    "item": "domum_ornamentum:light_blue_floating_carpet"
+  },
+  {
+    "item": "minecraft:tide_armor_trim_smithing_template"
+  },
+  {
+    "item": "minecraft:infested_stone"
+  },
+  {
+    "item": "minecraft:lapis_lazuli"
+  },
+  {
+    "item": "minecraft:stripped_birch_log"
+  },
+  {
+    "checkednbtkeys": [
+      {
+        "key": "Potion"
+      }
+    ],
+    "item": "minecraft:lingering_potion"
+  },
+  {
+    "item": "minecolonies:blockhutfisherman"
+  },
+  {
+    "item": "minecraft:danger_pottery_sherd"
+  },
+  {
+    "item": "minecraft:ravager_spawn_egg"
+  },
+  {
+    "item": "minecraft:torch"
+  },
+  {
+    "item": "minecraft:crimson_stem"
+  },
+  {
+    "item": "minecraft:blue_wool"
+  },
+  {
+    "item": "minecraft:andesite_stairs"
+  },
+  {
+    "item": "minecraft:command_block_minecart"
+  },
+  {
+    "item": "minecraft:fire_coral_fan"
+  },
+  {
+    "item": "minecraft:dead_horn_coral"
+  },
+  {
+    "item": "minecraft:music_disc_5"
+  },
+  {
+    "item": "minecolonies:sifter_mesh_string"
+  },
+  {
+    "item": "minecraft:coal_block"
+  },
+  {
+    "item": "minecraft:golden_helmet"
+  },
+  {
+    "item": "minecolonies:blockhutarchery"
+  },
+  {
+    "item": "minecraft:spectral_arrow"
+  },
+  {
+    "item": "minecraft:yellow_concrete"
+  },
+  {
+    "item": "minecraft:mangrove_stairs"
+  },
+  {
+    "item": "minecraft:packed_ice"
+  },
+  {
+    "item": "minecraft:red_terracotta"
+  },
+  {
+    "item": "minecraft:stripped_warped_hyphae"
+  },
+  {
+    "item": "minecolonies:blockhutbeekeeper"
+  },
+  {
+    "item": "minecraft:stripped_oak_wood"
+  },
+  {
+    "item": "minecraft:emerald_block"
+  },
+  {
+    "item": "minecraft:birch_slab"
+  },
+  {
+    "item": "minecraft:smooth_sandstone"
+  },
+  {
+    "item": "minecraft:miner_pottery_sherd"
+  },
+  {
+    "item": "minecraft:stripped_cherry_wood"
+  },
+  {
+    "item": "minecraft:water_bucket"
+  },
+  {
+    "item": "minecraft:iron_bars"
+  },
+  {
+    "item": "minecraft:raw_copper_block"
+  },
+  {
+    "item": "minecraft:melon_slice"
+  },
+  {
+    "item": "minecraft:bamboo"
+  },
+  {
+    "item": "minecraft:mycelium"
+  },
+  {
+    "checkednbtkeys": [
+      {
+        "children": [
+          {
+            "key": "minecraft:block/oak_planks"
+          },
+          {
+            "key": "minecraft:block/dark_oak_planks"
+          }
+        ],
+        "key": "textureData"
+      }
+    ],
+    "item": "domum_ornamentum:down_gated"
+  },
+  {
+    "item": "minecraft:oak_sign"
+  },
+  {
+    "item": "domum_ornamentum:green_cactus_extra"
+  },
+  {
+    "item": "minecraft:gray_shulker_box"
+  },
+  {
+    "item": "minecraft:gray_carpet"
+  },
+  {
+    "item": "minecraft:spruce_chest_boat"
+  },
+  {
+    "item": "minecolonies:sifter_mesh_diamond"
+  },
+  {
+    "item": "minecolonies:iron_scimitar"
+  },
+  {
+    "item": "minecraft:medium_amethyst_bud"
+  },
+  {
+    "item": "minecraft:sugar_cane"
+  },
+  {
+    "item": "minecraft:lime_candle"
+  },
+  {
+    "item": "minecraft:red_nether_brick_wall"
+  },
+  {
+    "item": "minecraft:brown_shulker_box"
+  },
+  {
+    "item": "minecraft:poisonous_potato"
+  },
+  {
+    "item": "minecraft:oak_fence"
+  },
+  {
+    "item": "minecraft:bamboo_stairs"
+  },
+  {
+    "item": "minecraft:axolotl_bucket"
+  },
+  {
+    "item": "minecraft:dark_oak_planks"
+  },
+  {
+    "item": "minecraft:deepslate"
+  },
+  {
+    "item": "minecraft:light_gray_dye"
+  },
+  {
+    "checkednbtkeys": [
+      {
+        "children": [
+          {
+            "key": "minecraft:block/oak_planks"
+          },
+          {
+            "key": "minecraft:block/dark_oak_planks"
+          }
+        ],
+        "key": "textureData"
+      }
+    ],
+    "item": "domum_ornamentum:one_crossed_rl"
+  },
+  {
+    "item": "minecraft:rooted_dirt"
+  },
+  {
+    "item": "minecraft:tall_grass"
+  },
+  {
+    "item": "minecraft:charcoal"
+  },
+  {
+    "item": "minecraft:copper_ore"
+  },
+  {
+    "item": "minecraft:mangrove_trapdoor"
+  },
+  {
+    "item": "minecraft:sniffer_egg"
+  },
+  {
+    "checkednbtkeys": [
+      {
+        "children": [
+          {
+            "key": "minecraft:block/oak_planks"
+          }
+        ],
+        "key": "textureData"
+      }
+    ],
+    "item": "domum_ornamentum:vanilla_wall_compat"
+  },
+  {
+    "item": "minecolonies:blockhutplantation"
+  },
+  {
+    "item": "minecraft:stripped_mangrove_wood"
+  },
+  {
+    "item": "minecolonies:gate_wood"
+  },
+  {
+    "item": "minecraft:emerald_ore"
+  },
+  {
+    "item": "minecraft:prize_pottery_sherd"
+  },
+  {
+    "item": "minecraft:dead_bubble_coral_block"
+  },
+  {
+    "item": "minecraft:cobbled_deepslate_slab"
+  },
+  {
+    "item": "minecraft:netherite_sword"
+  },
+  {
+    "item": "minecraft:host_armor_trim_smithing_template"
+  }
+]

--- a/src/datagen/generated/minecolonies/data/minecolonies/tags/items/ignore_nbt.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/tags/items/ignore_nbt.json
@@ -1,0 +1,5 @@
+{
+  "values": [
+    "#minecraft:banners"
+  ]
+}

--- a/src/main/java/com/minecolonies/coremod/datalistener/ItemNbtListener.java
+++ b/src/main/java/com/minecolonies/coremod/datalistener/ItemNbtListener.java
@@ -1,0 +1,81 @@
+package com.minecolonies.coremod.datalistener;
+
+import com.google.gson.*;
+import com.minecolonies.api.items.CheckedNbtKey;
+import com.minecolonies.api.util.ItemStackUtils;
+import com.minecolonies.api.util.Log;
+import com.minecolonies.coremod.generation.ItemNbtCalculator;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.server.packs.resources.ResourceManager;
+import net.minecraft.server.packs.resources.SimpleJsonResourceReloadListener;
+import net.minecraft.util.profiling.ProfilerFiller;
+import net.minecraftforge.registries.ForgeRegistries;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.*;
+
+/**
+ * Loads and listens to get custom nbt matching rules.
+ */
+public class ItemNbtListener extends SimpleJsonResourceReloadListener
+{
+    /**
+     * Gson instance
+     */
+    private static final Gson GSON = new GsonBuilder().setPrettyPrinting().disableHtmlEscaping().create();
+
+    /**
+     * Create a new listener.
+     */
+    public ItemNbtListener()
+    {
+        super(GSON, "compatibility");
+    }
+
+    @Override
+    protected void apply(final Map<ResourceLocation, JsonElement> jsonElementMap, final @NotNull ResourceManager resourceManager, final @NotNull ProfilerFiller profiler)
+    {
+        ItemStackUtils.CHECKED_NBT_KEYS.clear();
+        for (final Map.Entry<ResourceLocation, JsonElement> entry : jsonElementMap.entrySet())
+        {
+            tryParse(entry);
+        }
+    }
+
+    /**
+     * Tries to parse the entry
+     *
+     * @param entry
+     */
+    private void tryParse(final Map.Entry<ResourceLocation, JsonElement> entry)
+    {
+        for (final JsonElement element : entry.getValue().getAsJsonArray())
+        {
+            try
+            {
+                final JsonObject jsonObj = element.getAsJsonObject();
+                final ResourceLocation itemLoc = new ResourceLocation(jsonObj.get("item").getAsString());
+                if (jsonObj.has("checkednbtkeys"))
+                {
+                    final HashSet<CheckedNbtKey> set = new HashSet<>();
+                    final JsonArray jsonArray = jsonObj.getAsJsonArray("checkednbtkeys");
+                    for (final JsonElement subElement : jsonArray)
+                    {
+                        set.add(ItemNbtCalculator.deserializeKeyFromJson(subElement.getAsJsonObject()));
+                    }
+
+                    ItemStackUtils.CHECKED_NBT_KEYS.put(ForgeRegistries.ITEMS.getValue(itemLoc), set);
+                }
+                else
+                {
+                    ItemStackUtils.CHECKED_NBT_KEYS.put(ForgeRegistries.ITEMS.getValue(itemLoc), new HashSet<>());
+                }
+            }
+            catch (Exception e)
+            {
+                Log.getLogger().warn("Could not nbt comparator for:" + entry.getKey(), e);
+            }
+        }
+        Log.getLogger().warn("Read " + ItemStackUtils.CHECKED_NBT_KEYS.size() + " items with their nbt keys for compatibility.");
+    }
+}

--- a/src/main/java/com/minecolonies/coremod/event/FMLEventHandler.java
+++ b/src/main/java/com/minecolonies/coremod/event/FMLEventHandler.java
@@ -52,6 +52,7 @@ public class FMLEventHandler
         event.addListener(new CustomVisitorListener());
         event.addListener(new CitizenNameListener());
         event.addListener(new QuestJsonListener());
+        event.addListener(new ItemNbtListener());
     }
 
     @SubscribeEvent

--- a/src/main/java/com/minecolonies/coremod/event/GatherDataHandler.java
+++ b/src/main/java/com/minecolonies/coremod/event/GatherDataHandler.java
@@ -1,6 +1,7 @@
 package com.minecolonies.coremod.event;
 
 import com.minecolonies.coremod.generation.DatagenLootTableManager;
+import com.minecolonies.coremod.generation.ItemNbtCalculator;
 import com.minecolonies.coremod.generation.defaults.*;
 import com.minecolonies.coremod.generation.defaults.workers.*;
 import com.minecolonies.coremod.util.SchemFixerUtil;
@@ -61,5 +62,7 @@ public class GatherDataHandler
         generator.addProvider(event.includeServer(), new DefaultSifterCraftingProvider(generator.getPackOutput(), lootTableManager));
         generator.addProvider(event.includeServer(), new DefaultStonemasonCraftingProvider(generator.getPackOutput()));
         generator.addProvider(event.includeServer(), new DefaultStoneSmelteryCraftingProvider(generator.getPackOutput()));
+
+        generator.addProvider(event.includeClient() && event.includeServer(), new ItemNbtCalculator(generator.getPackOutput(), event.getLookupProvider()));
     }
 }

--- a/src/main/java/com/minecolonies/coremod/generation/ItemNbtCalculator.java
+++ b/src/main/java/com/minecolonies/coremod/generation/ItemNbtCalculator.java
@@ -1,0 +1,219 @@
+package com.minecolonies.coremod.generation;
+
+import com.google.common.collect.ImmutableList;
+import com.google.gson.JsonArray;
+import com.google.gson.JsonObject;
+import com.ldtteam.domumornamentum.block.IMateriallyTexturedBlock;
+import com.ldtteam.domumornamentum.block.IMateriallyTexturedBlockComponent;
+import com.minecolonies.api.items.CheckedNbtKey;
+import com.minecolonies.api.items.ModTags;
+import com.minecolonies.api.util.Log;
+import com.minecolonies.api.util.constant.Constants;
+import net.minecraft.Util;
+import net.minecraft.core.HolderLookup;
+import net.minecraft.core.registries.Registries;
+import net.minecraft.data.CachedOutput;
+import net.minecraft.data.DataProvider;
+import net.minecraft.data.PackOutput;
+import net.minecraft.nbt.CompoundTag;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.tags.ItemTags;
+import net.minecraft.world.flag.FeatureFlagSet;
+import net.minecraft.world.item.*;
+import org.jetbrains.annotations.NotNull;
+
+import java.nio.file.Path;
+import java.util.*;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+import java.util.stream.Collectors;
+
+import static com.minecolonies.api.util.constant.Constants.MOD_ID;
+
+/**
+ * Automatically calculated vanilla level nbts of items.
+ */
+public class ItemNbtCalculator implements DataProvider
+{
+    private final PackOutput                               packOutput;
+    private final CompletableFuture<HolderLookup.Provider> lookupProvider;
+
+    public ItemNbtCalculator(@NotNull final PackOutput packOutput, final CompletableFuture<HolderLookup.Provider> lookupProvider)
+    {
+        this.packOutput = packOutput;
+        this.lookupProvider = lookupProvider;
+    }
+
+    @NotNull
+    @Override
+    public String getName()
+    {
+        return "ItemNBTCalculator";
+    }
+
+    @NotNull
+    @Override
+    public CompletableFuture<?> run(@NotNull final CachedOutput cache)
+    {
+        final List<ItemStack> allStacks;
+        final HolderLookup.Provider provider = lookupProvider.join();
+        final CreativeModeTab.ItemDisplayParameters tempDisplayParams = new CreativeModeTab.ItemDisplayParameters(FeatureFlagSet.of(), true, provider);
+
+        final ImmutableList.Builder<ItemStack> listBuilder = new ImmutableList.Builder<>();
+        final HolderLookup.RegistryLookup<CreativeModeTab> registry = provider.lookup(Registries.CREATIVE_MODE_TAB).get();
+
+        for (CreativeModeTab tab : CreativeModeTabs.allTabs())
+        {
+            if (tab != registry.get(CreativeModeTabs.SEARCH).get().get() && tab != registry.get(CreativeModeTabs.HOTBAR).get().get())
+            {
+                final Collection<ItemStack> stacks;
+                if (tab.getDisplayItems().isEmpty())
+                {
+                    stacks = new HashSet<>();
+                    try
+                    {
+                        tab.displayItemsGenerator.accept(tempDisplayParams, (stack, vis) -> {
+                            stacks.add(stack);
+                        });
+                    }
+                    catch (final Throwable ex)
+                    {
+                        Log.getLogger().warn("Error populating items for " + tab.getDisplayName().getString() + "; using fallback", ex);
+                    }
+                }
+                else
+                {
+                    stacks = tab.getDisplayItems();
+                }
+
+                for (final ItemStack item : stacks)
+                {
+                    if (item.getItem() instanceof BlockItem blockItem && blockItem.getBlock() instanceof IMateriallyTexturedBlock texturedBlock)
+                    {
+                        final CompoundTag tag = item.hasTag() ? item.getTag() : new CompoundTag();
+                        final CompoundTag textureData = new CompoundTag();
+                        for (final IMateriallyTexturedBlockComponent key : texturedBlock.getComponents())
+                        {
+                            textureData.putString(key.getId().toString(), key.getDefault().builtInRegistryHolder().key().location().toString());
+                        }
+                        tag.put("textureData", textureData);
+                        final ItemStack copy = item.copy();
+                        copy.setTag(tag);
+                        listBuilder.add(copy);
+                    }
+                    else
+                    {
+                        listBuilder.add(item);
+                    }
+                }
+            }
+        }
+
+        allStacks = listBuilder.build();
+
+        final TreeMap<String, Set<CheckedNbtKey>> keyMapping = new TreeMap<>();
+        for (final ItemStack stack : allStacks)
+        {
+            final ResourceLocation resourceLocation = stack.getItemHolder().unwrapKey().get().location();
+            final CompoundTag tag = (stack.hasTag() && !stack.is(ModTags.ignoreNBT)) ? stack.getTag() : new CompoundTag();
+            final Set<String> keys = tag.getAllKeys();
+
+            // We ignore damage in nbt.
+            keys.remove("Damage");
+
+            final Set<CheckedNbtKey> keyObjectList = new HashSet<>();
+            for (String key : keys)
+            {
+                keyObjectList.add(createKeyFromNbt(key, tag));
+            }
+
+            if (keyMapping.containsKey(resourceLocation.toString()))
+            {
+                final Set<CheckedNbtKey> list = keyMapping.get(resourceLocation.toString());
+                list.addAll(keyObjectList);
+                keyMapping.put(resourceLocation.toString(), list);
+            }
+            else
+            {
+                keyMapping.put(resourceLocation.toString(), keyObjectList);
+            }
+        }
+
+        final Path path = packOutput.createPathProvider(PackOutput.Target.DATA_PACK, "compatibility").file(new ResourceLocation(MOD_ID, "itemnbtmatching"), "json");
+        final JsonArray jsonArray = new JsonArray();
+        for (final Map.Entry<String, Set<CheckedNbtKey>> entry : keyMapping.entrySet())
+        {
+            final JsonObject jsonObject = new JsonObject();
+            jsonObject.addProperty("item", entry.getKey());
+
+            if (!entry.getValue().isEmpty())
+            {
+                final JsonArray subArray = new JsonArray();
+                entry.getValue().forEach(key -> subArray.add(serializeKeyToJson(key)));
+                jsonObject.add("checkednbtkeys", subArray);
+            }
+
+            jsonArray.add(jsonObject);
+        }
+
+        return DataProvider.saveStable(cache, jsonArray, path);
+    }
+
+    /**
+     * Serialize a checked nbt key to json.
+     * @param keyObject the key object to serialize.
+     * @return the output json.
+     */
+    public static JsonObject serializeKeyToJson(final CheckedNbtKey keyObject)
+    {
+        final JsonObject obj = new JsonObject();
+        obj.addProperty("key", keyObject.key);
+
+        if (!keyObject.children.isEmpty())
+        {
+            final JsonArray jsonArray = new JsonArray();
+            keyObject.children.forEach(child -> jsonArray.add(serializeKeyToJson(child)));
+            obj.add("children", jsonArray);
+        }
+        return obj;
+    }
+
+    /**
+     * Create a checked nbt key from nbt.
+     * @param key the key to retrieve.
+     * @param tag the tag to deserialize it from.
+     * @return a new checked nbt key.
+     */
+    public static CheckedNbtKey createKeyFromNbt(final String key, final CompoundTag tag)
+    {
+        if (tag.get(key) instanceof CompoundTag)
+        {
+            final CompoundTag subTag = tag.getCompound(key);
+            return new CheckedNbtKey(key, subTag.getAllKeys().stream().map(subKey -> createKeyFromNbt(subKey, subTag)).collect(Collectors.toSet()));
+        }
+        else
+        {
+            return new CheckedNbtKey(key, Collections.emptySet());
+        }
+    }
+
+    /**
+     * Create a checked nbt key from json.
+     * @param jsonObject the object to serialize it from.
+     * @return the output key.
+     */
+    public static CheckedNbtKey deserializeKeyFromJson(final JsonObject jsonObject)
+    {
+        final String key = jsonObject.get("key").getAsString();
+        if (jsonObject.has("children"))
+        {
+            final Set<CheckedNbtKey> children = new HashSet<>();
+            jsonObject.getAsJsonArray("children").forEach(child -> deserializeKeyFromJson(child.getAsJsonObject()));
+            return new CheckedNbtKey(key, children);
+        }
+        else
+        {
+            return new CheckedNbtKey(key, Collections.emptySet());
+        }
+    }
+}

--- a/src/main/java/com/minecolonies/coremod/generation/ItemNbtCalculator.java
+++ b/src/main/java/com/minecolonies/coremod/generation/ItemNbtCalculator.java
@@ -208,7 +208,7 @@ public class ItemNbtCalculator implements DataProvider
         if (jsonObject.has("children"))
         {
             final Set<CheckedNbtKey> children = new HashSet<>();
-            jsonObject.getAsJsonArray("children").forEach(child -> deserializeKeyFromJson(child.getAsJsonObject()));
+            jsonObject.getAsJsonArray("children").forEach(child -> children.add(deserializeKeyFromJson(child.getAsJsonObject())));
             return new CheckedNbtKey(key, children);
         }
         else

--- a/src/main/java/com/minecolonies/coremod/generation/defaults/DefaultItemTagsProvider.java
+++ b/src/main/java/com/minecolonies/coremod/generation/defaults/DefaultItemTagsProvider.java
@@ -471,6 +471,9 @@ public class DefaultItemTagsProvider extends ItemTagsProvider
           .addTags(Tags.Items.STONE, Tags.Items.COBBLESTONE)
           .addTags(Tags.Items.GRAVEL, Tags.Items.SAND)
           .addTags(Tags.Items.INGOTS, storageBlocks);
+
+        tag(ModTags.ignoreNBT)
+          .addTag(ItemTags.BANNERS);
     }
 
     @NotNull


### PR DESCRIPTION
Closes #
Closes #
Closes #

# Changes proposed in this pull request:
- Base our nbt comparisons on the creative inventory setup of minecraft. For minecraft and minecolonies & dep items.


-> Special Rules
- DO-Items pull their tags from their components.
- Banners opt out from it.

This still needs some more testing.


[ ] Yes I tested this before submitting it.
[ ] I also did a multiplayer test.

Review please
