### PR TITLE
Fix correct tool checks able to clear blocks that require iron or higher tools

### DIFF
--- a/src/main/java/com/minecolonies/coremod/util/WorkerUtil.java
+++ b/src/main/java/com/minecolonies/coremod/util/WorkerUtil.java
@@ -15,7 +15,6 @@ import com.minecolonies.api.util.constant.IToolType;
 import com.minecolonies.api.util.constant.ToolType;
 import com.minecolonies.coremod.colony.buildings.AbstractBuilding;
 import com.minecolonies.coremod.colony.buildings.modules.SettingsModule;
-import com.minecolonies.coremod.colony.buildings.modules.settings.BoolSetting;
 import com.minecolonies.coremod.colony.buildings.workerbuildings.BuildingFlorist;
 import com.minecolonies.coremod.entity.ai.citizen.miner.MinerLevel;
 import com.minecolonies.coremod.entity.citizen.EntityCitizen;
@@ -89,10 +88,10 @@ public final class WorkerUtil
         if (tools == null)
         {
             tools = new ArrayList<>();
-            tools.add(new Tuple<>(ToolType.HOE, new ItemStack(Items.WOODEN_HOE)));
-            tools.add(new Tuple<>(ToolType.SHOVEL, new ItemStack(Items.WOODEN_SHOVEL)));
-            tools.add(new Tuple<>(ToolType.AXE, new ItemStack(Items.WOODEN_AXE)));
-            tools.add(new Tuple<>(ToolType.PICKAXE, new ItemStack(Items.WOODEN_PICKAXE)));
+            tools.add(new Tuple<>(ToolType.HOE, new ItemStack(Items.NETHERITE_HOE)));
+            tools.add(new Tuple<>(ToolType.SHOVEL, new ItemStack(Items.NETHERITE_SHOVEL)));
+            tools.add(new Tuple<>(ToolType.AXE, new ItemStack(Items.NETHERITE_AXE)));
+            tools.add(new Tuple<>(ToolType.PICKAXE, new ItemStack(Items.NETHERITE_PICKAXE)));
         }
         return tools;
     }


### PR DESCRIPTION
Closes [discord report](https://discord.com/channels/139070364159311872/1125094832143077456/1192920483251896412) (Nether miners seeming incapable of providing ancient debris)

# Changes proposed in this pull request:
- Correct tool checks verify if the tags NEEDS_DIAMOND_TOOL or NEEDS_IRON_TOOL are met by the tool tier, however our tool type checks always pass in wooden tools, causing the tool type to be empty, essentially stating the workers are unable to mine those blocks.


[ ] Yes I tested this before submitting it.
[ ] I also did a multiplayer test.

Review please
