### PR TITLE
pathfinding heuristics

### DIFF
--- a/src/main/java/com/minecolonies/core/client/render/worldevent/PathfindingDebugRenderer.java
+++ b/src/main/java/com/minecolonies/core/client/render/worldevent/PathfindingDebugRenderer.java
@@ -21,12 +21,15 @@ public class PathfindingDebugRenderer
     /**
      * Set of visited nodes.
      */
-    public static Set<MNode> lastDebugNodesVisited = new HashSet<>();
+    public static Set<MNode> lastDebugNodesVisited      = new HashSet<>();
+    public static Set<MNode> lastDebugNodesVisitedLater = new HashSet<>();
+    public static Set<MNode> debugNodesOrgPath          = new HashSet<>();
+    public static Set<MNode> debugNodesExtra            = new HashSet<>();
 
     /**
      * Set of not visited nodes.
      */
-    public static Set<MNode> lastDebugNodesNotVisited  = new HashSet<>();
+    public static Set<MNode> lastDebugNodesNotVisited = new HashSet<>();
 
     /**
      * Set of nodes that belong to the chosen path.
@@ -47,6 +50,21 @@ public class PathfindingDebugRenderer
                 debugDrawNode(n, 0xffff0000, ctx);
             }
 
+            for (final MNode n : lastDebugNodesVisitedLater)
+            {
+                debugDrawNode(n, 0xffff5050, ctx);
+            }
+
+            for (final MNode n : debugNodesOrgPath)
+            {
+                debugDrawNode(n, 0xff808080, ctx);
+            }
+
+            for (final MNode n : debugNodesExtra)
+            {
+                debugDrawNode(n, 0xff9999ff, ctx);
+            }
+
             for (final MNode n : lastDebugNodesNotVisited)
             {
                 debugDrawNode(n, 0xff0000ff, ctx);
@@ -56,7 +74,7 @@ public class PathfindingDebugRenderer
             {
                 if (n.isReachedByWorker())
                 {
-                    debugDrawNode(n, 0xffff6600, ctx);
+                    debugDrawNode(n, 0xffffff00, ctx);
                 }
                 else
                 {

--- a/src/main/java/com/minecolonies/core/commands/CommandEntityTrack.java
+++ b/src/main/java/com/minecolonies/core/commands/CommandEntityTrack.java
@@ -54,7 +54,8 @@ public class CommandEntityTrack implements IMCColonyOfficerCommand
             {
                 context.getSource().sendSuccess(() -> Component.translatable(CommandTranslationConstants.COMMAND_ENTITY_TRACK_DISABLED), true);
                 PathfindingUtils.trackingMap.remove(sender.getUUID());
-                Network.getNetwork().sendToPlayer(new SyncPathMessage(new HashSet<>(), new HashSet<>(), new HashSet<>()), (ServerPlayer) sender);
+                Network.getNetwork()
+                  .sendToPlayer(new SyncPathMessage(new HashSet<>(), new HashSet<>(), new HashSet<>(), new HashSet<>(), new HashSet<>(), new HashSet<>()), (ServerPlayer) sender);
             }
             else
             {

--- a/src/main/java/com/minecolonies/core/commands/citizencommands/CommandCitizenTrack.java
+++ b/src/main/java/com/minecolonies/core/commands/citizencommands/CommandCitizenTrack.java
@@ -76,7 +76,8 @@ public class CommandCitizenTrack implements IMCColonyOfficerCommand
         {
             context.getSource().sendSuccess(() -> Component.translatable(CommandTranslationConstants.COMMAND_ENTITY_TRACK_DISABLED), true);
             PathfindingUtils.trackingMap.remove(sender.getUUID());
-            Network.getNetwork().sendToPlayer(new SyncPathMessage(new HashSet<>(), new HashSet<>(), new HashSet<>()), (ServerPlayer) sender);
+            Network.getNetwork()
+              .sendToPlayer(new SyncPathMessage(new HashSet<>(), new HashSet<>(), new HashSet<>(), new HashSet<>(), new HashSet<>(), new HashSet<>()), (ServerPlayer) sender);
         }
         else
         {

--- a/src/main/java/com/minecolonies/core/entity/ai/workers/AbstractEntityAIBasic.java
+++ b/src/main/java/com/minecolonies/core/entity/ai/workers/AbstractEntityAIBasic.java
@@ -1468,6 +1468,8 @@ public abstract class AbstractEntityAIBasic<J extends AbstractJob<?, J>, B exten
             return targetPos;
         }
 
+        // TODO: Use pathfinding for this instead? Or find around Util
+
         @NotNull final Direction[] directions = {Direction.EAST, Direction.WEST, Direction.NORTH, Direction.SOUTH};
 
         //then get a solid place with two air spaces above it in any direction.

--- a/src/main/java/com/minecolonies/core/entity/ai/workers/production/EntityAIWorkLumberjack.java
+++ b/src/main/java/com/minecolonies/core/entity/ai/workers/production/EntityAIWorkLumberjack.java
@@ -468,6 +468,7 @@ public class EntityAIWorkLumberjack extends AbstractEntityAICrafting<JobLumberja
         return chopTree();
     }
 
+    //TODO: On walking to the zone(no tree found) leaves are not getting broken
     /**
      * Work on the tree. First find your way to the tree trunk. Then chop away and wait for saplings to drop then place a sapling if shouldReplant is true
      *

--- a/src/main/java/com/minecolonies/core/entity/pathfinding/MNode.java
+++ b/src/main/java/com/minecolonies/core/entity/pathfinding/MNode.java
@@ -222,14 +222,6 @@ public class MNode implements Comparable<MNode>
     }
 
     /**
-     * Sets the node as closed.
-     */
-    public void unSetVisited()
-    {
-        visited = true;
-    }
-
-    /**
      * Getter of the score of the node.
      *
      * @return the score.

--- a/src/main/java/com/minecolonies/core/entity/pathfinding/MNode.java
+++ b/src/main/java/com/minecolonies/core/entity/pathfinding/MNode.java
@@ -222,6 +222,14 @@ public class MNode implements Comparable<MNode>
     }
 
     /**
+     * Sets the node as closed.
+     */
+    public void unSetVisited()
+    {
+        visited = true;
+    }
+
+    /**
      * Getter of the score of the node.
      *
      * @return the score.
@@ -364,6 +372,16 @@ public class MNode implements Comparable<MNode>
     public boolean isCornerNode()
     {
         return isCornerNode;
+    }
+
+    /**
+     * Get the added index
+     *
+     * @return
+     */
+    public int getCounterAdded()
+    {
+        return counterAdded;
     }
 
     /**

--- a/src/main/java/com/minecolonies/core/entity/pathfinding/PathingOptions.java
+++ b/src/main/java/com/minecolonies/core/entity/pathfinding/PathingOptions.java
@@ -10,12 +10,12 @@ public class PathingOptions
     /**
      * Additional cost of jumping
      */
-    public double jumpCost = 3D;
+    public double jumpCost = 2D;
 
     /**
      * Additional cost of dropping
      */
-    public double dropCost = 2D;
+    public double dropCost = 1D;
 
     /**
      * Cost improvement of paths - base 1.
@@ -30,32 +30,37 @@ public class PathingOptions
     /**
      * The rails exit cost.
      */
-    public double railsExitCost = 5;
+    public double railsExitCost = 4;
 
     /**
      * Additional cost of swimming - base 1.
      */
-    public double swimCost = 3D;
+    public double swimCost = 2D;
 
     /**
      * Additional cost of cave air.
      */
-    public double caveAirCost = 4D;
+    public double caveAirCost = 3D;
 
     /**
      * Additional cost enter entering water
      */
-    public double swimCostEnter = 25D;
+    public double swimCostEnter = 24D;
 
     /**
      * Cost to traverse trap doors
      */
-    public double traverseToggleAbleCost = 10D;
+    public double traverseToggleAbleCost = 5D;
 
     /**
      * Cost to climb a non ladder.
      */
-    public double nonLadderClimbableCost = 4D;
+    public double nonLadderClimbableCost = 3D;
+
+    /**
+     * Cost for walking within shapes(e.g. panels)
+     */
+    public double walkInShapesCost = 2D;
 
     /**
      * Factor multiplied to the small random base cost of values, increases this increases the paths randomness/volatilty. Set to 0 to disable rng.

--- a/src/main/java/com/minecolonies/core/entity/pathfinding/PathingOptions.java
+++ b/src/main/java/com/minecolonies/core/entity/pathfinding/PathingOptions.java
@@ -8,6 +8,11 @@ public class PathingOptions
     // x2: Weak dislike, x3: clear dislike, x4 strong dislike x5 very strong dislike
 
     /**
+     * Maximum cost used
+     */
+    public static final int MAX_COST = 25;
+
+    /**
      * Additional cost of jumping
      */
     public double jumpCost = 2D;

--- a/src/main/java/com/minecolonies/core/entity/pathfinding/navigation/AbstractAdvancedPathNavigate.java
+++ b/src/main/java/com/minecolonies/core/entity/pathfinding/navigation/AbstractAdvancedPathNavigate.java
@@ -6,6 +6,7 @@ import com.minecolonies.api.entity.pathfinding.IPathJob;
 import com.minecolonies.api.entity.pathfinding.IStuckHandler;
 import com.minecolonies.api.util.Tuple;
 import com.minecolonies.core.entity.pathfinding.PathingOptions;
+import com.minecolonies.core.entity.pathfinding.pathjobs.AbstractPathJob;
 import com.minecolonies.core.entity.pathfinding.pathresults.PathResult;
 import com.minecolonies.core.entity.pathfinding.pathresults.TreePathResult;
 import com.minecolonies.core.entity.pathfinding.pathresults.WaterPathResult;
@@ -97,11 +98,23 @@ public abstract class AbstractAdvancedPathNavigate extends GroundPathNavigation
 
     /**
      * Attempt to move to a specific pos.
+     *
      * @param position the position to move to.
-     * @param speed the speed.
+     * @param speed    the speed.
      * @return true if successful.
      */
     public abstract boolean tryMoveToBlockPos(final BlockPos position, final double speed);
+
+    /**
+     * Attemps to move in the given direction, walking at least range blocks
+     *
+     * @param towards
+     * @param range
+     * @param speedFactor
+     * @return
+     */
+    @Nullable
+    public abstract PathResult<AbstractPathJob> moveTowards(BlockPos towards, double range, double speedFactor);
 
     /**
      * Used to path towards a random pos.
@@ -206,4 +219,11 @@ public abstract class AbstractAdvancedPathNavigate extends GroundPathNavigation
     public abstract void setStuckHandler(final IStuckHandler stuckHandler);
 
     public abstract void setSwimSpeedFactor(double factor);
+
+    /**
+     * Sets the navigation to not accept new jobs for a time
+     *
+     * @param pauseTicks
+     */
+    protected abstract void setPauseTicks(int pauseTicks);
 }

--- a/src/main/java/com/minecolonies/core/entity/pathfinding/navigation/IDynamicHeuristicNavigatior.java
+++ b/src/main/java/com/minecolonies/core/entity/pathfinding/navigation/IDynamicHeuristicNavigatior.java
@@ -1,6 +1,0 @@
-package com.minecolonies.core.entity.pathfinding.navigation;
-
-public interface IDynamicHeuristicNavigatior
-{
-    public double getAvgHeuristicModifier();
-}

--- a/src/main/java/com/minecolonies/core/entity/pathfinding/navigation/IDynamicHeuristicNavigatior.java
+++ b/src/main/java/com/minecolonies/core/entity/pathfinding/navigation/IDynamicHeuristicNavigatior.java
@@ -1,0 +1,6 @@
+package com.minecolonies.core.entity.pathfinding.navigation;
+
+public interface IDynamicHeuristicNavigatior
+{
+    public double getAvgHeuristicModifier();
+}

--- a/src/main/java/com/minecolonies/core/entity/pathfinding/navigation/IDynamicHeuristicNavigator.java
+++ b/src/main/java/com/minecolonies/core/entity/pathfinding/navigation/IDynamicHeuristicNavigator.java
@@ -1,0 +1,12 @@
+package com.minecolonies.core.entity.pathfinding.navigation;
+
+/**
+ * Interface for navigators which keep an internal heuristic mod
+ */
+public interface IDynamicHeuristicNavigator
+{
+    /**
+     * Get the heuristic modifier
+     */
+    public double getAvgHeuristicModifier();
+}

--- a/src/main/java/com/minecolonies/core/entity/pathfinding/navigation/MinecoloniesAdvancedPathNavigate.java
+++ b/src/main/java/com/minecolonies/core/entity/pathfinding/navigation/MinecoloniesAdvancedPathNavigate.java
@@ -7,6 +7,7 @@ import com.minecolonies.api.entity.citizen.AbstractEntityCitizen;
 import com.minecolonies.api.entity.other.MinecoloniesMinecart;
 import com.minecolonies.api.entity.pathfinding.*;
 import com.minecolonies.api.util.*;
+import com.minecolonies.api.util.constant.ColonyConstants;
 import com.minecolonies.core.entity.pathfinding.*;
 import com.minecolonies.core.entity.pathfinding.pathjobs.*;
 import com.minecolonies.core.entity.pathfinding.pathresults.PathResult;
@@ -39,10 +40,13 @@ import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
 
+import static com.minecolonies.core.entity.pathfinding.PathFindingStatus.IN_PROGRESS_FOLLOWING;
+import static com.minecolonies.core.entity.pathfinding.pathjobs.AbstractPathJob.MAX_NODES;
+
 /**
  * Minecolonies async PathNavigate.
  */
-public class MinecoloniesAdvancedPathNavigate extends AbstractAdvancedPathNavigate
+public class MinecoloniesAdvancedPathNavigate extends AbstractAdvancedPathNavigate implements IDynamicHeuristicNavigatior
 {
     private static final double ON_PATH_SPEED_MULTIPLIER = 1.3D;
     public static final  double MIN_Y_DISTANCE           = 0.001;
@@ -88,6 +92,16 @@ public class MinecoloniesAdvancedPathNavigate extends AbstractAdvancedPathNaviga
     private double swimSpeedFactor = 1.0;
 
     /**
+     * Average heuristic
+     */
+    private double heuristicAvg = 1;
+
+    /**
+     * Paused ticks, during those no new pathjob is allowed
+     */
+    private int pauseTicks = 0;
+
+    /**
      * Instantiates the navigation of an ourEntity.
      *
      * @param entity the ourEntity.
@@ -126,6 +140,17 @@ public class MinecoloniesAdvancedPathNavigate extends AbstractAdvancedPathNaviga
           (int) range,
           (int) ourEntity.getAttribute(Attributes.FOLLOW_RANGE).getValue(),
           ourEntity), null, speedFactor, safeDestination);
+    }
+
+    @Nullable
+    @Override
+    public PathResult<AbstractPathJob> moveTowards(final BlockPos towards, final double range, final double speedFactor)
+    {
+        return setPathJob(new PathJobMoveTowards(CompatibilityUtils.getWorldFromEntity(ourEntity),
+          PathfindingUtils.prepareStart(ourEntity),
+          towards,
+          (int) range,
+          ourEntity), null, speedFactor, false);
     }
 
     @Nullable
@@ -201,6 +226,11 @@ public class MinecoloniesAdvancedPathNavigate extends AbstractAdvancedPathNaviga
       final BlockPos dest,
       final double speedFactor, final boolean safeDestination)
     {
+        if (pauseTicks > 0)
+        {
+            return null;
+        }
+
         stop();
 
         this.destination = dest;
@@ -243,6 +273,11 @@ public class MinecoloniesAdvancedPathNavigate extends AbstractAdvancedPathNaviga
             {
                 desiredPos = null;
             }
+        }
+
+        if (pauseTicks > 0)
+        {
+            pauseTicks--;
         }
 
         if (pathResult != null)
@@ -326,7 +361,6 @@ public class MinecoloniesAdvancedPathNavigate extends AbstractAdvancedPathNaviga
         if (pathResult != null && isDone())
         {
             pathResult.setStatus(PathFindingStatus.COMPLETE);
-            pathResult = null;
         }
 
         stuckHandler.checkStuck(this);
@@ -358,15 +392,23 @@ public class MinecoloniesAdvancedPathNavigate extends AbstractAdvancedPathNaviga
         final int newY = (int) y;
         final int newZ = Mth.floor(z);
 
-        if (pathResult != null && pathResult.getJob() instanceof PathJobMoveToLocation &&
-              (
-                pathResult.isComputing()
-                  || (destination != null && BlockPosUtil.equals(destination, newX, newY, newZ))
-                  || (originalDestination != null && BlockPosUtil.equals(originalDestination, newX, newY, newZ))
-              )
-        )
+        if (pathResult != null && pathResult.getJob() instanceof PathJobMoveToLocation)
         {
-            return pathResult;
+            if (pathResult.isComputing())
+            {
+                return pathResult;
+            }
+
+            if (((destination != null && BlockPosUtil.equals(destination, newX, newY, newZ)) || (originalDestination != null && BlockPosUtil.equals(originalDestination,
+              newX,
+              newY,
+              newZ))))
+            {
+                if (pathResult.getStatus() == IN_PROGRESS_FOLLOWING || ColonyConstants.rand.nextInt(20) != 0)
+                {
+                    return pathResult;
+                }
+            }
         }
 
         @NotNull final BlockPos start = PathfindingUtils.prepareStart(ourEntity);
@@ -561,15 +603,37 @@ public class MinecoloniesAdvancedPathNavigate extends AbstractAdvancedPathNaviga
         return tempPath == null ? path : tempPath;
     }
 
-    private boolean processCompletedCalculationResult()
+    /**
+     * Processes the pathreult when it finished computing
+     */
+    private void processCompletedCalculationResult()
     {
+        if (pathResult == null)
+        {
+            return;
+        }
+
         pathResult.getJob().syncDebug();
         moveTo(pathResult.getPath(), getSpeedFactor());
         if (pathResult != null)
         {
-            pathResult.setStatus(PathFindingStatus.IN_PROGRESS_FOLLOWING);
+            pathResult.setStatus(IN_PROGRESS_FOLLOWING);
         }
-        return false;
+
+        // Calculate an overtime-heuristic adjustment for pathfinding to use which fits the terrain
+        if (pathResult.costPerDist != 1)
+        {
+            heuristicAvg -= heuristicAvg / 20;
+            heuristicAvg += pathResult.costPerDist / 20;
+        }
+
+        if (pathResult.failedToReachDestination())
+        {
+            if (pathResult.searchedNodes >= MAX_NODES)
+            {
+                pauseTicks = 50;
+            }
+        }
     }
 
     private boolean handleLadders(int oldIndex)
@@ -948,7 +1012,7 @@ public class MinecoloniesAdvancedPathNavigate extends AbstractAdvancedPathNaviga
      */
     private void onPathFinish()
     {
-        stop();
+        super.stop();
     }
 
     public void recomputePath() {}
@@ -1072,5 +1136,17 @@ public class MinecoloniesAdvancedPathNavigate extends AbstractAdvancedPathNaviga
     public void setSwimSpeedFactor(final double factor)
     {
         this.swimSpeedFactor = factor;
+    }
+
+    @Override
+    public double getAvgHeuristicModifier()
+    {
+        return heuristicAvg;
+    }
+
+    @Override
+    protected void setPauseTicks(final int pauseTicks)
+    {
+        this.pauseTicks = pauseTicks;
     }
 }

--- a/src/main/java/com/minecolonies/core/entity/pathfinding/navigation/MinecoloniesAdvancedPathNavigate.java
+++ b/src/main/java/com/minecolonies/core/entity/pathfinding/navigation/MinecoloniesAdvancedPathNavigate.java
@@ -46,7 +46,7 @@ import static com.minecolonies.core.entity.pathfinding.pathjobs.AbstractPathJob.
 /**
  * Minecolonies async PathNavigate.
  */
-public class MinecoloniesAdvancedPathNavigate extends AbstractAdvancedPathNavigate implements IDynamicHeuristicNavigatior
+public class MinecoloniesAdvancedPathNavigate extends AbstractAdvancedPathNavigate implements IDynamicHeuristicNavigator
 {
     private static final double ON_PATH_SPEED_MULTIPLIER = 1.3D;
     public static final  double MIN_Y_DISTANCE           = 0.001;
@@ -604,7 +604,7 @@ public class MinecoloniesAdvancedPathNavigate extends AbstractAdvancedPathNaviga
     }
 
     /**
-     * Processes the pathreult when it finished computing
+     * Processes the pathresult when it finished computing
      */
     private void processCompletedCalculationResult()
     {

--- a/src/main/java/com/minecolonies/core/entity/pathfinding/pathjobs/AbstractPathJob.java
+++ b/src/main/java/com/minecolonies/core/entity/pathfinding/pathjobs/AbstractPathJob.java
@@ -316,11 +316,6 @@ public abstract class AbstractPathJob implements Callable<Path>, IPathJob
                 }
             }
 
-            if (Math.abs(node.getHeuristic() - computeHeuristic(node.x, node.y, node.z) * heuristicMod) > 1)
-            {
-                Log.getLogger().warn("err");
-            }
-
             if (!reachesDestination && isAtDestination(node))
             {
                 bestNode = node;
@@ -740,10 +735,6 @@ public abstract class AbstractPathJob implements Callable<Path>, IPathJob
                 nextNode.setLadder();
             }
 
-            if (Math.abs(nextNode.getHeuristic() - computeHeuristic(nextNode.x, nextNode.y, nextNode.z) * heuristicMod) > 1)
-            {
-                Log.getLogger().warn("err");
-            }
             nodesToVisit.offer(nextNode);
         }
         else
@@ -789,11 +780,6 @@ public abstract class AbstractPathJob implements Callable<Path>, IPathJob
         nextNode.parent = node;
         nextNode.setCost(cost);
         nextNode.setHeuristic(heuristic);
-
-        if (Math.abs(nextNode.getHeuristic() - computeHeuristic(nextNode.x, nextNode.y, nextNode.z) * heuristicMod) > 1)
-        {
-            Log.getLogger().warn("err");
-        }
 
         nodesToVisit.offer(nextNode);
     }

--- a/src/main/java/com/minecolonies/core/entity/pathfinding/pathjobs/AbstractPathJob.java
+++ b/src/main/java/com/minecolonies/core/entity/pathfinding/pathjobs/AbstractPathJob.java
@@ -40,6 +40,7 @@ import java.util.*;
 import java.util.concurrent.Callable;
 
 import static com.minecolonies.api.util.constant.PathingConstants.*;
+import static com.minecolonies.core.entity.pathfinding.PathingOptions.MAX_COST;
 
 /**
  * Abstract class for Jobs that run in the multithreaded path finder.
@@ -151,8 +152,6 @@ public abstract class AbstractPathJob implements Callable<Path>, IPathJob
      * First node
      */
     private MNode startNode = null;
-
-    private double avgCost = 1;
 
     /**
      * AbstractPathJob constructor.
@@ -394,9 +393,7 @@ public abstract class AbstractPathJob implements Callable<Path>, IPathJob
         if (extraNodes > 0 && reachesDestination)
         {
             // Make sure to expand from the final node
-            bestNode.unSetVisited();
             visitNode(bestNode);
-            bestNode.setVisited();
 
             // Search only closest nodes to the goal
             final Queue<MNode> original = nodesToVisit;
@@ -705,15 +702,11 @@ public abstract class AbstractPathJob implements Callable<Path>, IPathJob
             }
 
             nextCost = computeCost(costFrom, dX, dY, dZ, isSwimming, onRoad, onRails, railsExit, swimStart, ladder, state, nextX, nextY, nextZ);
-
-            avgCost -= avgCost / 20;
-            avgCost += nextCost / 20;
-
             nextCost = modifyCost(nextCost, costFrom, swimStart, isSwimming, nextX, nextY, nextZ, state);
 
             if (nextCost > maxCost)
             {
-                maxCost = Math.min(25, Math.ceil(nextCost));
+                maxCost = Math.min(MAX_COST, Math.ceil(nextCost));
             }
         }
 

--- a/src/main/java/com/minecolonies/core/entity/pathfinding/pathjobs/PathJobFindTree.java
+++ b/src/main/java/com/minecolonies/core/entity/pathfinding/pathjobs/PathJobFindTree.java
@@ -191,7 +191,7 @@ public class PathJobFindTree extends AbstractPathJob
     }
 
     @Override
-    protected double modifyCost(double cost, final MNode parent, final int x, final int y, final int z, final BlockState state)
+    protected double modifyCost(double cost, final MNode parent, final boolean swimstart, final boolean swimming, final int x, final int y, final int z, final BlockState state)
     {
         if (!state.isAir() && state.is(BlockTags.LEAVES))
         {

--- a/src/main/java/com/minecolonies/core/entity/pathfinding/pathjobs/PathJobMoveAwayFromLocation.java
+++ b/src/main/java/com/minecolonies/core/entity/pathfinding/pathjobs/PathJobMoveAwayFromLocation.java
@@ -96,7 +96,7 @@ public class PathJobMoveAwayFromLocation extends AbstractPathJob
      */
     @Override
     protected double computeHeuristic(final int x, final int y, final int z)
-    {
+    {  // TODO: Check heuristic
         return BlockPosUtil.dist(preferredDirection, x, y, z) + 100 / Math.max(1, BlockPosUtil.dist(avoid, x, y, z));
     }
 

--- a/src/main/java/com/minecolonies/core/entity/pathfinding/pathjobs/PathJobMoveAwayFromLocation.java
+++ b/src/main/java/com/minecolonies/core/entity/pathfinding/pathjobs/PathJobMoveAwayFromLocation.java
@@ -11,6 +11,7 @@ import com.minecolonies.core.entity.pathfinding.MNode;
 import net.minecraft.core.BlockPos;
 import net.minecraft.world.entity.Mob;
 import net.minecraft.world.level.Level;
+import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.pathfinder.Path;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -96,8 +97,26 @@ public class PathJobMoveAwayFromLocation extends AbstractPathJob
      */
     @Override
     protected double computeHeuristic(final int x, final int y, final int z)
-    {  // TODO: Check heuristic
-        return BlockPosUtil.dist(preferredDirection, x, y, z) + 100 / Math.max(1, BlockPosUtil.dist(avoid, x, y, z));
+    {
+        return BlockPosUtil.dist(preferredDirection, x, y, z);
+    }
+
+    protected double modifyCost(
+      final double cost,
+      final MNode parent,
+      final boolean swimstart,
+      final boolean swimming,
+      final int x,
+      final int y,
+      final int z,
+      final BlockState state)
+    {
+        if (BlockPosUtil.dist(avoid, x, y, z) < 3)
+        {
+            return cost + 100;
+        }
+
+        return cost;
     }
 
     /**

--- a/src/main/java/com/minecolonies/core/entity/pathfinding/pathjobs/PathJobMoveToLocation.java
+++ b/src/main/java/com/minecolonies/core/entity/pathfinding/pathjobs/PathJobMoveToLocation.java
@@ -8,7 +8,7 @@ import com.minecolonies.core.MineColonies;
 import com.minecolonies.core.entity.pathfinding.MNode;
 import com.minecolonies.core.entity.pathfinding.PathfindingUtils;
 import com.minecolonies.core.entity.pathfinding.SurfaceType;
-import com.minecolonies.core.entity.pathfinding.navigation.IDynamicHeuristicNavigatior;
+import com.minecolonies.core.entity.pathfinding.navigation.IDynamicHeuristicNavigator;
 import com.minecolonies.core.entity.pathfinding.pathresults.PathResult;
 import net.minecraft.core.BlockPos;
 import net.minecraft.world.entity.Mob;
@@ -53,9 +53,9 @@ public class PathJobMoveToLocation extends AbstractPathJob
         maxNodes += range;
         this.destination = new BlockPos(end);
 
-        if (entity != null && entity.getNavigation() instanceof IDynamicHeuristicNavigatior)
+        if (entity != null && entity.getNavigation() instanceof IDynamicHeuristicNavigator)
         {
-            heuristicModifier = ((IDynamicHeuristicNavigatior) entity.getNavigation()).getAvgHeuristicModifier();
+            heuristicModifier = ((IDynamicHeuristicNavigator) entity.getNavigation()).getAvgHeuristicModifier();
         }
 
         // Overestimate for long distances, +1 per 100 blocks

--- a/src/main/java/com/minecolonies/core/entity/pathfinding/pathjobs/PathJobMoveToLocation.java
+++ b/src/main/java/com/minecolonies/core/entity/pathfinding/pathjobs/PathJobMoveToLocation.java
@@ -1,12 +1,15 @@
 package com.minecolonies.core.entity.pathfinding.pathjobs;
 
-import com.minecolonies.core.entity.pathfinding.PathfindingUtils;
-import com.minecolonies.core.entity.pathfinding.pathresults.PathResult;
-import com.minecolonies.core.entity.pathfinding.SurfaceType;
 import com.minecolonies.api.util.BlockPosUtil;
 import com.minecolonies.api.util.Log;
+import com.minecolonies.api.util.ShapeUtil;
+import com.minecolonies.api.util.constant.ColonyConstants;
 import com.minecolonies.core.MineColonies;
 import com.minecolonies.core.entity.pathfinding.MNode;
+import com.minecolonies.core.entity.pathfinding.PathfindingUtils;
+import com.minecolonies.core.entity.pathfinding.SurfaceType;
+import com.minecolonies.core.entity.pathfinding.navigation.IDynamicHeuristicNavigatior;
+import com.minecolonies.core.entity.pathfinding.pathresults.PathResult;
 import net.minecraft.core.BlockPos;
 import net.minecraft.world.entity.Mob;
 import net.minecraft.world.level.Level;
@@ -29,7 +32,10 @@ public class PathJobMoveToLocation extends AbstractPathJob
     // 0 = exact match
     private              float    destinationSlack           = DESTINATION_SLACK_NONE;
 
-    // TODO: Adjust and scale heuristics, overestimate for large distances to lower cost & increase reachability/smart entity heuristics
+    /**
+     * Modifier to the heuristics
+     */
+    private double heuristicModifier = 1;
 
     /**
      * Prepares the PathJob for the path finding system.
@@ -44,7 +50,17 @@ public class PathJobMoveToLocation extends AbstractPathJob
     {
         super(world, start, end, new PathResult<PathJobMoveToLocation>(), entity);
 
+        maxNodes += range;
         this.destination = new BlockPos(end);
+
+        if (entity != null && entity.getNavigation() instanceof IDynamicHeuristicNavigatior)
+        {
+            heuristicModifier = ((IDynamicHeuristicNavigatior) entity.getNavigation()).getAvgHeuristicModifier();
+        }
+
+        // Overestimate for long distances, +1 per 100 blocks
+        heuristicModifier += BlockPosUtil.distManhattan(start, end) / 100.0;
+        extraNodes = 4;
     }
 
     /**
@@ -74,8 +90,7 @@ public class PathJobMoveToLocation extends AbstractPathJob
     @Override
     protected double computeHeuristic(final int x, final int y, final int z)
     {
-        // TODO: Improve heuristics
-        return BlockPosUtil.distManhattan(destination, x, y, z);
+        return BlockPosUtil.distManhattan(destination, x, y, z) * heuristicModifier;
     }
 
     /**
@@ -121,12 +136,40 @@ public class PathJobMoveToLocation extends AbstractPathJob
     @Override
     protected double getEndNodeScore(@NotNull final MNode n)
     {
-        if (PathfindingUtils.isLiquid(cachedBlockLookup.getBlockState(n.x, n.y, n.z)))
+        if (PathfindingUtils.isLiquid(cachedBlockLookup.getBlockState(n.x, n.y - 1, n.z)))
         {
             return BlockPosUtil.distManhattan(destination, n.x, n.y, n.z) + 30;
         }
 
+        if (!ShapeUtil.isEmpty(cachedBlockLookup.getBlockState(n.x, n.y, n.z).getCollisionShape(cachedBlockLookup, tempWorldPos.set(n.x, n.y, n.z))))
+        {
+            return BlockPosUtil.distManhattan(destination, n.x, n.y, n.z) + 10;
+        }
+
         //  For Result Score lower is better
-        return BlockPosUtil.distManhattan(destination, n.x, n.y, n.z);
+
+        int xDist = Math.abs(destination.getX() - n.x);
+        int yDist = Math.abs(destination.getY() - n.y);
+        int zDist = Math.abs(destination.getZ() - n.z);
+        return xDist + yDist + zDist;
+    }
+
+    @Override
+    protected boolean stopOnNodeLimit(final int totalNodesVisited, final MNode bestNode, final int nodesSinceEndNode)
+    {
+        // Small chance to go full limit to maybe find a path still, when we did not find any good nodes to move towards
+        if (totalNodesVisited < MAX_NODES && BlockPosUtil.distManhattan(start, bestNode.x, bestNode.y, bestNode.z) < 10 && ColonyConstants.rand.nextInt(100) <= 20)
+        {
+            maxNodes += 1000;
+            return false;
+        }
+        // 10k limit for progressing
+        else if (nodesSinceEndNode < 200 && totalNodesVisited < MAX_NODES * 2)
+        {
+            maxNodes += 500;
+            return false;
+        }
+
+        return true;
     }
 }

--- a/src/main/java/com/minecolonies/core/entity/pathfinding/pathjobs/PathJobMoveToWithPassable.java
+++ b/src/main/java/com/minecolonies/core/entity/pathfinding/pathjobs/PathJobMoveToWithPassable.java
@@ -2,8 +2,6 @@ package com.minecolonies.core.entity.pathfinding.pathjobs;
 
 import com.minecolonies.core.entity.pathfinding.MNode;
 import net.minecraft.core.BlockPos;
-import net.minecraft.tags.BlockTags;
-import net.minecraft.world.entity.LivingEntity;
 import net.minecraft.world.entity.Mob;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.state.BlockState;
@@ -52,7 +50,15 @@ public class PathJobMoveToWithPassable extends PathJobMoveToLocation
     }
 
     @Override
-    protected double modifyCost(final double cost, final MNode parent, final int x, final int y, final int z, final BlockState state)
+    protected double modifyCost(
+      final double cost,
+      final MNode parent,
+      final boolean swimstart,
+      final boolean swimming,
+      final int x,
+      final int y,
+      final int z,
+      final BlockState state)
     {
         if (!state.isAir() && isPassable.apply(state))
         {

--- a/src/main/java/com/minecolonies/core/entity/pathfinding/pathjobs/PathJobMoveTowards.java
+++ b/src/main/java/com/minecolonies/core/entity/pathfinding/pathjobs/PathJobMoveTowards.java
@@ -1,0 +1,73 @@
+package com.minecolonies.core.entity.pathfinding.pathjobs;
+
+import com.minecolonies.api.util.BlockPosUtil;
+import com.minecolonies.core.entity.pathfinding.MNode;
+import com.minecolonies.core.entity.pathfinding.SurfaceType;
+import com.minecolonies.core.entity.pathfinding.pathresults.PathResult;
+import net.minecraft.core.BlockPos;
+import net.minecraft.world.entity.Mob;
+import net.minecraft.world.level.Level;
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * Job that handles moving in a direction
+ */
+public class PathJobMoveTowards extends AbstractPathJob
+{
+    /**
+     * Position to run to, in order to
+     */
+    protected final BlockPos target;
+    /**
+     * Required avoidDistance.
+     */
+    protected final int      minDistance;
+
+    /**
+     * Prepares the PathJob for the path finding system.
+     *
+     * @param world       world the entity is in.
+     * @param start       starting location.
+     * @param direction   location to avoid.
+     * @param minDistance how far to move away.
+     * @param range       max range to search.
+     * @param entity      the entity.
+     */
+    public PathJobMoveTowards(
+      final Level world,
+      @NotNull final BlockPos start,
+      @NotNull final BlockPos direction,
+      final int minDistance,
+      final Mob entity)
+    {
+        super(world, start, minDistance * 2, new PathResult<PathJobMoveTowards>(), entity);
+
+        this.target = direction;
+        this.minDistance = minDistance;
+    }
+
+    /**
+     * For MoveAwayFromLocation we want our heuristic to weight.
+     *
+     * @return heuristic as a double - Manhatten Distance with tie-breaker.
+     */
+    @Override
+    protected double computeHeuristic(final int x, final int y, final int z)
+    {
+        return BlockPosUtil.distManhattan(target, x, y, z);
+    }
+
+    /**
+     * Checks if the destination has been reached. Meaning that the avoid distance has been reached.
+     *
+     * @param n Node to test.
+     * @return true if so.
+     */
+    @Override
+    protected boolean isAtDestination(@NotNull final MNode n)
+    {
+        return BlockPosUtil.distManhattan(start, n.x, n.y, n.z) > minDistance
+                 && SurfaceType.getSurfaceType(world, cachedBlockLookup.getBlockState(n.x, n.y - 1, n.z), tempWorldPos.set(n.x, n.y - 1, n.z), getPathingOptions())
+                      == SurfaceType.WALKABLE;
+    }
+}

--- a/src/main/java/com/minecolonies/core/entity/pathfinding/pathjobs/PathJobPathway.java
+++ b/src/main/java/com/minecolonies/core/entity/pathfinding/pathjobs/PathJobPathway.java
@@ -103,7 +103,15 @@ public class PathJobPathway extends AbstractPathJob
     }
 
     @Override
-    protected double modifyCost(final double stepCost, final MNode parent, final int x, final int y, final int z, final BlockState state)
+    protected double modifyCost(
+      final double stepCost,
+      final MNode parent,
+      final boolean swimstart,
+      final boolean swimming,
+      final int x,
+      final int y,
+      final int z,
+      final BlockState state)
     {
         if (parent.parent != null && parent.x == parent.parent.x && x != parent.x)
         {

--- a/src/main/java/com/minecolonies/core/entity/pathfinding/pathjobs/PathJobRaiderPathing.java
+++ b/src/main/java/com/minecolonies/core/entity/pathfinding/pathjobs/PathJobRaiderPathing.java
@@ -148,7 +148,15 @@ public class PathJobRaiderPathing extends AbstractPathJob
     }
 
     @Override
-    protected double modifyCost(final double cost, final MNode parent, final int x, final int y, final int z, final BlockState state)
+    protected double modifyCost(
+      final double cost,
+      final MNode parent,
+      final boolean swimstart,
+      final boolean swimming,
+      final int x,
+      final int y,
+      final int z,
+      final BlockState state)
     {
         double modifier = addCost;
         addCost = 1.0;

--- a/src/main/java/com/minecolonies/core/entity/pathfinding/pathjobs/PathJobRandomPos.java
+++ b/src/main/java/com/minecolonies/core/entity/pathfinding/pathjobs/PathJobRandomPos.java
@@ -2,6 +2,7 @@ package com.minecolonies.core.entity.pathfinding.pathjobs;
 
 import com.minecolonies.core.entity.pathfinding.PathfindingUtils;
 import com.minecolonies.core.entity.pathfinding.navigation.AbstractAdvancedPathNavigate;
+import com.minecolonies.core.entity.pathfinding.navigation.IDynamicHeuristicNavigatior;
 import com.minecolonies.core.entity.pathfinding.pathresults.PathResult;
 import com.minecolonies.core.entity.pathfinding.SurfaceType;
 import com.minecolonies.api.util.BlockPosUtil;
@@ -49,6 +50,11 @@ public class PathJobRandomPos extends AbstractPathJob
     private BlockPos centerBox      = null;
 
     /**
+     * Modifier to the heuristics
+     */
+    private double heuristicModifier = 1.0;
+
+    /**
      * Prepares the PathJob for the path finding system.
      *
      * @param world            world the entity is in.
@@ -70,6 +76,11 @@ public class PathJobRandomPos extends AbstractPathJob
 
         final Tuple<Direction, Direction> dir = BlockPosUtil.getRandomDirectionTuple();
         this.destination = start.relative(dir.getA(), minDistFromStart).relative(dir.getB(), minDistFromStart);
+
+        if (entity != null && entity.getNavigation() instanceof IDynamicHeuristicNavigatior)
+        {
+            heuristicModifier = ((IDynamicHeuristicNavigatior) entity.getNavigation()).getAvgHeuristicModifier();
+        }
     }
 
     /**
@@ -134,7 +145,7 @@ public class PathJobRandomPos extends AbstractPathJob
     @Override
     protected double computeHeuristic(final int x, final int y, final int z)
     {
-        return BlockPosUtil.dist(destination, x, y, z);
+        return BlockPosUtil.dist(destination, x, y, z) * heuristicModifier;
     }
 
     @Override

--- a/src/main/java/com/minecolonies/core/entity/pathfinding/pathjobs/PathJobRandomPos.java
+++ b/src/main/java/com/minecolonies/core/entity/pathfinding/pathjobs/PathJobRandomPos.java
@@ -1,26 +1,19 @@
 package com.minecolonies.core.entity.pathfinding.pathjobs;
 
 import com.minecolonies.core.entity.pathfinding.PathfindingUtils;
-import com.minecolonies.core.entity.pathfinding.navigation.AbstractAdvancedPathNavigate;
-import com.minecolonies.core.entity.pathfinding.navigation.IDynamicHeuristicNavigatior;
+import com.minecolonies.core.entity.pathfinding.navigation.IDynamicHeuristicNavigator;
 import com.minecolonies.core.entity.pathfinding.pathresults.PathResult;
 import com.minecolonies.core.entity.pathfinding.SurfaceType;
 import com.minecolonies.api.util.BlockPosUtil;
-import com.minecolonies.api.util.Log;
 import com.minecolonies.api.util.constant.ColonyConstants;
-import com.minecolonies.core.MineColonies;
 import com.minecolonies.core.entity.pathfinding.MNode;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
 import net.minecraft.util.Tuple;
 import net.minecraft.world.entity.Mob;
 import net.minecraft.world.level.Level;
-import net.minecraft.world.level.pathfinder.Path;
 import net.minecraft.world.phys.AABB;
 import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
-
-import static com.minecolonies.api.util.constant.PathingConstants.DEBUG_VERBOSITY_NONE;
 
 /**
  * Job that handles random pathing.
@@ -77,9 +70,9 @@ public class PathJobRandomPos extends AbstractPathJob
         final Tuple<Direction, Direction> dir = BlockPosUtil.getRandomDirectionTuple();
         this.destination = start.relative(dir.getA(), minDistFromStart).relative(dir.getB(), minDistFromStart);
 
-        if (entity != null && entity.getNavigation() instanceof IDynamicHeuristicNavigatior)
+        if (entity != null && entity.getNavigation() instanceof IDynamicHeuristicNavigator)
         {
-            heuristicModifier = ((IDynamicHeuristicNavigatior) entity.getNavigation()).getAvgHeuristicModifier();
+            heuristicModifier = ((IDynamicHeuristicNavigator) entity.getNavigation()).getAvgHeuristicModifier();
         }
     }
 

--- a/src/main/java/com/minecolonies/core/entity/pathfinding/pathresults/PathResult.java
+++ b/src/main/java/com/minecolonies/core/entity/pathfinding/pathresults/PathResult.java
@@ -46,6 +46,16 @@ public class PathResult<T extends Callable<Path>>
     private boolean pathingDoneAndProcessed = false;
 
     /**
+     * Cost per distance traveled factor, only if path reaches
+     */
+    public double costPerDist = 1;
+
+    /**
+     * Amount of searched nodes
+     */
+    public int searchedNodes = 0;
+
+    /**
      * Get Status of the Path.
      *
      * @return status.

--- a/src/main/java/com/minecolonies/core/network/messages/client/SyncPathMessage.java
+++ b/src/main/java/com/minecolonies/core/network/messages/client/SyncPathMessage.java
@@ -26,12 +26,15 @@ public class SyncPathMessage implements IMessage
     /**
      * Set of not visited nodes.
      */
-    public Set<MNode> lastDebugNodesNotVisited  = new HashSet<>();
+    public Set<MNode> lastDebugNodesNotVisited = new HashSet<>();
 
     /**
      * Set of chosen nodes for the path.
      */
-    public Set<MNode> lastDebugNodesPath  = new HashSet<>();
+    public Set<MNode> lastDebugNodesPath = new HashSet<>();
+    public Set<MNode> debugNodesVisitedLater = new HashSet<>();
+    public Set<MNode> debugNodesOrgPath = new HashSet<>();
+    public Set<MNode> debugNodesExtra = new HashSet<>();
 
     /**
      * Default constructor.
@@ -44,12 +47,21 @@ public class SyncPathMessage implements IMessage
     /**
      * Create a new path message with the filled pathpoints.
      */
-    public SyncPathMessage(final Set<MNode> lastDebugNodesVisited, final Set<MNode> lastDebugNodesNotVisited, final Set<MNode>  lastDebugNodesPath)
+    public SyncPathMessage(
+      final Set<MNode> lastDebugNodesVisited,
+      final Set<MNode> lastDebugNodesNotVisited,
+      final Set<MNode> lastDebugNodesPath,
+      final Set<MNode> debugNodesVisitedLater,
+      final Set<MNode> debugNodesOrgPath,
+      final Set<MNode> debugNodesExtra)
     {
         super();
         this.lastDebugNodesVisited = lastDebugNodesVisited;
         this.lastDebugNodesNotVisited = lastDebugNodesNotVisited;
         this.lastDebugNodesPath = lastDebugNodesPath;
+        this.debugNodesVisitedLater = debugNodesVisitedLater;
+        this.debugNodesOrgPath = debugNodesOrgPath;
+        this.debugNodesExtra = debugNodesExtra;
     }
 
     @Override
@@ -69,6 +81,24 @@ public class SyncPathMessage implements IMessage
 
         buf.writeInt(lastDebugNodesPath.size());
         for (final MNode node : lastDebugNodesPath)
+        {
+            node.serializeToBuf(buf);
+        }
+
+        buf.writeInt(debugNodesVisitedLater.size());
+        for (final MNode node : debugNodesVisitedLater)
+        {
+            node.serializeToBuf(buf);
+        }
+
+        buf.writeInt(debugNodesOrgPath.size());
+        for (final MNode node : debugNodesOrgPath)
+        {
+            node.serializeToBuf(buf);
+        }
+
+        buf.writeInt(debugNodesExtra.size());
+        for (final MNode node : debugNodesExtra)
         {
             node.serializeToBuf(buf);
         }
@@ -94,6 +124,24 @@ public class SyncPathMessage implements IMessage
         {
             lastDebugNodesPath.add(new MNode(buf));
         }
+
+        size = buf.readInt();
+        for (int i = 0; i < size; i++)
+        {
+            debugNodesVisitedLater.add(new MNode(buf));
+        }
+
+        size = buf.readInt();
+        for (int i = 0; i < size; i++)
+        {
+            debugNodesOrgPath.add(new MNode(buf));
+        }
+
+        size = buf.readInt();
+        for (int i = 0; i < size; i++)
+        {
+            debugNodesExtra.add(new MNode(buf));
+        }
     }
 
     @Nullable
@@ -110,5 +158,8 @@ public class SyncPathMessage implements IMessage
         PathfindingDebugRenderer.lastDebugNodesVisited = lastDebugNodesVisited;
         PathfindingDebugRenderer.lastDebugNodesNotVisited = lastDebugNodesNotVisited;
         PathfindingDebugRenderer.lastDebugNodesPath = lastDebugNodesPath;
+        PathfindingDebugRenderer.lastDebugNodesVisitedLater = debugNodesVisitedLater;
+        PathfindingDebugRenderer.debugNodesOrgPath = debugNodesOrgPath;
+        PathfindingDebugRenderer.debugNodesExtra = debugNodesExtra;
     }
 }


### PR DESCRIPTION
# Changes proposed in this pull request:
- Navigators now keep a long-time average of cost vs distance relation to allow adaptation of heuristics to the terrain (for reachability/nodes explored)
- Pathjobs now re-evalute heuristic values used on reaching the target or when progress is going badly
- Add a node limit hit callback to pathjobs to allow increasing a limit when conditions are met

- Improved pathing stuck handler to not take action while an entity is progressing on a path
- Improved pathing stuck handler to try walking in all 4 directions, instead of only opposite direction
- Add new pathjob to move into a given direction for X range

- Extend debug draw with more types of nodes, path reached nodes are now yellow instead of orange
- Pathfinding costs are now applied in order, boni are multiplied first, mali are additive (reduced base for all by one due to this)
- Navigator now keeps the pathresult of finished paths, to allow comparing new incomming ones
- Fix block lookup cache sometimes shifting previous blockstates to wrong places


[x] Yes I tested this before submitting it.
[x] I also did a multiplayer test.

Review please
