### PR TITLE
Improve pathfinding overhead

### DIFF
--- a/src/api/java/com/minecolonies/api/util/BlockPosUtil.java
+++ b/src/api/java/com/minecolonies/api/util/BlockPosUtil.java
@@ -702,6 +702,18 @@ public final class BlockPosUtil
     }
 
     /**
+     * Calculate in which direction a pos is facing. Ignoring y.
+     *
+     * @param pos      the pos.
+     * @param neighbor the block its facing.
+     * @return the directions its facing.
+     */
+    public static Direction getXZFacing(final int pos1X, final int pos1Z, final int pos2X, final int pos2Z)
+    {
+        return Direction.getNearest(pos1X - pos2X, 0, pos1Z - pos2Z);
+    }
+
+    /**
      * Calculates the direction a position is from the building.
      *
      * @param building the building.

--- a/src/main/java/com/minecolonies/coremod/entity/pathfinding/CachingBlockLookup.java
+++ b/src/main/java/com/minecolonies/coremod/entity/pathfinding/CachingBlockLookup.java
@@ -1,0 +1,120 @@
+package com.minecolonies.coremod.entity.pathfinding;
+
+import net.minecraft.core.BlockPos;
+import net.minecraft.world.level.LevelReader;
+import net.minecraft.world.level.block.state.BlockState;
+
+/**
+ * Small block lookup cache, to avoid repeated lookups
+ */
+public class CachingBlockLookup
+{
+    /**
+     * Center of the cache
+     */
+    private       int                      centerX;
+    private       int                      centerY;
+    private       int                      centerZ;
+
+    /**
+     * Original world lookup
+     */
+    private final LevelReader              world;
+
+    /**
+     * Temp world access
+     */
+    private final BlockPos.MutableBlockPos temp   = new BlockPos.MutableBlockPos();
+
+    /**
+     * States array
+     */
+    private final BlockState[][][]         states = new BlockState[5][5][5];
+
+    public CachingBlockLookup(final BlockPos center, final LevelReader world)
+    {
+        centerX = center.getX() + 2;
+        centerY = center.getY() + 2;
+        centerZ = center.getZ() + 2;
+        this.world = world;
+    }
+
+    /**
+     * Get a blockstate
+     * @param pos
+     * @return
+     */
+    public BlockState getBlockState(final BlockPos pos)
+    {
+        final int xPos = centerX - pos.getX();
+        final int yPos = centerY - pos.getY();
+        final int zPos = centerZ - pos.getZ();
+
+        if (xPos < 0 || xPos > 4 || yPos < 0 || yPos > 4 || zPos < 0 || zPos > 4)
+        {
+            return world.getBlockState(pos);
+        }
+        else
+        {
+            BlockState state = states[xPos][yPos][zPos];
+            if (state == null)
+            {
+                state = world.getBlockState(pos);
+                states[xPos][yPos][zPos] = state;
+            }
+            return state;
+        }
+    }
+
+    /**
+     * Get a blockstate
+     * @param x
+     * @param y
+     * @param z
+     * @return
+     */
+    public BlockState getBlockState(final int x, final int y, final int z)
+    {
+        final int xPos = centerX - x;
+        final int yPos = centerY - y;
+        final int zPos = centerZ - z;
+
+        if (xPos < 0 || xPos > 4 || yPos < 0 || yPos > 4 || zPos < 0 || zPos > 4)
+        {
+            return world.getBlockState(temp.set(x, y, z));
+        }
+        else
+        {
+            BlockState state = states[xPos][yPos][zPos];
+            if (state == null)
+            {
+                state = world.getBlockState(temp.set(x, y, z));
+                states[xPos][yPos][zPos] = state;
+            }
+
+            return state;
+        }
+    }
+
+    /**
+     * Resets the cache's position and data
+     * @param next
+     */
+    public void resetToNextPos(final BlockPos next)
+    {
+        for (int i = 0; i < 5; i++)
+        {
+            for (int j = 0; j < 5; j++)
+            {
+                for (int k = 0; k < 5; k++)
+                {
+                    states[i][j][k] = null;
+                }
+            }
+        }
+
+        centerX = next.getX() + 2;
+        centerY = next.getY() + 2;
+        centerZ = next.getZ() + 2;
+    }
+}

--- a/src/main/java/com/minecolonies/coremod/entity/pathfinding/ChunkCache.java
+++ b/src/main/java/com/minecolonies/coremod/entity/pathfinding/ChunkCache.java
@@ -53,6 +53,12 @@ public class ChunkCache implements LevelReader
      */
     protected     Level          world;
 
+    /**
+     * Dimension limits
+     */
+    private final int minBuildHeight;
+    private final int maxBuildHeight;
+
     public ChunkCache(Level worldIn, BlockPos posFromIn, BlockPos posToIn, int subIn, final DimensionType type)
     {
         this.world = worldIn;
@@ -78,6 +84,9 @@ public class ChunkCache implements LevelReader
             }
         }
         this.dimType = type;
+
+        minBuildHeight = worldIn.getMinBuildHeight();
+        maxBuildHeight = worldIn.getMaxBuildHeight();
     }
 
     /**
@@ -108,6 +117,18 @@ public class ChunkCache implements LevelReader
             return null;
         }
         return this.chunkArray[i][j].getBlockEntity(pos, createType);
+    }
+
+    @Override
+    public int getMinBuildHeight()
+    {
+        return minBuildHeight;
+    }
+
+    @Override
+    public int getMaxBuildHeight()
+    {
+        return maxBuildHeight;
     }
 
     @NotNull

--- a/src/main/java/com/minecolonies/coremod/entity/pathfinding/pathjobs/AbstractPathJob.java
+++ b/src/main/java/com/minecolonies/coremod/entity/pathfinding/pathjobs/AbstractPathJob.java
@@ -1,6 +1,5 @@
 package com.minecolonies.coremod.entity.pathfinding.pathjobs;
 
-import com.ldtteam.domumornamentum.block.AbstractBlock;
 import com.ldtteam.domumornamentum.block.decorative.FloatingCarpetBlock;
 import com.ldtteam.domumornamentum.block.decorative.PanelBlock;
 import com.minecolonies.api.blocks.decorative.AbstractBlockMinecoloniesConstructionTape;
@@ -14,6 +13,7 @@ import com.minecolonies.api.util.Log;
 import com.minecolonies.coremod.MineColonies;
 import com.minecolonies.coremod.Network;
 import com.minecolonies.coremod.blocks.BlockDecorationController;
+import com.minecolonies.coremod.entity.pathfinding.CachingBlockLookup;
 import com.minecolonies.coremod.entity.pathfinding.ChunkCache;
 import com.minecolonies.coremod.entity.pathfinding.MNode;
 import com.minecolonies.coremod.entity.pathfinding.PathPointExtended;
@@ -31,17 +31,14 @@ import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.LevelReader;
 import net.minecraft.world.level.block.*;
-import net.minecraft.world.level.block.state.BlockBehaviour;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.block.state.properties.BlockStateProperties;
 import net.minecraft.world.level.block.state.properties.Half;
 import net.minecraft.world.level.pathfinder.BlockPathTypes;
 import net.minecraft.world.level.pathfinder.Node;
 import net.minecraft.world.level.pathfinder.Path;
-import net.minecraft.world.level.pathfinder.WalkNodeEvaluator;
 import net.minecraft.world.phys.AABB;
 import net.minecraft.world.phys.shapes.VoxelShape;
-import net.minecraftforge.common.property.Properties;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -74,6 +71,11 @@ public abstract class AbstractPathJob implements Callable<Path>
     protected final LevelReader world;
 
     /**
+     * Cached block lookup
+     */
+    protected CachingBlockLookup cachedBlockLookup;
+
+    /**
      * The result of the path calculation.
      */
     protected final PathResult result;
@@ -94,17 +96,17 @@ public abstract class AbstractPathJob implements Callable<Path>
     private final Map<Integer, MNode> nodesVisited = new HashMap<>();
 
     //  Debug Rendering
-    protected        boolean    debugDrawEnabled     = false;
+    protected     boolean    debugDrawEnabled     = false;
     @Nullable
-    protected        Set<MNode> debugNodesVisited    = new HashSet<>();
+    protected     Set<MNode> debugNodesVisited    = new HashSet<>();
     @Nullable
-    protected        Set<MNode> debugNodesNotVisited = new HashSet<>();
+    protected     Set<MNode> debugNodesNotVisited = new HashSet<>();
     @Nullable
-    protected        Set<MNode> debugNodesPath       = new HashSet<>();
+    protected     Set<MNode> debugNodesPath       = new HashSet<>();
     //  May be faster, but can produce strange results
-    private final    boolean    allowJumpPointSearchTypeWalk;
-    private          int                totalNodesAdded      = 0;
-    private          int                totalNodesVisited    = 0;
+    private final boolean    allowJumpPointSearchTypeWalk;
+    private       int        totalNodesAdded      = 0;
+    private       int        totalNodesVisited    = 0;
 
     /**
      * Which citizens are being tracked by which players.
@@ -181,6 +183,7 @@ public abstract class AbstractPathJob implements Callable<Path>
         this.start = new BlockPos(start);
         this.end = end;
 
+        cachedBlockLookup = new CachingBlockLookup(start, this.world);
         this.maxRange = range;
 
         this.result = result;
@@ -211,15 +214,16 @@ public abstract class AbstractPathJob implements Callable<Path>
      * @param result           path result.
      * @param entity           the entity.
      */
-    public AbstractPathJob(final Level world,
-        final BlockPos start,
-        final BlockPos startRestriction,
-        final BlockPos endRestriction,
-        final int range,
-        final boolean hardRestriction,
-        final PathResult result,
-        final LivingEntity entity,
-        final AbstractAdvancedPathNavigate.RestrictionType restrictionType)
+    public AbstractPathJob(
+      final Level world,
+      final BlockPos start,
+      final BlockPos startRestriction,
+      final BlockPos endRestriction,
+      final int range,
+      final boolean hardRestriction,
+      final PathResult result,
+      final LivingEntity entity,
+      final AbstractAdvancedPathNavigate.RestrictionType restrictionType)
     {
         this(world, start, startRestriction, endRestriction, range, Vec3i.ZERO, hardRestriction, result, entity, restrictionType);
     }
@@ -240,16 +244,17 @@ public abstract class AbstractPathJob implements Callable<Path>
      * @param result           path result.
      * @param entity           the entity.
      */
-    public AbstractPathJob(final Level world,
-        @NotNull final BlockPos start,
-        final BlockPos startRestriction,
-        final BlockPos endRestriction,
-        final int range,
-        final Vec3i grow,
-        final boolean hardRestriction,
-        final PathResult result,
-        final LivingEntity entity,
-        final AbstractAdvancedPathNavigate.RestrictionType restrictionType)
+    public AbstractPathJob(
+      final Level world,
+      @NotNull final BlockPos start,
+      final BlockPos startRestriction,
+      final BlockPos endRestriction,
+      final int range,
+      final Vec3i grow,
+      final boolean hardRestriction,
+      final PathResult result,
+      final LivingEntity entity,
+      final AbstractAdvancedPathNavigate.RestrictionType restrictionType)
     {
         this.minX = Math.min(startRestriction.getX(), endRestriction.getX()) - grow.getX();
         this.minZ = Math.min(startRestriction.getZ(), endRestriction.getZ()) - grow.getZ();
@@ -264,7 +269,7 @@ public abstract class AbstractPathJob implements Callable<Path>
         this.world = new ChunkCache(world, new BlockPos(minX, world.getMinBuildHeight(), minZ), new BlockPos(maxX, world.getMaxBuildHeight(), maxZ), range, world.dimensionType());
 
         this.start = start;
-
+        cachedBlockLookup = new CachingBlockLookup(start, this.world);
         this.maxRange = range;
 
         this.result = result;
@@ -715,6 +720,8 @@ public abstract class AbstractPathJob implements Callable<Path>
 
     private void walkCurrentNode(@NotNull final MNode currentNode)
     {
+        cachedBlockLookup.resetToNextPos(currentNode.pos);
+
         BlockPos dPos = BLOCKPOS_IDENTITY;
         if (currentNode.parent != null)
         {
@@ -741,7 +748,7 @@ public abstract class AbstractPathJob implements Callable<Path>
         }
 
         // Walk downwards node if passable
-        if (isPassable(currentNode.pos.below(), false, currentNode.parent) && (!currentNode.isSwimming() && isLiquid(world.getBlockState(currentNode.pos.below()))))
+        if (isPassable(currentNode.pos.below(), false, currentNode.parent) && (!currentNode.isSwimming() && isLiquid(cachedBlockLookup.getBlockState(currentNode.pos.below()))))
         {
             walk(currentNode, BLOCKPOS_DOWN);
         }
@@ -1043,9 +1050,9 @@ public abstract class AbstractPathJob implements Callable<Path>
         }
 
         final boolean swimStart = isSwimming && !parent.isSwimming();
-        final BlockState state = world.getBlockState(pos);
-        final boolean onRoad = WorkerUtil.isPathBlock(world.getBlockState(pos.below()).getBlock());
-        final boolean onRails = pathingOptions.canUseRails() && world.getBlockState(corner ? pos.below() : pos).getBlock() instanceof BaseRailBlock;
+        final BlockState state = cachedBlockLookup.getBlockState(pos);
+        final boolean onRoad = WorkerUtil.isPathBlock(cachedBlockLookup.getBlockState(pos.below()).getBlock());
+        final boolean onRails = pathingOptions.canUseRails() && cachedBlockLookup.getBlockState(corner ? pos.below() : pos).getBlock() instanceof BaseRailBlock;
         final boolean railsExit = !onRails && parent != null && parent.isOnRails();
         //  Cost may have changed due to a jump up or drop
         double stepCost = computeCost(dPos, isSwimming, onRoad, onRails, railsExit, swimStart, corner, state, pos);
@@ -1078,6 +1085,7 @@ public abstract class AbstractPathJob implements Callable<Path>
 
     /**
      * Calculates additional costs if needed for node
+     *
      * @param stepCost
      * @param parent
      * @param pos
@@ -1155,7 +1163,7 @@ public abstract class AbstractPathJob implements Callable<Path>
      */
     protected int getGroundHeight(final MNode parent, @NotNull final BlockPos pos)
     {
-        if (isLiquid(world.getBlockState(pos.above())))
+        if (isLiquid(cachedBlockLookup.getBlockState(pos.above())))
         {
             return -100;
         }
@@ -1163,18 +1171,18 @@ public abstract class AbstractPathJob implements Callable<Path>
         //  lower body (headroom drop) or lower body (jump up)
         if (checkHeadBlock(parent, pos))
         {
-            return handleTargetNotPassable(parent, pos.above(), world.getBlockState(pos.above()));
+            return handleTargetNotPassable(parent, pos.above(), cachedBlockLookup.getBlockState(pos.above()));
         }
 
         //  Now check the block we want to move to
-        final BlockState target = world.getBlockState(pos);
+        final BlockState target = cachedBlockLookup.getBlockState(pos);
         if (!isPassable(target, pos, parent, false))
         {
             return handleTargetNotPassable(parent, pos, target);
         }
 
         //  Do we have something to stand on in the target space?
-        final BlockState below = world.getBlockState(pos.below());
+        final BlockState below = cachedBlockLookup.getBlockState(pos.below());
         final SurfaceType walkability = SurfaceType.getSurfaceType(world, below, pos);
         if (walkability == SurfaceType.WALKABLE)
         {
@@ -1211,14 +1219,14 @@ public abstract class AbstractPathJob implements Callable<Path>
         final boolean canDrop = parent != null && !parent.isLadder();
         //  Nothing to stand on
         if (!canDrop || ((parent.pos.getX() != pos.getX() || parent.pos.getZ() != pos.getZ()) && isPassable(parent.pos.below(), false, parent)
-                           && SurfaceType.getSurfaceType(world, world.getBlockState(parent.pos.below()), parent.pos.below()) == SurfaceType.DROPABLE))
+                           && SurfaceType.getSurfaceType(world, cachedBlockLookup.getBlockState(parent.pos.below()), parent.pos.below()) == SurfaceType.DROPABLE))
         {
             return -100;
         }
 
         for (int i = 2; i <= 10; i++)
         {
-            final BlockState below = world.getBlockState(pos.below(i));
+            final BlockState below = cachedBlockLookup.getBlockState(pos.below(i));
             if (SurfaceType.getSurfaceType(world, below, pos) == SurfaceType.WALKABLE && i <= 3 || isLiquid(below))
             {
                 //  Level path
@@ -1263,8 +1271,8 @@ public abstract class AbstractPathJob implements Callable<Path>
         //  Check for headroom in the target space
         if (!isPassable(pos.above(2), false, parent))
         {
-            final VoxelShape bb1 = world.getBlockState(pos).getCollisionShape(world, pos);
-            final VoxelShape bb2 = world.getBlockState(pos.above(2)).getCollisionShape(world, pos.above(2));
+            final VoxelShape bb1 = cachedBlockLookup.getBlockState(pos).getCollisionShape(world, pos);
+            final VoxelShape bb2 = cachedBlockLookup.getBlockState(pos.above(2)).getCollisionShape(world, pos.above(2));
             if ((pos.above(2).getY() + getStartY(bb2, 1)) - (pos.getY() + getEndY(bb1, 0)) < 2)
             {
                 return -100;
@@ -1279,8 +1287,8 @@ public abstract class AbstractPathJob implements Callable<Path>
         //  Check for jump room from the origin space
         if (!isPassable(parent.pos.above(2), false, parent))
         {
-            final VoxelShape bb1 = world.getBlockState(pos).getCollisionShape(world, pos);
-            final VoxelShape bb2 = world.getBlockState(parent.pos.above(2)).getCollisionShape(world, parent.pos.above(2));
+            final VoxelShape bb1 = cachedBlockLookup.getBlockState(pos).getCollisionShape(world, pos);
+            final VoxelShape bb2 = cachedBlockLookup.getBlockState(parent.pos.above(2)).getCollisionShape(world, parent.pos.above(2));
             if ((parent.pos.above(2).getY() + getStartY(bb2, 1)) - (pos.getY() + getEndY(bb1, 0)) < 2)
             {
                 return -100;
@@ -1288,7 +1296,7 @@ public abstract class AbstractPathJob implements Callable<Path>
         }
 
 
-        final BlockState parentBelow = world.getBlockState(parent.pos.below());
+        final BlockState parentBelow = cachedBlockLookup.getBlockState(parent.pos.below());
         final VoxelShape parentBB = parentBelow.getCollisionShape(world, parent.pos.below());
 
         double parentY = parentBB.max(Direction.Axis.Y);
@@ -1311,7 +1319,7 @@ public abstract class AbstractPathJob implements Callable<Path>
     private boolean checkHeadBlock(@Nullable final MNode parent, @NotNull final BlockPos pos)
     {
         BlockPos localPos = pos;
-        final VoxelShape bb = world.getBlockState(localPos).getCollisionShape(world, localPos);
+        final VoxelShape bb = cachedBlockLookup.getBlockState(localPos).getCollisionShape(world, localPos);
         if (bb.max(Direction.Axis.Y) < 1)
         {
             localPos = pos.above();
@@ -1324,15 +1332,15 @@ public abstract class AbstractPathJob implements Callable<Path>
 
         if (!isPassable(pos.above(), true, parent))
         {
-            final VoxelShape bb1 = world.getBlockState(pos.below()).getCollisionShape(world, pos.below());
-            final VoxelShape bb2 = world.getBlockState(pos.above()).getCollisionShape(world, pos.above());
+            final VoxelShape bb1 = cachedBlockLookup.getBlockState(pos.below()).getCollisionShape(world, pos.below());
+            final VoxelShape bb2 = cachedBlockLookup.getBlockState(pos.above()).getCollisionShape(world, pos.above());
             if ((pos.above().getY() + getStartY(bb2, 1)) - (pos.below().getY() + getEndY(bb1, 0)) < 2)
             {
                 return true;
             }
             if (parent != null)
             {
-                final VoxelShape bb3 = world.getBlockState(parent.pos.below()).getCollisionShape(world, pos.below());
+                final VoxelShape bb3 = cachedBlockLookup.getBlockState(parent.pos.below()).getCollisionShape(world, pos.below());
                 if ((pos.above().getY() + getStartY(bb2, 1)) - (parent.pos.below().getY() + getEndY(bb3, 0)) < 1.75)
                 {
                     return true;
@@ -1342,9 +1350,9 @@ public abstract class AbstractPathJob implements Callable<Path>
 
         if (parent != null)
         {
-            final BlockState hereState = world.getBlockState(localPos.below());
-            final VoxelShape bb1 = world.getBlockState(pos).getCollisionShape(world, pos);
-            final VoxelShape bb2 = world.getBlockState(localPos.above()).getCollisionShape(world, localPos.above());
+            final BlockState hereState = cachedBlockLookup.getBlockState(localPos.below());
+            final VoxelShape bb1 = cachedBlockLookup.getBlockState(pos).getCollisionShape(world, pos);
+            final VoxelShape bb2 = cachedBlockLookup.getBlockState(localPos.above()).getCollisionShape(world, localPos.above());
             if ((localPos.above().getY() + getStartY(bb2, 1)) - (pos.getY() + getEndY(bb1, 0)) >= 2)
             {
                 return false;
@@ -1483,7 +1491,7 @@ public abstract class AbstractPathJob implements Callable<Path>
 
     protected boolean isPassable(final BlockPos pos, final boolean head, final MNode parent)
     {
-        final BlockState state = world.getBlockState(pos);
+        final BlockState state = cachedBlockLookup.getBlockState(pos);
         final VoxelShape shape = state.getCollisionShape(world, pos);
         if (shape.isEmpty() || shape.max(Direction.Axis.Y) <= 0.1)
         {
@@ -1508,7 +1516,7 @@ public abstract class AbstractPathJob implements Callable<Path>
         {
             parentPos = parentPos.above();
         }
-        final BlockState parentBlock = world.getBlockState(parentPos);
+        final BlockState parentBlock = cachedBlockLookup.getBlockState(parentPos);
         if (parentBlock.getBlock() instanceof TrapDoorBlock || parentBlock.getBlock() instanceof PanelBlock)
         {
             final BlockPos dir = pos.subtract(parentPos);
@@ -1544,12 +1552,12 @@ public abstract class AbstractPathJob implements Callable<Path>
      */
     protected boolean isLadder(@NotNull final Block block, final BlockPos pos)
     {
-        return block.isLadder(this.world.getBlockState(pos), world, pos, entity.get()) && (block != Blocks.VINE || pathingOptions.canClimbVines());
+        return block.isLadder(this.cachedBlockLookup.getBlockState(pos), world, pos, entity.get()) && (block != Blocks.VINE || pathingOptions.canClimbVines());
     }
 
     protected boolean isLadder(final BlockPos pos)
     {
-        return isLadder(world.getBlockState(pos).getBlock(), pos);
+        return isLadder(cachedBlockLookup.getBlockState(pos).getBlock(), pos);
     }
 
     /**


### PR DESCRIPTION
# Changes proposed in this pull request:
- Introduces a small blockstate cache for repeated lookups during pathfinding when exploring around a node, reduces state lookups by ~65% and pathfinding cpu usage by ~40%


[x ] Yes I tested this before submitting it.
[ ] I also did a multiplayer test.

Review please
