### PR TITLE
Add block diversity stat to schematic analyzer

### DIFF
--- a/src/main/java/com/minecolonies/api/configuration/ServerConfiguration.java
+++ b/src/main/java/com/minecolonies/api/configuration/ServerConfiguration.java
@@ -142,8 +142,8 @@ public class ServerConfiguration extends AbstractConfiguration
         minThLevelToTeleport = defineInteger(builder, "minthleveltoteleport", 3, 0, 5);
         foodModifier = defineDouble(builder, "foodmodifier", 1.0, 0.1, 100);
         diseaseModifier = defineInteger(builder, "diseasemodifier", 5, 1, 100);
-        forceLoadColony = defineBoolean(builder, "forceloadcolony", false);
-        loadtime = defineInteger(builder, "loadtime", 10,1,1440);
+        forceLoadColony = defineBoolean(builder, "forceloadcolony", true);
+        loadtime = defineInteger(builder, "loadtime", 10, 1, 1440);
         colonyLoadStrictness = defineInteger(builder, "colonyloadstrictness", 3, 1, 15);
         maxTreeSize = defineInteger(builder, "maxtreesize", 400, 1, 1000);
         noSupplyPlacementRestrictions = defineBoolean(builder, "nosupplyplacementrestrictions", false);

--- a/src/main/java/com/minecolonies/core/client/gui/WindowSchematicAnalyzer.java
+++ b/src/main/java/com/minecolonies/core/client/gui/WindowSchematicAnalyzer.java
@@ -44,6 +44,7 @@ public class WindowSchematicAnalyzer extends AbstractWindowSkeleton
     private static final String BOX_LEFT                = "left";
     private static final String BOX_RIGHT               = "right";
     private static final String LABEL_SCORE             = "score";
+    private static final String LABEL_BLOCK_COUNTS      = "blockcounts";
     private static final String LABEL_SIZE              = "size";
     private static final String LABEL_BUILDINGS         = "buildings";
     private static final String BUTTON_SHOW_RES         = "showresources";
@@ -366,14 +367,25 @@ public class WindowSchematicAnalyzer extends AbstractWindowSkeleton
 
         box.findPaneOfTypeByID(LABEL_SCORE, Text.class)
           .setText(Component.translatable("com.minecolonies.coremod.gui.analyzer.complexity", Component.literal("" + next.costScore).withStyle(
-            ChatFormatting.RED)));
+            ChatFormatting.RED).withStyle(ChatFormatting.BOLD)));
+
+        box.findPaneOfTypeByID(LABEL_BLOCK_COUNTS, Text.class)
+          .setText(Component.translatable("com.minecolonies.coremod.gui.analyzer.blockcounts", Component.literal("" + next.differentBlocks.size()).withStyle(
+            ChatFormatting.BLUE).withStyle(ChatFormatting.BOLD)));
+
+        PaneBuilders.tooltipBuilder()
+          .append(Component.translatable("com.minecolonies.coremod.gui.analyzer.score", next.differentBlocks.size() * 40, next.costScore))
+          .hoverPane(box.findPaneOfTypeByID(LABEL_BLOCK_COUNTS, Text.class))
+          .build();
 
         box.findPaneOfTypeByID(LABEL_SIZE, Text.class)
           .setText(Component.translatable("com.minecolonies.coremod.gui.analyzer.size", Component.literal("[" + next.blueprint.getSizeX() + " " + next.blueprint.getSizeY() + " "
-                                                                                                            + next.blueprint.getSizeZ() + "]").withStyle(ChatFormatting.YELLOW)));
-
+                                                                                                            + next.blueprint.getSizeZ() + "]")
+            .withStyle(ChatFormatting.YELLOW)
+            .withStyle(ChatFormatting.BOLD)));
         box.findPaneOfTypeByID(LABEL_BUILDINGS, Text.class)
-          .setText(Component.translatable("com.minecolonies.coremod.gui.analyzer.buildings", Component.literal("" + next.containedBuildings).withStyle(ChatFormatting.GOLD)));
+          .setText(Component.translatable("com.minecolonies.coremod.gui.analyzer.buildings",
+            Component.literal("" + next.containedBuildings).withStyle(ChatFormatting.GOLD).withStyle(ChatFormatting.BOLD)));
 
         final ScrollingList resourceList = box.findPaneOfTypeByID(LIST_RES, ScrollingList.class);
         resourceList.setVisible(false);

--- a/src/main/resources/assets/minecolonies/gui/analyzer/analyzedisplay.xml
+++ b/src/main/resources/assets/minecolonies/gui/analyzer/analyzedisplay.xml
@@ -9,10 +9,11 @@
     <box id="results" size="100% 165" label="list" pos="1 45" linewidth="1">
         <label id="score" size="100% 14" pos="3 1" color="white"/>
         <label id="size" size="100% 14" pos="3 15" color="white"/>
-        <label id="buildings" size="100% 14" pos="3 29" color="white"/>
-        <buttonimage label="$(com.ldtteam.structurize.gui.scantool.showres)" id="showresources" pos="3 43" size="86 20"
+        <label id="blockcounts" size="100% 14" pos="3 29" color="white"/>
+        <label id="buildings" size="100% 14" pos="3 43" color="white"/>
+        <buttonimage label="$(com.ldtteam.structurize.gui.scantool.showres)" id="showresources" pos="3 57" size="86 20"
                      source="structurize:textures/gui/builderhut/builder_button_medium.png" textcolor="black"/>
-        <list id="resources" size="100% 120" pos="0 43" childspacing="-1" visible="false">
+        <list id="resources" size="100% 120" pos="0 57" childspacing="-1" visible="false">
             <box size="100% 19" linewidth="1">
                 <itemicon id="resourceIcon" size="16 16" pos="1 1"/>
                 <label id="resourceName" size="86 12" pos="19 1" color="white" wrap="true"/>

--- a/src/main/resources/assets/minecolonies/lang/manual_en_us.json
+++ b/src/main/resources/assets/minecolonies/lang/manual_en_us.json
@@ -985,6 +985,7 @@
   "com.minecolonies.coremod.gui.analyzer.select": "Select Schematic",
   "com.minecolonies.coremod.gui.analyzer.buildings": "Buildings: %d",
   "com.minecolonies.coremod.gui.analyzer.complexity": "Complexity-score: %d",
+  "com.minecolonies.coremod.gui.analyzer.blockcounts": "Different blocks : %d",
   "com.minecolonies.coremod.gui.analyzer.score": "Score: %s total: %s",
   "com.minecolonies.coremod.gui.analyzer.size": "Size %s",
   "com.minecolonies.coremod.tooltip.schematic.tier": "Schematic tier: %s",


### PR DESCRIPTION
Closes #
Closes #
Closes #

# Changes proposed in this pull request:
- Add block diversity stat to schematic analyzer
- Default forceload to true


[ x] Yes I tested this before submitting it.
[ ] I also did a multiplayer test.

Review please
