### PR TITLE
Downgrade template error to warning and hide unless auditing

### DIFF
--- a/src/main/java/com/minecolonies/coremod/colony/crafting/CustomRecipe.java
+++ b/src/main/java/com/minecolonies/coremod/colony/crafting/CustomRecipe.java
@@ -533,7 +533,10 @@ public class CustomRecipe
         if (!recipeJson.has(RECIPE_RESULT_PROP) && !recipeJson.has(RECIPE_LOOTTABLE_PROP) &&
                 (!recipeJson.has(RECIPE_ALTERNATE_PROP) || recipeJson.getAsJsonArray(RECIPE_ALTERNATE_PROP).isEmpty()))
         {
-            Log.getLogger().error("Template {} with {}: rejecting, no outputs", templateId, itemId);
+            if (logStatus)
+            {
+                Log.getLogger().warn("Template {} with {}: rejecting, no outputs", templateId, itemId);
+            }
             return null;
         }
 


### PR DESCRIPTION
# Changes proposed in this pull request:
- Hides the "no outputs" template error unless you're auditing (matching the other errors), and downgrades it to a warning.

[ ] Yes I tested this before submitting it.
[ ] I also did a multiplayer test.

Review please (could port)
