### PR TITLE
More raid fixes

### DIFF
--- a/src/api/java/com/minecolonies/api/entity/citizen/AbstractCivilianEntity.java
+++ b/src/api/java/com/minecolonies/api/entity/citizen/AbstractCivilianEntity.java
@@ -8,13 +8,17 @@ import net.minecraft.server.level.ServerLevel;
 import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.world.entity.AgeableMob;
 import net.minecraft.world.entity.Entity;
+import net.minecraft.world.entity.EntitySelector;
 import net.minecraft.world.entity.EntityType;
 import net.minecraft.world.entity.npc.Npc;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.level.Level;
+import net.minecraft.world.level.entity.EntityTypeTest;
 import net.minecraftforge.common.util.ITeleporter;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
+
+import java.util.List;
 
 import static com.minecolonies.api.sounds.EventType.GREETING;
 import static com.minecolonies.api.sounds.EventType.SUCCESS;
@@ -114,6 +118,30 @@ public abstract class AbstractCivilianEntity extends AgeableMob implements Npc, 
         if (level().isClientSide)
         {
             soundManager.tick();
+        }
+    }
+
+    /**
+     * Ignores cramming
+     */
+    @Override
+    public void pushEntities()
+    {
+        if (this.level().isClientSide())
+        {
+            this.level().getEntities(EntityTypeTest.forClass(Player.class), this.getBoundingBox(), EntitySelector.pushableBy(this)).forEach(this::doPush);
+        }
+        else
+        {
+            List<Entity> list = this.level().getEntities(this, this.getBoundingBox(), EntitySelector.pushableBy(this));
+            if (!list.isEmpty())
+            {
+                for (int l = 0; l < list.size(); ++l)
+                {
+                    Entity entity = list.get(l);
+                    this.doPush(entity);
+                }
+            }
         }
     }
 

--- a/src/main/java/com/minecolonies/coremod/colony/CitizenData.java
+++ b/src/main/java/com/minecolonies/coremod/colony/CitizenData.java
@@ -527,7 +527,7 @@ public class CitizenData implements ICitizenData
 
         setLastPosition(citizen.blockPosition());
 
-        citizen.getCitizenJobHandler().onJobChanged(citizen.getCitizenJobHandler().getColonyJob());
+        citizen.getCitizenJobHandler().onJobChanged(workBuilding == null ? null : citizen.getCitizenJobHandler().getColonyJob());
 
         applyResearchEffects();
 

--- a/src/main/java/com/minecolonies/coremod/commands/colonycommands/CommandColonyPrintStats.java
+++ b/src/main/java/com/minecolonies/coremod/commands/colonycommands/CommandColonyPrintStats.java
@@ -83,15 +83,26 @@ public class CommandColonyPrintStats implements IMCOPCommand
             context.getSource().sendSuccess(() -> literalAndRemember(last.toString()), false);
         }
 
-        context.getSource().sendSuccess(() -> literalAndRemember("Buildings:" + colony.getBuildingManager().getBuildings().size()), false);
-        context.getSource()
-          .sendSuccess(() -> literalAndRemember(colony.getBuildingManager()
-            .getBuildings()
-            .values()
-            .stream()
-            .map(building -> building.getSchematicName() + building.getBuildingLevel() + " pos:" + building.getPosition().toShortString())
-            .collect(
-              Collectors.joining("\n"))), false);
+        if (colony.getBuildingManager().getBuildings().size() > 0)
+        {
+            context.getSource()
+              .sendSuccess(() -> literalAndRemember("Buildings:" + colony.getBuildingManager().getBuildings().size() + " average level:" + colony.getBuildingManager()
+                .getBuildings()
+                .values()
+                .stream()
+                .filter(iBuilding -> iBuilding.getBuildingLevel() != 0)
+                .collect(
+                  Collectors.summingInt(ibuilding -> ibuilding.getBuildingLevel() / colony.getBuildingManager().getBuildings().size()))), false);
+            context.getSource()
+              .sendSuccess(() -> literalAndRemember(colony.getBuildingManager()
+                .getBuildings()
+                .values()
+                .stream()
+                .filter(iBuilding -> iBuilding.getBuildingLevel() != 0)
+                .map(building -> building.getSchematicName() + building.getBuildingLevel() + " pos:" + building.getPosition().toShortString())
+                .collect(
+                  Collectors.joining("\n"))), false);
+        }
 
         List<ResourceLocation> completed = ((LocalResearchTree) colony.getResearchManager().getResearchTree()).getCompletedList();
         context.getSource().sendSuccess(() -> literalAndRemember("Reasearches completed count:" + completed.size()), false);

--- a/src/main/java/com/minecolonies/coremod/entity/CustomArrowEntity.java
+++ b/src/main/java/com/minecolonies/coremod/entity/CustomArrowEntity.java
@@ -89,7 +89,6 @@ public class CustomArrowEntity extends Arrow
                 {
                     source = level.damageSources().arrow(this, shooter);
                 }
-                setPlayerArmorPierce();
                 player.hurt(source, (float) getBaseDamage());
                 setBaseDamage(0);
             }

--- a/src/main/java/com/minecolonies/coremod/entity/ai/combat/CombatUtils.java
+++ b/src/main/java/com/minecolonies/coremod/entity/ai/combat/CombatUtils.java
@@ -43,7 +43,6 @@ public class CombatUtils
     public static AbstractArrow createArrowForShooter(final LivingEntity shooter)
     {
         AbstractArrow arrowEntity = ModEntities.MC_NORMAL_ARROW.create(shooter.level);
-        arrowEntity.setOwner(shooter);
 
         final ItemStack rangedWeapon = shooter.getItemInHand(InteractionHand.MAIN_HAND);
         final Item rangedWeaponItem = rangedWeapon.getItem();
@@ -60,6 +59,7 @@ public class CombatUtils
             arrowEntity = EntityType.TRIDENT.create(shooter.level);
         }
 
+        arrowEntity.setOwner(shooter);
         arrowEntity.setPos(shooter.getX(), shooter.getY() + 1, shooter.getZ());
         return arrowEntity;
     }

--- a/src/main/java/com/minecolonies/coremod/entity/mobs/aitasks/RaiderWalkAI.java
+++ b/src/main/java/com/minecolonies/coremod/entity/mobs/aitasks/RaiderWalkAI.java
@@ -14,6 +14,8 @@ import com.minecolonies.coremod.colony.colonyEvents.raidEvents.HordeRaidEvent;
 import com.minecolonies.coremod.colony.colonyEvents.raidEvents.pirateEvent.ShipBasedRaiderUtils;
 import net.minecraft.core.BlockPos;
 
+import java.util.List;
+
 import static com.minecolonies.api.util.constant.Constants.TICKS_SECOND;
 
 /**
@@ -67,13 +69,17 @@ public class RaiderWalkAI implements IStateAI
             {
                 targetBlock = raider.getColony().getRaiderManager().getRandomBuilding();
                 walkTimer = raider.level.getGameTime() + TICKS_SECOND * 240;
-                final BlockPos moveToPos = ShipBasedRaiderUtils.chooseWaypointFor(((IColonyRaidEvent) event).getWayPoints(), raider.blockPosition(), targetBlock);
-                raider.getNavigation().moveToXYZ(moveToPos.getX(), moveToPos.getY(), moveToPos.getZ(), 1.1);
+
+                final List<BlockPos> wayPoints = ((IColonyRaidEvent) event).getWayPoints();
+                final BlockPos moveToPos = ShipBasedRaiderUtils.chooseWaypointFor(wayPoints, raider.blockPosition(), targetBlock);
+                raider.getNavigation().moveToXYZ(moveToPos.getX(), moveToPos.getY(), moveToPos.getZ(), !moveToPos.equals(targetBlock) && moveToPos.distManhattan(wayPoints.get(0)) > 50 ? 1.8 : 1.1);
             }
             else if (raider.getNavigation().isDone() || raider.getNavigation().getDesiredPos() == null)
             {
-                final BlockPos moveToPos = ShipBasedRaiderUtils.chooseWaypointFor(((IColonyRaidEvent) event).getWayPoints(), raider.blockPosition(), targetBlock);
-                raider.getNavigation().moveToXYZ(moveToPos.getX(), moveToPos.getY(), moveToPos.getZ(), 1.8);
+                final List<BlockPos> wayPoints = ((IColonyRaidEvent) event).getWayPoints();
+                final BlockPos moveToPos = ShipBasedRaiderUtils.chooseWaypointFor(wayPoints, raider.blockPosition(), targetBlock);
+                raider.getNavigation()
+                  .moveToXYZ(moveToPos.getX(), moveToPos.getY(), moveToPos.getZ(), !moveToPos.equals(targetBlock) && moveToPos.distManhattan(wayPoints.get(0)) > 50 ? 1.8 : 1.1);
             }
         }
 


### PR DESCRIPTION
# Changes proposed in this pull request:
- Make our entities ignore cramming, as they already resolve collisions themselves
- Fix raiders not spreading out again after stacking up for a bit
- Fix raiders doing friendly fire damage
- Fix colony npe when a citizen has a job but not a building
- Add average building colony level to the stats command
- Fix raiders constantly moving too fast, they now get a speed boost while far away from the colony


[ X] Yes I tested this before submitting it.
[ ] I also did a multiplayer test.

Review please
