### PR TITLE
Cap data fixes

### DIFF
--- a/src/api/java/com/minecolonies/api/colony/requestsystem/StandardFactoryController.java
+++ b/src/api/java/com/minecolonies/api/colony/requestsystem/StandardFactoryController.java
@@ -285,7 +285,6 @@ public final class StandardFactoryController implements IFactoryController
         if (compound.contains(NEW_NBT_TYPE))
         {
             short classId = compound.getShort(NEW_NBT_TYPE);
-
             try
             {
                 factory = getFactoryForOutput(classId);
@@ -307,7 +306,6 @@ public final class StandardFactoryController implements IFactoryController
             {
                 throw (IllegalArgumentException) new IllegalArgumentException("The given compound holds an unknown output type for this Controller: " + className).initCause(e);
             }
-
         }
 
         try

--- a/src/main/java/com/minecolonies/coremod/colony/IColonyManagerCapability.java
+++ b/src/main/java/com/minecolonies/coremod/colony/IColonyManagerCapability.java
@@ -9,7 +9,6 @@ import com.minecolonies.api.util.NBTUtils;
 import com.minecolonies.coremod.util.BackUpHelper;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.nbt.Tag;
-import net.minecraft.core.Direction;
 import net.minecraft.core.BlockPos;
 import net.minecraft.world.level.Level;
 import net.minecraftforge.common.capabilities.Capability;
@@ -127,19 +126,22 @@ public interface IColonyManagerCapability
     class Storage
     {
 
-        public static Tag writeNBT(@NotNull final Capability<IColonyManagerCapability> capability, @NotNull final IColonyManagerCapability instance, @Nullable final Direction side)
+        public static Tag writeNBT(@NotNull final Capability<IColonyManagerCapability> capability, @NotNull final IColonyManagerCapability instance, final boolean overworld)
         {
             final CompoundTag compound = new CompoundTag();
             compound.put(TAG_COLONIES, instance.getColonies().stream().map(IColony::getColonyTag).filter(Objects::nonNull).collect(NBTUtils.toListNBT()));
-            final CompoundTag managerCompound = new CompoundTag();
-            IColonyManager.getInstance().write(managerCompound);
-            compound.put(TAG_COLONY_MANAGER, managerCompound);
+
+            if (overworld)
+            {
+                final CompoundTag managerCompound = new CompoundTag();
+                IColonyManager.getInstance().write(managerCompound);
+                compound.put(TAG_COLONY_MANAGER, managerCompound);
+            }
             return compound;
         }
 
         public static void readNBT(
-          @NotNull final Capability<IColonyManagerCapability> capability, @NotNull final IColonyManagerCapability instance,
-          @Nullable final Direction side, @NotNull final Tag nbt)
+          @NotNull final Capability<IColonyManagerCapability> capability, @NotNull final IColonyManagerCapability instance, final boolean overworld, @NotNull final Tag nbt)
         {
             // Notify that we did load the cap for this world
             IColonyManager.getInstance().setCapLoaded();
@@ -189,7 +191,7 @@ public interface IColonyManagerCapability
                     }
                 }
 
-                if (compound.contains(TAG_COLONY_MANAGER))
+                if (compound.contains(TAG_COLONY_MANAGER) && overworld)
                 {
                     IColonyManager.getInstance().read(compound.getCompound(TAG_COLONY_MANAGER));
                 }

--- a/src/main/java/com/minecolonies/coremod/colony/crafting/RecipeStorageFactory.java
+++ b/src/main/java/com/minecolonies/coremod/colony/crafting/RecipeStorageFactory.java
@@ -26,6 +26,8 @@ import org.jetbrains.annotations.NotNull;
 import java.util.ArrayList;
 import java.util.List;
 
+import static com.minecolonies.api.colony.requestsystem.StandardFactoryController.NBT_TYPE;
+import static com.minecolonies.api.colony.requestsystem.StandardFactoryController.NEW_NBT_TYPE;
 import static com.minecolonies.api.util.constant.NbtTagConstants.TAG_TOKEN;
 
 /**
@@ -173,7 +175,7 @@ public class RecipeStorageFactory implements IRecipeStorageFactory
         for (int i = 0; i < inputTagList.size(); ++i)
         {
             final CompoundTag inputTag = inputTagList.getCompound(i);
-            if(inputTag.contains("Type")) //Check to see if it's something the factorycontroller can handle
+            if(inputTag.contains(NEW_NBT_TYPE) || inputTag.contains(NBT_TYPE)) //Check to see if it's something the factorycontroller can handle
             {
                 input.add(StandardFactoryController.getInstance().deserialize(inputTag));
             }

--- a/src/main/java/com/minecolonies/coremod/event/EventHandler.java
+++ b/src/main/java/com/minecolonies/coremod/event/EventHandler.java
@@ -81,9 +81,11 @@ import net.minecraftforge.eventbus.api.Event;
 import net.minecraftforge.eventbus.api.SubscribeEvent;
 import org.jetbrains.annotations.NotNull;
 
+import java.awt.*;
 import java.time.LocalDateTime;
 import java.time.Month;
 import java.util.*;
+import java.util.List;
 
 import static com.minecolonies.api.colony.IColony.CLOSE_COLONY_CAP;
 import static com.minecolonies.api.research.util.ResearchConstants.SOFT_SHOES;
@@ -161,7 +163,7 @@ public class EventHandler
     public static void onAttachingCapabilitiesWorld(@NotNull final AttachCapabilitiesEvent<Level> event)
     {
         event.addCapability(new ResourceLocation(Constants.MOD_ID, "chunkupdate"), new MinecoloniesWorldCapabilityProvider());
-        event.addCapability(new ResourceLocation(Constants.MOD_ID, "colonymanager"), new MinecoloniesWorldColonyManagerCapabilityProvider());
+        event.addCapability(new ResourceLocation(Constants.MOD_ID, "colonymanager"), new MinecoloniesWorldColonyManagerCapabilityProvider(event.getObject().dimension() == Level.OVERWORLD));
     }
 
     /**

--- a/src/main/java/com/minecolonies/coremod/event/capabilityproviders/MinecoloniesWorldColonyManagerCapabilityProvider.java
+++ b/src/main/java/com/minecolonies/coremod/event/capabilityproviders/MinecoloniesWorldColonyManagerCapabilityProvider.java
@@ -27,24 +27,30 @@ public class MinecoloniesWorldColonyManagerCapabilityProvider implements ICapabi
     private final IColonyManagerCapability colonyManager;
 
     /**
+     * Is this the main overworld cap?
+     */
+    private final boolean overworld;
+
+    /**
      * Constructor of the provider.
      */
-    public MinecoloniesWorldColonyManagerCapabilityProvider()
+    public MinecoloniesWorldColonyManagerCapabilityProvider(final boolean overworld)
     {
         this.colonyManager = new IColonyManagerCapability.Impl();
         this.colonyManagerOptional = LazyOptional.of(() -> colonyManager);
+        this.overworld = overworld;
     }
 
     @Override
     public Tag serializeNBT()
     {
-        return IColonyManagerCapability.Storage.writeNBT(COLONY_MANAGER_CAP, colonyManager, null);
+        return IColonyManagerCapability.Storage.writeNBT(COLONY_MANAGER_CAP, colonyManager, overworld);
     }
 
     @Override
     public void deserializeNBT(final Tag nbt)
     {
-        IColonyManagerCapability.Storage.readNBT(COLONY_MANAGER_CAP, colonyManager, null, nbt);
+        IColonyManagerCapability.Storage.readNBT(COLONY_MANAGER_CAP, colonyManager, overworld, nbt);
     }
 
     @Nonnull


### PR DESCRIPTION
Closes #
Closes #
Closes #

# Changes proposed in this pull request:
- Make RS write short ids instead of the long classnames for nbt saving
- Colony manager only saved in overworld cap now
-


[ x ] Yes I tested this before submitting it.
[ ] I also did a multiplayer test.

Review please
