### PR TITLE
Improve hire window sorting

### DIFF
--- a/src/main/java/com/minecolonies/coremod/client/gui/WindowHireWorker.java
+++ b/src/main/java/com/minecolonies/coremod/client/gui/WindowHireWorker.java
@@ -14,7 +14,6 @@ import com.minecolonies.api.colony.buildings.modules.IAssignmentModuleView;
 import com.minecolonies.api.colony.buildings.views.IBuildingView;
 import com.minecolonies.api.colony.jobs.registry.JobEntry;
 import com.minecolonies.api.entity.citizen.Skill;
-import com.minecolonies.api.util.BlockPosUtil;
 import com.minecolonies.api.util.constant.Constants;
 import com.minecolonies.coremod.Network;
 import com.minecolonies.coremod.colony.CitizenDataView;
@@ -139,7 +138,10 @@ public class WindowHireWorker extends AbstractWindowSkeleton
     private void switchHiringMode(final Button settingsButton)
     {
         int index = selectedModule.getHiringMode().ordinal() + 1;
-        if (index == HiringMode.LOCKED.ordinal()) { ++index; }  // only homes can be locked, not workplaces
+        if (index == HiringMode.LOCKED.ordinal())
+        {
+            ++index;
+        }  // only homes can be locked, not workplaces
 
         if (index >= HiringMode.values().length)
         {
@@ -216,10 +218,10 @@ public class WindowHireWorker extends AbstractWindowSkeleton
         // Fire citizen if they already have a job
         if (citizen.getWorkBuilding() != null && selectedModule instanceof WorkerBuildingModuleView)
         {
-            IBuildingView oldJob =  colony.getBuilding(citizen.getWorkBuilding());
+            IBuildingView oldJob = colony.getBuilding(citizen.getWorkBuilding());
             oldJob.getModuleViewMatching(IAssignmentModuleView.class,
-                                         m -> m.getJobEntry() == citizen.getJobView().getEntry())
-                    .removeCitizen(citizen);
+                m -> m.getJobEntry() == citizen.getJobView().getEntry())
+              .removeCitizen(citizen);
         }
 
 
@@ -236,13 +238,21 @@ public class WindowHireWorker extends AbstractWindowSkeleton
     protected int getCitizenPriority(ICitizenDataView citizen)
     {
         if (building.getPosition().equals(citizen.getWorkBuilding()))
+        {
             return 0;
+        }
+        else if (!selectedModule.canAssign(citizen))
+        {
+            return 3;
+        }
         else if (citizen.getWorkBuilding() == null)
+        {
             return 1;
-        else if (selectedModule.canAssign(citizen))
-            return citizen.getHomeBuilding() == null ? 2 : (int) BlockPosUtil.getDistance2D(building.getPosition(), citizen.getHomeBuilding());
+        }
         else
-            return citizen.getHomeBuilding() == null ? 3 : (int) BlockPosUtil.getDistance2D(building.getPosition(), citizen.getHomeBuilding());
+        {
+            return 2;
+        }
     }
 
     /**
@@ -269,6 +279,7 @@ public class WindowHireWorker extends AbstractWindowSkeleton
 
     /**
      * Show Employed button clicked to show/hide employed citizens
+     *
      * @param button the clicked button
      */
     protected void showEmployedToggled(@NotNull final Button button)
@@ -288,13 +299,14 @@ public class WindowHireWorker extends AbstractWindowSkeleton
     {
         Button button = findPaneOfTypeByID(TOGGLE_SHOW_EMPLOYED, Button.class);
         button.setEnabled(selectedModule instanceof WorkerBuildingModuleView
-                && !(selectedModule instanceof PupilBuildingModuleView));
+                            && !(selectedModule instanceof PupilBuildingModuleView));
         button.setText(Component.translatable("gui.no"));
         showEmployed = false;
     }
 
     /**
      * Helper function to show _all_ citizens that aren't children if viable.
+     *
      * @param citizen the citizen to check
      * @return whether the citizen can be assigned to the module
      */
@@ -311,11 +323,29 @@ public class WindowHireWorker extends AbstractWindowSkeleton
         citizens.clear();
 
         citizens = colony.getCitizens().values().stream()
-                .filter(this::canAssign)
-                .sorted(Comparator.comparing(this::getCitizenPriority)
-                        .thenComparing(ICitizenDataView::getName))
-                .collect(Collectors.toList());
+          .filter(this::canAssign)
+          .sorted(Comparator.comparing(this::getCitizenPriority)
+            .thenComparing(citizen -> {
+                final BlockPos home = citizen.getHomeBuilding();
+                if (home == null)
+                {
+                    return 100.0;
+                }
 
+                double distance = Math.sqrt(citizen.getHomeBuilding().distSqr(building.getPosition()));
+                if (distance % 40 > 20)
+                {
+                    distance = (distance - (distance % 40)) + 40;
+                }
+                else
+                {
+                    distance = (distance - (distance % 40));
+                }
+
+                return distance;
+            })
+            .thenComparing(ICitizenDataView::getName))
+          .collect(Collectors.toList());
     }
 
     /**
@@ -379,8 +409,8 @@ public class WindowHireWorker extends AbstractWindowSkeleton
                 textBuilder.append(Component.literal(""));
                 int skillCount = citizen.getCitizenSkillHandler().getSkills().entrySet().size();
 
-                final Skill primary = selectedModule instanceof  WorkerBuildingModuleView ? ((WorkerBuildingModuleView) selectedModule).getPrimarySkill() : null;
-                final Skill secondary = selectedModule instanceof  WorkerBuildingModuleView ? ((WorkerBuildingModuleView) selectedModule).getSecondarySkill() : null;
+                final Skill primary = selectedModule instanceof WorkerBuildingModuleView ? ((WorkerBuildingModuleView) selectedModule).getPrimarySkill() : null;
+                final Skill secondary = selectedModule instanceof WorkerBuildingModuleView ? ((WorkerBuildingModuleView) selectedModule).getSecondarySkill() : null;
 
                 final List<Map.Entry<Skill, Tuple<Integer, Double>>> skills = new ArrayList<>(citizen.getCitizenSkillHandler().getSkills().entrySet());
                 skills.sort(Comparator.comparingInt(s -> (s.getKey() == primary ? 1 : (s.getKey() == secondary ? 2 : 3))));
@@ -400,7 +430,9 @@ public class WindowHireWorker extends AbstractWindowSkeleton
                 }
                 textBuilder.newLine(); // finish the current line
 
-                Component citizenLabelComponent = Component.translatable(citizen.getJob().isEmpty() ? COM_MINECOLONIES_COREMOD_GUI_TOWNHALL_CITIZEN_UNEMPLOYED : citizen.getJob()).append(": ").append(citizen.getName());
+                Component citizenLabelComponent = Component.translatable(citizen.getJob().isEmpty() ? COM_MINECOLONIES_COREMOD_GUI_TOWNHALL_CITIZEN_UNEMPLOYED : citizen.getJob())
+                  .append(": ")
+                  .append(citizen.getName());
                 rowPane.findPaneOfTypeByID(CITIZEN_LABEL, Text.class).setText(citizenLabelComponent);
                 if (citizen.getHomeBuilding() == null)
                 {
@@ -416,7 +448,8 @@ public class WindowHireWorker extends AbstractWindowSkeleton
                 }
                 else
                 {
-                    rowPane.findPaneOfTypeByID(DISTANCE_LABEL, Text.class).setText(Component.translatable("com.minecolonies.core.gui.hiring.distance", BlockPosUtil.getDistance2D(citizen.getHomeBuilding(), building.getPosition())));
+                    rowPane.findPaneOfTypeByID(DISTANCE_LABEL, Text.class)
+                      .setText(Component.translatable("com.minecolonies.core.gui.hiring.distance", (int) Math.sqrt(citizen.getHomeBuilding().distSqr(building.getPosition()))));
                 }
 
                 rowPane.findPaneOfTypeByID(ATTRIBUTES_LABEL, Text.class).setText(textBuilder.getText());
@@ -440,7 +473,7 @@ public class WindowHireWorker extends AbstractWindowSkeleton
             final JobEntry entry = hireModule.getJobEntry();
 
             final ButtonImage jobButton = new ButtonImage();
-            jobButton.setImage( new ResourceLocation("minecolonies:textures/gui/builderhut/builder_button_medium.png"), false);
+            jobButton.setImage(new ResourceLocation("minecolonies:textures/gui/builderhut/builder_button_medium.png"), false);
             jobButton.setPosition(xOffset, 30);
             if (hireModule.getAssignedCitizens().size() > 0)
             {

--- a/src/main/java/com/minecolonies/coremod/colony/requestsystem/management/manager/StandardRecipeManager.java
+++ b/src/main/java/com/minecolonies/coremod/colony/requestsystem/management/manager/StandardRecipeManager.java
@@ -7,11 +7,9 @@ import com.minecolonies.api.colony.requestsystem.StandardFactoryController;
 import com.minecolonies.api.colony.requestsystem.token.IToken;
 import com.minecolonies.api.crafting.IRecipeManager;
 import com.minecolonies.api.crafting.IRecipeStorage;
-import com.minecolonies.api.util.Log;
 import com.minecolonies.api.util.NBTUtils;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.nbt.ListTag;
-
 import net.minecraft.nbt.Tag;
 import org.jetbrains.annotations.NotNull;
 
@@ -101,7 +99,6 @@ public class StandardRecipeManager implements IRecipeManager
         if (dirty || nbtCache == null)
         {
             nbtCache = recipes.entrySet().stream().filter(recipeEntry -> usedRecipes.contains(recipeEntry.getKey())).map(entry -> StandardFactoryController.getInstance().serialize(entry.getValue())).collect(NBTUtils.toListNBT());
-            Log.getLogger().warn("Writing Recipe Manager: " + recipes.size() + " recipes!");
         }
 
         compound.put(TAG_RECIPES, nbtCache);


### PR DESCRIPTION
# Changes proposed in this pull request:
- Improves hire window sorting to make their ordering a bit more natural. Now groups distance by grps of 20 blocks and  sorts unassignable citizens lower. Also uses proper distances instead of cheap corner distances
- Removed recipe manager logging


[ x] Yes I tested this before submitting it.
[x ] I also did a multiplayer test.

Review please
