### PR TITLE
Fix thread blocking in miner during startup

### DIFF
--- a/src/api/java/com/minecolonies/api/colony/workorders/IWorkOrder.java
+++ b/src/api/java/com/minecolonies/api/colony/workorders/IWorkOrder.java
@@ -1,14 +1,17 @@
 package com.minecolonies.api.colony.workorders;
 
+import com.ldtteam.structurize.blueprints.v1.Blueprint;
 import com.minecolonies.api.colony.ICitizenData;
 import com.minecolonies.api.colony.IColony;
 import com.minecolonies.api.colony.jobs.IJob;
+import net.minecraft.core.BlockPos;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.network.FriendlyByteBuf;
-import net.minecraft.core.BlockPos;
 import net.minecraft.network.chat.Component;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
+
+import java.util.concurrent.Future;
 
 import static com.minecolonies.api.util.constant.Suppression.UNUSED_METHOD_PARAMETERS_SHOULD_BE_REMOVED;
 
@@ -55,6 +58,12 @@ public interface IWorkOrder
      * @return the pack name.
      */
     String getStructurePack();
+
+    /**
+     * Get a blueprint future.
+     * @return the blueprint future (might contain null).
+     */
+    Future<Blueprint> getBlueprintFuture();
 
     /**
      * Get the current level of the structure of the work order.

--- a/src/main/java/com/minecolonies/coremod/colony/buildings/workerbuildings/BuildingMiner.java
+++ b/src/main/java/com/minecolonies/coremod/colony/buildings/workerbuildings/BuildingMiner.java
@@ -1,6 +1,5 @@
 package com.minecolonies.coremod.colony.buildings.workerbuildings;
 
-import com.ldtteam.structurize.storage.StructurePacks;
 import com.minecolonies.api.colony.ICitizenData;
 import com.minecolonies.api.colony.IColony;
 import com.minecolonies.api.colony.buildings.modules.settings.ISettingKey;
@@ -32,7 +31,6 @@ import java.util.Map;
 import java.util.Set;
 
 import static com.minecolonies.api.util.constant.BuildingConstants.*;
-import static com.minecolonies.api.util.constant.Constants.STORAGE_STYLE;
 import static com.minecolonies.api.util.constant.Constants.STACKSIZE;
 import static com.minecolonies.api.util.constant.ToolLevelConstants.TOOL_LEVEL_WOOD_OR_GOLD;
 
@@ -278,26 +276,22 @@ public class BuildingMiner extends AbstractBuildingStructureBuilder
     {
         final String structurePack = buildingMiner.getStructurePack();
         int rotateCount;
-        final boolean needsFallback;
         final String style;
 
         if (mineNode == null)
         {
             rotateCount = getRotationFromVector(buildingMiner);
             style = Node.NodeType.SHAFT.getSchematicName();
-            needsFallback = needsFallBack(structurePack, style) ;
         }
-
         else
         {
             rotateCount = rotateTimes;
             style = mineNode.getStyle().getSchematicName();
-            needsFallback = needsFallBack(structurePack, style);
         }
 
         if (job == null || job.getWorkOrder() == null)
         {
-            final WorkOrderMiner wo = new WorkOrderMiner(needsFallback ? STORAGE_STYLE : structurePack, style + ".blueprint", style, rotateCount, structurePos, false, buildingMiner.getPosition());
+            final WorkOrderMiner wo = new WorkOrderMiner(structurePack, style + ".blueprint", style, rotateCount, structurePos, false, buildingMiner.getPosition());
             wo.setClaimedBy(buildingMiner.getPosition());
             buildingMiner.getColony().getWorkManager().addWorkOrder(wo, false);
             if (job != null)
@@ -338,17 +332,5 @@ public class BuildingMiner extends AbstractBuildingStructureBuilder
             return 4;
         }
         return 0;
-    }
-
-    /**
-     * Get the correct style for the shaft. Return default back.
-     *
-     * @param structurePacks the structurePacks to check.
-     * @param shaft the shaft.
-     * @return the correct location.
-     */
-    private static boolean needsFallBack(final String structurePacks, final String shaft)
-    {
-        return StructurePacks.getBlueprint(structurePacks, shaft + ".blueprint", true) == null;
     }
 }

--- a/src/main/java/com/minecolonies/coremod/colony/workorders/AbstractWorkOrder.java
+++ b/src/main/java/com/minecolonies/coremod/colony/workorders/AbstractWorkOrder.java
@@ -2,6 +2,8 @@ package com.minecolonies.coremod.colony.workorders;
 
 import com.google.common.collect.BiMap;
 import com.google.common.collect.HashBiMap;
+import com.ldtteam.structurize.blueprints.v1.Blueprint;
+import com.ldtteam.structurize.storage.StructurePacks;
 import com.minecolonies.api.colony.ICitizenData;
 import com.minecolonies.api.colony.IColony;
 import com.minecolonies.api.colony.jobs.IJob;
@@ -25,6 +27,7 @@ import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
 import java.util.Map;
 import java.util.Optional;
+import java.util.concurrent.Future;
 
 import static com.minecolonies.api.util.constant.Suppression.UNUSED_METHOD_PARAMETERS_SHOULD_BE_REMOVED;
 
@@ -94,7 +97,7 @@ public abstract class AbstractWorkOrder implements IWorkOrder
     /**
      * The structurize schematic name.
      */
-    private String packName;
+    protected String packName;
 
     /**
      * The work order name.
@@ -154,7 +157,7 @@ public abstract class AbstractWorkOrder implements IWorkOrder
     /**
      * Internal flag to see if anything has been changed.
      */
-    private boolean changed;
+    protected boolean changed;
 
     /**
      * Add a given Work Order mapping.
@@ -396,6 +399,12 @@ public abstract class AbstractWorkOrder implements IWorkOrder
     public String getStructurePack()
     {
         return packName;
+    }
+
+    @Override
+    public Future<Blueprint> getBlueprintFuture()
+    {
+        return StructurePacks.getBlueprintFuture(getStructurePack(), getStructurePath());
     }
 
     @Override

--- a/src/main/java/com/minecolonies/coremod/colony/workorders/WorkOrderMiner.java
+++ b/src/main/java/com/minecolonies/coremod/colony/workorders/WorkOrderMiner.java
@@ -1,5 +1,8 @@
 package com.minecolonies.coremod.colony.workorders;
 
+import com.ldtteam.structurize.blueprints.v1.Blueprint;
+import com.ldtteam.structurize.storage.StructurePacks;
+import com.ldtteam.structurize.util.IOPool;
 import com.minecolonies.api.colony.ICitizenData;
 import com.minecolonies.api.colony.IColony;
 import com.minecolonies.api.colony.jobs.IJob;
@@ -11,6 +14,9 @@ import net.minecraft.nbt.CompoundTag;
 import net.minecraft.core.BlockPos;
 import org.jetbrains.annotations.NotNull;
 
+import java.util.concurrent.Future;
+
+import static com.minecolonies.api.util.constant.Constants.STORAGE_STYLE;
 import static com.minecolonies.api.util.constant.NbtTagConstants.TAG_POS;
 
 /**
@@ -53,6 +59,26 @@ public class WorkOrderMiner extends AbstractWorkOrder
     {
         super(packName, structureName, workOrderName, WorkOrderType.BUILD, location, rotation, mirror, 0, 1);
         this.minerBuilding = minerBuilding;
+    }
+
+    @Override
+    public Future<Blueprint> getBlueprintFuture()
+    {
+        return IOPool.submit(() ->
+        {
+            Blueprint blueprint = StructurePacks.getBlueprint(getStructurePack(), getStructurePath(), true);
+            if (blueprint == null)
+            {
+                // automatic fallback to default style
+                blueprint = StructurePacks.getBlueprint(STORAGE_STYLE, getStructurePath());
+                if (blueprint != null)
+                {
+                    packName = STORAGE_STYLE;
+                    changed = true;
+                }
+            }
+            return blueprint;
+        });
     }
 
     @Override

--- a/src/main/java/com/minecolonies/coremod/entity/ai/basic/AbstractEntityAIStructure.java
+++ b/src/main/java/com/minecolonies/coremod/entity/ai/basic/AbstractEntityAIStructure.java
@@ -8,7 +8,6 @@ import com.ldtteam.structurize.placement.StructurePhasePlacementResult;
 import com.ldtteam.structurize.placement.StructurePlacer;
 import com.ldtteam.structurize.placement.structure.IStructureHandler;
 import com.ldtteam.structurize.storage.ServerFutureProcessor;
-import com.ldtteam.structurize.storage.StructurePacks;
 import com.ldtteam.structurize.util.BlockUtils;
 import com.ldtteam.structurize.util.BlueprintPositionInfo;
 import com.ldtteam.structurize.util.PlacementSettings;
@@ -18,6 +17,7 @@ import com.minecolonies.api.colony.buildings.IBuilding;
 import com.minecolonies.api.colony.requestsystem.request.IRequest;
 import com.minecolonies.api.colony.requestsystem.requestable.IDeliverable;
 import com.minecolonies.api.colony.requestsystem.requestable.Stack;
+import com.minecolonies.api.colony.workorders.IWorkOrder;
 import com.minecolonies.api.crafting.ItemStorage;
 import com.minecolonies.api.entity.ai.citizen.builder.IBuilderUndestroyable;
 import com.minecolonies.api.entity.ai.statemachine.AIEventTarget;
@@ -562,23 +562,22 @@ public abstract class AbstractEntityAIStructure<J extends AbstractJobStructure<?
     /**
      * Loads the structure given the name, rotation and position.
      *
-     * @param packName the pack name.
-     * @param blueprintPath the path of the blueprint.
+     * @param workOrder   the work order.
      * @param rotateTimes number of times to rotateWithMirror it.
      * @param position    the position to set it.
      * @param isMirrored  is the structure mirroed?
      * @param removal     if removal step.
      */
-    public void loadStructure(@NotNull final String packName, final String blueprintPath, final int rotateTimes, final BlockPos position, final boolean isMirrored, final boolean removal)
+    public void loadStructure(@NotNull final IWorkOrder workOrder, final int rotateTimes, final BlockPos position, final boolean isMirrored, final boolean removal)
     {
-        final Future<Blueprint> blueprintFuture = StructurePacks.getBlueprintFuture(packName, blueprintPath);
+        final Future<Blueprint> blueprintFuture = workOrder.getBlueprintFuture();
         this.loadingBlueprint = true;
 
         ServerFutureProcessor.queueBlueprint(new ServerFutureProcessor.BlueprintProcessingData(blueprintFuture, world, (blueprint -> {
             if (blueprint == null)
             {
                 handleSpecificCancelActions();
-                Log.getLogger().warn("Couldn't find structure with name: " + blueprintPath + " in: " + packName + ". Aborting loading procedure");
+                Log.getLogger().warn("Couldn't find structure with name: " + workOrder.getStructurePath() + " in: " + workOrder.getStructurePack() + ". Aborting loading procedure");
                 this.loadingBlueprint = false;
                 return;
             }

--- a/src/main/java/com/minecolonies/coremod/entity/ai/basic/AbstractEntityAIStructureWithWorkOrder.java
+++ b/src/main/java/com/minecolonies/coremod/entity/ai/basic/AbstractEntityAIStructureWithWorkOrder.java
@@ -182,7 +182,7 @@ public abstract class AbstractEntityAIStructureWithWorkOrder<J extends AbstractJ
         final int tempRotation = workOrder.getRotation();
         final boolean removal = workOrder.getWorkOrderType() == WorkOrderType.REMOVE;
 
-        loadStructure(workOrder.getStructurePack(), workOrder.getStructurePath(), tempRotation, pos, workOrder.isMirrored(), removal);
+        loadStructure(workOrder, tempRotation, pos, workOrder.isMirrored(), removal);
         workOrder.setCleared(false);
         workOrder.setRequested(removal);
     }

--- a/src/main/java/com/minecolonies/coremod/entity/ai/citizen/builder/ConstructionTapeHelper.java
+++ b/src/main/java/com/minecolonies/coremod/entity/ai/citizen/builder/ConstructionTapeHelper.java
@@ -41,7 +41,7 @@ public final class ConstructionTapeHelper
      */
     public static void placeConstructionTape(@NotNull final IWorkOrder workOrder, @NotNull final Level world)
     {
-        ServerFutureProcessor.queueBlueprint(new ServerFutureProcessor.BlueprintProcessingData(StructurePacks.getBlueprintFuture(workOrder.getStructurePack(), workOrder.getStructurePath()), world, (blueprint -> {
+        ServerFutureProcessor.queueBlueprint(new ServerFutureProcessor.BlueprintProcessingData(workOrder.getBlueprintFuture(), world, (blueprint -> {
             final Tuple<BlockPos, BlockPos> corners = ColonyUtils.calculateCorners(workOrder.getLocation(), world, blueprint, workOrder.getRotation(), workOrder.isMirrored());
             placeConstructionTape(corners, world);
         })));
@@ -163,7 +163,7 @@ public final class ConstructionTapeHelper
      */
     public static void removeConstructionTape(@NotNull final IWorkOrder workOrder, @NotNull final Level world)
     {
-        ServerFutureProcessor.queueBlueprint(new ServerFutureProcessor.BlueprintProcessingData(StructurePacks.getBlueprintFuture(workOrder.getStructurePack(), workOrder.getStructurePath()), world, (blueprint -> {
+        ServerFutureProcessor.queueBlueprint(new ServerFutureProcessor.BlueprintProcessingData(workOrder.getBlueprintFuture(), world, (blueprint -> {
             final Tuple<BlockPos, BlockPos> corners = ColonyUtils.calculateCorners(workOrder.getLocation(), world, blueprint, workOrder.getRotation(), workOrder.isMirrored());
             removeConstructionTape(corners, world);
         })));

--- a/src/main/java/com/minecolonies/coremod/entity/ai/citizen/miner/EntityAIQuarrier.java
+++ b/src/main/java/com/minecolonies/coremod/entity/ai/citizen/miner/EntityAIQuarrier.java
@@ -5,11 +5,11 @@ import com.ldtteam.structurize.placement.BlockPlacementResult;
 import com.ldtteam.structurize.placement.StructurePhasePlacementResult;
 import com.ldtteam.structurize.placement.StructurePlacer;
 import com.ldtteam.structurize.storage.ServerFutureProcessor;
-import com.ldtteam.structurize.storage.StructurePacks;
 import com.ldtteam.structurize.util.PlacementSettings;
 import com.minecolonies.api.colony.IColonyManager;
 import com.minecolonies.api.colony.buildings.IBuilding;
 import com.minecolonies.api.colony.interactionhandling.ChatPriority;
+import com.minecolonies.api.colony.workorders.IWorkOrder;
 import com.minecolonies.api.entity.ai.citizen.builder.IBuilderUndestroyable;
 import com.minecolonies.api.entity.ai.statemachine.AITarget;
 import com.minecolonies.api.entity.ai.statemachine.states.IAIState;
@@ -202,21 +202,20 @@ public class EntityAIQuarrier extends AbstractEntityAIStructureWithWorkOrder<Job
 
     @Override
     public void loadStructure(
-      @NotNull final String packName,
-      final String blueprintPath,
-      final int rotateTimes,
-      final BlockPos position,
-      final boolean isMirrored,
-      final boolean removal)
+            @NotNull final IWorkOrder workOrder,
+            final int rotateTimes,
+            final BlockPos position,
+            final boolean isMirrored,
+            final boolean removal)
     {
-        final Future<Blueprint> blueprintFuture = StructurePacks.getBlueprintFuture(packName, blueprintPath);
+        final Future<Blueprint> blueprintFuture = workOrder.getBlueprintFuture();
         this.loadingBlueprint = true;
 
         ServerFutureProcessor.queueBlueprint(new ServerFutureProcessor.BlueprintProcessingData(blueprintFuture, world, (blueprint -> {
             if (blueprint == null)
             {
                 handleSpecificCancelActions();
-                Log.getLogger().warn("Couldn't find structure with name: " + blueprintPath + " in: " + packName + ". Aborting loading procedure");
+                Log.getLogger().warn("Couldn't find structure with name: " + workOrder.getStructurePath() + " in: " + workOrder.getStructurePack() + ". Aborting loading procedure");
                 this.loadingBlueprint = false;
                 return;
             }
@@ -232,7 +231,7 @@ public class EntityAIQuarrier extends AbstractEntityAIStructureWithWorkOrder<Job
             if (!structure.hasBluePrint())
             {
                 handleSpecificCancelActions();
-                Log.getLogger().warn("Couldn't find structure with name: " + blueprintPath + " aborting loading procedure");
+                Log.getLogger().warn("Couldn't find structure with name: " + workOrder.getStructurePath() + " aborting loading procedure");
                 this.loadingBlueprint = false;
                 return;
             }


### PR DESCRIPTION
Closes [github report](https://github.com/ldtteam/minecolonies/issues/9375#issuecomment-1823866001) (distinct from original issue)

# Changes proposed in this pull request:
- Avoids miner AI directly loading blueprints when Structurize is possibly not finished loading (which can block startup).

[x] Yes I tested this before submitting it.
[ ] I also did a multiplayer test.

Review please (could port)
