### PR TITLE
Fix some textual issues

### DIFF
--- a/src/datagen/generated/minecolonies/assets/minecolonies/lang/default.json
+++ b/src/datagen/generated/minecolonies/assets/minecolonies/lang/default.json
@@ -248,7 +248,7 @@
   "com.minecolonies.research.effects.plantationexotic.description": "Plantations Unlock Fields For: Glowberries",
   "com.minecolonies.research.effects.plantationjungle.description": "Plantations Unlock Fields For: Bamboo, Cocoa and Vines",
   "com.minecolonies.research.effects.plantationlarge.description": "Plantations Unlock 1 Additional Field",
-  "com.minecolonies.research.effects.plantationnether.description": "Plantations Unlock Fields For: Crimson fungi and Warped fungi",
+  "com.minecolonies.research.effects.plantationnether.description": "Plantations Unlock Fields For: Crimson/Warped fungi, roots and vines",
   "com.minecolonies.research.effects.plantationsea.description": "Plantations Unlock Fields For: Kelp, Seagrass and Sea pickles",
   "com.minecolonies.research.effects.platearmorunlock.description": "Blacksmith Learns Plate Armor Recipes",
   "com.minecolonies.research.effects.podzolchancemultiplier.description": "Composters Get +%3$s%% More Podzol",

--- a/src/main/java/com/minecolonies/coremod/generation/defaults/DefaultResearchProvider.java
+++ b/src/main/java/com/minecolonies/coremod/generation/defaults/DefaultResearchProvider.java
@@ -8,12 +8,9 @@ import com.minecolonies.api.research.AbstractResearchProvider;
 import com.minecolonies.api.research.ResearchBranchType;
 import com.minecolonies.api.util.constant.CitizenConstants;
 import com.minecolonies.api.util.constant.Constants;
-import net.minecraft.data.DataGenerator;
 import net.minecraft.data.PackOutput;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.tags.ItemTags;
-import net.minecraft.world.item.Items;
-import net.minecraft.world.item.crafting.Ingredient;
 import net.minecraft.world.item.Items;
 import org.jetbrains.annotations.NotNull;
 
@@ -123,7 +120,7 @@ public class DefaultResearchProvider extends AbstractResearchProvider
         effects.add(new ResearchEffect(PLANTATION_JUNGLE).setTranslatedName("Plantations Unlock Fields For: Bamboo, Cocoa and Vines"));
         effects.add(new ResearchEffect(PLANTATION_SEA).setTranslatedName("Plantations Unlock Fields For: Kelp, Seagrass and Sea pickles"));
         effects.add(new ResearchEffect(PLANTATION_EXOTIC).setTranslatedName("Plantations Unlock Fields For: Glowberries"));
-        effects.add(new ResearchEffect(PLANTATION_NETHER).setTranslatedName("Plantations Unlock Fields For: Crimson fungi and Warped fungi"));
+        effects.add(new ResearchEffect(PLANTATION_NETHER).setTranslatedName("Plantations Unlock Fields For: Crimson/Warped fungi, roots and vines"));
         effects.add(new ResearchEffect(BEEKEEP_2).setTranslatedName("Beekeepers Can Harvest Both Honey Bottles and Combs at Once"));
         effects.add(new ResearchEffect(RAILS).setTranslatedName("Citizens use Rails"));
         effects.add(new ResearchEffect(VINES).setTranslatedName("Citizens can climb Vines"));


### PR DESCRIPTION
Closes #9664
Closes #9340

# Changes proposed in this pull request:
- Fixes plantation field research for nether fields to include all unlocked fields
- Fixes item tooltips with multiple recipes in the same building to only list the lowest possible minimum building level (and not all of them)


[X] Yes I tested this before submitting it.
[ ] I also did a multiplayer test.

Review please
