### PR TITLE
Fix tooltip appearing on settings where it shouldn't

### DIFF
--- a/src/main/java/com/minecolonies/api/colony/buildings/modules/settings/ISetting.java
+++ b/src/main/java/com/minecolonies/api/colony/buildings/modules/settings/ISetting.java
@@ -117,25 +117,26 @@ public interface ISetting<S>
         final Component tooltip = Component.translatable(tooltipKey);
         final Component inActiveReason = getInactiveReason();
 
-        if (tooltip.getString().equals(tooltipKey) && inActiveReason == null)
-        {
-            component.setHoverPane(null);
-            return;
-        }
+        final boolean hasTooltip = !tooltip.getString().equals(tooltipKey);
+        final boolean isActive = isActive(settingsModuleView);
 
-        if (isActive(settingsModuleView))
+        if (isActive && hasTooltip)
         {
             PaneBuilders.tooltipBuilder()
               .append(tooltip)
               .hoverPane(component)
               .build();
         }
-        else
+        else if (!isActive && (hasTooltip || inActiveReason != null))
         {
             PaneBuilders.tooltipBuilder()
               .append(inActiveReason != null ? inActiveReason : tooltip)
               .hoverPane(component)
               .build();
+        }
+        else
+        {
+            component.setHoverPane(null);
         }
     }
 


### PR DESCRIPTION
Closes #9847 

# Changes proposed in this pull request:
- Fix issue when tooltips have an inactive reason, the tooltip would show when it shouldn't


[X] Yes I tested this before submitting it.
[ ] I also did a multiplayer test.

Review please
