### PR TITLE
Switch free-form style in message utils to priority presets

### DIFF
--- a/src/main/java/com/minecolonies/coremod/client/gui/citizen/RequestWindowCitizen.java
+++ b/src/main/java/com/minecolonies/coremod/client/gui/citizen/RequestWindowCitizen.java
@@ -9,6 +9,7 @@ import com.minecolonies.api.colony.requestsystem.requestable.IDeliverable;
 import com.minecolonies.api.colony.requestsystem.token.IToken;
 import com.minecolonies.api.util.InventoryUtils;
 import com.minecolonies.api.util.MessageUtils;
+import com.minecolonies.api.util.MessageUtils.MessagePriority;
 import com.minecolonies.api.util.constant.Constants;
 import com.minecolonies.coremod.Network;
 import com.minecolonies.coremod.network.messages.server.colony.UpdateRequestStateMessage;
@@ -16,7 +17,6 @@ import com.minecolonies.coremod.network.messages.server.colony.citizen.TransferI
 import net.minecraft.client.Minecraft;
 import net.minecraft.world.entity.player.Inventory;
 import net.minecraft.world.item.ItemStack;
-import net.minecraft.ChatFormatting;
 import net.minecraftforge.items.wrapper.InvWrapper;
 import org.jetbrains.annotations.NotNull;
 
@@ -150,8 +150,8 @@ public class RequestWindowCitizen extends AbstractWindowCitizen
             if (slot == -1)
             {
                 MessageUtils.format("<%s> ")
-                  .with(ChatFormatting.BOLD, ChatFormatting.WHITE)
                   .append(COM_MINECOLONIES_CANT_TAKE_EQUIPPED, citizen.getName())
+                  .withPriority(MessagePriority.IMPORTANT)
                   .sendTo(Minecraft.getInstance().player);
 
                 return; // We don't have one that isn't in our armour slot

--- a/src/main/java/com/minecolonies/coremod/client/gui/townhall/WindowAlliancePage.java
+++ b/src/main/java/com/minecolonies/coremod/client/gui/townhall/WindowAlliancePage.java
@@ -7,19 +7,18 @@ import com.ldtteam.blockui.views.ScrollingList;
 import com.minecolonies.api.colony.CompactColonyReference;
 import com.minecolonies.api.util.BlockPosUtil;
 import com.minecolonies.api.util.MessageUtils;
+import com.minecolonies.api.util.MessageUtils.MessagePriority;
 import com.minecolonies.coremod.MineColonies;
 import com.minecolonies.coremod.Network;
 import com.minecolonies.coremod.colony.buildings.workerbuildings.BuildingTownHall;
 import com.minecolonies.coremod.commands.ClickEventWithExecutable;
 import com.minecolonies.coremod.network.messages.server.colony.TeleportToColonyMessage;
-import net.minecraft.ChatFormatting;
 import net.minecraft.client.Minecraft;
-import net.minecraft.network.chat.ClickEvent;
 import net.minecraft.network.chat.Component;
-import net.minecraft.network.chat.Style;
 import org.jetbrains.annotations.NotNull;
 
-import static com.minecolonies.api.util.constant.TranslationConstants.*;
+import static com.minecolonies.api.util.constant.TranslationConstants.DO_REALLY_WANNA_TP;
+import static com.minecolonies.api.util.constant.TranslationConstants.TH_TOO_LOW;
 import static com.minecolonies.api.util.constant.WindowConstants.*;
 
 /**
@@ -63,10 +62,8 @@ public class WindowAlliancePage extends AbstractWindowTownHall
         final CompactColonyReference ally = building.getColony().getAllies().get(row);
 
         MessageUtils.format(DO_REALLY_WANNA_TP, ally.name)
-          .with(Style.EMPTY.withClickEvent(new ClickEventWithExecutable(ClickEvent.Action.RUN_COMMAND,
-            "",
-            () -> Network.getNetwork().sendToServer(new TeleportToColonyMessage(ally.dimension, ally.id)))))
-          .with(ChatFormatting.BOLD, ChatFormatting.GOLD)
+          .withPriority(MessagePriority.IMPORTANT)
+          .withClickEvent(new ClickEventWithExecutable(() -> Network.getNetwork().sendToServer(new TeleportToColonyMessage(ally.dimension, ally.id))))
           .sendTo(Minecraft.getInstance().player);
         this.close();
     }

--- a/src/main/java/com/minecolonies/coremod/client/gui/townhall/WindowInfoPage.java
+++ b/src/main/java/com/minecolonies/coremod/client/gui/townhall/WindowInfoPage.java
@@ -99,7 +99,7 @@ public class WindowInfoPage extends AbstractWindowTownHall
                 else if (event instanceof IBuildingEventDescription)
                 {
                     IBuildingEventDescription buildEvent = (IBuildingEventDescription) event;
-                    nameLabel.setText(MessageUtils.format(buildEvent.getBuildingName()).append(" " + buildEvent.getLevel()).create());
+                    nameLabel.setText(MessageUtils.format(buildEvent.getBuildingName()).append(Component.literal(" " + buildEvent.getLevel())).create());
                 }
                 rowPane.findPaneOfTypeByID(POS_LABEL, Text.class)
                   .setText(Component.literal(event.getEventPos().getX() + " " + event.getEventPos().getY() + " " + event.getEventPos().getZ()));

--- a/src/main/java/com/minecolonies/coremod/colony/colonyEvents/raidEvents/AbstractShipRaidEvent.java
+++ b/src/main/java/com/minecolonies/coremod/colony/colonyEvents/raidEvents/AbstractShipRaidEvent.java
@@ -12,12 +12,12 @@ import com.minecolonies.api.entity.mobs.RaiderMobUtils;
 import com.minecolonies.api.entity.pathfinding.PathResult;
 import com.minecolonies.api.util.BlockPosUtil;
 import com.minecolonies.api.util.MessageUtils;
+import com.minecolonies.api.util.MessageUtils.MessagePriority;
 import com.minecolonies.api.util.Tuple;
 import com.minecolonies.api.util.WorldUtil;
 import com.minecolonies.coremod.MineColonies;
 import com.minecolonies.coremod.colony.colonyEvents.raidEvents.pirateEvent.ShipBasedRaiderUtils;
 import com.minecolonies.coremod.colony.colonyEvents.raidEvents.pirateEvent.ShipSize;
-import net.minecraft.ChatFormatting;
 import net.minecraft.core.BlockPos;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.nbt.ListTag;
@@ -202,9 +202,8 @@ public abstract class AbstractShipRaidEvent implements IColonyRaidEvent, IColony
 
             updateRaidBar();
 
-            MessageUtils.format(RAID_EVENT_MESSAGE_PIRATE + shipSize.messageID,
-                BlockPosUtil.calcDirection(colony.getCenter(), spawnPoint), colony.getName())
-              .with(ChatFormatting.DARK_RED)
+            MessageUtils.format(RAID_EVENT_MESSAGE_PIRATE + shipSize.messageID, BlockPosUtil.calcDirection(colony.getCenter(), spawnPoint), colony.getName())
+              .withPriority(MessagePriority.DANGER)
               .sendTo(colony).forManagers();
             colony.markDirty();
         })));

--- a/src/main/java/com/minecolonies/coremod/colony/colonyEvents/raidEvents/HordeRaidEvent.java
+++ b/src/main/java/com/minecolonies/coremod/colony/colonyEvents/raidEvents/HordeRaidEvent.java
@@ -13,11 +13,11 @@ import com.minecolonies.api.entity.mobs.RaiderMobUtils;
 import com.minecolonies.api.entity.pathfinding.PathResult;
 import com.minecolonies.api.sounds.RaidSounds;
 import com.minecolonies.api.util.*;
+import com.minecolonies.api.util.MessageUtils.MessagePriority;
 import com.minecolonies.api.util.constant.NbtTagConstants;
 import com.minecolonies.coremod.colony.colonyEvents.raidEvents.barbarianEvent.Horde;
 import com.minecolonies.coremod.colony.colonyEvents.raidEvents.pirateEvent.ShipBasedRaiderUtils;
 import com.minecolonies.coremod.network.messages.client.PlayAudioMessage;
-import net.minecraft.ChatFormatting;
 import net.minecraft.core.BlockPos;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.nbt.ListTag;
@@ -379,9 +379,10 @@ public abstract class HordeRaidEvent implements IColonyRaidEvent, IColonyCampFir
 
         updateRaidBar();
 
-        MessageUtils.format(RAID_EVENT_MESSAGE + horde.getMessageID(),
-                        BlockPosUtil.calcDirection(colony.getCenter(), spawnPoint), colony.getName())
-                .with(ChatFormatting.DARK_RED).sendTo(colony).forManagers();
+        MessageUtils.format(RAID_EVENT_MESSAGE + horde.getMessageID(), BlockPosUtil.calcDirection(colony.getCenter(), spawnPoint), colony.getName())
+          .withPriority(MessagePriority.DANGER)
+          .sendTo(colony)
+          .forManagers();
         Log.getLogger().debug("Raiders coming from: " + spawnPoint.toShortString() + " towards colony: " + colony.getName());
 
         PlayAudioMessage audio = new PlayAudioMessage(horde.initialSize <= SMALL_HORDE_SIZE ? RaidSounds.WARNING_EARLY : RaidSounds.WARNING, SoundSource.RECORDS);

--- a/src/main/java/com/minecolonies/coremod/colony/managers/ProgressManager.java
+++ b/src/main/java/com/minecolonies/coremod/colony/managers/ProgressManager.java
@@ -7,17 +7,16 @@ import com.minecolonies.api.colony.managers.interfaces.IProgressManager;
 import com.minecolonies.api.colony.workorders.IWorkOrder;
 import com.minecolonies.api.colony.workorders.WorkOrderType;
 import com.minecolonies.api.util.MessageUtils;
+import com.minecolonies.api.util.MessageUtils.MessagePriority;
 import com.minecolonies.api.util.NBTUtils;
 import com.minecolonies.coremod.colony.Colony;
 import com.minecolonies.coremod.colony.buildings.modules.BuildingModules;
 import com.minecolonies.coremod.colony.buildings.modules.LivingBuildingModule;
-import com.minecolonies.coremod.colony.buildings.modules.TavernBuildingModule;
 import com.minecolonies.coremod.colony.buildings.workerbuildings.*;
-import net.minecraft.nbt.Tag;
-import net.minecraft.world.level.block.Block;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.nbt.ListTag;
-
+import net.minecraft.nbt.Tag;
+import net.minecraft.world.level.block.Block;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.ArrayList;
@@ -193,7 +192,10 @@ public class ProgressManager implements IProgressManager
         if (!notifiedProgress.contains(type))
         {
             notifiedProgress.add(type);
-            MessageUtils.format(PARTIAL_PROGRESSION_NAME + type.name().toLowerCase(Locale.US)).sendTo(colony).forAllPlayers();
+            MessageUtils.format(PARTIAL_PROGRESSION_NAME + type.name().toLowerCase(Locale.US))
+              .withPriority(MessagePriority.IMPORTANT)
+              .sendTo(colony)
+              .forAllPlayers();
             colony.markDirty();
         }
     }

--- a/src/main/java/com/minecolonies/coremod/colony/managers/ReproductionManager.java
+++ b/src/main/java/com/minecolonies/coremod/colony/managers/ReproductionManager.java
@@ -10,11 +10,11 @@ import com.minecolonies.api.colony.buildings.IBuilding;
 import com.minecolonies.api.colony.managers.interfaces.IReproductionManager;
 import com.minecolonies.api.util.BlockPosUtil;
 import com.minecolonies.api.util.MessageUtils;
+import com.minecolonies.api.util.MessageUtils.MessagePriority;
 import com.minecolonies.coremod.colony.Colony;
 import com.minecolonies.coremod.colony.buildings.modules.LivingBuildingModule;
 import com.minecolonies.coremod.colony.colonyEvents.citizenEvents.CitizenBornEvent;
 import com.minecolonies.coremod.util.AdvancementUtils;
-import net.minecraft.ChatFormatting;
 import net.minecraft.core.BlockPos;
 import org.jetbrains.annotations.NotNull;
 
@@ -197,7 +197,10 @@ public class ReproductionManager implements IReproductionManager
             final int populationCount = colony.getCitizenManager().getCurrentCitizenCount();
             AdvancementUtils.TriggerAdvancementPlayersForColony(colony, playerMP -> AdvancementTriggers.COLONY_POPULATION.trigger(playerMP, populationCount));
 
-            MessageUtils.format(MESSAGE_NEW_CHILD_BORN, newCitizen.getName(), colony.getName()).with(ChatFormatting.GOLD).sendTo(colony).forManagers();
+            MessageUtils.format(MESSAGE_NEW_CHILD_BORN, newCitizen.getName(), colony.getName())
+              .withPriority(MessagePriority.IMPORTANT)
+              .sendTo(colony)
+              .forManagers();
             colony.getCitizenManager().spawnOrCreateCitizen(newCitizen, colony.getWorld(), newHome.getPosition());
 
             colony.getEventDescriptionManager().addEventDescription(new CitizenBornEvent(newHome.getPosition(), newCitizen.getName()));

--- a/src/main/java/com/minecolonies/coremod/commands/ClickEventWithExecutable.java
+++ b/src/main/java/com/minecolonies/coremod/commands/ClickEventWithExecutable.java
@@ -3,8 +3,6 @@ package com.minecolonies.coremod.commands;
 import net.minecraft.network.chat.ClickEvent;
 import org.jetbrains.annotations.NotNull;
 
-import net.minecraft.network.chat.ClickEvent.Action;
-
 /**
  * Small utility class to run an executable on a chat click event.
  */
@@ -15,9 +13,14 @@ public class ClickEventWithExecutable extends ClickEvent
      */
     private Runnable[] actions;
 
-    public ClickEventWithExecutable(final ClickEvent.Action action, final String actionString, @NotNull final Runnable... actions)
+    /**
+     * Default constructor.
+     *
+     * @param actions the actions this event should execute.
+     */
+    public ClickEventWithExecutable(@NotNull final Runnable... actions)
     {
-        super(action, actionString);
+        super(ClickEvent.Action.RUN_COMMAND, "");
         this.actions = actions;
     }
 
@@ -25,6 +28,7 @@ public class ClickEventWithExecutable extends ClickEvent
      * Triggered when the chat component is clicked.
      */
     @Override
+    @NotNull
     public Action getAction()
     {
         if (actions != null)

--- a/src/main/java/com/minecolonies/coremod/entity/citizen/EntityCitizen.java
+++ b/src/main/java/com/minecolonies/coremod/entity/citizen/EntityCitizen.java
@@ -35,6 +35,7 @@ import com.minecolonies.api.inventory.container.ContainerCitizenInventory;
 import com.minecolonies.api.items.ModItems;
 import com.minecolonies.api.sounds.EventType;
 import com.minecolonies.api.util.*;
+import com.minecolonies.api.util.MessageUtils.MessagePriority;
 import com.minecolonies.api.util.constant.HappinessConstants;
 import com.minecolonies.api.util.constant.TypeConstants;
 import com.minecolonies.coremod.MineColonies;
@@ -64,7 +65,6 @@ import com.minecolonies.coremod.network.messages.client.colony.ColonyViewCitizen
 import com.minecolonies.coremod.network.messages.client.colony.PlaySoundForCitizenMessage;
 import com.minecolonies.coremod.network.messages.server.colony.OpenInventoryMessage;
 import com.minecolonies.coremod.util.TeleportHelper;
-import net.minecraft.ChatFormatting;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
 import net.minecraft.core.particles.ParticleTypes;
@@ -461,7 +461,7 @@ public class EntityCitizen extends AbstractEntityCitizen implements IThreatTable
             {
                 playSound(SoundEvents.VILLAGER_NO, 0.5f, (float) SoundUtils.getRandomPitch(getRandom()));
                 MessageUtils.format(WARNING_INTERACTION_CANT_DO_NOW, this.getCitizenData().getName())
-                  .with(ChatFormatting.RED)
+                  .withPriority(MessagePriority.DANGER)
                   .sendTo(player);
             }
             return null;
@@ -607,7 +607,7 @@ public class EntityCitizen extends AbstractEntityCitizen implements IThreatTable
             {
                 playSound(SoundEvents.VILLAGER_NO, 1.0f, (float) SoundUtils.getRandomPitch(getRandom()));
                 MessageUtils.format(MESSAGE_INTERACTION_COOKIE, this.getCitizenData().getName())
-                  .with(ChatFormatting.RED)
+                  .withPriority(MessagePriority.DANGER)
                   .sendTo(player);
             }
         }

--- a/src/main/java/com/minecolonies/coremod/entity/citizen/VisitorCitizen.java
+++ b/src/main/java/com/minecolonies/coremod/entity/citizen/VisitorCitizen.java
@@ -12,6 +12,7 @@ import com.minecolonies.api.entity.citizen.citizenhandlers.*;
 import com.minecolonies.api.inventory.InventoryCitizen;
 import com.minecolonies.api.inventory.container.ContainerCitizenInventory;
 import com.minecolonies.api.util.*;
+import com.minecolonies.api.util.MessageUtils.MessagePriority;
 import com.minecolonies.api.util.constant.TypeConstants;
 import com.minecolonies.coremod.MineColonies;
 import com.minecolonies.coremod.Network;
@@ -34,14 +35,16 @@ import net.minecraft.sounds.SoundEvents;
 import net.minecraft.world.InteractionHand;
 import net.minecraft.world.InteractionResult;
 import net.minecraft.world.damagesource.DamageSource;
-import net.minecraft.world.entity.*;
+import net.minecraft.world.entity.Entity;
+import net.minecraft.world.entity.EntityType;
+import net.minecraft.world.entity.LivingEntity;
+import net.minecraft.world.entity.PathfinderMob;
 import net.minecraft.world.entity.ai.goal.FloatGoal;
 import net.minecraft.world.entity.ai.goal.InteractGoal;
 import net.minecraft.world.entity.ai.goal.OpenDoorGoal;
 import net.minecraft.world.entity.player.Inventory;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.inventory.AbstractContainerMenu;
-import net.minecraft.world.item.BowlFoodItem;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.NameTagItem;
 import net.minecraft.world.level.Level;
@@ -678,7 +681,10 @@ VisitorCitizen extends AbstractEntityCitizen
 
                 final String deathLocation = BlockPosUtil.getString(blockPosition());
 
-                MessageUtils.format(MESSAGE_INFO_COLONY_VISITOR_DIED, getCitizenData().getName(), cause.getMsgId(), deathLocation).sendTo(colony).forManagers();
+                MessageUtils.format(MESSAGE_INFO_COLONY_VISITOR_DIED, getCitizenData().getName(), cause.getMsgId(), deathLocation)
+                  .withPriority(MessagePriority.DANGER)
+                  .sendTo(colony)
+                  .forManagers();
             }
         }
     }

--- a/src/main/java/com/minecolonies/coremod/entity/citizen/citizenhandlers/CitizenChatHandler.java
+++ b/src/main/java/com/minecolonies/coremod/entity/citizen/citizenhandlers/CitizenChatHandler.java
@@ -4,8 +4,8 @@ import com.minecolonies.api.colony.jobs.IJob;
 import com.minecolonies.api.entity.citizen.AbstractEntityCitizen;
 import com.minecolonies.api.entity.citizen.citizenhandlers.ICitizenChatHandler;
 import com.minecolonies.api.util.MessageUtils;
+import com.minecolonies.api.util.MessageUtils.MessagePriority;
 import com.minecolonies.api.util.constant.TranslationConstants;
-import net.minecraft.ChatFormatting;
 import net.minecraft.network.chat.Component;
 import net.minecraft.world.damagesource.DamageSource;
 
@@ -39,14 +39,10 @@ public class CitizenChatHandler implements ICitizenChatHandler
     {
         if (citizen.getCitizenColonyHandler().getColony() != null && citizen.getCitizenData() != null)
         {
-            MessageUtils.format("")
-              .with(ChatFormatting.RED)
-              .append(citizen.getCombatTracker().getDeathMessage())
+            MessageUtils.format(citizen.getCombatTracker().getDeathMessage())
               .append(Component.literal("! "))
-              .append(Component.translatable(TranslationConstants.COLONIST_GRAVE_LOCATION,
-                Math.round(citizen.getX()),
-                Math.round(citizen.getY()),
-                Math.round(citizen.getZ())))
+              .append(Component.translatable(TranslationConstants.COLONIST_GRAVE_LOCATION, Math.round(citizen.getX()), Math.round(citizen.getY()), Math.round(citizen.getZ())))
+              .withPriority(MessagePriority.DANGER)
               .sendTo(citizen.getCitizenColonyHandler().getColony()).forManagers();
         }
     }

--- a/src/main/java/com/minecolonies/coremod/network/messages/client/CreateColonyMessage.java
+++ b/src/main/java/com/minecolonies/coremod/network/messages/client/CreateColonyMessage.java
@@ -8,8 +8,8 @@ import com.minecolonies.api.network.IMessage;
 import com.minecolonies.api.tileentities.TileEntityColonyBuilding;
 import com.minecolonies.api.util.BlockPosUtil;
 import com.minecolonies.api.util.MessageUtils;
+import com.minecolonies.api.util.MessageUtils.MessagePriority;
 import com.minecolonies.coremod.MineColonies;
-import net.minecraft.ChatFormatting;
 import net.minecraft.core.BlockPos;
 import net.minecraft.network.FriendlyByteBuf;
 import net.minecraft.server.level.ServerLevel;
@@ -115,7 +115,9 @@ public class CreateColonyMessage implements IMessage
 
         if (!(tileEntity instanceof TileEntityColonyBuilding))
         {
-            MessageUtils.format(WARNING_TOWN_HALL_NO_TILE_ENTITY).with(ChatFormatting.BOLD, ChatFormatting.DARK_RED).sendTo(sender);
+            MessageUtils.format(WARNING_TOWN_HALL_NO_TILE_ENTITY)
+              .withPriority(MessagePriority.DANGER)
+              .sendTo(sender);
             return;
         }
 
@@ -170,7 +172,9 @@ public class CreateColonyMessage implements IMessage
         {
             final IColony createdColony = IColonyManager.getInstance().createColony(world, townHall, sender, colonyName, pack);
             createdColony.getBuildingManager().addNewBuilding((TileEntityColonyBuilding) tileEntity, world);
-            MessageUtils.format(MESSAGE_COLONY_FOUNDED).with(ChatFormatting.GOLD).sendTo(sender);
+            MessageUtils.format(MESSAGE_COLONY_FOUNDED)
+              .withPriority(MessagePriority.IMPORTANT)
+              .sendTo(sender);
 
             if (isLogicalServer)
             {
@@ -181,6 +185,8 @@ public class CreateColonyMessage implements IMessage
 
         ownedColony.getPackageManager().sendColonyViewPackets();
         ownedColony.getPackageManager().sendPermissionsPackets();
-        MessageUtils.format(WARNING_COLONY_FOUNDING_FAILED).with(ChatFormatting.BOLD, ChatFormatting.DARK_RED).sendTo(sender);
+        MessageUtils.format(WARNING_COLONY_FOUNDING_FAILED)
+          .withPriority(MessagePriority.DANGER)
+          .sendTo(sender);
     }
 }


### PR DESCRIPTION
# Changes proposed in this pull request:
- MessageUtils.with(style) has been removed, no longer allowing completely free customization of chat messages
- MessageUtils has a new priority enum that allows for rendering messages in 1 of 3 predetermined styles, to improve message consistency
- Normal messages have been changed to display in gray, to improve readability next to regular chat in multiplayer
- All usages have been updated

Note: There should be no changes to messages just yet (short of the default to gray), I am planning that for the future.

![Example](https://cdn.discordapp.com/attachments/956880930608410704/1190388472003964978/2023-12-29_21_18_30-Minecraft_Forge__1.20.1_-_Singleplayer.png?ex=65a19ea8&is=658f29a8&hm=fc71a5f5d5b57fdbd0eb2f457d54f01ee1f72b3d16f090bd2b55cc128ff84d20&)


[X] Yes I tested this before submitting it.
[ ] I also did a multiplayer test.

Review please