### PR TITLE
Fix backups not loading from all dimensions

### DIFF
--- a/src/main/java/com/minecolonies/core/colony/IColonyManagerCapability.java
+++ b/src/main/java/com/minecolonies/core/colony/IColonyManagerCapability.java
@@ -7,9 +7,9 @@ import com.minecolonies.api.colony.IColonyManager;
 import com.minecolonies.api.util.Log;
 import com.minecolonies.api.util.NBTUtils;
 import com.minecolonies.core.util.BackUpHelper;
+import net.minecraft.core.BlockPos;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.nbt.Tag;
-import net.minecraft.core.BlockPos;
 import net.minecraft.world.level.Level;
 import net.minecraftforge.common.capabilities.Capability;
 import org.jetbrains.annotations.NotNull;
@@ -151,7 +151,6 @@ public interface IColonyManagerCapability
 
                 if (!compound.contains(TAG_COLONIES))
                 {
-                    BackUpHelper.loadMissingColonies();
                     BackUpHelper.loadManagerBackup();
                     return;
                 }
@@ -172,9 +171,6 @@ public interface IColonyManagerCapability
                         instance.addColony(colony);
                     }
                 }
-
-                // Check if some colonies are missing
-                BackUpHelper.loadMissingColonies();
 
                 // Check colonies for duplicates causing issues.
                 for (final BlockPos pos : tempColonies.keySet())
@@ -203,7 +199,6 @@ public interface IColonyManagerCapability
             }
             else
             {
-                BackUpHelper.loadMissingColonies();
                 BackUpHelper.loadManagerBackup();
             }
         }

--- a/src/main/java/com/minecolonies/core/event/FMLEventHandler.java
+++ b/src/main/java/com/minecolonies/core/event/FMLEventHandler.java
@@ -3,13 +3,15 @@ package com.minecolonies.core.event;
 import com.minecolonies.api.colony.IColonyManager;
 import com.minecolonies.core.datalistener.*;
 import com.minecolonies.core.entity.pathfinding.Pathfinding;
+import com.minecolonies.core.util.BackUpHelper;
 import net.minecraft.server.level.ServerPlayer;
 import net.minecraftforge.event.AddReloadListenerEvent;
 import net.minecraftforge.event.TickEvent;
 import net.minecraftforge.event.entity.player.PlayerEvent;
-import net.minecraftforge.eventbus.api.SubscribeEvent;
 import net.minecraftforge.event.server.ServerAboutToStartEvent;
+import net.minecraftforge.event.server.ServerStartedEvent;
 import net.minecraftforge.event.server.ServerStoppingEvent;
+import net.minecraftforge.eventbus.api.SubscribeEvent;
 import org.jetbrains.annotations.NotNull;
 
 /**
@@ -67,5 +69,11 @@ public class FMLEventHandler
     public static void onServerStopped(@NotNull final ServerStoppingEvent event)
     {
         Pathfinding.shutdown();
+    }
+
+    @SubscribeEvent
+    public static void onServerStarted(@NotNull final ServerStartedEvent event)
+    {
+        BackUpHelper.loadMissingColonies();
     }
 }


### PR DESCRIPTION
Closes #
Closes #
Closes #

# Changes proposed in this pull request:
-Fix backups not loading from all dimensions, at cap init the levels do not exist yet so we cannot loop them by name


[x ] Yes I tested this before submitting it.
[ ] I also did a multiplayer test.

Review please
