### PR TITLE
Rebalance baker foods

### DIFF
--- a/src/datagen/generated/minecolonies/data/minecolonies/crafterrecipes/baker/cake.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/crafterrecipes/baker/cake.json
@@ -7,6 +7,6 @@
     }
   ],
   "intermediate": "minecraft:furnace",
-  "min-building-level": 2,
+  "min-building-level": 4,
   "result": "minecraft:cake"
 }

--- a/src/datagen/generated/minecolonies/data/minecolonies/crafterrecipes/baker/cake_batter.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/crafterrecipes/baker/cake_batter.json
@@ -19,7 +19,7 @@
     }
   ],
   "intermediate": "minecraft:air",
-  "min-building-level": 2,
+  "min-building-level": 4,
   "result": "minecolonies:cake_batter",
   "show-tooltip": true
 }

--- a/src/datagen/generated/minecolonies/data/minecolonies/crafterrecipes/baker/cookie.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/crafterrecipes/baker/cookie.json
@@ -7,6 +7,6 @@
     }
   ],
   "intermediate": "minecraft:furnace",
-  "min-building-level": 4,
+  "min-building-level": 2,
   "result": "minecraft:cookie"
 }

--- a/src/datagen/generated/minecolonies/data/minecolonies/crafterrecipes/baker/cookie_dough.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/crafterrecipes/baker/cookie_dough.json
@@ -13,7 +13,7 @@
     }
   ],
   "intermediate": "minecraft:air",
-  "min-building-level": 4,
+  "min-building-level": 2,
   "result": "minecolonies:cookie_dough",
   "show-tooltip": true
 }

--- a/src/main/java/com/minecolonies/core/compatibility/CraftingTagAuditor.java
+++ b/src/main/java/com/minecolonies/core/compatibility/CraftingTagAuditor.java
@@ -18,6 +18,7 @@ import net.minecraft.network.chat.Component;
 import net.minecraft.resources.ResourceKey;
 import net.minecraft.server.MinecraftServer;
 import net.minecraft.world.entity.animal.Animal;
+import net.minecraft.world.food.FoodProperties;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.storage.LevelResource;
@@ -57,6 +58,7 @@ public class CraftingTagAuditor
         createFile("recipe audit", server, "recipe_audit.csv", writer -> doRecipeAudit(writer, server, customRecipeManager));
         createFile("domum audit", server, "domum_audit.csv", writer -> doDomumAudit(writer, server));
         createFile("tools audit", server, "tools_audit.csv", writer -> doToolsAudit(writer, server));
+        createFile("food audit", server, "food_audit.csv", writer -> doFoodAudit(writer, server));
     }
 
     private static boolean createFile(@NotNull final String description,
@@ -314,6 +316,34 @@ public class CraftingTagAuditor
                     }
                 }
             }
+
+            writer.newLine();
+        }
+    }
+
+    private static void doFoodAudit(@NotNull final BufferedWriter writer,
+                                    @NotNull final MinecraftServer server) throws IOException
+    {
+        writeItemHeaders(writer);
+        writer.write(",nutrition,maxlevel");
+        writer.newLine();
+
+        for (final ItemStack item : getAllItems())
+        {
+            if (!ItemStackUtils.ISFOOD.test(item)) continue;
+
+            final FoodProperties properties = item.getItem().getFoodProperties(item, null);
+            if (properties == null) continue;
+
+            writeItemData(writer, item);
+
+            writer.write(',');
+            writer.write(Integer.toString(properties.getNutrition()));
+            writer.write(',');
+
+            // minNutrition = getBuildingLevel() - 1
+            // maxLevel     = getNutrition()     + 1
+            writer.write(Integer.toString(Math.min(5, properties.getNutrition() + 1)));
 
             writer.newLine();
         }

--- a/src/main/java/com/minecolonies/core/generation/defaults/workers/DefaultBakerCraftingProvider.java
+++ b/src/main/java/com/minecolonies/core/generation/defaults/workers/DefaultBakerCraftingProvider.java
@@ -103,19 +103,17 @@ public class DefaultBakerCraftingProvider extends CustomRecipeProvider
                 .showTooltip(true)
                 .build(consumer);
 
-        CustomRecipeBuilder.create(BAKER, MODULE_CRAFTING, "cake_batter")
-                .inputs(List.of(new ItemStorage(new ItemStack(Items.WHEAT, 3)),
-                        new ItemStorage(new ItemStack(Items.MILK_BUCKET, 3)),
-                        new ItemStorage(new ItemStack(Items.SUGAR, 2)),
-                        new ItemStorage(new ItemStack(Items.EGG))))
-                .result(new ItemStack(ModItems.cakeBatter))
+        CustomRecipeBuilder.create(BAKER, MODULE_CRAFTING, "cookie_dough")
+                .inputs(List.of(new ItemStorage(new ItemStack(Items.WHEAT, 2)),
+                        new ItemStorage(new ItemStack(Items.COCOA_BEANS, 2))))
+                .result(new ItemStack(ModItems.cookieDough, 8))
                 .minBuildingLevel(2)
                 .showTooltip(true)
                 .build(consumer);
 
-        CustomRecipeBuilder.create(BAKER, MODULE_SMELTING, "cake")
-                .inputs(List.of(new ItemStorage(new ItemStack(ModItems.cakeBatter))))
-                .result(new ItemStack(Items.CAKE))
+        CustomRecipeBuilder.create(BAKER, MODULE_SMELTING, "cookie")
+                .inputs(List.of(new ItemStorage(new ItemStack(ModItems.cookieDough))))
+                .result(new ItemStack(Items.COOKIE))
                 .minBuildingLevel(2)
                 .intermediate(Blocks.FURNACE)
                 .build(consumer);
@@ -136,17 +134,19 @@ public class DefaultBakerCraftingProvider extends CustomRecipeProvider
                 .intermediate(Blocks.FURNACE)
                 .build(consumer);
 
-        CustomRecipeBuilder.create(BAKER, MODULE_CRAFTING, "cookie_dough")
-                .inputs(List.of(new ItemStorage(new ItemStack(Items.WHEAT, 2)),
-                        new ItemStorage(new ItemStack(Items.COCOA_BEANS, 2))))
-                .result(new ItemStack(ModItems.cookieDough, 8))
+        CustomRecipeBuilder.create(BAKER, MODULE_CRAFTING, "cake_batter")
+                .inputs(List.of(new ItemStorage(new ItemStack(Items.WHEAT, 3)),
+                        new ItemStorage(new ItemStack(Items.MILK_BUCKET, 3)),
+                        new ItemStorage(new ItemStack(Items.SUGAR, 2)),
+                        new ItemStorage(new ItemStack(Items.EGG))))
+                .result(new ItemStack(ModItems.cakeBatter))
                 .minBuildingLevel(4)
                 .showTooltip(true)
                 .build(consumer);
 
-        CustomRecipeBuilder.create(BAKER, MODULE_SMELTING, "cookie")
-                .inputs(List.of(new ItemStorage(new ItemStack(ModItems.cookieDough))))
-                .result(new ItemStack(Items.COOKIE))
+        CustomRecipeBuilder.create(BAKER, MODULE_SMELTING, "cake")
+                .inputs(List.of(new ItemStorage(new ItemStack(ModItems.cakeBatter))))
+                .result(new ItemStack(Items.CAKE))
                 .minBuildingLevel(4)
                 .intermediate(Blocks.FURNACE)
                 .build(consumer);


### PR DESCRIPTION
# Changes proposed in this pull request:
- Adds [food audit](https://docs.google.com/spreadsheets/d/1i6EQuPuxVWDmH2Z9_CHiXOmDG5sXVF2cscHg6lwXs9o/edit#gid=1343555397).
- Rebalances baker foods based on nutrition levels:
    - Bread is left at level 1 (total nutrition is 5), since it makes sense for this to be the fundamental food, especially given the improved recipe at level 3 and the other advanced bread types.
    - Cake is moved from level 2 to level 4, because it has 16 total nutrition (and is only usable by the player anyway).
    - Pumpkin pie remains at level 3, with 8 total nutrition.
    - Cookies are moved from level 4 to level 2, because each cookie only has 2 nutrition (and so colonists won't eat them at level 4+), albeit each dough crafting operation will produce 8 cookies (so technically the total nutrition is the same as the cake, but that doesn't really matter to colonists).
        - Arguably this should be the level 1 recipe due to having the lowest effective nutrition, but since it requires a jungle-only ingredient and bread seems more fundamental, it doesn't seem wrong to keep it at level 2.

[ ] Yes I tested this before submitting it.
[ ] I also did a multiplayer test.

Review please (could port)
