### PR TITLE
Forbid dyer from improving recipes

### DIFF
--- a/src/main/java/com/minecolonies/coremod/colony/buildings/workerbuildings/BuildingDyer.java
+++ b/src/main/java/com/minecolonies/coremod/colony/buildings/workerbuildings/BuildingDyer.java
@@ -97,7 +97,13 @@ public class BuildingDyer extends AbstractBuilding
             if (!super.isRecipeCompatible(recipe)) return false;
             return CraftingUtils.isRecipeCompatibleBasedOnTags(recipe, CRAFTING_DYER).orElse(false);
         }
-        
+
+        @Override
+        public void improveRecipe(final IRecipeStorage recipe, final int count, final ICitizenData citizen)
+        {
+            // don't improve any dyeing recipes
+        }
+
         @Override
         public IRecipeStorage getFirstRecipe(Predicate<ItemStack> stackPredicate)
         {
@@ -236,6 +242,12 @@ public class BuildingDyer extends AbstractBuilding
                 return false;
             }
             return CraftingUtils.isRecipeCompatibleBasedOnTags(recipe, CRAFTING_DYER_SMELTING).orElse(false);
+        }
+
+        @Override
+        public void improveRecipe(final IRecipeStorage recipe, final int count, final ICitizenData citizen)
+        {
+            // don't improve any dyeing recipes
         }
     }
 }


### PR DESCRIPTION
Closes [discord report](https://discord.com/channels/472875599422291968/473575384445878273/1158922542946451487)

# Changes proposed in this pull request:
- The Dyer's Hut can no longer improve any recipes at all, regardless of reduceable tags.
    - Almost all of their recipes are either of the form "N dyes in -> N dyes out" or "N items + 1 dye -> N similar items" (the latter most commonly with terracotta and stained glass), such that they're easily susceptible to positive feedback loops if allowed to reduce, since they can be chained together.
    - This will not remove any already-improved recipes in existing colonies, but it will prevent further improvements.

[x] Yes I tested this before submitting it.
[ ] I also did a multiplayer test.

Review please (could port)
