### PR TITLE
make mangrove roots compostable

### DIFF
--- a/src/datagen/generated/minecolonies/data/minecolonies/tags/items/compostables.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/tags/items/compostables.json
@@ -26,6 +26,7 @@
     "minecraft:fermented_spider_eye",
     "minecraft:nether_wart_block",
     "minecraft:warped_wart_block",
+    "minecraft:mangrove_roots",
     "#forge:crops",
     "#forge:eggs",
     "#minecraft:flowers",

--- a/src/main/java/com/minecolonies/coremod/generation/defaults/DefaultItemTagsProvider.java
+++ b/src/main/java/com/minecolonies/coremod/generation/defaults/DefaultItemTagsProvider.java
@@ -53,7 +53,7 @@ public class DefaultItemTagsProvider extends ItemTagsProvider
           .add(Items.COCOA_BEANS, Items.LILY_PAD, Items.SEA_PICKLE)
           .add(Items.BROWN_MUSHROOM_BLOCK, Items.RED_MUSHROOM_BLOCK, Items.MUSHROOM_STEM)
           .add(Items.CAKE, Items.RABBIT_FOOT, Items.FERMENTED_SPIDER_EYE)
-          .add(Items.NETHER_WART_BLOCK, Items.WARPED_WART_BLOCK)
+          .add(Items.NETHER_WART_BLOCK, Items.WARPED_WART_BLOCK, Items.MANGROVE_ROOTS)
           .addTags(Tags.Items.CROPS, Tags.Items.EGGS, ItemTags.FLOWERS, ItemTags.FISHES, ItemTags.LEAVES, ItemTags.WOOL);
         tag(ModTags.compostables_rich).add(Items.PODZOL, ModBlocks.blockCompostedDirt.asItem());
 


### PR DESCRIPTION
# Changes proposed in this pull request:
- Makes Mangrove Roots compostable. They don't really have a use besides being used as fuel, so I figured making them compostable too would be a good idea.

[ ] Yes I tested this before submitting it.
[ ] I also did a multiplayer test.

Review please
