### PR TITLE
Fix plantation field assignment

### DIFF
--- a/src/main/java/com/minecolonies/coremod/network/messages/server/colony/building/fields/AssignFieldMessage.java
+++ b/src/main/java/com/minecolonies/coremod/network/messages/server/colony/building/fields/AssignFieldMessage.java
@@ -60,17 +60,17 @@ public class AssignFieldMessage extends AbstractBuildingServerMessage<IBuilding>
     {
         fieldData.resetReaderIndex();
         buf.writeBoolean(assign);
-        buf.writeBytes(fieldData);
         buf.writeInt(moduleID);
+        buf.writeBytes(fieldData);
     }
 
     @Override
     public void fromBytesOverride(@NotNull final FriendlyByteBuf buf)
     {
         assign = buf.readBoolean();
+        moduleID = buf.readInt();
         fieldData = new FriendlyByteBuf(Unpooled.buffer(buf.readableBytes()));
         buf.readBytes(fieldData, buf.readableBytes());
-        moduleID = buf.readInt();
     }
 
     @Override


### PR DESCRIPTION
# Changes proposed in this pull request:
- Module rework caused a moduleID to be passed in the message, but that was put after a "remainder read", causing the buffer to be empty prior to reading the moduleID, which caused an exception.


[X] Yes I tested this before submitting it.
[ ] I also did a multiplayer test.

Review please
