### PR TITLE
make quests more uncommon, move research

### DIFF
--- a/src/datagen/generated/minecolonies/data/minecolonies/colony/quests/general/alchemy.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/colony/quests/general/alchemy.json
@@ -246,7 +246,7 @@
   "triggers": [
     {
       "type": "minecolonies:random",
-      "rarity": 250000
+      "rarity": 2500000
     },
     {
       "type": "minecolonies:state",

--- a/src/datagen/generated/minecolonies/data/minecolonies/colony/quests/general/cookies.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/colony/quests/general/cookies.json
@@ -230,7 +230,7 @@
   "triggers": [
     {
       "type": "minecolonies:random",
-      "rarity": 250000
+      "rarity": 2500000
     },
     {
       "type": "minecolonies:state",

--- a/src/datagen/generated/minecolonies/data/minecolonies/colony/quests/general/cookies.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/colony/quests/general/cookies.json
@@ -237,7 +237,7 @@
       "state": {
         "match": {
           "type": "minecolonies:baker",
-          "level": 1
+          "level": 2
         },
         "path": "buildingManager/buildings"
       }

--- a/src/datagen/generated/minecolonies/data/minecolonies/colony/quests/general/hungrycourier.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/colony/quests/general/hungrycourier.json
@@ -104,7 +104,7 @@
   "triggers": [
     {
       "type": "minecolonies:random",
-      "rarity": 5000000
+      "rarity": 50000000
     },
     {
       "type": "minecolonies:state",

--- a/src/datagen/generated/minecolonies/data/minecolonies/colony/quests/general/thezombiemenace1.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/colony/quests/general/thezombiemenace1.json
@@ -80,7 +80,7 @@
   "triggers": [
     {
       "type": "minecolonies:random",
-      "rarity": 250000
+      "rarity": 2500000
     },
     {
       "type": "minecolonies:state",

--- a/src/datagen/generated/minecolonies/data/minecolonies/colony/quests/general/thezombiemenace2.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/colony/quests/general/thezombiemenace2.json
@@ -82,7 +82,7 @@
   "triggers": [
     {
       "type": "minecolonies:random",
-      "rarity": 250000
+      "rarity": 2500000
     },
     {
       "type": "minecolonies:state",

--- a/src/datagen/generated/minecolonies/data/minecolonies/colony/quests/romance/aromanticgesture.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/colony/quests/romance/aromanticgesture.json
@@ -113,7 +113,7 @@
   "triggers": [
     {
       "type": "minecolonies:random",
-      "rarity": 500
+      "rarity": 10000000
     },
     {
       "type": "minecolonies:citizen",

--- a/src/datagen/generated/minecolonies/data/minecolonies/colony/quests/romance/atokenofapp.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/colony/quests/romance/atokenofapp.json
@@ -120,7 +120,7 @@
   "triggers": [
     {
       "type": "minecolonies:random",
-      "rarity": 500
+      "rarity": 10000000
     },
     {
       "type": "minecolonies:citizen",

--- a/src/datagen/generated/minecolonies/data/minecolonies/researches/technology/theflintstones.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/researches/technology/theflintstones.json
@@ -16,7 +16,7 @@
       "type": "minecolonies:item_list",
       "item": {
         "items": [
-          "minecraft:bricks"
+          "minecraft:brick"
         ]
       },
       "quantity": 64

--- a/src/datagen/generated/minecolonies/data/minecolonies/researches/technology/theflintstones.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/researches/technology/theflintstones.json
@@ -6,17 +6,17 @@
     }
   ],
   "icon": "minecolonies:blockhutstonesmeltery",
-  "parentResearch": "minecolonies:technology/hot",
+  "parentResearch": "minecolonies:technology/stonecake",
   "requirements": [
     {
-      "building": "smeltery",
-      "level": 3
+      "building": "stonemason",
+      "level": 1
     },
     {
       "type": "minecolonies:item_list",
       "item": {
         "items": [
-          "minecraft:stone_bricks"
+          "minecraft:bricks"
         ]
       },
       "quantity": 64

--- a/src/main/java/com/minecolonies/api/colony/ICitizenData.java
+++ b/src/main/java/com/minecolonies/api/colony/ICitizenData.java
@@ -413,4 +413,10 @@ public interface ICitizenData extends ICivilianData, IQuestGiver, IQuestParticip
      * @param player the player that interacted
      */
     void setInteractedRecently(final UUID player);
+
+    /**
+     * If any quest is assigned to the citizen.
+     * @return true if so.
+     */
+    boolean hasQuestAssignment();
 }

--- a/src/main/java/com/minecolonies/core/client/gui/WindowInteraction.java
+++ b/src/main/java/com/minecolonies/core/client/gui/WindowInteraction.java
@@ -7,11 +7,13 @@ import com.ldtteam.blockui.controls.ItemIcon;
 import com.ldtteam.blockui.controls.Text;
 import com.ldtteam.blockui.views.Box;
 import com.minecolonies.api.colony.ICitizenDataView;
+import com.minecolonies.api.colony.interactionhandling.ChatPriority;
 import com.minecolonies.api.colony.interactionhandling.IInteractionResponseHandler;
 import com.minecolonies.api.util.Log;
 import com.minecolonies.api.util.constant.Constants;
 import com.minecolonies.core.Network;
 import com.minecolonies.core.client.gui.citizen.MainWindowCitizen;
+import com.minecolonies.core.colony.interactionhandling.QuestDialogueInteraction;
 import com.minecolonies.core.network.messages.server.colony.InteractionClose;
 import net.minecraft.client.Minecraft;
 import net.minecraft.resources.ResourceLocation;
@@ -92,6 +94,12 @@ public class WindowInteraction extends AbstractWindowSkeleton
         window.findPaneOfTypeByID("requestItem", ItemIcon.class).hide();
 
         final IInteractionResponseHandler handler = interactions.get(currentInteraction);
+        if (handler.getPriority().getPriority() <= ChatPriority.CHITCHAT.getPriority() && currentInteraction > 0 && !(handler instanceof QuestDialogueInteraction))
+        {
+            currentInteraction++;
+            setupInteraction();
+            return;
+        }
         handler.onOpened(Minecraft.getInstance().player);
         final Box group = findPaneOfTypeByID(RESPONSE_BOX_ID, Box.class);
         group.getChildren().clear();
@@ -106,7 +114,6 @@ public class WindowInteraction extends AbstractWindowSkeleton
         {
             final ButtonImage button = new ButtonImage();
             button.setImage(new ResourceLocation(Constants.MOD_ID, MEDIUM_SIZED_BUTTON_RES), false);
-
 
             final int textLen = mc.font.width(component.getString());
             int buttonHeight = BUTTON_HEIGHT;

--- a/src/main/java/com/minecolonies/core/client/gui/WindowInteraction.java
+++ b/src/main/java/com/minecolonies/core/client/gui/WindowInteraction.java
@@ -58,6 +58,12 @@ public class WindowInteraction extends AbstractWindowSkeleton
         super(Constants.MOD_ID + INTERACTION_RESOURCE_SUFFIX, new MainWindowCitizen(citizen));
         this.citizen = citizen;
         this.interactions = new ArrayList<>(citizen.getOrderedInteractions());
+        registerButton(BUTTON_CANCEL, this::cancelClicked);
+    }
+
+    private void cancelClicked()
+    {
+        close();
     }
 
     /**
@@ -152,7 +158,11 @@ public class WindowInteraction extends AbstractWindowSkeleton
     @Override
     public void onButtonClicked(@NotNull final Button button)
     {
-        if (!interactions.isEmpty())
+        if (button.getID().equals(BUTTON_CANCEL))
+        {
+            super.onButtonClicked(button);
+        }
+        else if (!interactions.isEmpty())
         {
             final IInteractionResponseHandler handler = interactions.get(currentInteraction);
             try

--- a/src/main/java/com/minecolonies/core/client/gui/questlog/WindowQuestLogInProgressQuestQuestModule.java
+++ b/src/main/java/com/minecolonies/core/client/gui/questlog/WindowQuestLogInProgressQuestQuestModule.java
@@ -89,7 +89,7 @@ public class WindowQuestLogInProgressQuestQuestModule implements WindowQuestLogQ
      */
     private Component getQuestGiverName(final IColonyView colonyView, final IQuestInstance quest)
     {
-        final ICitizenDataView citizen = colonyView.getCitizen(quest.getQuestGiverId());
+        final ICitizenDataView citizen = colonyView.getCitizen(quest.getQuestTarget());
         if (citizen != null)
         {
             return Component.literal(citizen.getName());

--- a/src/main/java/com/minecolonies/core/colony/CitizenData.java
+++ b/src/main/java/com/minecolonies/core/colony/CitizenData.java
@@ -1894,6 +1894,12 @@ public class CitizenData implements ICitizenData
     }
 
     @Override
+    public boolean hasQuestAssignment()
+    {
+        return !this.availableQuests.isEmpty() || !this.participatingQuests.isEmpty();
+    }
+
+    @Override
     public void onInteractionClosed(final Component key, final ServerPlayer sender)
     {
         final IInteractionResponseHandler chatOption = citizenChatOptions.get(key);

--- a/src/main/java/com/minecolonies/core/colony/interactionhandling/ServerCitizenInteraction.java
+++ b/src/main/java/com/minecolonies/core/colony/interactionhandling/ServerCitizenInteraction.java
@@ -28,8 +28,7 @@ import java.util.Set;
 import java.util.function.Predicate;
 
 import static com.minecolonies.api.util.constant.Constants.TICKS_SECOND;
-import static com.minecolonies.core.colony.interactionhandling.StandardInteraction.INTERACTION_R_IGNORE;
-import static com.minecolonies.core.colony.interactionhandling.StandardInteraction.INTERACTION_R_REMIND;
+import static com.minecolonies.core.colony.interactionhandling.StandardInteraction.*;
 
 /**
  * The server side interaction response handler.
@@ -143,13 +142,20 @@ public abstract class ServerCitizenInteraction extends AbstractInteractionRespon
     {
         if (response.getContents() instanceof TranslatableContents)
         {
-            if (((TranslatableContents) response.getContents()).getKey().equals(INTERACTION_R_REMIND))
+            if (((TranslatableContents) response.getContents()).getKey().equals(INTERACTION_R_IGNORE))
             {
-                displayAtWorldTick = (int) (player.level.getGameTime() + (TICKS_SECOND * 60 * 10));
+                // 6 hours later
+                displayAtWorldTick = (int) (player.level.getGameTime() + (TICKS_SECOND * 60 * 60 * 6));
             }
-            else if (((TranslatableContents) response.getContents()).getKey().equals(INTERACTION_R_IGNORE))
+            else if (((TranslatableContents) response.getContents()).getKey().equals(INTERACTION_R_REMIND))
             {
-                displayAtWorldTick = (int) (player.level.getGameTime() + (TICKS_SECOND * 60 * 20));
+                // 1 hour later
+                displayAtWorldTick = (int) (player.level.getGameTime() + (TICKS_SECOND * 60 * 60));
+            }
+            else if (((TranslatableContents) response.getContents()).getKey().equals(INTERACTION_R_OKAY) || ((TranslatableContents) response.getContents()).getKey().equals(INTERACTION_R_SKIP))
+            {
+                // 5 minutes
+                displayAtWorldTick = (int) (player.level.getGameTime() + (TICKS_SECOND * 60 * 5));
             }
         }
     }

--- a/src/main/java/com/minecolonies/core/generation/defaults/DefaultResearchProvider.java
+++ b/src/main/java/com/minecolonies/core/generation/defaults/DefaultResearchProvider.java
@@ -1434,6 +1434,25 @@ public class DefaultResearchProvider extends AbstractResearchProvider
                                        .addItemCost(Items.STONE, 64)
                                        .addEffect(ModBuildings.crusher.get().getBuildingBlock(), 1)
                                        .addToList(r);
+
+        final Research theFlintstones = new Research(new ResourceLocation(Constants.MOD_ID, "technology/theflintstones"), TECH).setParentResearch(stoneCake)
+                                          .setTranslatedName("The Flintstones")
+                                          .setTranslatedSubtitle("Yabba Dabba Doo!")
+                                          .setIcon(ModBlocks.blockHutStoneSmeltery.asItem())
+                                          .addBuildingRequirement(ModBuildings.STONE_MASON_ID, 1)
+                                          .addItemCost(Items.BRICKS, 64)
+                                          .addEffect(ModBuildings.stoneSmelter.get().getBuildingBlock(), 1)
+                                          .addToList(r);
+        new Research(new ResourceLocation(Constants.MOD_ID, "technology/knowtheend"), TECH).setParentResearch(theFlintstones)
+          .setTranslatedName("Know the End")
+          .setTranslatedSubtitle("Unlock the secrets of the most mysterious dimension.")
+          .setIcon(ModItems.chorusBread)
+          .addBuildingRequirement("baker", 3)
+          .addItemCost(Items.CHORUS_FRUIT, 64)
+          .addEffect(new ResourceLocation("minecolonies:effects/knowledgeoftheendunlock"), 1)
+          .addToList(r);
+
+
         new Research(new ResourceLocation(Constants.MOD_ID, "technology/gildedhammer"), TECH).setParentResearch(rockingRoll)
           .setTranslatedName("Gilded Hammer")
           .setTranslatedSubtitle("When in doubt, cover in shiny stuff.")
@@ -1649,23 +1668,6 @@ public class DefaultResearchProvider extends AbstractResearchProvider
           .setIcon(Items.REPEATER)
           .addItemCost(Items.REDSTONE, 2048)
           .addEffect(BLOCK_BREAK_SPEED, 5)
-          .addToList(r);
-
-        final Research theFlintstones = new Research(new ResourceLocation(Constants.MOD_ID, "technology/theflintstones"), TECH).setParentResearch(hot)
-                                          .setTranslatedName("The Flintstones")
-                                          .setTranslatedSubtitle("Yabba Dabba Doo!")
-                                          .setIcon(ModBlocks.blockHutStoneSmeltery.asItem())
-                                          .addBuildingRequirement(ModBuildings.SMELTERY_ID, 3)
-                                          .addItemCost(Items.STONE_BRICKS, 64)
-                                          .addEffect(ModBuildings.stoneSmelter.get().getBuildingBlock(), 1)
-                                          .addToList(r);
-        new Research(new ResourceLocation(Constants.MOD_ID, "technology/knowtheend"), TECH).setParentResearch(theFlintstones)
-          .setTranslatedName("Know the End")
-          .setTranslatedSubtitle("Unlock the secrets of the most mysterious dimension.")
-          .setIcon(ModItems.chorusBread)
-          .addBuildingRequirement("baker", 3)
-          .addItemCost(Items.CHORUS_FRUIT, 64)
-          .addEffect(new ResourceLocation("minecolonies:effects/knowledgeoftheendunlock"), 1)
           .addToList(r);
 
         new Research(new ResourceLocation(Constants.MOD_ID, "technology/thoselungs"), TECH).setParentResearch(hot)

--- a/src/main/java/com/minecolonies/core/generation/defaults/DefaultResearchProvider.java
+++ b/src/main/java/com/minecolonies/core/generation/defaults/DefaultResearchProvider.java
@@ -1440,7 +1440,7 @@ public class DefaultResearchProvider extends AbstractResearchProvider
                                           .setTranslatedSubtitle("Yabba Dabba Doo!")
                                           .setIcon(ModBlocks.blockHutStoneSmeltery.asItem())
                                           .addBuildingRequirement(ModBuildings.STONE_MASON_ID, 1)
-                                          .addItemCost(Items.BRICKS, 64)
+                                          .addItemCost(Items.BRICK, 64)
                                           .addEffect(ModBuildings.stoneSmelter.get().getBuildingBlock(), 1)
                                           .addToList(r);
         new Research(new ResourceLocation(Constants.MOD_ID, "technology/knowtheend"), TECH).setParentResearch(theFlintstones)

--- a/src/main/java/com/minecolonies/core/quests/triggers/CitizenQuestTriggerTemplate.java
+++ b/src/main/java/com/minecolonies/core/quests/triggers/CitizenQuestTriggerTemplate.java
@@ -71,6 +71,10 @@ public class CitizenQuestTriggerTemplate implements IQuestTriggerTemplate
         Collections.shuffle(citizenDataList);
         for (final ICitizenData data : citizenDataList)
         {
+            if (data.hasQuestAssignment())
+            {
+                continue;
+            }
             if (matchTag != null && !IQuestTriggerTemplate.matchNbt(data.serializeNBT(), matchTag))
             {
                 continue;

--- a/src/main/resources/assets/minecolonies/gui/citizen/windowinteraction.xml
+++ b/src/main/resources/assets/minecolonies/gui/citizen/windowinteraction.xml
@@ -8,4 +8,6 @@
             <itemicon id="requestItem" size="32 32" pos="30 60"/>
         </view>
     </switch>
+    <buttonimage id="cancel" pos="303 1" size="14 15"
+                 source="minecolonies:textures/gui/button_x.png" textcolor="black" tooltip="$(com.minecolonies.core.exit_interactions)"/>
 </window>

--- a/src/main/resources/assets/minecolonies/lang/manual_en_us.json
+++ b/src/main/resources/assets/minecolonies/lang/manual_en_us.json
@@ -2574,5 +2574,6 @@
   "com.minecolonies.core.gui.supplies.guide": "Use these supplies to assemble a %s to serve as a foundation for your own colony. Within it, aside from §2ample resources§r, you shall find\na salvaged §2townhall block§r and §2build tool§r to lay the groundworks of the new colony. Founding a colony demands resilience; beyond the basic necessities of shelter, sustenance, and healing, lies the imperative to fortify against the looming threats of piracy and barbarism. Yet, should you endure these trials, the potential for growth knows no bounds. From artisans to scholars, miners to alchemists, your settlement holds the promise of evolving into a §2self-sustaining bastion of prosperity and knowledge§r.",
 
   "com.minecolonies.core.gui.supplycamp.guide": "Make sure to find a flat, open area large enough for the camp's layout to place it.",
-  "com.minecolonies.core.gui.supplyship.guide": "Make sure to place it in open waters spacious enough to accommodate the ship's size."
+  "com.minecolonies.core.gui.supplyship.guide": "Make sure to place it in open waters spacious enough to accommodate the ship's size.",
+  "com.minecolonies.core.exit_interactions": "Exit Interactions"
 }

--- a/src/main/resources/data/minecolonies/colony/quests/general/alchemy.json
+++ b/src/main/resources/data/minecolonies/colony/quests/general/alchemy.json
@@ -5,7 +5,7 @@
   "triggers": [
     {
       "type": "minecolonies:random",
-      "rarity": 250000
+      "rarity": 2500000
     },
     {
       "type": "minecolonies:state",

--- a/src/main/resources/data/minecolonies/colony/quests/general/cookies.json
+++ b/src/main/resources/data/minecolonies/colony/quests/general/cookies.json
@@ -5,7 +5,7 @@
   "triggers": [
     {
       "type": "minecolonies:random",
-      "rarity": 250000
+      "rarity": 2500000
     },
     {
       "type": "minecolonies:state",

--- a/src/main/resources/data/minecolonies/colony/quests/general/cookies.json
+++ b/src/main/resources/data/minecolonies/colony/quests/general/cookies.json
@@ -13,7 +13,7 @@
         "path": "buildingManager/buildings",
         "match": {
           "type": "minecolonies:baker",
-          "level": 1
+          "level": 2
         }
       }
     },

--- a/src/main/resources/data/minecolonies/colony/quests/general/hungrycourier.json
+++ b/src/main/resources/data/minecolonies/colony/quests/general/hungrycourier.json
@@ -5,7 +5,7 @@
   "triggers": [
     {
       "type": "minecolonies:random",
-      "rarity": 5000000
+      "rarity": 50000000
     },
     {
       "type": "minecolonies:state",

--- a/src/main/resources/data/minecolonies/colony/quests/general/thezombiemenace1.json
+++ b/src/main/resources/data/minecolonies/colony/quests/general/thezombiemenace1.json
@@ -5,7 +5,7 @@
   "triggers": [
     {
       "type": "minecolonies:random",
-      "rarity": 250000
+      "rarity": 2500000
     },
     {
       "type": "minecolonies:state",

--- a/src/main/resources/data/minecolonies/colony/quests/general/thezombiemenace2.json
+++ b/src/main/resources/data/minecolonies/colony/quests/general/thezombiemenace2.json
@@ -7,7 +7,7 @@
   "triggers": [
     {
       "type": "minecolonies:random",
-      "rarity": 250000
+      "rarity": 2500000
     },
     {
       "type": "minecolonies:state",

--- a/src/main/resources/data/minecolonies/colony/quests/romance/aromanticgesture.json
+++ b/src/main/resources/data/minecolonies/colony/quests/romance/aromanticgesture.json
@@ -5,7 +5,7 @@
   "triggers": [
     {
       "type": "minecolonies:random",
-      "rarity": 500
+      "rarity": 10000000
     },
     {
       "type": "minecolonies:citizen",

--- a/src/main/resources/data/minecolonies/colony/quests/romance/atokenofapp.json
+++ b/src/main/resources/data/minecolonies/colony/quests/romance/atokenofapp.json
@@ -7,7 +7,7 @@
   "triggers": [
     {
       "type": "minecolonies:random",
-      "rarity": 500
+      "rarity": 10000000
     },
     {
       "type": "minecolonies:citizen",


### PR DESCRIPTION
Closes #
Closes #
Closes #

# Changes proposed in this pull request:
- Adjust how common quests are by factor 10 at least
- Move stonesmeltery after stonemason level 1, require brick instead of stonebricks (to not be too similar)
-


[ ] Yes I tested this before submitting it.
[ ] I also did a multiplayer test.

Review please
