### PR TITLE
Fix how research requirement dividers are rendered

### DIFF
--- a/src/main/java/com/minecolonies/coremod/client/gui/WindowResearchTree.java
+++ b/src/main/java/com/minecolonies/coremod/client/gui/WindowResearchTree.java
@@ -922,21 +922,21 @@ public class WindowResearchTree extends AbstractWindowSkeleton
             storageXOffset += ICON_X_OFFSET;
         }
 
-        for (final IResearchRequirement requirement : research.getResearchRequirement())
+        for (final BuildingResearchRequirement requirement : buildingRequirements)
         {
             final Item item;
             if (IMinecoloniesAPI.getInstance().getBuildingRegistry().containsKey(
-              new ResourceLocation(Constants.MOD_ID, ((BuildingResearchRequirement) requirement).getBuilding())))
+              new ResourceLocation(Constants.MOD_ID, requirement.getBuilding())))
             {
                 item = IMinecoloniesAPI.getInstance().getBuildingRegistry().getValue(
-                  new ResourceLocation(Constants.MOD_ID, ((BuildingResearchRequirement) requirement).getBuilding())).getBuildingBlock().asItem();
+                  new ResourceLocation(Constants.MOD_ID, requirement.getBuilding())).getBuildingBlock().asItem();
             }
             else
             {
                 item = Items.AIR.asItem();
             }
             final ItemStack stack = new ItemStack(item);
-            stack.setCount(((BuildingResearchRequirement) requirement).getBuildingLevel());
+            stack.setCount(requirement.getBuildingLevel());
             final ItemIcon icon = new ItemIcon();
             icon.setItem(stack);
             icon.setPosition(offsetX + storageXOffset, offsetY + NAME_LABEL_HEIGHT + TEXT_Y_OFFSET);


### PR DESCRIPTION
Closes [discord issue](https://discord.com/channels/472875599422291968/486940969737125922/1157837723420336169)

# Changes proposed in this pull request:
- Removes the unneeded separator between building and item requirements, due to item requirements being aligned to the right
- Improves the iteration over requirements by only loading the list of requirements once


[X] Yes I tested this before submitting it.
[ ] I also did a multiplayer test.

Review please
