### PR TITLE
Update rendering of max citizen count in research tree

### DIFF
--- a/src/datagen/generated/minecolonies/assets/minecolonies/lang/default.json
+++ b/src/datagen/generated/minecolonies/assets/minecolonies/lang/default.json
@@ -215,7 +215,7 @@
   "com.minecolonies.research.effects.blockhutstonesmeltery.description": "Unlocks Stone Smeltery",
   "com.minecolonies.research.effects.blockplacespeedmultiplier.description": "Citizen Block Place Speed +%3$s%%",
   "com.minecolonies.research.effects.buildermodeunlock.description": "Add the option to select different build-modes for your builders",
-  "com.minecolonies.research.effects.citizencapaddition.description": "Max Citizens +%s",
+  "com.minecolonies.research.effects.citizencapaddition.description": "Max Citizens to %2$s",
   "com.minecolonies.research.effects.citizeninvslotsaddition.description": "Citizen Inventory +%s Slots",
   "com.minecolonies.research.effects.consumearrowsunlock.description": "Archers Use Arrows For +2 Damage",
   "com.minecolonies.research.effects.consumepotions.description": "Druids request Magic Potions to unlock new Abilities",

--- a/src/main/java/com/minecolonies/coremod/client/gui/WindowResearchTree.java
+++ b/src/main/java/com/minecolonies/coremod/client/gui/WindowResearchTree.java
@@ -8,6 +8,7 @@ import com.minecolonies.api.MinecoloniesAPIProxy;
 import com.minecolonies.api.colony.buildings.views.IBuildingView;
 import com.minecolonies.api.crafting.ItemStorage;
 import com.minecolonies.api.research.*;
+import com.minecolonies.api.research.effects.IResearchEffect;
 import com.minecolonies.api.research.util.ResearchState;
 import com.minecolonies.api.util.InventoryUtils;
 import com.minecolonies.api.util.ItemStackUtils;
@@ -629,22 +630,27 @@ public class WindowResearchTree extends AbstractWindowSkeleton
         }
         for (int txt = 0; txt < research.getEffects().size(); txt++)
         {
+            final IResearchEffect<?> researchEffect = research.getEffects().get(txt);
             // CITIZEN_CAP's meaningful effect range is controlled by configuration file settings. Very low values will necessarily make their researches a little weird, but we should at least handle 'sane' ranges.
             // Only change the effect description, rather than removing the effect, as someone may plausibly use the research as a parent research.
             // I'd rather make these modifications during ResearchListener.apply, but that's called before config files can be loaded, and the other workarounds are even uglier.
-            if (research.getEffects().get(txt).getId().equals(CITIZEN_CAP)
-                  && (((GlobalResearchEffect) research.getEffects().get(txt)).getEffect()) > IMinecoloniesAPI.getInstance().getConfig().getServer().maxCitizenPerColony.get())
+            if (researchEffect instanceof GlobalResearchEffect globalResearchEffect && researchEffect.getId().equals(CITIZEN_CAP)
+                  && globalResearchEffect.getEffect() > IMinecoloniesAPI.getInstance().getConfig().getServer().maxCitizenPerColony.get())
             {
-                hoverPaneBuilder.paragraphBreak().append(Component.translatable("com.minecolonies.research.effects.citizencapaddition.description", Component.translatable(
-                  "com.minecolonies.coremod.research.limit.maxeffect")));
+                final MutableComponent mainText =
+                  Component.translatable(researchEffect.getDesc().getKey(), 0, IMinecoloniesAPI.getInstance().getConfig().getServer().maxCitizenPerColony.get());
+                // This call to `Math.round` doesn't serve any purpose, it's only meant to convert the double into a long, so that it will display correctly without any trailing zeroes.
+                final MutableComponent finishText = Component.translatable(researchEffect.getDesc().getKey() + ".over", Math.round(globalResearchEffect.getEffect()));
+                hoverPaneBuilder.paragraphBreak().append(mainText).append(Component.literal(" ")).append(finishText);
             }
             else
             {
-                hoverPaneBuilder.paragraphBreak().append(MutableComponent.create(research.getEffects().get(txt).getDesc()));
+                hoverPaneBuilder.paragraphBreak().append(MutableComponent.create(researchEffect.getDesc()));
             }
-            if (!research.getEffects().get(txt).getSubtitle().getKey().isEmpty())
+
+            if (!researchEffect.getSubtitle().getKey().isEmpty())
             {
-                hoverPaneBuilder.paragraphBreak().append(Component.literal("-")).append(MutableComponent.create(research.getEffects().get(txt).getSubtitle())).italic().colorName("GRAY");
+                hoverPaneBuilder.paragraphBreak().append(Component.literal("-")).append(MutableComponent.create(researchEffect.getSubtitle())).italic().colorName("GRAY");
             }
         }
         if (state != ResearchButtonState.FINISHED && state != ResearchButtonState.IN_PROGRESS)

--- a/src/main/resources/assets/minecolonies/lang/manual_en_us.json
+++ b/src/main/resources/assets/minecolonies/lang/manual_en_us.json
@@ -1375,7 +1375,6 @@
   "com.minecolonies.coremod.research.requirement.university.level": "Requires University Level %d",
   "com.minecolonies.coremod.research.limit.onemaxperbranch": "Only one max-level research can be unlocked per branch.",
   "com.minecolonies.coremod.research.limit.immutable": "This research cannot be undone.",
-  "com.minecolonies.coremod.research.limit.maxeffect": "MAX",
   "com.minecolonies.coremod.research.limit.requirement": "Requirement : %s %s",
   "com.minecolonies.coremod.research.effect.modifier.multiplication": "%s by %d percent",
   "com.minecolonies.coremod.research.effect.modifier.addition": "%s + %d",
@@ -2447,5 +2446,7 @@
   "com.minecolonies.coremod.gui.townhall.patreon.hover": "Unlock Custom Colonist Skins, Name Packs and get Access to Official Servers",
   "com.minecolonies.coremod.placement.outofcolony": "Error on placement! Building or Decoration partially outside of the colony!",
   "com.minecolonies.coremod.placement.noperm": "Error on placement! You don't have the permission in this colony!",
-  "com.minecolonies.coremod.placement.townhalltooclose": "Error on placement! You are too close to an existing colony!"
+  "com.minecolonies.coremod.placement.townhalltooclose": "Error on placement! You are too close to an existing colony!",
+
+  "com.minecolonies.research.effects.citizencapaddition.description.over": "(%1$s, reduced to configuration limit)"
 }


### PR DESCRIPTION
# Changes proposed in this pull request:
- Updates the research texts to an absolute value once again, easier to see what the actual value will be (without having to internally think of the +25)
- Text will also indicate when the value of the research goes beyond the citizen limit, at which point the citizen limit from the configuration will be shown, as well as the original value, plus text stating that it is lower due to configuration limits

![](https://cdn.discordapp.com/attachments/472879361800929290/1161203545362661386/2023-10-10_09_27_38-Window.png?ex=65377213&is=6524fd13&hm=bd7db4a05ba62c94e28f3d2720ec904d067600502a61c54f2a918390319b7046&)
![](https://cdn.discordapp.com/attachments/472879361800929290/1161398649302028368/2023-10-10_22_22_33-Window.png?ex=653827c7&is=6525b2c7&hm=e02a78eb3937e1627e5c5a14fd7f4a247389f4f8448222c20f75279f60942be5&)

[X] Yes I tested this before submitting it.
[ ] I also did a multiplayer test.

Review please
