### PR TITLE
Fix 9645 - Builders now use empty hand for mining when posible

### DIFF
--- a/src/main/java/com/minecolonies/coremod/entity/ai/basic/AbstractEntityAIBasic.java
+++ b/src/main/java/com/minecolonies/coremod/entity/ai/basic/AbstractEntityAIBasic.java
@@ -1271,7 +1271,7 @@ public abstract class AbstractEntityAIBasic<J extends AbstractJob<?, J>, B exten
 
         if (toolType == ToolType.NONE)
         {
-            final int heldSlot = worker.getInventoryCitizen().getHeldItemSlot(InteractionHand.MAIN_HAND);
+            final int heldSlot = InventoryUtils.getFirstOpenSlotFromItemHandler(worker.getInventoryCitizen());
             return heldSlot >= 0 ? heldSlot : 0;
         }
 


### PR DESCRIPTION
Closes #9645 
Closes #
Closes #

# Changes proposed in this pull request:
-Fixed a bug where citizens would use tools for breaking things like grass which can be broken bare-handed.
-
-


[x] Yes I tested this before submitting it.
[] I also did a multiplayer test.

Review please
