### PR TITLE
Dynamic trees re-compat

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -47,6 +47,11 @@ mantleVersion=1.9.20
 # then drop the regular jar into the "libs" dir and set this to true (editing version if needed)
 runWithJourneymap=false
 
+# comment these out to disable loading Dynamic Trees; if you comment both you'll have to change code and mods.toml though.
+dynamicTreesMcVersion=1.20.1
+dynamicTreesVersion=1.3.0-BETA7
+#runWithDynamicTrees=true
+
 useShadowJar=true
 
 githubUrl=https://github.com/ldtteam/Minecolonies

--- a/gradle/configuration.gradle
+++ b/gradle/configuration.gradle
@@ -7,5 +7,10 @@ project.ext.customChangelogHeader = "\n" +
         "\n" +
         "### Optional Dependencies\n" +
         "- JEI: ${project.jei_version} (or above)\n" +
-        "- Journeymap: ${project.jmapVersion} (or above)\n" +
-        "\n"
+        "- Journeymap: ${project.jmapVersion} (or above)\n"
+
+if (project.hasProperty("dynamicTreesVersion")) {
+    project.ext.customChangelogHeader += "- Dynamic Trees: ${project.dynamicTreesVersion} (or above)\n"
+}
+
+project.ext.customChangelogHeader += "\n"

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -13,6 +13,10 @@ repositories {
         name "Rei"
         url "https://maven.shedaniel.me/"
     }
+    maven {
+        name "Dynamic Trees"
+        url "https://harleyoconnor.com/maven"
+    }
 }
 
 dependencies {
@@ -58,6 +62,15 @@ dependencies {
     if (project.hasProperty("runWithJourneymap") && project.runWithJourneymap.toBoolean()) {
          runtimeOnly fg.deobf("flat:journeymap:${project.jmapMcVersion}-${project.jmapVersion}-forge")
     }
+
+    if (project.hasProperty("dynamicTreesVersion")) {
+        if (project.hasProperty("runWithDynamicTrees") && project.runWithDynamicTrees.toBoolean()) {
+            implementation fg.deobf("com.ferreusveritas.dynamictrees:DynamicTrees-${project.dynamicTreesMcVersion}:${project.dynamicTreesVersion}")
+        } else {
+            compileOnly fg.deobf("com.ferreusveritas.dynamictrees:DynamicTrees-${project.dynamicTreesMcVersion}:${project.dynamicTreesVersion}")
+        }
+    }
+
     // replace "compileOnly" with "library" when you want to include it for testing
     // compileOnly fg.deobf("slimeknights.tconstruct:TConstruct:${project.exactMinecraftVersion}-${project.tinkersConstructVersion}")
     // compileOnly fg.deobf("slimeknights.mantle:Mantle:${project.exactMinecraftVersion}-${project.mantleVersion}")

--- a/src/main/java/com/minecolonies/api/compatibility/dynamictrees/DynamicTreeCompat.java
+++ b/src/main/java/com/minecolonies/api/compatibility/dynamictrees/DynamicTreeCompat.java
@@ -1,8 +1,18 @@
 package com.minecolonies.api.compatibility.dynamictrees;
 
+import com.ferreusveritas.dynamictrees.block.branch.BranchBlock;
+import com.ferreusveritas.dynamictrees.block.branch.TrunkShellBlock;
+import com.ferreusveritas.dynamictrees.block.leaves.DynamicLeavesBlock;
+import com.ferreusveritas.dynamictrees.entity.animation.AnimationConstants;
+import com.ferreusveritas.dynamictrees.item.Seed;
+import com.ferreusveritas.dynamictrees.tree.family.Family;
+import com.minecolonies.api.util.Log;
+import com.mojang.authlib.GameProfile;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.NonNullList;
 import net.minecraft.resources.ResourceKey;
+import net.minecraft.server.level.ServerLevel;
+import net.minecraft.world.InteractionHand;
 import net.minecraft.world.damagesource.DamageType;
 import net.minecraft.world.item.Item;
 import net.minecraft.world.item.ItemStack;
@@ -15,14 +25,10 @@ import org.jetbrains.annotations.NotNull;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.UUID;
 
 public final class DynamicTreeCompat extends DynamicTreeProxy
 {
-
-    private static DynamicTreeCompat instance = new DynamicTreeCompat();
-
-    private static final String DYNAMIC_TREE_DAMAGE = "fallingtree";
-
     private static final Map<ResourceKey<Level>, FakePlayer> fakePlayers = new HashMap<>();
 
     public DynamicTreeCompat()
@@ -44,16 +50,6 @@ public final class DynamicTreeCompat extends DynamicTreeProxy
     }
 
     /**
-     * Check whether dynamic tree's mod is present
-     *
-     * @return true or false
-     */
-    public static boolean isDynTreePresent()
-    {
-        return instance.isDynamicTreePresent();
-    }
-
-    /**
      * Check whether the block is part of a dynamic Tree
      *
      * @param block Block to check
@@ -61,42 +57,18 @@ public final class DynamicTreeCompat extends DynamicTreeProxy
     @Override
     public boolean checkForDynamicTreeBlock(@NotNull final Block block)
     {
-        return false;
-        //return block instanceof BranchBlock;
+        return block instanceof BranchBlock;
     }
 
     /**
-     * Check wether the block is part of a dynamic Tree
-     *
-     * @param block Block to check
-     * @return true if so.
-     */
-    public static boolean isDynamicTreeBlock(final Block block)
-    {
-        return instance.checkForDynamicTreeBlock(block);
-    }
-
-    /**
-     * Check wether the block is a dynamic leaf
+     * Check whether the block is a dynamic leaf
      *
      * @param block Block to check
      */
     @Override
     public boolean checkForDynamicLeavesBlock(final Block block)
     {
-        return false;
-        //return block instanceof DynamicLeavesBlock;
-    }
-
-    /**
-     * Check wether the block is a dynamic leaf
-     *
-     * @param block Block to check
-     * @return true if so.
-     */
-    public static boolean isDynamicLeavesBlock(final Block block)
-    {
-        return instance.checkForDynamicLeavesBlock(block);
+        return block instanceof DynamicLeavesBlock;
     }
 
     /**
@@ -108,19 +80,7 @@ public final class DynamicTreeCompat extends DynamicTreeProxy
     @Override
     public boolean checkForDynamicTrunkShellBlock(final Block block)
     {
-        return false;
-        //return block instanceof TrunkShellBlock;
-    }
-
-    /**
-     * Check whether the block is a shell block.
-     *
-     * @param block the block to check
-     * @return true if it is a shell block.
-     */
-    public static boolean isDynamicTrunkShellBlock(final Block block)
-    {
-        return instance.checkForDynamicTrunkShellBlock(block);
+        return block instanceof TrunkShellBlock;
     }
 
     /**
@@ -140,63 +100,26 @@ public final class DynamicTreeCompat extends DynamicTreeProxy
       final int fortune,
       final Block leaf)
     {
-        /*if (isDynamicLeavesBlock(leaf))
+        if (leaf instanceof final DynamicLeavesBlock leaves)
         {
-            ItemStack stack = ((DynamicLeavesBlock) leaf).getFamily(blockState, world, pos).getCommonSpecies().getSeedStack(1);
+            ItemStack stack = leaves.getFamily(blockstate, world, pos).getCommonSpecies().getSeedStack(1);
             final NonNullList<ItemStack> list = NonNullList.create();
             list.add(stack);
             return list;
-        }*/
+        }
+
         return NonNullList.create();
     }
 
     /**
-     * Returns drops of a dynamic seed as List
-     *
-     * @param world      world the Leaf is in
-     * @param pos        position of the Leaf
-     * @param blockState Blockstate of the Leaf
-     * @param fortune    amount of fortune to use
-     * @param leaf       The leaf to check
-     * @return the list of drops.
-     */
-    public static NonNullList<ItemStack> getDropsForLeafCompat(final LevelAccessor world, final BlockPos pos, final BlockState blockState, final int fortune, final Block leaf)
-    {
-        return instance.getDropsForLeaf(world, pos, blockState, fortune, leaf);
-    }
-
-    /**
-     * Check wether the item is a dynamic Sapling
+     * Check whether the item is a dynamic Sapling
      *
      * @param item Item to check
      */
     @Override
     public boolean checkForDynamicSapling(@NotNull final Item item)
     {
-        return false;
-        //return item instanceof Seed;
-    }
-
-    /**
-     * Check wether the item is a dynamic Sapling
-     *
-     * @param item Item to check
-     * @return true if so.
-     */
-    public static boolean isDynamicTreeSapling(final Item item)
-    {
-        return instance.checkForDynamicSapling(item);
-    }
-
-    /**
-     * Check wether the Itemstack is a dynamic Sapling
-     *
-     * @param stack Itemstack to check
-     * @return true if it is a dynamic Sapling
-     */
-    public static boolean isDynamicTreeSapling(final ItemStack stack)
-    {
-        return instance.checkForDynamicSapling(stack.getItem());
+        return item instanceof Seed;
     }
 
     /**
@@ -213,7 +136,7 @@ public final class DynamicTreeCompat extends DynamicTreeProxy
     {
         return () ->
         {
-            /*final BlockState curBlockState = world.getBlockState(blockToBreak);
+            final BlockState curBlockState = world.getBlockState(blockToBreak);
             final Block curBlock = curBlockState.getBlock();
 
             if (world.getServer() == null)
@@ -242,22 +165,8 @@ public final class DynamicTreeCompat extends DynamicTreeProxy
                 fake.setItemInHand(InteractionHand.MAIN_HAND, toolToUse);
             }
 
-            curBlock.removedByPlayer(curBlockState, world, blockToBreak, fake, true, world.getFluidState(blockToBreak));*/
+            curBlock.onDestroyedByPlayer(curBlockState, world, blockToBreak, fake, true, world.getFluidState(blockToBreak));
         };
-    }
-
-    /**
-     * Creates a runnable to harvest/break a dynamic tree
-     *
-     * @param world        The world the tree is in
-     * @param blockToBreak The block of the dynamic tree
-     * @param toolToUse    The tool to break the tree with, optional
-     * @param workerPos    The position the fakeplayer breaks the tree from, optional
-     * @return Runnable to break the Tree
-     */
-    public static Runnable getTreeBreakAction(final Level world, final BlockPos blockToBreak, final ItemStack toolToUse, final BlockPos workerPos)
-    {
-        return instance.getTreeBreakActionCompat(world, blockToBreak, toolToUse, workerPos);
     }
 
     /**
@@ -271,27 +180,12 @@ public final class DynamicTreeCompat extends DynamicTreeProxy
     @Override
     public boolean plantDynamicSaplingCompat(@NotNull final Level world, @NotNull final BlockPos location, @NotNull final ItemStack saplingStack)
     {
-        /*if (saplingStack.getItem() instanceof Seed)
+        if (saplingStack.getItem() instanceof final Seed seed)
         {
-            return ((Seed) saplingStack.getItem()).getSpecies().plantSapling(world, location, false);
+            return seed.getSpecies().plantSapling(world, location, false);
         }
-        else*/
-        {
-            return false;
-        }
-    }
 
-    /**
-     * Tries to plant a sapling at the given location
-     *
-     * @param world    World to plant the sapling in
-     * @param location location to plant the sapling
-     * @param sapling  Itemstack of the sapling
-     * @return true if successful
-     */
-    public static boolean plantDynamicSapling(final Level world, final BlockPos location, final ItemStack sapling)
-    {
-        return instance.plantDynamicSaplingCompat(world, location, sapling);
+        return false;
     }
 
     /**
@@ -302,7 +196,7 @@ public final class DynamicTreeCompat extends DynamicTreeProxy
     @Override
     public ResourceKey<DamageType> getDynamicTreeDamage()
     {
-        return null;
+        return AnimationConstants.TREE_DAMAGE_TYPE;
     }
 
     /**
@@ -315,13 +209,13 @@ public final class DynamicTreeCompat extends DynamicTreeProxy
     @Override
     public boolean hasFittingTreeFamilyCompat(@NotNull final BlockPos block1, @NotNull final BlockPos block2, @NotNull final LevelAccessor world)
     {
-        /*Family fam1 = getFamilyForBlock(block1, world);
-        Family fam2 = getFamilyForBlock(block2, world);
+        final Family fam1 = getFamilyForBlock(block1, world);
+        final Family fam2 = getFamilyForBlock(block2, world);
 
         if (fam1 != null && fam2 != null)
         {
             return fam1 == fam2;
-        }*/
+        }
         return false;
     }
 
@@ -332,31 +226,18 @@ public final class DynamicTreeCompat extends DynamicTreeProxy
      * @param world    world
      * @return dynamic tree family
      */
-    /*private static Family getFamilyForBlock(@NotNull final BlockPos blockPos, @NotNull final IWorld world)
+    private static Family getFamilyForBlock(@NotNull final BlockPos blockPos, @NotNull final LevelAccessor world)
     {
         final Block block = world.getBlockState(blockPos).getBlock();
-        if (block instanceof BranchBlock)
+        if (block instanceof final BranchBlock branch)
         {
-            return ((BranchBlock) block).getFamily();
+            return branch.getFamily();
         }
-        if (block instanceof DynamicLeavesBlock)
+        if (block instanceof final DynamicLeavesBlock leaves)
         {
-            return ((DynamicLeavesBlock) block).getFamily(world.getBlockState(blockPos), world, blockPos);
+            return leaves.getFamily(world.getBlockState(blockPos), world, blockPos);
         }
 
         return null;
-    }*/
-
-    /**
-     * Method to check if two given blocks have the same Tree family
-     *
-     * @param block1 First blockpos to compare
-     * @param block2 Second blockpos to compare
-     * @param world  the world.
-     * @return true when same family
-     */
-    public static boolean hasFittingTreeFamily(@NotNull final BlockPos block1, @NotNull final BlockPos block2, @NotNull final LevelAccessor world)
-    {
-        return instance.hasFittingTreeFamilyCompat(block1, block2, world);
     }
 }

--- a/src/main/resources/META-INF/mods.toml
+++ b/src/main/resources/META-INF/mods.toml
@@ -83,3 +83,9 @@ MineColonies is a colony simulator within Minecraft! There are numerous types of
     versionRange="[${project.jmapVersion},)"
     ordering="NONE"
     side="BOTH"
+[[dependencies.minecolonies]]
+    modId="dynamictrees"
+    mandatory=false
+    versionRange="[${project.dynamicTreesVersion},)"
+    ordering="NONE"
+    side="BOTH"


### PR DESCRIPTION
Closes [discord request](https://discord.com/channels/139070364159311872/1141796121958678639/1195780723186089984)
Closes [discord request](https://discord.com/channels/139070364159311872/240841248750043137/1257470648687530084)

# Changes proposed in this pull request:
- Enable Dynamic Trees compatibility for 1.20

[x] Yes I tested this before submitting it.
[ ] I also did a multiplayer test.

Review please (do not backport)

~Might want to avoid merging until DynamicTreesTeam/DynamicTrees#835 is fixed; it didn't crash on me when the forester was felling the tree, but then nobody was standing in the way...~