### PR TITLE
Change shepherd ITEM_USED statistics to ITEM_OBTAINED

### DIFF
--- a/src/main/java/com/minecolonies/core/entity/ai/workers/production/herders/AbstractEntityAIHerder.java
+++ b/src/main/java/com/minecolonies/core/entity/ai/workers/production/herders/AbstractEntityAIHerder.java
@@ -541,8 +541,8 @@ public abstract class AbstractEntityAIHerder<J extends AbstractJob<?, J>, B exte
 
             // Values taken from vanilla.
             worker.swing(InteractionHand.MAIN_HAND);
-            worker.getMainHandItem().shrink(1);
             building.getModule(STATS_MODULE).increment(ITEM_USED + ";" + worker.getMainHandItem().getItem().getDescriptionId());
+            worker.getMainHandItem().shrink(1);
             worker.getCitizenExperienceHandler().addExperience(XP_PER_ACTION);
             worker.level.broadcastEntityEvent(toFeed, (byte) 18);
             toFeed.playSound(SoundEvents.GENERIC_EAT, 1.0F, 1.0F);

--- a/src/main/java/com/minecolonies/core/entity/ai/workers/production/herders/EntityAIWorkShepherd.java
+++ b/src/main/java/com/minecolonies/core/entity/ai/workers/production/herders/EntityAIWorkShepherd.java
@@ -22,7 +22,7 @@ import java.util.List;
 
 import static com.minecolonies.api.entity.ai.statemachine.states.AIWorkerState.*;
 import static com.minecolonies.api.util.constant.Constants.TICKS_SECOND;
-import static com.minecolonies.api.util.constant.StatisticsConstants.ITEM_USED;
+import static com.minecolonies.api.util.constant.StatisticsConstants.ITEM_OBTAINED;
 import static com.minecolonies.core.colony.buildings.modules.BuildingModules.STATS_MODULE;
 import static net.minecraft.world.entity.animal.Sheep.ITEM_BY_DYE;
 
@@ -155,7 +155,7 @@ public class EntityAIWorkShepherd extends AbstractEntityAIHerder<JobShepherd, Bu
 
             for (final ItemStack item : items)
             {
-                building.getModule(STATS_MODULE).incrementBy(ITEM_USED + ";" + item.getItem().getDescriptionId(), item.getCount());
+                building.getModule(STATS_MODULE).incrementBy(ITEM_OBTAINED + ";" + item.getItem().getDescriptionId(), item.getCount());
                 InventoryUtils.transferItemStackIntoNextBestSlotInItemHandler(item, (worker.getInventoryCitizen()));
             }
         }


### PR DESCRIPTION
Closes [discord report](https://discord.com/channels/472875599422291968/486940969737125922/1222455410426904687) (Gathered items show as "Used" instead of "Obtained")

# Changes proposed in this pull request:
- Fix statistics for gathering items showing as "Used"


[ ] Yes I tested this before submitting it.
[ ] I also did a multiplayer test.

Review please
