### PR TITLE
Fix citizens not getting unassigned on building removal

### DIFF
--- a/src/main/java/com/minecolonies/coremod/colony/buildings/modules/AbstractAssignedCitizenModule.java
+++ b/src/main/java/com/minecolonies/coremod/colony/buildings/modules/AbstractAssignedCitizenModule.java
@@ -1,10 +1,12 @@
 package com.minecolonies.coremod.colony.buildings.modules;
 
 import com.google.common.collect.Lists;
+import com.minecolonies.api.colony.ICitizen;
 import com.minecolonies.api.colony.ICitizenData;
 import com.minecolonies.api.colony.buildings.HiringMode;
 import com.minecolonies.api.colony.buildings.modules.*;
 import com.minecolonies.api.entity.citizen.AbstractEntityCitizen;
+import com.minecolonies.coremod.colony.CitizenData;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.network.FriendlyByteBuf;
 import org.jetbrains.annotations.NotNull;
@@ -22,7 +24,7 @@ import static com.minecolonies.api.util.constant.NbtTagConstants.TAG_HIRING_MODE
 /**
  * Abstract assignment module.
  */
-public abstract class AbstractAssignedCitizenModule extends AbstractBuildingModule implements IAssignsCitizen, IPersistentModule
+public abstract class AbstractAssignedCitizenModule extends AbstractBuildingModule implements IAssignsCitizen, IPersistentModule, IBuildingEventsModule
 {
     /**
      * List of worker assosiated to the building.
@@ -73,6 +75,15 @@ public abstract class AbstractAssignedCitizenModule extends AbstractBuildingModu
      * @param citizen the assigned citizen.
      */
     abstract void onRemoval(final ICitizenData citizen);
+
+    @Override
+    public void onDestroyed()
+    {
+        for(final ICitizenData citizenData: new ArrayList<>(assignedCitizen))
+        {
+            removeCitizen(citizenData);
+        }
+    }
 
     @Override
     public List<ICitizenData> getAssignedCitizen()

--- a/src/main/java/com/minecolonies/coremod/colony/buildings/moduleviews/WorkerBuildingModuleView.java
+++ b/src/main/java/com/minecolonies/coremod/colony/buildings/moduleviews/WorkerBuildingModuleView.java
@@ -145,7 +145,7 @@ public class WorkerBuildingModuleView extends AbstractBuildingModuleView impleme
         return !citizen.isChild() &&
                  (citizen.getWorkBuilding() == null
                     || workerIDs.contains(citizen.getId())
-                    || buildingView.getColony().getBuilding(citizen.getWorkBuilding()).getModuleViewMatching(WorkerBuildingModuleView.class, m -> m.canBeHiredAs(getJobEntry()))
+                    || buildingView.getColony().getBuilding(citizen.getWorkBuilding()) != null && buildingView.getColony().getBuilding(citizen.getWorkBuilding()).getModuleViewMatching(WorkerBuildingModuleView.class, m -> m.canBeHiredAs(getJobEntry()))
                          != null);
     }
 


### PR DESCRIPTION
Closes #9526
Closes #
Closes #

# Changes proposed in this pull request:
-Fix citizens not getting unassigned on building removal


[x ] Yes I tested this before submitting it.
[ ] I also did a multiplayer test.

Review please
