### PR TITLE
Fix nullpointer in getting best tools

### DIFF
--- a/src/main/java/com/minecolonies/coremod/util/WorkerUtil.java
+++ b/src/main/java/com/minecolonies/coremod/util/WorkerUtil.java
@@ -178,7 +178,8 @@ public final class WorkerUtil
      */
     public static IToolType getBestToolForBlock(final BlockState state, float blockHardness, final AbstractBuilding building)
     {
-        if (state.getBlock() instanceof IForgeShearable && building.hasModule(SettingsModule.class) && building.getFirstModuleOccurance(SettingsModule.class).getSetting(USE_SHEARS).getValue())
+        if (state.getBlock() instanceof IForgeShearable && building.hasModule(SettingsModule.class)
+              && building.getFirstModuleOccurance(SettingsModule.class).getOptionalSetting(USE_SHEARS).orElse(new BoolSetting(true)).getValue())
         {
             return ToolType.SHEARS;
         }


### PR DESCRIPTION
Closes #9619
Closes several discord reports

# Changes proposed in this pull request:
- USE_SHEARS traditionally had been an optional setting since not all buildings implement this setting, but it may always appear randomly in the best tool check, for this reason it cannot be "mandatory", which causes nullpointers in several different workers.


[ ] Yes I tested this before submitting it.
[ ] I also did a multiplayer test.

Review please
