### PR TITLE
Fix snowy graveyard

### DIFF
--- a/src/main/java/com/minecolonies/coremod/colony/buildings/modules/GraveyardManagementModule.java
+++ b/src/main/java/com/minecolonies/coremod/colony/buildings/modules/GraveyardManagementModule.java
@@ -8,22 +8,25 @@ import com.minecolonies.api.colony.buildings.modules.AbstractBuildingModule;
 import com.minecolonies.api.colony.buildings.modules.IBuildingEventsModule;
 import com.minecolonies.api.colony.buildings.modules.IBuildingModule;
 import com.minecolonies.api.colony.buildings.modules.IPersistentModule;
+import com.minecolonies.api.entity.citizen.AbstractEntityCitizen;
 import com.minecolonies.api.tileentities.TileEntityGrave;
 import com.minecolonies.api.tileentities.TileEntityNamedGrave;
 import com.minecolonies.api.util.Tuple;
 import com.minecolonies.api.util.WorldUtil;
+import net.minecraft.core.BlockPos;
+import net.minecraft.core.Direction;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.nbt.ListTag;
 import net.minecraft.nbt.StringTag;
 import net.minecraft.network.FriendlyByteBuf;
 import net.minecraft.world.level.block.entity.BlockEntity;
-import net.minecraft.core.Direction;
-import net.minecraft.core.BlockPos;
 import org.apache.commons.lang3.StringUtils;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
-import java.util.*;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
 
 import static com.minecolonies.api.util.constant.Constants.TAG_STRING;
 
@@ -164,7 +167,7 @@ public class GraveyardManagementModule extends AbstractBuildingModule implements
     /**
      * Add a citizen to the list of resting citizen in this graveyard
      */
-    public void buryCitizenHere(final Tuple<BlockPos, Direction> positionAndDirection)
+    public void buryCitizenHere(final Tuple<BlockPos, Direction> positionAndDirection, final AbstractEntityCitizen worker)
     {
         if(lastGraveData != null && !restingCitizen.contains(lastGraveData.getCitizenName()))
         {
@@ -174,7 +177,10 @@ public class GraveyardManagementModule extends AbstractBuildingModule implements
             {
                 facing = Direction.NORTH; //prevent setting an invalid HorizontalDirection
             }
-            colony.getWorld().setBlockAndUpdate(positionAndDirection.getA(), ModBlocks.blockNamedGrave.defaultBlockState().setValue(AbstractBlockMinecoloniesNamedGrave.FACING, facing));
+
+            colony.getWorld().destroyBlock(positionAndDirection.getA(), true, worker);
+            colony.getWorld().setBlockAndUpdate(positionAndDirection.getA(),
+                    ModBlocks.blockNamedGrave.defaultBlockState().setValue(AbstractBlockMinecoloniesNamedGrave.FACING, facing));
 
             BlockEntity tileEntity = colony.getWorld().getBlockEntity(positionAndDirection.getA());
             if (tileEntity instanceof TileEntityNamedGrave)

--- a/src/main/java/com/minecolonies/coremod/colony/buildings/workerbuildings/BuildingGraveyard.java
+++ b/src/main/java/com/minecolonies/coremod/colony/buildings/workerbuildings/BuildingGraveyard.java
@@ -1,29 +1,25 @@
 package com.minecolonies.coremod.colony.buildings.workerbuildings;
 
-import com.ldtteam.blockui.views.BOWindow;
 import com.minecolonies.api.blocks.AbstractBlockMinecoloniesNamedGrave;
 import com.minecolonies.api.blocks.ModBlocks;
 import com.minecolonies.api.colony.IColony;
-import com.minecolonies.api.colony.IColonyView;
 import com.minecolonies.api.tileentities.TileEntityGrave;
 import com.minecolonies.api.util.BlockPosUtil;
 import com.minecolonies.api.util.ItemStackUtils;
 import com.minecolonies.api.util.Tuple;
 import com.minecolonies.api.util.WorldUtil;
 import com.minecolonies.api.util.constant.ToolType;
-import com.minecolonies.coremod.client.gui.huts.WindowHutWorkerModulePlaceholder;
 import com.minecolonies.coremod.colony.buildings.AbstractBuilding;
-import com.minecolonies.coremod.colony.buildings.views.AbstractBuildingView;
+import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.nbt.ListTag;
-import net.minecraft.core.BlockPos;
 import net.minecraft.nbt.Tag;
+import net.minecraft.tags.BlockTags;
 import net.minecraft.world.item.Items;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.entity.BlockEntity;
 import net.minecraft.world.level.block.state.BlockState;
-
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -213,7 +209,7 @@ public class BuildingGraveyard extends AbstractBuilding
         final List<Tuple<BlockPos, Direction>> availablePos = new ArrayList<Tuple<BlockPos, Direction>>();
         for(final Tuple<BlockPos, Direction> tuple : visualGravePositions)
         {
-            if(getColony().getWorld().getBlockState(tuple.getA()).isAir())
+            if (getColony().getWorld().getBlockState(tuple.getA()).is(BlockTags.REPLACEABLE))
             {
                 availablePos.add(tuple);
             }

--- a/src/main/java/com/minecolonies/coremod/colony/buildings/workerbuildings/BuildingGraveyard.java
+++ b/src/main/java/com/minecolonies/coremod/colony/buildings/workerbuildings/BuildingGraveyard.java
@@ -15,7 +15,6 @@ import net.minecraft.core.Direction;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.nbt.ListTag;
 import net.minecraft.nbt.Tag;
-import net.minecraft.tags.BlockTags;
 import net.minecraft.world.item.Items;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.entity.BlockEntity;
@@ -209,7 +208,7 @@ public class BuildingGraveyard extends AbstractBuilding
         final List<Tuple<BlockPos, Direction>> availablePos = new ArrayList<Tuple<BlockPos, Direction>>();
         for(final Tuple<BlockPos, Direction> tuple : visualGravePositions)
         {
-            if (getColony().getWorld().getBlockState(tuple.getA()).is(BlockTags.REPLACEABLE))
+            if (getColony().getWorld().getBlockState(tuple.getA()).canBeReplaced())
             {
                 availablePos.add(tuple);
             }

--- a/src/main/java/com/minecolonies/coremod/entity/ai/citizen/undertaker/EntityAIWorkUndertaker.java
+++ b/src/main/java/com/minecolonies/coremod/entity/ai/citizen/undertaker/EntityAIWorkUndertaker.java
@@ -37,6 +37,7 @@ import java.util.Random;
 
 import static com.minecolonies.api.entity.ai.statemachine.states.AIWorkerState.*;
 import static com.minecolonies.api.research.util.ResearchConstants.*;
+import static com.minecolonies.api.util.constant.CitizenConstants.FACING_DELTA_YAW;
 import static com.minecolonies.api.util.constant.Constants.DEFAULT_SPEED;
 import static com.minecolonies.api.util.constant.ToolLevelConstants.TOOL_LEVEL_WOOD_OR_GOLD;
 import static com.minecolonies.api.util.constant.TranslationConstants.MESSAGE_INFO_CITIZEN_UNDERTAKER_GRAVEYARD_NO_SPACE;
@@ -320,6 +321,7 @@ public class EntityAIWorkUndertaker extends AbstractEntityAIInteract<JobUndertak
         {
             if (effortCounter < EFFORT_RESURRECT)
             {
+                worker.getLookControl().setLookAt(gravePos.getX(), gravePos.getY(), gravePos.getZ(), FACING_DELTA_YAW, worker.getMaxHeadXRot());
                 worker.swing(InteractionHand.MAIN_HAND);
                 Network.getNetwork().sendToTrackingEntity(new VanillaParticleMessage(gravePos.getX() + 0.5f, gravePos.getY() + 0.05f, gravePos.getZ() + 0.5f, ParticleTypes.ENCHANT), worker);
                 effortCounter += getSecondarySkillLevel();
@@ -439,7 +441,7 @@ public class EntityAIWorkUndertaker extends AbstractEntityAIInteract<JobUndertak
         if(effortCounter < EFFORT_BURY)
         {
             equipShovel();
-            worker.swing(InteractionHand.MAIN_HAND);
+            worker.getCitizenItemHandler().hitBlockWithToolInHand(burialPos.getA(), false);
             effortCounter += getPrimarySkillLevel();
             return getState();
         }

--- a/src/main/java/com/minecolonies/coremod/entity/ai/citizen/undertaker/EntityAIWorkUndertaker.java
+++ b/src/main/java/com/minecolonies/coremod/entity/ai/citizen/undertaker/EntityAIWorkUndertaker.java
@@ -14,13 +14,16 @@ import com.minecolonies.api.util.InventoryUtils;
 import com.minecolonies.api.util.MessageUtils;
 import com.minecolonies.api.util.Tuple;
 import com.minecolonies.api.util.constant.ToolType;
+import com.minecolonies.coremod.Network;
 import com.minecolonies.coremod.colony.buildings.modules.GraveyardManagementModule;
 import com.minecolonies.coremod.colony.buildings.workerbuildings.BuildingGraveyard;
 import com.minecolonies.coremod.colony.jobs.JobUndertaker;
 import com.minecolonies.coremod.entity.ai.basic.AbstractEntityAIInteract;
+import com.minecolonies.coremod.network.messages.client.VanillaParticleMessage;
 import com.minecolonies.coremod.util.AdvancementUtils;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
+import net.minecraft.core.particles.ParticleTypes;
 import net.minecraft.network.chat.Component;
 import net.minecraft.sounds.SoundEvents;
 import net.minecraft.tags.BlockTags;
@@ -319,6 +322,7 @@ public class EntityAIWorkUndertaker extends AbstractEntityAIInteract<JobUndertak
             if (effortCounter < EFFORT_RESURRECT)
             {
                 worker.swing(InteractionHand.MAIN_HAND);
+                Network.getNetwork().sendToTrackingEntity(new VanillaParticleMessage(gravePos.getX() + 0.5f, gravePos.getY() + 0.05f, gravePos.getZ() + 0.5f, ParticleTypes.ENCHANT), worker);
                 effortCounter += getSecondarySkillLevel();
                 return getState();
             }
@@ -335,6 +339,8 @@ public class EntityAIWorkUndertaker extends AbstractEntityAIInteract<JobUndertak
 
             if (chance >= random.nextDouble())
             {
+                Network.getNetwork().sendToTrackingEntity(new VanillaParticleMessage(gravePos.getX() + 0.5f, gravePos.getY() + 0.05f, gravePos.getZ() + 0.5f, ParticleTypes.HEART), worker);
+
                 final ICitizenData citizenData = buildingGraveyard.getColony().getCitizenManager().resurrectCivilianData(buildingGraveyard.getFirstModuleOccurance(GraveyardManagementModule.class).getLastGraveData().getCitizenDataNBT(), true, world, gravePos);
                 MessageUtils.format(MESSAGE_INFO_CITIZEN_UNDERTAKER_RESURRECTED_SUCCESS, citizenData.getName()).sendTo(buildingGraveyard.getColony()).forManagers();
                 worker.getCitizenColonyHandler().getColony().getCitizenManager().updateCitizenMourn(citizenData, false);

--- a/src/main/java/com/minecolonies/coremod/entity/ai/citizen/undertaker/EntityAIWorkUndertaker.java
+++ b/src/main/java/com/minecolonies/coremod/entity/ai/citizen/undertaker/EntityAIWorkUndertaker.java
@@ -26,7 +26,6 @@ import net.minecraft.core.Direction;
 import net.minecraft.core.particles.ParticleTypes;
 import net.minecraft.network.chat.Component;
 import net.minecraft.sounds.SoundEvents;
-import net.minecraft.tags.BlockTags;
 import net.minecraft.world.InteractionHand;
 import net.minecraft.world.item.Items;
 import net.minecraft.world.level.block.Blocks;
@@ -419,7 +418,7 @@ public class EntityAIWorkUndertaker extends AbstractEntityAIInteract<JobUndertak
         }
         worker.getCitizenData().setVisibleStatus(BURYING_ICON);
 
-        if(burialPos == null || !world.getBlockState(burialPos.getA()).is(BlockTags.REPLACEABLE))
+        if(burialPos == null || !world.getBlockState(burialPos.getA()).canBeReplaced())
         {
             burialPos = building.getRandomFreeVisualGravePos();
         }

--- a/src/main/java/com/minecolonies/coremod/entity/ai/citizen/undertaker/EntityAIWorkUndertaker.java
+++ b/src/main/java/com/minecolonies/coremod/entity/ai/citizen/undertaker/EntityAIWorkUndertaker.java
@@ -273,11 +273,8 @@ public class EntityAIWorkUndertaker extends AbstractEntityAIInteract<JobUndertak
         if (!checkForToolOrWeapon(ToolType.SHOVEL))
         {
             equipShovel();
-            worker.swing(worker.getUsedItemHand());
             if (mineBlock(position))
             {
-                world.setBlockAndUpdate(position, Blocks.AIR.defaultBlockState());
-                worker.getCitizenItemHandler().damageItemInHand(InteractionHand.MAIN_HAND, 1);
                 worker.decreaseSaturationForContinuousAction();
                 building.ClearCurrentGrave();
                 return true;

--- a/src/main/java/com/minecolonies/coremod/entity/ai/citizen/undertaker/EntityAIWorkUndertaker.java
+++ b/src/main/java/com/minecolonies/coremod/entity/ai/citizen/undertaker/EntityAIWorkUndertaker.java
@@ -23,6 +23,7 @@ import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
 import net.minecraft.network.chat.Component;
 import net.minecraft.sounds.SoundEvents;
+import net.minecraft.tags.BlockTags;
 import net.minecraft.world.InteractionHand;
 import net.minecraft.world.item.Items;
 import net.minecraft.world.level.block.Blocks;
@@ -412,7 +413,7 @@ public class EntityAIWorkUndertaker extends AbstractEntityAIInteract<JobUndertak
         }
         worker.getCitizenData().setVisibleStatus(BURYING_ICON);
 
-        if(burialPos == null || !world.getBlockState(burialPos.getA()).isAir())
+        if(burialPos == null || !world.getBlockState(burialPos.getA()).is(BlockTags.REPLACEABLE))
         {
             burialPos = building.getRandomFreeVisualGravePos();
         }
@@ -440,7 +441,7 @@ public class EntityAIWorkUndertaker extends AbstractEntityAIInteract<JobUndertak
         effortCounter = 0;
         unequip();
 
-        module.buryCitizenHere(burialPos);
+        module.buryCitizenHere(burialPos, worker);
         //Disabled until Mourning AI update: worker.getCitizenColonyHandler().getColony().setNeedToMourn(false, buildingGraveyard.getLastGraveData().getCitizenName());
         AdvancementUtils.TriggerAdvancementPlayersForColony(worker.getCitizenColonyHandler().getColony(), playerMP -> AdvancementTriggers.CITIZEN_BURY.trigger(playerMP));
 

--- a/src/main/java/com/minecolonies/coremod/entity/ai/citizen/undertaker/EntityAIWorkUndertaker.java
+++ b/src/main/java/com/minecolonies/coremod/entity/ai/citizen/undertaker/EntityAIWorkUndertaker.java
@@ -378,15 +378,15 @@ public class EntityAIWorkUndertaker extends AbstractEntityAIInteract<JobUndertak
      */
     private double getTotemResurrectChance()
     {
-        final int totems = InventoryUtils.getItemCountInItemHandler(worker.getInventoryCitizen(), Items.TOTEM_OF_UNDYING);
-
-        if (totems > 0)
-        {
-            AdvancementUtils.TriggerAdvancementPlayersForColony(worker.getCitizenColonyHandler().getColony(), playerMP -> AdvancementTriggers.UNDERTAKER_TOTEM.trigger(playerMP));
-        }
-
         if (worker.getCitizenColonyHandler().getColony().getResearchManager().getResearchEffects().getEffectStrength(USE_TOTEM) > 0)
         {
+            final int totems = InventoryUtils.getItemCountInItemHandler(worker.getInventoryCitizen(), Items.TOTEM_OF_UNDYING);
+
+            if (totems > 0)
+            {
+                AdvancementUtils.TriggerAdvancementPlayersForColony(worker.getCitizenColonyHandler().getColony(), AdvancementTriggers.UNDERTAKER_TOTEM::trigger);
+            }
+
             if ( totems == 1 )
             {
                 return SINGLE_TOTEM_RESURRECTION_CHANCE_BONUS;


### PR DESCRIPTION
# Changes proposed in this pull request:
- The undertaker can now dig up `replaceable()` blocks when making a grave.
    - Notably, this means that snow or tall-grass growth over otherwise empty grave sites will no longer treat the site as occupied.  (Other blocks, including flowers, will still block a grave site.)
- An "enchantment" particle effect is now shown while the undertaker is waving their hands over the original grave (and they'll now face the grave while doing it, not pictured below) in an attempt to resurrect the citizen (since it was otherwise not obvious what they were doing).  A heart effect will also briefly appear if they succeed.
    ![image](https://github.com/ldtteam/minecolonies/assets/539951/66b12b29-6492-4c36-9d9e-e854be6f87d1)
- Don't trigger the "A Powerful Artifact" advancement unless the colony actually has the research.

[x] Yes I tested this before submitting it.
[ ] I also did a multiplayer test.

Review please (could backport)
