### PR TITLE
Make miner/quarrier/nether miner immune to magma block damage [119]

### DIFF
--- a/src/main/java/com/minecolonies/coremod/colony/jobs/JobMiner.java
+++ b/src/main/java/com/minecolonies/coremod/colony/jobs/JobMiner.java
@@ -1,6 +1,5 @@
 package com.minecolonies.coremod.colony.jobs;
 
-import net.minecraft.resources.ResourceLocation;
 import com.minecolonies.api.client.render.modeltype.ModModelTypes;
 import com.minecolonies.api.colony.ICitizenData;
 import com.minecolonies.coremod.entity.ai.citizen.miner.EntityAIStructureMiner;
@@ -53,7 +52,7 @@ public class JobMiner extends AbstractJobStructure<EntityAIStructureMiner, JobMi
     @Override
     public boolean ignoresDamage(@NotNull final DamageSource damageSource)
     {
-        if (damageSource == DamageSource.LAVA || damageSource == DamageSource.IN_FIRE || damageSource == DamageSource.ON_FIRE)
+        if (damageSource.isFire())
         {
             return getColony().getResearchManager().getResearchEffects().getEffectStrength(FIRE_RES) > 0;
         }

--- a/src/main/java/com/minecolonies/coremod/colony/jobs/JobNetherWorker.java
+++ b/src/main/java/com/minecolonies/coremod/colony/jobs/JobNetherWorker.java
@@ -198,7 +198,7 @@ public class JobNetherWorker extends AbstractJobCrafter<EntityAIWorkNether, JobN
     @Override
     public boolean ignoresDamage(@NotNull final DamageSource damageSource)
     {
-        if (damageSource == DamageSource.LAVA || damageSource == DamageSource.IN_FIRE || damageSource == DamageSource.ON_FIRE)
+        if (damageSource.isFire())
         {
             return getColony().getResearchManager().getResearchEffects().getEffectStrength(FIRE_RES) > 0;
         }

--- a/src/main/java/com/minecolonies/coremod/colony/jobs/JobQuarrier.java
+++ b/src/main/java/com/minecolonies/coremod/colony/jobs/JobQuarrier.java
@@ -102,7 +102,7 @@ public class JobQuarrier extends AbstractJobStructure<EntityAIQuarrier, JobQuarr
     @Override
     public boolean ignoresDamage(@NotNull final DamageSource damageSource)
     {
-        if (damageSource == DamageSource.LAVA || damageSource == DamageSource.IN_FIRE || damageSource == DamageSource.ON_FIRE)
+        if (damageSource.isFire())
         {
             return getColony().getResearchManager().getResearchEffects().getEffectStrength(FIRE_RES) > 0;
         }

--- a/src/main/java/com/minecolonies/coremod/util/WorkerUtil.java
+++ b/src/main/java/com/minecolonies/coremod/util/WorkerUtil.java
@@ -86,10 +86,10 @@ public final class WorkerUtil
         if (tools == null)
         {
             tools = new ArrayList<>();
-            tools.add(new Tuple<>(ToolType.HOE, new ItemStack(Items.WOODEN_HOE)));
-            tools.add(new Tuple<>(ToolType.SHOVEL, new ItemStack(Items.WOODEN_SHOVEL)));
-            tools.add(new Tuple<>(ToolType.AXE, new ItemStack(Items.WOODEN_AXE)));
-            tools.add(new Tuple<>(ToolType.PICKAXE, new ItemStack(Items.WOODEN_PICKAXE)));
+            tools.add(new Tuple<>(ToolType.HOE, new ItemStack(Items.NETHERITE_HOE)));
+            tools.add(new Tuple<>(ToolType.SHOVEL, new ItemStack(Items.NETHERITE_SHOVEL)));
+            tools.add(new Tuple<>(ToolType.AXE, new ItemStack(Items.NETHERITE_AXE)));
+            tools.add(new Tuple<>(ToolType.PICKAXE, new ItemStack(Items.NETHERITE_PICKAXE)));
         }
         return tools;
     }
@@ -215,7 +215,7 @@ public final class WorkerUtil
             TagKey<Block> tag = tier.getTag();
             if (tag != null && target.is(tag))
             {
-                required = tiers.indexOf(tier);
+                required = tier.getLevel();
                 break;
             }
         }


### PR DESCRIPTION
See #9688 

Implementation differs from 1.20 due do DamageTypes being implemented differently, in 1.19.2 we can use `.isFire()` (which applies to `in_fire`, `on_fire`, `hot_floor` and `lava`.

```java
    public static final DamageSource IN_FIRE = (new DamageSource("inFire")).bypassArmor().setIsFire();
    public static final DamageSource ON_FIRE = (new DamageSource("onFire")).bypassArmor().setIsFire();
    public static final DamageSource LAVA = (new DamageSource("lava")).setIsFire();
    public static final DamageSource HOT_FLOOR = (new DamageSource("hotFloor")).setIsFire();
    ```