### PR TITLE
Copy github templates from old main branch

### DIFF
--- a/.github/ISSUE_TEMPLATE/10-bug-report.yaml
+++ b/.github/ISSUE_TEMPLATE/10-bug-report.yaml
@@ -34,7 +34,7 @@ body:
     attributes:
       label: Minecraft Version
       description: Minecraft Version
-      options: [1.16, 1.18]
+      options: [1.19.2, 1.20.1]
     validations:
       required: true
   - type: input

--- a/.github/ISSUE_TEMPLATE/11-log-report.yaml
+++ b/.github/ISSUE_TEMPLATE/11-log-report.yaml
@@ -28,7 +28,7 @@ body:
     attributes:
       label: Minecraft Version
       description: Minecraft Version
-      options: [1.16, 1.18]
+      options: [1.19.2, 1.20.1]
     validations:
       required: true
   - type: input


### PR DESCRIPTION
# Changes proposed in this pull request:
- Fixes github templates after changing main branch.

[ ] Yes I tested this before submitting it.
[ ] I also did a multiplayer test.

Review please (do not port)

FYI there are also some TeamCity script patch files that are only present on the old branch and not the new one.  I didn't bring those across because I'm less sure what they do or if they're needed.  Someone should probably check those too.