### PR TITLE
Make miner/quarrier/nether miner immune to magma block damage

### DIFF
--- a/src/api/java/com/minecolonies/api/research/util/ResearchConstants.java
+++ b/src/api/java/com/minecolonies/api/research/util/ResearchConstants.java
@@ -2,7 +2,12 @@ package com.minecolonies.api.research.util;
 
 import com.ldtteam.blockui.Color;
 import com.minecolonies.api.util.constant.Constants;
+import net.minecraft.resources.ResourceKey;
 import net.minecraft.resources.ResourceLocation;
+import net.minecraft.world.damagesource.DamageType;
+import net.minecraft.world.damagesource.DamageTypes;
+
+import java.util.function.Predicate;
 
 /**
  * Class for research constants.
@@ -178,6 +183,14 @@ public final class ResearchConstants
     public static final ResourceLocation SIFTER_FLINT      = new ResourceLocation(Constants.MOD_ID, "effects/sifterflintunlock");
     public static final ResourceLocation SIFTER_IRON       = new ResourceLocation(Constants.MOD_ID, "effects/sifterironunlock");
     public static final ResourceLocation SIFTER_DIAMOND    = new ResourceLocation(Constants.MOD_ID, "effects/sifterdiamondunlock");
+
+    /**
+     * Predicate for selecting any fire-related damage
+     */
+    public static final Predicate<ResourceKey<DamageType>> FIRE_DAMAGE_PREDICATE = type -> type.equals(DamageTypes.LAVA)
+                                                                                             || type.equals(DamageTypes.HOT_FLOOR)
+                                                                                             || type.equals(DamageTypes.IN_FIRE)
+                                                                                             || type.equals(DamageTypes.ON_FIRE);
 
     /**
      * Private constructor to hide implicit public one.

--- a/src/main/java/com/minecolonies/coremod/colony/jobs/JobMiner.java
+++ b/src/main/java/com/minecolonies/coremod/colony/jobs/JobMiner.java
@@ -1,15 +1,13 @@
 package com.minecolonies.coremod.colony.jobs;
 
-import net.minecraft.resources.ResourceLocation;
 import com.minecolonies.api.client.render.modeltype.ModModelTypes;
 import com.minecolonies.api.colony.ICitizenData;
 import com.minecolonies.coremod.entity.ai.citizen.miner.EntityAIStructureMiner;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.damagesource.DamageSource;
-import net.minecraft.world.damagesource.DamageType;
-import net.minecraft.world.damagesource.DamageTypes;
 import org.jetbrains.annotations.NotNull;
 
+import static com.minecolonies.api.research.util.ResearchConstants.FIRE_DAMAGE_PREDICATE;
 import static com.minecolonies.api.research.util.ResearchConstants.FIRE_RES;
 
 /**
@@ -55,7 +53,7 @@ public class JobMiner extends AbstractJobStructure<EntityAIStructureMiner, JobMi
     @Override
     public boolean ignoresDamage(@NotNull final DamageSource damageSource)
     {
-        if (damageSource.typeHolder().is(DamageTypes.LAVA) || damageSource.typeHolder().is(DamageTypes.IN_FIRE) || damageSource.typeHolder().is(DamageTypes.ON_FIRE))
+        if (damageSource.typeHolder().is(FIRE_DAMAGE_PREDICATE))
         {
             return getColony().getResearchManager().getResearchEffects().getEffectStrength(FIRE_RES) > 0;
         }

--- a/src/main/java/com/minecolonies/coremod/colony/jobs/JobNetherWorker.java
+++ b/src/main/java/com/minecolonies/coremod/colony/jobs/JobNetherWorker.java
@@ -1,21 +1,20 @@
 package com.minecolonies.coremod.colony.jobs;
 
-import java.util.Collection;
-import java.util.LinkedList;
-import java.util.Queue;
-
 import com.minecolonies.api.client.render.modeltype.ModModelTypes;
 import com.minecolonies.api.colony.ICitizenData;
 import com.minecolonies.coremod.entity.ai.citizen.netherworker.EntityAIWorkNether;
-
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.nbt.ListTag;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.damagesource.DamageSource;
-import net.minecraft.world.damagesource.DamageTypes;
 import net.minecraft.world.item.ItemStack;
 import org.jetbrains.annotations.NotNull;
 
+import java.util.Collection;
+import java.util.LinkedList;
+import java.util.Queue;
+
+import static com.minecolonies.api.research.util.ResearchConstants.FIRE_DAMAGE_PREDICATE;
 import static com.minecolonies.api.research.util.ResearchConstants.FIRE_RES;
 
 public class JobNetherWorker extends AbstractJobCrafter<EntityAIWorkNether, JobNetherWorker>
@@ -199,7 +198,7 @@ public class JobNetherWorker extends AbstractJobCrafter<EntityAIWorkNether, JobN
     @Override
     public boolean ignoresDamage(@NotNull final DamageSource damageSource)
     {
-        if (damageSource.typeHolder().is(DamageTypes.LAVA) || damageSource.typeHolder().is(DamageTypes.IN_FIRE) || damageSource.typeHolder().is(DamageTypes.ON_FIRE))
+        if (damageSource.typeHolder().is(FIRE_DAMAGE_PREDICATE))
         {
             return getColony().getResearchManager().getResearchEffects().getEffectStrength(FIRE_RES) > 0;
         }

--- a/src/main/java/com/minecolonies/coremod/colony/jobs/JobQuarrier.java
+++ b/src/main/java/com/minecolonies/coremod/colony/jobs/JobQuarrier.java
@@ -10,13 +10,12 @@ import com.minecolonies.coremod.colony.buildings.modules.QuarryModule;
 import com.minecolonies.coremod.entity.ai.citizen.miner.EntityAIQuarrier;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.damagesource.DamageSource;
-import net.minecraft.world.damagesource.DamageTypes;
 import org.jetbrains.annotations.NotNull;
 
-import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 
+import static com.minecolonies.api.research.util.ResearchConstants.FIRE_DAMAGE_PREDICATE;
 import static com.minecolonies.api.research.util.ResearchConstants.FIRE_RES;
 
 /**
@@ -103,7 +102,7 @@ public class JobQuarrier extends AbstractJobStructure<EntityAIQuarrier, JobQuarr
     @Override
     public boolean ignoresDamage(@NotNull final DamageSource damageSource)
     {
-        if (damageSource.typeHolder().is(DamageTypes.LAVA) || damageSource.typeHolder().is(DamageTypes.IN_FIRE) || damageSource.typeHolder().is(DamageTypes.ON_FIRE))
+        if (damageSource.typeHolder().is(FIRE_DAMAGE_PREDICATE))
         {
             return getColony().getResearchManager().getResearchEffects().getEffectStrength(FIRE_RES) > 0;
         }


### PR DESCRIPTION
Closes [discord report](https://discord.com/channels/472875599422291968/473575384445878273/1193314078186295307) (nether miner died to magma block)

# Changes proposed in this pull request:
- Magma blocks fall under a different damage type, which wasn't checked by the damage ignore, so hot floor has been added
- Rewrote ignores damage of all affected jobs to a reusable predicate (unsure of where to place this constant)


[X] Yes I tested this before submitting it.
[ ] I also did a multiplayer test.

Review please
