### PR TITLE
Pathingfixes

### DIFF
--- a/src/api/java/com/minecolonies/api/colony/ICitizenData.java
+++ b/src/api/java/com/minecolonies/api/colony/ICitizenData.java
@@ -20,6 +20,7 @@ import org.jetbrains.annotations.Nullable;
 import java.util.List;
 import java.util.Optional;
 import java.util.Random;
+import java.util.UUID;
 
 public interface ICitizenData extends ICivilianData, IQuestGiver, IQuestParticipant
 {
@@ -405,4 +406,11 @@ public interface ICitizenData extends ICivilianData, IQuestGiver, IQuestParticip
      * Called after buildings loaded
      */
     void onBuildingLoad();
+
+    /**
+     * Called when a player interacts with a citizen
+     *
+     * @param player the player that interacted
+     */
+    void setInteractedRecently(final UUID player);
 }

--- a/src/api/java/com/minecolonies/api/entity/citizen/AbstractCivilianEntity.java
+++ b/src/api/java/com/minecolonies/api/entity/citizen/AbstractCivilianEntity.java
@@ -141,10 +141,20 @@ public abstract class AbstractCivilianEntity extends AbstractFastMinecoloniesEnt
 
     /**
      * Get the sound manager.
+     *
      * @return the sound manager.
      */
     public SoundManager getSoundManager()
     {
         return soundManager;
+    }
+
+    @Override
+    public String toString()
+    {
+        final ICivilianData data = getCivilianData();
+        final String id = data == null ? "none" : "" + data.getId();
+        final String colony = data == null ? "none" : "" + data.getColony().getName();
+        return "Enity: " + getDisplayName().getString() + " Type: [" + getClass().getSimpleName() + "] at pos: " + blockPosition() + " civilian id: " + id + " colony: " + colony;
     }
 }

--- a/src/api/java/com/minecolonies/api/entity/mobs/AbstractEntityRaiderMob.java
+++ b/src/api/java/com/minecolonies/api/entity/mobs/AbstractEntityRaiderMob.java
@@ -7,14 +7,14 @@ import com.minecolonies.api.colony.IColonyManager;
 import com.minecolonies.api.colony.colonyEvents.IColonyCampFireRaidEvent;
 import com.minecolonies.api.colony.colonyEvents.IColonyEvent;
 import com.minecolonies.api.enchants.ModEnchants;
-import com.minecolonies.api.entity.other.AbstractFastMinecoloniesEntity;
 import com.minecolonies.api.entity.CustomGoalSelector;
-import com.minecolonies.api.entity.ai.statemachine.states.IState;
-import com.minecolonies.api.entity.ai.statemachine.tickratestatemachine.ITickRateStateMachine;
-import com.minecolonies.api.entity.ai.statemachine.tickratestatemachine.TickRateStateMachine;
 import com.minecolonies.api.entity.ai.combat.CombatAIStates;
 import com.minecolonies.api.entity.ai.combat.threat.IThreatTableEntity;
 import com.minecolonies.api.entity.ai.combat.threat.ThreatTable;
+import com.minecolonies.api.entity.ai.statemachine.states.IState;
+import com.minecolonies.api.entity.ai.statemachine.tickratestatemachine.ITickRateStateMachine;
+import com.minecolonies.api.entity.ai.statemachine.tickratestatemachine.TickRateStateMachine;
+import com.minecolonies.api.entity.other.AbstractFastMinecoloniesEntity;
 import com.minecolonies.api.entity.pathfinding.AbstractAdvancedPathNavigate;
 import com.minecolonies.api.entity.pathfinding.PathingStuckHandler;
 import com.minecolonies.api.entity.pathfinding.registry.IPathNavigateRegistry;
@@ -288,13 +288,14 @@ public abstract class AbstractEntityRaiderMob extends AbstractFastMinecoloniesEn
             this.newNavigator.setCanFloat(true);
             newNavigator.setSwimSpeedFactor(getSwimSpeedFactor());
             this.newNavigator.getPathingOptions().setEnterDoors(true);
-            newNavigator.getPathingOptions().withDropCost(1.3D);
+            newNavigator.getPathingOptions().withDropCost(1D);
+            newNavigator.getPathingOptions().withJumpCost(1D);
             newNavigator.getPathingOptions().setPassDanger(true);
             PathingStuckHandler stuckHandler = PathingStuckHandler.createStuckHandler()
-                                                 .withTakeDamageOnStuck(0.4f)
-                                                 .withBuildLeafBridges()
-                                                 .withChanceToByPassMovingAway(0.20)
-                                                 .withPlaceLadders();
+              .withTakeDamageOnStuck(0.4f)
+              .withBuildLeafBridges()
+              .withChanceToByPassMovingAway(0.20)
+              .withPlaceLadders();
 
             if (MinecoloniesAPIProxy.getInstance().getConfig().getServer().raidersbreakblocks.get())
             {

--- a/src/api/java/com/minecolonies/api/entity/pathfinding/AbstractAdvancedPathNavigate.java
+++ b/src/api/java/com/minecolonies/api/entity/pathfinding/AbstractAdvancedPathNavigate.java
@@ -129,13 +129,16 @@ public abstract class AbstractAdvancedPathNavigate extends GroundPathNavigation
     /**
      * Used to path towards a random pos within some restrictions
      *
-     * @param range the range he should move out of.
-     * @param speed the speed to run at.
+     * @param range   the range he should move out of.
+     * @param speed   the speed to run at.
      * @param corners the corners they can't leave.
-     * @param prioDoors if doors should have higher path prio.
      * @return the result of the pathing.
      */
-    public abstract PathResult<? extends IPathJob> moveToRandomPos(final int range, final double speed, final net.minecraft.util.Tuple<BlockPos, BlockPos> corners, final RestrictionType restrictionType, boolean prioDoors);
+    public abstract PathResult<? extends IPathJob> moveToRandomPos(
+      final int range,
+      final double speed,
+      final net.minecraft.util.Tuple<BlockPos, BlockPos> corners,
+      final RestrictionType restrictionType);
 
     /**
      * Used to find a tree.

--- a/src/api/java/com/minecolonies/api/entity/pathfinding/PathingOptions.java
+++ b/src/api/java/com/minecolonies/api/entity/pathfinding/PathingOptions.java
@@ -6,12 +6,12 @@ package com.minecolonies.api.entity.pathfinding;
 public class PathingOptions
 {
     /**
-     * Additional cost of jumping and dropping - base 1.
+     * Additional cost of jumping
      */
-    public double jumpCost = 1.1D;
+    public double jumpCost = 1.5D;
 
     /**
-     * Additional cost of jumping and dropping - base 1.
+     * Additional cost of dropping
      */
     public double dropCost = 1.1D;
 

--- a/src/api/java/com/minecolonies/api/entity/pathfinding/PathingOptions.java
+++ b/src/api/java/com/minecolonies/api/entity/pathfinding/PathingOptions.java
@@ -5,40 +5,42 @@ package com.minecolonies.api.entity.pathfinding;
  */
 public class PathingOptions
 {
+    // x2: Weak dislike, x3: clear dislike, x4 strong dislike x5 very strong dislike
+
     /**
      * Additional cost of jumping
      */
-    public double jumpCost = 1.5D;
+    public double jumpCost = 3D;
 
     /**
      * Additional cost of dropping
      */
-    public double dropCost = 1.1D;
+    public double dropCost = 2D;
 
     /**
      * Cost improvement of paths - base 1.
      */
-    public double onPathCost = 0.5D;
+    public double onPathCost = 1 / 4d;
 
     /**
      * Cost improvement of paths - base 1.
      */
-    public double onRailCost = 0.1D;
+    public double onRailCost = 1 / 10D;
 
     /**
      * The rails exit cost.
      */
-    public double railsExitCost = 2;
+    public double railsExitCost = 5;
 
     /**
      * Additional cost of swimming - base 1.
      */
-    public double swimCost = 1.5D;
+    public double swimCost = 3D;
 
     /**
      * Additional cost of cave air.
      */
-    public double caveAirCost = 2D;
+    public double caveAirCost = 4D;
 
     /**
      * Additional cost enter entering water
@@ -51,9 +53,9 @@ public class PathingOptions
     public double traverseToggleAbleCost = 10D;
 
     /**
-     * Cost to climb a vine.
+     * Cost to climb a non ladder.
      */
-    public double vineCost = 2D;
+    public double nonLadderClimbableCost = 4D;
 
     /**
      * Whether to use minecart rail pathing
@@ -74,7 +76,7 @@ public class PathingOptions
     /**
      * Whether to path through vines.
      */
-    private boolean canClimbVines  = false;
+    private boolean canClimbNonLadders = false;
 
     /**
      * Whether to path through dangerous blocks.
@@ -99,9 +101,9 @@ public class PathingOptions
         return canUseRails;
     }
 
-    public boolean canClimbVines()
+    public boolean canClimbNonLadders()
     {
-        return canClimbVines;
+        return canClimbNonLadders;
     }
 
     public void setCanUseRails(final boolean canUseRails)
@@ -109,9 +111,9 @@ public class PathingOptions
         this.canUseRails = canUseRails;
     }
 
-    public void setCanClimbVines(final boolean canClimbVines)
+    public void setCanClimbNonLadders(final boolean canClimbNonLadders)
     {
-        this.canClimbVines = canClimbVines;
+        this.canClimbNonLadders = canClimbNonLadders;
     }
 
     public boolean canSwim()
@@ -192,9 +194,9 @@ public class PathingOptions
         return this;
     }
 
-    public PathingOptions withVineCost(final double vineCost)
+    public PathingOptions withNonLadderClimbableCost(final double nonLadderClimbableCost)
     {
-        this.vineCost = vineCost;
+        this.nonLadderClimbableCost = nonLadderClimbableCost;
         return this;
     }
 
@@ -236,12 +238,12 @@ public class PathingOptions
         caveAirCost = pathingOptions.caveAirCost;
         swimCostEnter = pathingOptions.swimCostEnter;
         traverseToggleAbleCost = pathingOptions.traverseToggleAbleCost;
-        vineCost = pathingOptions.vineCost;
+        nonLadderClimbableCost = pathingOptions.nonLadderClimbableCost;
         canUseRails = pathingOptions.canUseRails;
         canSwim = pathingOptions.canSwim;
         enterDoors = pathingOptions.enterDoors;
         canOpenDoors = pathingOptions.canOpenDoors;
-        canClimbVines = pathingOptions.canClimbVines;
+        canClimbNonLadders = pathingOptions.canClimbNonLadders;
         canPassDanger = pathingOptions.canPassDanger;
     }
 

--- a/src/main/java/com/minecolonies/core/colony/CitizenData.java
+++ b/src/main/java/com/minecolonies/core/colony/CitizenData.java
@@ -1663,7 +1663,7 @@ public class CitizenData implements ICitizenData
 
             // Applies entity related research effects.
             citizen.getNavigation().getPathingOptions().setCanUseRails(((EntityCitizen) citizen).canPathOnRails());
-            citizen.getNavigation().getPathingOptions().setCanClimbVines(((EntityCitizen) citizen).canClimbVines());
+            citizen.getNavigation().getPathingOptions().setCanClimbNonLadders(((EntityCitizen) citizen).canClimbVines());
 
             final AttributeModifier speedModifier = new AttributeModifier(RESEARCH_BONUS_MULTIPLIER,
               colony.getResearchManager().getResearchEffects().getEffectStrength(WALKING),

--- a/src/main/java/com/minecolonies/core/colony/buildings/AbstractBuildingGuards.java
+++ b/src/main/java/com/minecolonies/core/colony/buildings/AbstractBuildingGuards.java
@@ -305,7 +305,16 @@ public abstract class AbstractBuildingGuards extends AbstractBuilding implements
     @Nullable
     public Player getPlayerToFollowOrRally()
     {
-        return rallyLocation != null && rallyLocation instanceof EntityLocation ? ((EntityLocation) rallyLocation).getPlayerEntity() : getPlayerFromUUID(followPlayerUUID, this.colony.getWorld());
+        if (rallyLocation != null && rallyLocation instanceof EntityLocation)
+        {
+            return ((EntityLocation) rallyLocation).getPlayerEntity();
+        }
+        else if (getTask().equals(GuardTaskSetting.FOLLOW))
+        {
+            return getPlayerFromUUID(followPlayerUUID, this.colony.getWorld());
+        }
+
+        return null;
     }
 
     /**

--- a/src/main/java/com/minecolonies/core/colony/managers/StatisticsManager.java
+++ b/src/main/java/com/minecolonies/core/colony/managers/StatisticsManager.java
@@ -135,7 +135,7 @@ public class StatisticsManager implements IStatisticsManager
             final String id = buf.readUtf();
             final int statEntrySize = buf.readVarInt();
 
-            final Int2IntLinkedOpenHashMap statValues = fullSync ? new Int2IntLinkedOpenHashMap(statEntrySize) : stats.get(id);
+            final Int2IntLinkedOpenHashMap statValues = (fullSync || !stats.containsKey(id)) ? new Int2IntLinkedOpenHashMap(statEntrySize) : stats.get(id);
             for (int j = 0; j < statEntrySize; j++)
             {
                 statValues.put(buf.readVarInt(), buf.readVarInt());

--- a/src/main/java/com/minecolonies/core/entity/ai/minimal/EntityAICitizenWander.java
+++ b/src/main/java/com/minecolonies/core/entity/ai/minimal/EntityAICitizenWander.java
@@ -9,9 +9,9 @@ import com.minecolonies.api.entity.pathfinding.AbstractAdvancedPathNavigate;
 import com.minecolonies.api.tileentities.TileEntityColonyBuilding;
 import com.minecolonies.core.colony.buildings.workerbuildings.BuildingLibrary;
 import com.minecolonies.core.colony.jobs.AbstractJobGuard;
-import com.minecolonies.core.entity.other.SittingEntity;
 import com.minecolonies.core.entity.ai.workers.education.EntityAIStudy;
 import com.minecolonies.core.entity.citizen.EntityCitizen;
+import com.minecolonies.core.entity.other.SittingEntity;
 import net.minecraft.core.BlockPos;
 import net.minecraft.world.entity.EquipmentSlot;
 import net.minecraft.world.item.ItemStack;
@@ -163,7 +163,7 @@ public class EntityAICitizenWander implements IStateAI
             if (walkTo == null && citizen.getRandom().nextBoolean())
             {
                 citizen.getNavigation()
-                  .moveToRandomPos(10, DEFAULT_SPEED, ((IBlueprintDataProviderBE) blockEntity).getInWorldCorners(), AbstractAdvancedPathNavigate.RestrictionType.XYZ, false);
+                  .moveToRandomPos(10, DEFAULT_SPEED, ((IBlueprintDataProviderBE) blockEntity).getInWorldCorners(), AbstractAdvancedPathNavigate.RestrictionType.XYZ);
             }
             if (walkTo == null && blockEntity instanceof TileEntityColonyBuilding && ((TileEntityColonyBuilding) blockEntity).getBuilding() instanceof BuildingLibrary
                   && citizen.getRandom().nextInt(100) < 5)

--- a/src/main/java/com/minecolonies/core/entity/ai/minimal/EntityAIMournCitizen.java
+++ b/src/main/java/com/minecolonies/core/entity/ai/minimal/EntityAIMournCitizen.java
@@ -164,7 +164,7 @@ public class EntityAIMournCitizen implements IStateAI
         // Wander around randomly.
         if (MathUtils.RANDOM.nextInt(100) < 90)
         {
-            citizen.getNavigation().moveToRandomPos(10, DEFAULT_SPEED, graveyardBuilding.getCorners(), AbstractAdvancedPathNavigate.RestrictionType.XYZ, false);
+            citizen.getNavigation().moveToRandomPos(10, DEFAULT_SPEED, graveyardBuilding.getCorners(), AbstractAdvancedPathNavigate.RestrictionType.XYZ);
             return MourningState.WANDER_AT_GRAVEYARD;
         }
 

--- a/src/main/java/com/minecolonies/core/entity/ai/workers/crafting/AbstractEntityAICrafting.java
+++ b/src/main/java/com/minecolonies/core/entity/ai/workers/crafting/AbstractEntityAICrafting.java
@@ -145,7 +145,7 @@ public abstract class AbstractEntityAICrafting<J extends AbstractJobCrafter<?, J
             {
                 if (building.isInBuilding(worker.blockPosition()))
                 {
-                    worker.getNavigation().moveToRandomPos(10, DEFAULT_SPEED, building.getCorners(), AbstractAdvancedPathNavigate.RestrictionType.XYZ, false);
+                    worker.getNavigation().moveToRandomPos(10, DEFAULT_SPEED, building.getCorners(), AbstractAdvancedPathNavigate.RestrictionType.XYZ);
                 }
                 else
                 {

--- a/src/main/java/com/minecolonies/core/entity/ai/workers/crafting/EntityAIWorkAlchemist.java
+++ b/src/main/java/com/minecolonies/core/entity/ai/workers/crafting/EntityAIWorkAlchemist.java
@@ -24,7 +24,6 @@ import com.minecolonies.core.Network;
 import com.minecolonies.core.colony.buildings.workerbuildings.BuildingAlchemist;
 import com.minecolonies.core.colony.interactionhandling.StandardInteraction;
 import com.minecolonies.core.colony.jobs.JobAlchemist;
-import com.minecolonies.core.entity.ai.workers.crafting.AbstractEntityAICrafting;
 import com.minecolonies.core.network.messages.client.BlockParticleEffectMessage;
 import net.minecraft.core.BlockPos;
 import net.minecraft.network.chat.Component;
@@ -301,7 +300,7 @@ public class EntityAIWorkAlchemist extends AbstractEntityAICrafting<JobAlchemist
 
                 if (building.isInBuilding(worker.blockPosition()))
                 {
-                    worker.getNavigation().moveToRandomPos(10, DEFAULT_SPEED, building.getCorners(), AbstractAdvancedPathNavigate.RestrictionType.XYZ, false);
+                    worker.getNavigation().moveToRandomPos(10, DEFAULT_SPEED, building.getCorners(), AbstractAdvancedPathNavigate.RestrictionType.XYZ);
                 }
                 else
                 {

--- a/src/main/java/com/minecolonies/core/entity/ai/workers/crafting/EntityAIWorkCrusher.java
+++ b/src/main/java/com/minecolonies/core/entity/ai/workers/crafting/EntityAIWorkCrusher.java
@@ -12,13 +12,12 @@ import com.minecolonies.api.util.constant.Constants;
 import com.minecolonies.core.Network;
 import com.minecolonies.core.colony.buildings.workerbuildings.BuildingCrusher;
 import com.minecolonies.core.colony.jobs.JobCrusher;
-import com.minecolonies.core.entity.ai.workers.crafting.AbstractEntityAICrafting;
 import com.minecolonies.core.network.messages.client.LocalizedParticleEffectMessage;
 import com.minecolonies.core.util.WorkerUtil;
-import net.minecraft.world.item.ItemStack;
-import net.minecraft.world.InteractionHand;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.sounds.SoundEvents;
+import net.minecraft.world.InteractionHand;
+import net.minecraft.world.item.ItemStack;
 import org.jetbrains.annotations.NotNull;
 
 import static com.minecolonies.api.entity.ai.statemachine.states.AIWorkerState.*;
@@ -77,7 +76,7 @@ public class EntityAIWorkCrusher extends AbstractEntityAICrafting<JobCrusher, Bu
             {
                 if (building.isInBuilding(worker.blockPosition()))
                 {
-                    worker.getNavigation().moveToRandomPos(10, DEFAULT_SPEED, building.getCorners(), AbstractAdvancedPathNavigate.RestrictionType.XYZ, false);
+                    worker.getNavigation().moveToRandomPos(10, DEFAULT_SPEED, building.getCorners(), AbstractAdvancedPathNavigate.RestrictionType.XYZ);
                 }
                 else
                 {

--- a/src/main/java/com/minecolonies/core/entity/ai/workers/service/EntityAIWorkUndertaker.java
+++ b/src/main/java/com/minecolonies/core/entity/ai/workers/service/EntityAIWorkUndertaker.java
@@ -144,7 +144,7 @@ public class EntityAIWorkUndertaker extends AbstractEntityAIInteract<JobUndertak
         {
             if (building.isInBuilding(worker.blockPosition()))
             {
-                worker.getNavigation().moveToRandomPos(10, DEFAULT_SPEED, building.getCorners(), AbstractAdvancedPathNavigate.RestrictionType.XYZ, false);
+                worker.getNavigation().moveToRandomPos(10, DEFAULT_SPEED, building.getCorners(), AbstractAdvancedPathNavigate.RestrictionType.XYZ);
             }
             else
             {

--- a/src/main/java/com/minecolonies/core/entity/citizen/EntityCitizen.java
+++ b/src/main/java/com/minecolonies/core/entity/citizen/EntityCitizen.java
@@ -757,7 +757,7 @@ public class EntityCitizen extends AbstractEntityCitizen implements IThreatTable
             {
                 this.citizenDataView = colonyView.getCitizen(citizenId);
                 this.getNavigation().getPathingOptions().setCanUseRails(canPathOnRails());
-                this.getNavigation().getPathingOptions().setCanClimbVines(canClimbVines());
+                this.getNavigation().getPathingOptions().setCanClimbNonLadders(canClimbVines());
             }
         }
         return false;

--- a/src/main/java/com/minecolonies/core/entity/citizen/EntityCitizen.java
+++ b/src/main/java/com/minecolonies/core/entity/citizen/EntityCitizen.java
@@ -13,7 +13,8 @@ import com.minecolonies.api.colony.requestsystem.StandardFactoryController;
 import com.minecolonies.api.colony.requestsystem.location.ILocation;
 import com.minecolonies.api.compatibility.Compatibility;
 import com.minecolonies.api.entity.CustomGoalSelector;
-import com.minecolonies.api.entity.pathfinding.proxy.IWalkToProxy;
+import com.minecolonies.api.entity.ai.combat.threat.IThreatTableEntity;
+import com.minecolonies.api.entity.ai.combat.threat.ThreatTable;
 import com.minecolonies.api.entity.ai.statemachine.AIOneTimeEventTarget;
 import com.minecolonies.api.entity.ai.statemachine.states.CitizenAIState;
 import com.minecolonies.api.entity.ai.statemachine.states.EntityState;
@@ -27,9 +28,8 @@ import com.minecolonies.api.entity.citizen.VisibleCitizenStatus;
 import com.minecolonies.api.entity.citizen.citizenhandlers.*;
 import com.minecolonies.api.entity.citizen.happiness.ExpirationBasedHappinessModifier;
 import com.minecolonies.api.entity.citizen.happiness.StaticHappinessSupplier;
-import com.minecolonies.api.entity.ai.combat.threat.IThreatTableEntity;
-import com.minecolonies.api.entity.ai.combat.threat.ThreatTable;
 import com.minecolonies.api.entity.pathfinding.PathResult;
+import com.minecolonies.api.entity.pathfinding.proxy.IWalkToProxy;
 import com.minecolonies.api.inventory.InventoryCitizen;
 import com.minecolonies.api.inventory.container.ContainerCitizenInventory;
 import com.minecolonies.api.items.ModItems;
@@ -48,14 +48,14 @@ import com.minecolonies.core.colony.jobs.AbstractJobGuard;
 import com.minecolonies.core.colony.jobs.JobKnight;
 import com.minecolonies.core.colony.jobs.JobNetherWorker;
 import com.minecolonies.core.colony.jobs.JobRanger;
-import com.minecolonies.core.entity.citizen.citizenhandlers.*;
-import com.minecolonies.core.entity.other.SittingEntity;
-import com.minecolonies.core.entity.ai.workers.AbstractEntityAIBasic;
-import com.minecolonies.core.entity.ai.workers.CitizenAI;
-import com.minecolonies.core.entity.ai.workers.guard.AbstractEntityAIGuard;
 import com.minecolonies.core.entity.ai.minimal.EntityAICitizenChild;
 import com.minecolonies.core.entity.ai.minimal.EntityAIInteractToggleAble;
 import com.minecolonies.core.entity.ai.minimal.LookAtEntityGoal;
+import com.minecolonies.core.entity.ai.workers.AbstractEntityAIBasic;
+import com.minecolonies.core.entity.ai.workers.CitizenAI;
+import com.minecolonies.core.entity.ai.workers.guard.AbstractEntityAIGuard;
+import com.minecolonies.core.entity.citizen.citizenhandlers.*;
+import com.minecolonies.core.entity.other.SittingEntity;
 import com.minecolonies.core.entity.pathfinding.EntityCitizenWalkToProxy;
 import com.minecolonies.core.entity.pathfinding.MovementHandler;
 import com.minecolonies.core.event.EventHandler;
@@ -413,16 +413,19 @@ public class EntityCitizen extends AbstractEntityCitizen implements IThreatTable
 
         if (!level.isClientSide && getCitizenData() != null)
         {
+            citizenData.update();
+            citizenData.setInteractedRecently(player.getUUID());
             final ColonyViewCitizenViewMessage message = new ColonyViewCitizenViewMessage((Colony) getCitizenData().getColony(), getCitizenData());
             Network.getNetwork().sendToPlayer(message, (ServerPlayer) player);
+
+            if (citizenData.getJob() != null)
+            {
+                ((AbstractEntityAIBasic) citizenData.getJob().getWorkerAI()).setDelay(TICKS_SECOND * 3);
+                getNavigation().stop();
+                getLookControl().setLookAt(player);
+            }
         }
 
-        if (citizenData != null && citizenData.getJob() != null)
-        {
-            ((AbstractEntityAIBasic) citizenData.getJob().getWorkerAI()).setDelay(TICKS_SECOND * 3);
-            getNavigation().stop();
-            getLookControl().setLookAt(player);
-        }
         return InteractionResult.SUCCESS;
     }
 

--- a/src/main/java/com/minecolonies/core/entity/mobs/aitasks/RaiderWalkAI.java
+++ b/src/main/java/com/minecolonies/core/entity/mobs/aitasks/RaiderWalkAI.java
@@ -4,12 +4,13 @@ import com.minecolonies.api.colony.colonyEvents.EventStatus;
 import com.minecolonies.api.colony.colonyEvents.IColonyEvent;
 import com.minecolonies.api.colony.colonyEvents.IColonyRaidEvent;
 import com.minecolonies.api.entity.ai.IStateAI;
+import com.minecolonies.api.entity.ai.combat.CombatAIStates;
 import com.minecolonies.api.entity.ai.statemachine.states.IState;
 import com.minecolonies.api.entity.ai.statemachine.tickratestatemachine.ITickRateStateMachine;
 import com.minecolonies.api.entity.ai.statemachine.tickratestatemachine.TickingTransition;
-import com.minecolonies.api.entity.ai.combat.CombatAIStates;
 import com.minecolonies.api.entity.mobs.AbstractEntityRaiderMob;
 import com.minecolonies.api.entity.pathfinding.AbstractAdvancedPathNavigate;
+import com.minecolonies.api.entity.pathfinding.IPathJob;
 import com.minecolonies.api.entity.pathfinding.PathResult;
 import com.minecolonies.api.util.BlockPosUtil;
 import com.minecolonies.api.util.Log;
@@ -45,7 +46,7 @@ public class RaiderWalkAI implements IStateAI
     /**
      * Random path result.
      */
-    private PathResult randomPathResult;
+    private PathResult<? extends IPathJob> randomPathResult;
 
     /**
      * If we are currently trying to move to a random block.
@@ -155,7 +156,8 @@ public class RaiderWalkAI implements IStateAI
                   && building.getBuildingLevel() > 0
                   && !building.getCorners().getA().equals(building.getCorners().getB()))
             {
-                randomPathResult = raider.getNavigation().moveToRandomPos(10, 0.9, building.getCorners(), AbstractAdvancedPathNavigate.RestrictionType.XYZ, true);
+                randomPathResult = raider.getNavigation().moveToRandomPos(10, 0.9, building.getCorners(), AbstractAdvancedPathNavigate.RestrictionType.XYZ);
+                randomPathResult.getJob().getPathingOptions().withCanEnterDoors(true).withToggleCost(0).withNonLadderClimbableCost(0);
             }
             else
             {

--- a/src/main/java/com/minecolonies/core/entity/pathfinding/MinecoloniesAdvancedPathNavigate.java
+++ b/src/main/java/com/minecolonies/core/entity/pathfinding/MinecoloniesAdvancedPathNavigate.java
@@ -2,9 +2,9 @@ package com.minecolonies.core.entity.pathfinding;
 
 import com.minecolonies.api.colony.IColony;
 import com.minecolonies.api.crafting.ItemStorage;
-import com.minecolonies.api.entity.other.MinecoloniesMinecart;
 import com.minecolonies.api.entity.ModEntities;
 import com.minecolonies.api.entity.citizen.AbstractEntityCitizen;
+import com.minecolonies.api.entity.other.MinecoloniesMinecart;
 import com.minecolonies.api.entity.pathfinding.*;
 import com.minecolonies.api.util.*;
 import com.minecolonies.core.entity.pathfinding.pathjobs.*;
@@ -165,7 +165,11 @@ public class MinecoloniesAdvancedPathNavigate extends AbstractAdvancedPathNaviga
     }
 
     @Override
-    public PathResult<AbstractPathJob> moveToRandomPos(final int range, final double speedFactor, final net.minecraft.util.Tuple<BlockPos, BlockPos> corners, final RestrictionType restrictionType, final boolean prioDoors)
+    public PathResult<AbstractPathJob> moveToRandomPos(
+      final int range,
+      final double speedFactor,
+      final net.minecraft.util.Tuple<BlockPos, BlockPos> corners,
+      final RestrictionType restrictionType)
     {
         if (pathResult != null && pathResult.getJob() instanceof PathJobRandomPos)
         {
@@ -185,7 +189,7 @@ public class MinecoloniesAdvancedPathNavigate extends AbstractAdvancedPathNaviga
           corners.getB(),
           restrictionType), null, speedFactor, true);
 
-        result.getJob().getPathingOptions().withToggleCost(prioDoors ? 5 : 1).withJumpCost(1).withDropCost(1);
+        result.getJob().getPathingOptions().withJumpCost(1).withDropCost(1);
         return result;
     }
 

--- a/src/main/java/com/minecolonies/core/entity/pathfinding/pathjobs/AbstractPathJob.java
+++ b/src/main/java/com/minecolonies/core/entity/pathfinding/pathjobs/AbstractPathJob.java
@@ -142,11 +142,6 @@ public abstract class AbstractPathJob implements Callable<Path>, IPathJob
     protected WeakReference<LivingEntity> entity;
 
     /**
-     * Cost factor related to the reptition
-     */
-    private double repetitionCostFactor = 1;
-
-    /**
      * AbstractPathJob constructor.
      *
      * @param world  the world within which to path.
@@ -546,18 +541,18 @@ public abstract class AbstractPathJob implements Callable<Path>, IPathJob
 
         if (cachedBlockLookup.getBlockState(blockPos).getBlock() == Blocks.CAVE_AIR)
         {
-            cost *= pathingOptions.caveAirCost * repetitionCostFactor;
+            cost *= pathingOptions.caveAirCost;
         }
 
         if (dPos.getY() != 0 && !(cachedBlockLookup.getBlockState(blockPos.below()).is(BlockTags.STAIRS)))
         {
             if (dPos.getY() > 0)
             {
-                cost *= pathingOptions.jumpCost * repetitionCostFactor;
+                cost *= pathingOptions.jumpCost;
             }
             else if (pathingOptions.dropCost != 1)
             {
-                cost *= pathingOptions.dropCost * Math.abs(dPos.getY() * dPos.getY()) * repetitionCostFactor;
+                cost *= pathingOptions.dropCost * Math.abs(dPos.getY() * dPos.getY());
             }
         }
 
@@ -583,18 +578,18 @@ public abstract class AbstractPathJob implements Callable<Path>, IPathJob
 
         if (state.is(BlockTags.CLIMBABLE) && !(state.getBlock() instanceof LadderBlock))
         {
-            cost *= pathingOptions.nonLadderClimbableCost * repetitionCostFactor;
+            cost *= pathingOptions.nonLadderClimbableCost;
         }
 
         if (isSwimming)
         {
             if (swimStart)
             {
-                cost *= pathingOptions.swimCostEnter * repetitionCostFactor;
+                cost *= pathingOptions.swimCostEnter;
             }
             else
             {
-                cost *= pathingOptions.swimCost * repetitionCostFactor;
+                cost *= pathingOptions.swimCost;
             }
         }
 

--- a/src/main/java/com/minecolonies/core/entity/pathfinding/pathjobs/AbstractPathJob.java
+++ b/src/main/java/com/minecolonies/core/entity/pathfinding/pathjobs/AbstractPathJob.java
@@ -1,6 +1,5 @@
 package com.minecolonies.core.entity.pathfinding.pathjobs;
 
-import com.ldtteam.domumornamentum.block.AbstractBlockStairs;
 import com.ldtteam.domumornamentum.block.decorative.FloatingCarpetBlock;
 import com.ldtteam.domumornamentum.block.decorative.PanelBlock;
 import com.minecolonies.api.blocks.decorative.AbstractBlockMinecoloniesConstructionTape;
@@ -82,17 +81,17 @@ public abstract class AbstractPathJob implements Callable<Path>, IPathJob
     /**
      * Max range used to calculate the number of nodes we visit (square of maxrange).
      */
-    protected final int maxRange;
+    protected int maxRange;
 
     /**
      * Queue of all open nodes.
      */
-    private final Queue<MNode> nodesOpen = new PriorityQueue<>(500);
+    private Queue<MNode> nodesOpen = new PriorityQueue<>(500);
 
     /**
      * Queue of all the visited nodes.
      */
-    private final Map<Integer, MNode> nodesVisited = new HashMap<>();
+    private Map<Integer, MNode> nodesVisited = new HashMap<>();
 
     //  Debug Rendering
     protected     boolean    debugDrawEnabled     = false;
@@ -141,6 +140,11 @@ public abstract class AbstractPathJob implements Callable<Path>, IPathJob
      * The entity this job belongs to.
      */
     protected WeakReference<LivingEntity> entity;
+
+    /**
+     * Cost factor related to the reptition
+     */
+    private double repetitionCostFactor = 1;
 
     /**
      * AbstractPathJob constructor.
@@ -542,18 +546,18 @@ public abstract class AbstractPathJob implements Callable<Path>, IPathJob
 
         if (cachedBlockLookup.getBlockState(blockPos).getBlock() == Blocks.CAVE_AIR)
         {
-            cost *= pathingOptions.caveAirCost;
+            cost *= pathingOptions.caveAirCost * repetitionCostFactor;
         }
 
         if (dPos.getY() != 0 && !(cachedBlockLookup.getBlockState(blockPos.below()).is(BlockTags.STAIRS)))
         {
             if (dPos.getY() > 0)
             {
-                cost *= pathingOptions.jumpCost;
+                cost *= pathingOptions.jumpCost * repetitionCostFactor;
             }
             else if (pathingOptions.dropCost != 1)
             {
-                cost *= pathingOptions.dropCost * Math.abs(dPos.getY() * dPos.getY());
+                cost *= pathingOptions.dropCost * Math.abs(dPos.getY() * dPos.getY()) * repetitionCostFactor;
             }
         }
 
@@ -577,20 +581,20 @@ public abstract class AbstractPathJob implements Callable<Path>, IPathJob
             cost *= pathingOptions.railsExitCost;
         }
 
-        if (state.getBlock() instanceof VineBlock)
+        if (state.is(BlockTags.CLIMBABLE) && !(state.getBlock() instanceof LadderBlock))
         {
-            cost *= pathingOptions.vineCost;
+            cost *= pathingOptions.nonLadderClimbableCost * repetitionCostFactor;
         }
 
         if (isSwimming)
         {
             if (swimStart)
             {
-                cost *= pathingOptions.swimCostEnter;
+                cost *= pathingOptions.swimCostEnter * repetitionCostFactor;
             }
             else
             {
-                cost *= pathingOptions.swimCost;
+                cost *= pathingOptions.swimCost * repetitionCostFactor;
             }
         }
 
@@ -1218,7 +1222,7 @@ public abstract class AbstractPathJob implements Callable<Path>, IPathJob
             return handleInLiquid(pos, below, isSwimming);
         }
 
-        if (isLadder(below.getBlock(), pos.below()))
+        if (isLadder(below, pos.below()))
         {
             return pos.getY();
         }
@@ -1485,7 +1489,7 @@ public abstract class AbstractPathJob implements Callable<Path>, IPathJob
             }
             else
             {
-                if (isLadder(block.getBlock(), pos))
+                if (isLadder(block, pos))
                 {
                     return true;
                 }
@@ -1513,7 +1517,7 @@ public abstract class AbstractPathJob implements Callable<Path>, IPathJob
         {
             return !head
                      || !(state.getBlock() instanceof WoolCarpetBlock || state.getBlock() instanceof FloatingCarpetBlock)
-                     || isLadder(state.getBlock(), pos);
+                     || isLadder(state, pos);
         }
         return isPassable(state, pos, parent, head);
     }
@@ -1562,18 +1566,18 @@ public abstract class AbstractPathJob implements Callable<Path>, IPathJob
     /**
      * Is the block a ladder.
      *
-     * @param block block to check.
-     * @param pos   location of the block.
+     * @param blockState block to check.
+     * @param pos        location of the block.
      * @return true if the block is a ladder.
      */
-    protected boolean isLadder(@NotNull final Block block, final BlockPos pos)
+    protected boolean isLadder(@NotNull final BlockState blockState, final BlockPos pos)
     {
-        return block.isLadder(this.cachedBlockLookup.getBlockState(pos), world, pos, entity.get()) && (block != Blocks.VINE || pathingOptions.canClimbVines());
+        return blockState.isLadder(world, pos, entity.get()) && (blockState.getBlock() instanceof LadderBlock || pathingOptions.canClimbNonLadders());
     }
 
     protected boolean isLadder(final BlockPos pos)
     {
-        return isLadder(cachedBlockLookup.getBlockState(pos).getBlock(), pos);
+        return isLadder(cachedBlockLookup.getBlockState(pos), pos);
     }
 
     /**

--- a/src/main/java/com/minecolonies/core/entity/pathfinding/pathjobs/AbstractPathJob.java
+++ b/src/main/java/com/minecolonies/core/entity/pathfinding/pathjobs/AbstractPathJob.java
@@ -553,7 +553,7 @@ public abstract class AbstractPathJob implements Callable<Path>, IPathJob
             }
             else if (pathingOptions.dropCost != 1)
             {
-                cost *= pathingOptions.dropCost * Math.abs(dPos.getY());
+                cost *= pathingOptions.dropCost * Math.abs(dPos.getY() * dPos.getY());
             }
         }
 

--- a/src/main/java/com/minecolonies/core/entity/pathfinding/pathjobs/PathJobFindTree.java
+++ b/src/main/java/com/minecolonies/core/entity/pathfinding/pathjobs/PathJobFindTree.java
@@ -8,12 +8,12 @@ import com.minecolonies.api.entity.pathfinding.TreePathResult;
 import com.minecolonies.api.util.BlockPosUtil;
 import com.minecolonies.core.entity.ai.workers.util.Tree;
 import com.minecolonies.core.entity.pathfinding.MNode;
-import net.minecraft.world.level.block.state.BlockState;
-import net.minecraft.world.entity.LivingEntity;
-import net.minecraft.tags.BlockTags;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Vec3i;
+import net.minecraft.tags.BlockTags;
+import net.minecraft.world.entity.LivingEntity;
 import net.minecraft.world.level.Level;
+import net.minecraft.world.level.block.state.BlockState;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.List;
@@ -138,7 +138,7 @@ public class PathJobFindTree extends AbstractPathJob
     @Override
     protected double computeHeuristic(@NotNull final BlockPos pos)
     {
-        return boxCenter == null ? pos.distSqr(hutLocation) * TIE_BREAKER : BlockPosUtil.getDistanceSquared2D(pos, boxCenter);
+        return Math.sqrt(boxCenter == null ? pos.distSqr(hutLocation) * TIE_BREAKER : BlockPosUtil.getDistanceSquared2D(pos, boxCenter));
     }
 
     @Override


### PR DESCRIPTION
Closes #
Closes #
Closes #

# Changes proposed in this pull request:
- Fix guards being hit immune when not following or rallied
- Fix stat sync throwing errors when an untracked stat is added
- Add fast client updates for citizens that are being interacted with by a player
- Add string printout for our citizens and visitors to easier log them
- Changed pathing to differentiate between ladders and non-ladders instead of ladders and vines, vine research now applies to all non-ladder climbables
- Fix forester tree search heuristic using square distance instead of block distance, causing the heuristics to overrule cost factors
- Re-evaluated the values of all pathfinding cost factors, many of them were too small values to impact the pathfinding (they need to compete with the heuristics). New values roughly fall into these categories: Cost x2: Weak dislike, x3: clear dislike, x4 strong dislike x5 very strong dislike. Going forward we should increase/decrease by whole numbers to actually affect pathing. So either x2 or x1/2



[x ] Yes I tested this before submitting it.
[ x] I also did a multiplayer test.

Review please
