### PR TITLE
Update requests after teaching DO recipes

### DIFF
--- a/src/main/java/com/minecolonies/coremod/colony/buildings/modules/AbstractCraftingBuildingModule.java
+++ b/src/main/java/com/minecolonies/coremod/colony/buildings/modules/AbstractCraftingBuildingModule.java
@@ -52,6 +52,7 @@ import org.jetbrains.annotations.Nullable;
 import java.util.*;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import static com.minecolonies.api.research.util.ResearchConstants.RECIPES;
 import static com.minecolonies.api.util.constant.BuildingConstants.*;
@@ -429,7 +430,12 @@ public abstract class AbstractCraftingBuildingModule extends AbstractBuildingMod
             final IRecipeStorage recipeStorage = IColonyManager.getInstance().getRecipeManager().getRecipes().get(token);
             if (recipeStorage != null)
             {
-                building.getColony().getRequestManager().onColonyUpdate(request -> request.getRequest() instanceof IDeliverable && ((IDeliverable) request.getRequest()).matches(recipeStorage.getPrimaryOutput()));
+                final Stream<ItemStack> allOutputs = Stream.concat(Stream.of(recipeStorage.getPrimaryOutput()),
+                                recipeStorage.getAlternateOutputs().stream())
+                        .filter(ItemStackUtils::isNotEmpty);
+
+                building.getColony().getRequestManager().onColonyUpdate(request ->
+                        request.getRequest() instanceof IDeliverable delivery && allOutputs.anyMatch(delivery::matches));
             }
             return true;
         }


### PR DESCRIPTION
Closes #9528 (after porting)

# Changes proposed in this pull request:
- After teaching a DO recipe, update existing requests without needing to cancel and re-request.

[x] Yes I tested this before submitting it.
[ ] I also did a multiplayer test.

Review please (could port)
