### PR TITLE
Fix typo in manual_en_us.json

### DIFF
--- a/src/main/resources/assets/minecolonies/lang/manual_en_us.json
+++ b/src/main/resources/assets/minecolonies/lang/manual_en_us.json
@@ -2380,7 +2380,7 @@
   "com.minecolonies.building.archery.desc": "Teaches Archers-To-Be to Take a Bow.",
   "com.minecolonies.building.combatacademy.desc": "Teaches Knights-To-Be Which End is the Pointy End.",
   "com.minecolonies.building.sawmill.desc": "Turns Logs into Wood-based Products. Source: I Saw It Online.",
-  "com.minecolonies.building.blacksmith.desc": "Hammers Out The Details of Making Tools, Weaspons, and Armor.",
+  "com.minecolonies.building.blacksmith.desc": "Hammers Out The Details of Making Tools, Weapons, and Armor.",
   "com.minecolonies.building.stonemason.desc": "Not Michelangelo, but Can Still Craft Stone-based Items",
   "com.minecolonies.building.hospital.desc": "Heals Colonists from Illness. There's a Doctor In This House!",
   "com.minecolonies.building.school.desc": "Teaches Children to Be Smarter! No Standardized Tests, Either!",


### PR DESCRIPTION
"Weaspons" to "Weapons"

 Changes proposed in this pull request:
- small spelling fix for blacksmith description
-
-

Review please
