### PR TITLE
Support for overworld mushroom trees in forester

### DIFF
--- a/src/datagen/generated/minecolonies/data/minecolonies/tags/blocks/fungi.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/tags/blocks/fungi.json
@@ -1,0 +1,6 @@
+{
+  "values": [
+    "minecraft:warped_fungus",
+    "minecraft:crimson_fungus"
+  ]
+}

--- a/src/datagen/generated/minecolonies/data/minecolonies/tags/blocks/mushrooms.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/tags/blocks/mushrooms.json
@@ -1,0 +1,6 @@
+{
+  "values": [
+    "minecraft:brown_mushroom",
+    "minecraft:red_mushroom"
+  ]
+}

--- a/src/datagen/generated/minecolonies/data/minecolonies/tags/blocks/mushrooms_huge.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/tags/blocks/mushrooms_huge.json
@@ -1,0 +1,6 @@
+{
+  "values": [
+    "minecraft:brown_mushroom_block",
+    "minecraft:red_mushroom_block"
+  ]
+}

--- a/src/datagen/generated/minecolonies/data/minecolonies/tags/blocks/tree.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/tags/blocks/tree.json
@@ -1,6 +1,7 @@
 {
   "values": [
     "#minecraft:logs",
-    "#minecolonies:mangrove_tree"
+    "#minecolonies:mangrove_tree",
+    "minecraft:mushroom_stem"
   ]
 }

--- a/src/main/java/com/minecolonies/api/compatibility/CompatibilityManager.java
+++ b/src/main/java/com/minecolonies/api/compatibility/CompatibilityManager.java
@@ -33,11 +33,9 @@ import net.minecraft.world.item.crafting.RecipeManager;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.AirBlock;
 import net.minecraft.world.level.block.Block;
+import net.minecraft.world.level.block.Blocks;
 import net.minecraft.world.level.block.entity.FurnaceBlockEntity;
 import net.minecraft.world.level.block.state.BlockState;
-import net.minecraft.world.level.block.state.properties.BooleanProperty;
-import net.minecraft.world.level.block.state.properties.IntegerProperty;
-import net.minecraft.world.level.block.state.properties.Property;
 import net.minecraftforge.api.distmarker.Dist;
 import net.minecraftforge.api.distmarker.OnlyIn;
 import net.minecraftforge.common.Tags;
@@ -45,6 +43,7 @@ import net.minecraftforge.fml.ModList;
 import net.minecraftforge.registries.ForgeRegistries;
 import net.minecraftforge.registries.IForgeRegistry;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 import java.util.*;
 import java.util.stream.Collectors;
@@ -68,25 +67,12 @@ public class CompatibilityManager implements ICompatibilityManager
     /**
      * BiMap of saplings and leaves.
      */
-    private final Map<BlockStateStorage, ItemStorage> leavesToSaplingMap = new HashMap<>();
+    private final Map<Block, ItemStorage> leavesToSaplingMap = new HashMap<>();
 
     /**
      * List of saplings. Works on client and server-side.
      */
     private final List<ItemStorage> saplings = new ArrayList<>();
-
-    /**
-     * List of properties we're ignoring when comparing leaves.
-     */
-    private final List<Property<?>> leafCompareWithoutProperties = ImmutableList.of(checkDecay, decayable, DYN_PROP_HYDRO, TREE_DISTANCE);
-
-    /**
-     * Properties for leaves we're ignoring upon comparing.
-     */
-    private static final BooleanProperty checkDecay     = BooleanProperty.create("check_decay");
-    private static final BooleanProperty decayable      = BooleanProperty.create("decayable");
-    public static final  IntegerProperty DYN_PROP_HYDRO = IntegerProperty.create("hydro", 1, 4);
-    public static final  IntegerProperty TREE_DISTANCE  = IntegerProperty.create("distance", 1, 7);
 
     /**
      * List of all ore-like blocks. Works on client and server-side.
@@ -388,14 +374,13 @@ public class CompatibilityManager implements ICompatibilityManager
         return block.defaultBlockState().is(ModTags.oreChanceBlocks);
     }
 
+    @Nullable
     @Override
-    public ItemStack getSaplingForLeaf(final BlockState block)
+    public ItemStack getSaplingForLeaf(final Block block)
     {
-        final BlockStateStorage tempLeaf = new BlockStateStorage(block, leafCompareWithoutProperties, true);
-
-        if (leavesToSaplingMap.containsKey(tempLeaf))
+        if (leavesToSaplingMap.containsKey(block))
         {
-            return leavesToSaplingMap.get(tempLeaf).getItemStack();
+            return leavesToSaplingMap.get(block).getItemStack();
         }
         return null;
     }
@@ -560,7 +545,7 @@ public class CompatibilityManager implements ICompatibilityManager
           leavesToSaplingMap.entrySet()
             .stream()
             .filter(entry -> entry.getKey() != null)
-            .map(entry -> writeLeafSaplingEntryToNBT(entry.getKey().getState(), entry.getValue()))
+            .map(entry -> writeLeafSaplingEntryToNBT(entry.getKey().defaultBlockState(), entry.getValue()))
             .collect(NBTUtils.toListNBT());
         compound.put(TAG_SAP_LEAF, saplingsLeavesTagList);
     }
@@ -570,17 +555,16 @@ public class CompatibilityManager implements ICompatibilityManager
     {
         NBTUtils.streamCompound(compound.getList(TAG_SAP_LEAF, Tag.TAG_COMPOUND))
           .map(CompatibilityManager::readLeafSaplingEntryFromNBT)
-          .filter(key -> !leavesToSaplingMap.containsKey(new BlockStateStorage(key.getA(), leafCompareWithoutProperties, true)) && !leavesToSaplingMap.containsValue(key.getB()))
-          .forEach(key -> leavesToSaplingMap.put(new BlockStateStorage(key.getA(), leafCompareWithoutProperties, true), key.getB()));
+          .filter(key -> !key.getA().isAir() && !leavesToSaplingMap.containsKey(key.getA().getBlock()) && !leavesToSaplingMap.containsValue(key.getB()))
+          .forEach(key -> leavesToSaplingMap.put(key.getA().getBlock(), key.getB()));
     }
 
     @Override
-    public void connectLeafToSapling(final BlockState leaf, final ItemStack stack)
+    public void connectLeafToSapling(final Block leaf, final ItemStack stack)
     {
-        final BlockStateStorage store = new BlockStateStorage(leaf, leafCompareWithoutProperties, true);
-        if (!leavesToSaplingMap.containsKey(store))
+        if (!leavesToSaplingMap.containsKey(leaf))
         {
-            leavesToSaplingMap.put(store, new ItemStorage(stack, false, true));
+            leavesToSaplingMap.put(leaf, new ItemStorage(stack, false, true));
         }
     }
 
@@ -699,6 +683,8 @@ public class CompatibilityManager implements ICompatibilityManager
             }
         });
 
+        discoverFungi();
+
         beekeeperflowers = ImmutableSet.copyOf(tempFlowers);
         Log.getLogger().info("Finished discovering Ores " + oreBlocks.size() + " " + smeltableOres.size());
         Log.getLogger().info("Finished discovering saplings " + saplings.size());
@@ -746,10 +732,23 @@ public class CompatibilityManager implements ICompatibilityManager
      */
     private void discoverSaplings(final ItemStack stack)
     {
-        if (stack.is(ItemTags.SAPLINGS))
+        if (stack.is(ItemTags.SAPLINGS) || stack.is(Tags.Items.MUSHROOMS) || stack.is(ModTags.fungi))
         {
             saplings.add(new ItemStorage(stack, false, true));
         }
+    }
+
+    /**
+     * "Discover" associated saplings for fungi; there currently isn't a great way to do this automatically,
+     * so it's just hard-coded for now.  (TODO: datapack this in 1.20.4?)
+     */
+    private void discoverFungi()
+    {
+        // regular saplings and overworld mushrooms are discovered by loot drops, so will populate this table on
+        // their own (though only after the first tree is cut); nether "leaves" don't drop saplings by default
+        // though, so we instead use this table to force that.
+        leavesToSaplingMap.put(Blocks.NETHER_WART_BLOCK, new ItemStorage(new ItemStack(Items.CRIMSON_FUNGUS)));
+        leavesToSaplingMap.put(Blocks.WARPED_WART_BLOCK, new ItemStorage(new ItemStack(Items.WARPED_FUNGUS)));
     }
 
     /**

--- a/src/main/java/com/minecolonies/api/compatibility/ICompatibilityManager.java
+++ b/src/main/java/com/minecolonies/api/compatibility/ICompatibilityManager.java
@@ -18,6 +18,7 @@ import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.state.BlockState;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 import java.util.List;
 import java.util.Map;
@@ -55,12 +56,12 @@ public interface ICompatibilityManager
     void deserialize(@NotNull final FriendlyByteBuf buf, final ClientLevel level);
 
     /**
-     * Gets the sapling matching a leave.
+     * Gets the sapling matching a leaf.
      *
-     * @param block the leave.
-     * @return the sapling stack.
+     * @param block the leaves.
+     * @return the sapling stack or null.
      */
-    ItemStack getSaplingForLeaf(final BlockState block);
+    @Nullable ItemStack getSaplingForLeaf(final Block block);
 
     /**
      * Get a copy of the list of saplings.
@@ -218,7 +219,7 @@ public interface ICompatibilityManager
      * @param block the block to connect the sapling to.
      * @param stack the sapling.
      */
-    void connectLeafToSapling(BlockState block, ItemStack stack);
+    void connectLeafToSapling(Block block, ItemStack stack);
 
     /**
      * Test if an itemStack is plantable for the florist.

--- a/src/main/java/com/minecolonies/api/items/ModTags.java
+++ b/src/main/java/com/minecolonies/api/items/ModTags.java
@@ -48,6 +48,9 @@ public class ModTags
 
     public static final TagKey<Block> validSpawn = BlockTags.create(TagConstants.VALIDSPAWNBLOCKS);
 
+    public static final TagKey<Block> mushroomBlocks   = BlockTags.create(TagConstants.MUSHROOMS);
+    public static final TagKey<Block> hugeMushroomBlocks   = BlockTags.create(TagConstants.MUSHROOMS_HUGE);
+    public static final TagKey<Block> fungiBlocks      = BlockTags.create(TagConstants.FUNGI);
     public static final TagKey<Item> fungi             = ItemTags.create(TagConstants.FUNGI);
     public static final TagKey<Item> compostables      = ItemTags.create(TagConstants.COMPOSTABLES);
     public static final TagKey<Item> compostables_poor = ItemTags.create(TagConstants.COMPOSTABLES_POOR);

--- a/src/main/java/com/minecolonies/api/util/ItemStackUtils.java
+++ b/src/main/java/com/minecolonies/api/util/ItemStackUtils.java
@@ -12,7 +12,6 @@ import com.minecolonies.api.items.CheckedNbtKey;
 import com.minecolonies.api.items.ModItems;
 import com.minecolonies.api.util.constant.IToolType;
 import com.minecolonies.api.util.constant.ToolType;
-import com.minecolonies.core.entity.citizen.EntityCitizen;
 import com.minecolonies.core.util.AdvancementUtils;
 import com.mojang.brigadier.exceptions.CommandSyntaxException;
 import net.minecraft.nbt.CompoundTag;
@@ -35,6 +34,7 @@ import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.entity.BrewingStandBlockEntity;
 import net.minecraft.world.level.block.entity.FurnaceBlockEntity;
 import net.minecraft.world.phys.EntityHitResult;
+import net.minecraftforge.common.Tags;
 import net.minecraftforge.common.ToolAction;
 import net.minecraftforge.common.ToolActions;
 import net.minecraftforge.registries.ForgeRegistries;
@@ -903,7 +903,7 @@ public final class ItemStackUtils
             return false;
         }
 
-        return stack.is(ItemTags.SAPLINGS) || stack.is(fungi) || Compatibility.isDynamicTreeSapling(stack);
+        return stack.is(ItemTags.SAPLINGS) || stack.is(Tags.Items.MUSHROOMS) || stack.is(fungi) || Compatibility.isDynamicTreeSapling(stack);
     }
 
     /**

--- a/src/main/java/com/minecolonies/api/util/constant/TagConstants.java
+++ b/src/main/java/com/minecolonies/api/util/constant/TagConstants.java
@@ -31,6 +31,8 @@ public final class TagConstants
     public static final ResourceLocation ORECHANCEBLOCKS           = new ResourceLocation(MOD_ID, "orechanceblocks");
     public static final ResourceLocation VALIDSPAWNBLOCKS          = new ResourceLocation(MOD_ID, "validspawnblocks");
     public static final ResourceLocation COLONYPROTECTIONEXCEPTION = new ResourceLocation(MOD_ID, "protectionexception");
+    public static final ResourceLocation MUSHROOMS                 = new ResourceLocation(MOD_ID, "mushrooms");
+    public static final ResourceLocation MUSHROOMS_HUGE            = new ResourceLocation(MOD_ID, "mushrooms_huge");
     public static final ResourceLocation FUNGI                     = new ResourceLocation(MOD_ID, "fungi");
     public static final ResourceLocation COMPOSTABLES              = new ResourceLocation(MOD_ID, "compostables");
     public static final ResourceLocation COMPOSTABLES_POOR         = new ResourceLocation(MOD_ID, "compostables_poor");

--- a/src/main/java/com/minecolonies/core/colony/buildings/workerbuildings/BuildingLumberjack.java
+++ b/src/main/java/com/minecolonies/core/colony/buildings/workerbuildings/BuildingLumberjack.java
@@ -9,6 +9,7 @@ import com.minecolonies.api.colony.buildings.modules.settings.ISettingKey;
 import com.minecolonies.api.colony.jobs.registry.JobEntry;
 import com.minecolonies.api.colony.requestsystem.token.IToken;
 import com.minecolonies.api.crafting.ItemStorage;
+import com.minecolonies.api.items.ModTags;
 import com.minecolonies.api.util.BlockPosUtil;
 import com.minecolonies.api.util.ItemStackUtils;
 import com.minecolonies.api.util.WorldUtil;
@@ -33,7 +34,6 @@ import net.minecraft.util.Tuple;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.Block;
-import net.minecraft.world.level.block.Blocks;
 import net.minecraft.world.level.block.BonemealableBlock;
 import net.minecraft.world.level.block.state.BlockState;
 import org.jetbrains.annotations.NotNull;
@@ -287,7 +287,7 @@ public class BuildingLumberjack extends AbstractBuilding
             {
                 final BlockState blockState = world.getBlockState(pos);
                 final Block block = blockState.getBlock();
-                if (block == Blocks.CRIMSON_FUNGUS || block == Blocks.WARPED_FUNGUS)
+                if (blockState.is(ModTags.mushroomBlocks) || blockState.is(ModTags.fungiBlocks))
                 {
                     int threshold = modifier + (int) Math.ceil(data.getCitizenSkillHandler().getLevel(module.getPrimarySkill()) * (1 - ((float) modifier / 100)));
                     final int rand = world.getRandom().nextInt(100);

--- a/src/main/java/com/minecolonies/core/entity/ai/workers/production/EntityAIWorkLumberjack.java
+++ b/src/main/java/com/minecolonies/core/entity/ai/workers/production/EntityAIWorkLumberjack.java
@@ -1,13 +1,13 @@
 package com.minecolonies.core.entity.ai.workers.production;
 
+import com.minecolonies.api.colony.IColonyManager;
 import com.minecolonies.api.compatibility.Compatibility;
 import com.minecolonies.api.entity.ai.statemachine.AITarget;
 import com.minecolonies.api.entity.ai.statemachine.states.IAIState;
 import com.minecolonies.api.entity.citizen.VisibleCitizenStatus;
-import com.minecolonies.api.util.constant.ColonyConstants;
-import com.minecolonies.core.entity.pathfinding.pathresults.PathResult;
-import com.minecolonies.core.entity.pathfinding.pathresults.TreePathResult;
+import com.minecolonies.api.items.ModTags;
 import com.minecolonies.api.util.*;
+import com.minecolonies.api.util.constant.ColonyConstants;
 import com.minecolonies.api.util.constant.Constants;
 import com.minecolonies.api.util.constant.ToolType;
 import com.minecolonies.core.MineColonies;
@@ -17,9 +17,11 @@ import com.minecolonies.core.colony.buildings.workerbuildings.BuildingLumberjack
 import com.minecolonies.core.colony.jobs.JobLumberjack;
 import com.minecolonies.core.entity.ai.workers.crafting.AbstractEntityAICrafting;
 import com.minecolonies.core.entity.ai.workers.util.Tree;
+import com.minecolonies.core.entity.pathfinding.PathfindingUtils;
 import com.minecolonies.core.entity.pathfinding.navigation.MinecoloniesAdvancedPathNavigate;
 import com.minecolonies.core.entity.pathfinding.pathjobs.PathJobMoveToWithPassable;
-import com.minecolonies.core.entity.pathfinding.PathfindingUtils;
+import com.minecolonies.core.entity.pathfinding.pathresults.PathResult;
+import com.minecolonies.core.entity.pathfinding.pathresults.TreePathResult;
 import com.minecolonies.core.util.WorkerUtil;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
@@ -38,6 +40,7 @@ import net.minecraft.world.level.pathfinder.Node;
 import net.minecraft.world.level.pathfinder.Path;
 import net.minecraft.world.phys.AABB;
 import net.minecraftforge.common.IPlantable;
+import net.minecraftforge.common.Tags;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -48,7 +51,8 @@ import java.util.Objects;
 import static com.minecolonies.api.entity.ai.statemachine.states.AIWorkerState.*;
 import static com.minecolonies.api.items.ModTags.fungi;
 import static com.minecolonies.api.util.constant.Constants.TICKS_SECOND;
-import static com.minecolonies.api.util.constant.StatisticsConstants.*;
+import static com.minecolonies.api.util.constant.StatisticsConstants.ITEM_OBTAINED;
+import static com.minecolonies.api.util.constant.StatisticsConstants.TREE_CUT;
 import static com.minecolonies.core.colony.buildings.modules.BuildingModules.STATS_MODULE;
 
 /**
@@ -344,7 +348,7 @@ public class EntityAIWorkLumberjack extends AbstractEntityAICrafting<JobLumberja
         if (getState() == LUMBERJACK_GATHERING_2)
         {
             // we're only interested in saplings at this point
-            return stack.is(ItemTags.SAPLINGS) || stack.is(fungi);
+            return stack.is(ItemTags.SAPLINGS) || stack.is(Tags.Items.MUSHROOMS) || stack.is(fungi);
         }
 
         return super.isItemWorthPickingUp(stack);
@@ -532,7 +536,16 @@ public class EntityAIWorkLumberjack extends AbstractEntityAICrafting<JobLumberja
             }
         }
 
-        if (job.getTree().hasLogs())
+        if (job.getTree().hasLeaves() && shouldBreakLeaves)
+        {
+            final BlockPos leaf = job.getTree().peekNextLeaf();
+            if (!mineBlock(leaf, workFrom))
+            {
+                return getState();
+            }
+            job.getTree().pollNextLeaf();
+        }
+        else if (job.getTree().hasLogs())
         {
             //take first log from queue
             final BlockPos log = job.getTree().peekNextLog();
@@ -566,15 +579,6 @@ public class EntityAIWorkLumberjack extends AbstractEntityAICrafting<JobLumberja
             job.getTree().pollNextLog();
             worker.decreaseSaturationForContinuousAction();
         }
-        else if (job.getTree().hasLeaves() && shouldBreakLeaves)
-        {
-            final BlockPos leaf = job.getTree().peekNextLeaf();
-            if (!mineBlock(leaf, workFrom))
-            {
-                return getState();
-            }
-            job.getTree().pollNextLeaf();
-        }
         return getState();
     }
 
@@ -602,13 +606,14 @@ public class EntityAIWorkLumberjack extends AbstractEntityAICrafting<JobLumberja
         {
             if (world.getRandom().nextInt(100) > 95)
             {
-                if (stack.getItem() == Items.NETHER_WART_BLOCK)
+                if (stack.is(ItemTags.WART_BLOCKS))
                 {
-                    newDrops.add(new ItemStack(Items.CRIMSON_FUNGUS, 1));
-                }
-                else if (stack.getItem() == Items.WARPED_WART_BLOCK)
-                {
-                    newDrops.add(new ItemStack(Items.WARPED_FUNGUS, 1));
+                    final Block wartBlock = ((BlockItem) stack.getItem()).getBlock();
+                    final ItemStack fungus = IColonyManager.getInstance().getCompatibilityManager().getSaplingForLeaf(wartBlock);
+                    if (fungus != null)
+                    {
+                        newDrops.add(fungus);
+                    }
                 }
             }
         }
@@ -660,7 +665,7 @@ public class EntityAIWorkLumberjack extends AbstractEntityAICrafting<JobLumberja
      */
     private Boolean isPassable(final BlockState blockState)
     {
-        return blockState.is(BlockTags.LEAVES);
+        return blockState.is(BlockTags.LEAVES) || blockState.is(ModTags.hugeMushroomBlocks);
     }
 
     /**
@@ -726,6 +731,7 @@ public class EntityAIWorkLumberjack extends AbstractEntityAICrafting<JobLumberja
                 }
 
                 mineIfEqualsBlockTag(checkPositions, BlockTags.LEAVES);
+                mineIfEqualsBlockTag(checkPositions, ModTags.hugeMushroomBlocks);
                 return;
             }
         }
@@ -740,6 +746,7 @@ public class EntityAIWorkLumberjack extends AbstractEntityAICrafting<JobLumberja
         }
 
         mineIfEqualsBlockTag(checkPositions, BlockTags.LEAVES);
+        mineIfEqualsBlockTag(checkPositions, ModTags.hugeMushroomBlocks);
     }
 
     /**
@@ -905,20 +912,15 @@ public class EntityAIWorkLumberjack extends AbstractEntityAICrafting<JobLumberja
         {
             final BlockPos pos = job.getTree().getStumpLocations().get(0);
             final ItemStack sapling = getInventory().getStackInSlot(saplingSlot);
-            final Block new_block;
-            if (sapling.is(fungi))
+            if (sapling.is(Tags.Items.MUSHROOMS))
             {
-                if (sapling.getItem() == Items.WARPED_FUNGUS)
-                {
-                    new_block = Blocks.WARPED_NYLIUM;
-                }
-                else
-                {
-                    new_block = Blocks.CRIMSON_NYLIUM;
-                }
-
+                building.addNetherTree(pos);
+            }
+            else if (sapling.is(fungi))
+            {
                 if (world.getBlockState(pos.below()).getBlock() instanceof NetherrackBlock)
                 {
+                    final Block new_block = sapling.is(Items.WARPED_FUNGUS) ? Blocks.WARPED_NYLIUM : Blocks.CRIMSON_NYLIUM;
                     world.setBlockAndUpdate(pos.below(), new_block.defaultBlockState());
                     building.addNetherTree(pos);
                 }

--- a/src/main/java/com/minecolonies/core/entity/ai/workers/util/Tree.java
+++ b/src/main/java/com/minecolonies/core/entity/ai/workers/util/Tree.java
@@ -236,17 +236,17 @@ public class Tree
         {
             NonNullList<ItemStack> list = NonNullList.create();
 
-        if (checkFitsBase)
-        {
-            // Check if the tree's base log variant fits the leaf
-            if (Compatibility.isDynamicLeaf(block))
+            if (checkFitsBase)
             {
-                if (!isDynamicTree() || !Compatibility.isDynamicFamilyFitting(pos, location, world))
+                // Check if the tree's base log variant fits the leaf
+                if (Compatibility.isDynamicLeaf(block))
                 {
-                    return null;
+                    if (!isDynamicTree() || !Compatibility.isDynamicFamilyFitting(pos, location, world))
+                    {
+                        return null;
+                    }
                 }
             }
-        }
 
             // Dynamic trees is using a custom Drops function
             if (Compatibility.isDynamicLeaf(block))

--- a/src/main/java/com/minecolonies/core/entity/ai/workers/util/Tree.java
+++ b/src/main/java/com/minecolonies/core/entity/ai/workers/util/Tree.java
@@ -9,7 +9,6 @@ import com.minecolonies.api.crafting.ItemStorage;
 import com.minecolonies.api.items.ModTags;
 import com.minecolonies.api.util.BlockPosUtil;
 import com.minecolonies.api.util.BlockStateUtils;
-import com.minecolonies.api.util.ColonyUtils;
 import com.minecolonies.api.util.ItemStackUtils;
 import com.minecolonies.core.MineColonies;
 import net.minecraft.core.BlockPos;
@@ -32,11 +31,10 @@ import net.minecraft.world.level.block.Blocks;
 import net.minecraft.world.level.block.LeavesBlock;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.block.state.properties.Property;
-import net.minecraft.world.level.chunk.ChunkAccess;
-import net.minecraft.world.level.chunk.LevelChunk;
 import net.minecraft.world.level.storage.loot.LootParams;
 import net.minecraft.world.level.storage.loot.parameters.LootContextParams;
 import net.minecraft.world.phys.Vec3;
+import net.minecraftforge.common.Tags;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -163,7 +161,7 @@ public class Tree
             woodBlocks.clear();
             slimeTree = Compatibility.isSlimeBlock(block.getBlock());
             sapling = calcSapling(world);
-            if (sapling.is(fungi))
+            if (sapling.is(Tags.Items.MUSHROOMS) || sapling.is(fungi))
             {
                 netherTree = true;
             }
@@ -234,26 +232,26 @@ public class Tree
         BlockState blockState = world.getBlockState(pos);
         final Block block = blockState.getBlock();
 
-        if (blockState.is(BlockTags.LEAVES) || Compatibility.isDynamicLeaf(block))
+        if (blockState.is(BlockTags.LEAVES) || Compatibility.isDynamicLeaf(block) || blockState.is(ModTags.hugeMushroomBlocks))
         {
             NonNullList<ItemStack> list = NonNullList.create();
 
-            if (checkFitsBase)
+        if (checkFitsBase)
+        {
+            // Check if the tree's base log variant fits the leaf
+            if (Compatibility.isDynamicLeaf(block))
             {
-                // Check if the tree's base log variant fits the leaf
-                if (Compatibility.isDynamicLeaf(block))
+                if (!isDynamicTree() || !Compatibility.isDynamicFamilyFitting(pos, location, world))
                 {
-                    if (!isDynamicTree() || !Compatibility.isDynamicFamilyFitting(pos, location, world))
-                    {
-                        return null;
-                    }
+                    return null;
                 }
             }
+        }
 
             // Dynamic trees is using a custom Drops function
             if (Compatibility.isDynamicLeaf(block))
             {
-                list = (Compatibility.getDropsForDynamicLeaf(world, pos, blockState, A_LOT_OF_LUCK, block));
+                list = Compatibility.getDropsForDynamicLeaf(world, pos, blockState, A_LOT_OF_LUCK, block);
             }
             else
             {
@@ -268,20 +266,16 @@ public class Tree
                     continue;
                 }
 
-                if (stack.is(ItemTags.SAPLINGS))
+                if (stack.is(ItemTags.SAPLINGS) || stack.is(Tags.Items.MUSHROOMS))
                 {
-                    IColonyManager.getInstance().getCompatibilityManager().connectLeafToSapling(blockState, stack);
+                    IColonyManager.getInstance().getCompatibilityManager().connectLeafToSapling(block, stack);
                     return stack;
                 }
             }
         }
         else if (blockState.is(BlockTags.WART_BLOCKS))
         {
-            if (block == Blocks.WARPED_WART_BLOCK)
-            {
-                return new ItemStack(Items.WARPED_FUNGUS, 1);
-            }
-            return new ItemStack(Items.CRIMSON_FUNGUS, 1);
+            return IColonyManager.getInstance().getCompatibilityManager().getSaplingForLeaf(block);
         }
         return null;
     }
@@ -314,7 +308,7 @@ public class Tree
             {
                 for (ItemStack stack : list)
                 {
-                    if (stack.is(ItemTags.SAPLINGS))
+                    if (stack.is(ItemTags.SAPLINGS) || stack.is(Tags.Items.MUSHROOMS))
                     {
                         return list;
                     }
@@ -336,7 +330,7 @@ public class Tree
         for (int i = 1; (i + topLog.getY()) < 255 && i < 10; i++)
         {
             final BlockState blockState = world.getBlockState(topLog.offset(0, i, 0));
-            if (blockState.is(BlockTags.LEAVES))
+            if (blockState.is(BlockTags.LEAVES) || blockState.is(ModTags.hugeMushroomBlocks))
             {
                 return topLog.offset(0, i, 0);
             }
@@ -465,7 +459,8 @@ public class Tree
                 for (int dy = -3; dy <= 3 + dynamicBonusY; dy++)
                 {
                     final BlockPos leafPos = pos.offset(dx, dy, dz);
-                    if (world.getBlockState(leafPos).is(BlockTags.LEAVES) || world.getBlockState(leafPos).is(BlockTags.WART_BLOCKS))
+                    final BlockState block = world.getBlockState(leafPos);
+                    if (block.is(BlockTags.LEAVES) || block.is(ModTags.hugeMushroomBlocks) || block.is(BlockTags.WART_BLOCKS))
                     {
                         if (!checkedLeaves && !supposedToCut(world, treesToNotCut, leafPos))
                         {
@@ -475,7 +470,7 @@ public class Tree
 
                         leafCount++;
                         // Dynamic tree growth is checked by radius instead of leafcount
-                        if (leafCount >= NUMBER_OF_LEAVES || (Compatibility.isDynamicLeaf(world.getBlockState(leafPos).getBlock())))
+                        if (leafCount >= NUMBER_OF_LEAVES || (Compatibility.isDynamicLeaf(block.getBlock())))
                         {
                             return true;
                         }
@@ -496,12 +491,17 @@ public class Tree
      */
     private static boolean supposedToCut(final LevelReader world, final List<ItemStorage> treesToNotCut, final BlockPos leafPos)
     {
-        if (world.getBlockState(leafPos).getOptionalValue(LeavesBlock.PERSISTENT).orElse(false))
+        final BlockState leaf = world.getBlockState(leafPos);
+        if (leaf.getOptionalValue(LeavesBlock.PERSISTENT).orElse(false))
         {
             return false;
         }
 
-        final ItemStack sap = IColonyManager.getInstance().getCompatibilityManager().getSaplingForLeaf(world.getBlockState(leafPos));
+        // sadly this is called from pathfinding so can't directly access server loot; this means if the sapling
+        // isn't already cached (which it won't be the very first time we encounter a new tree type for this colony)
+        // then we will try to chop it regardless of hut settings.  but the *second* tree of that type we should
+        // obey the settings properly.
+        final ItemStack sap = IColonyManager.getInstance().getCompatibilityManager().getSaplingForLeaf(leaf.getBlock());
 
         if (sap == null)
         {
@@ -600,9 +600,10 @@ public class Tree
                 for (int y = -1; y <= 1; y++)
                 {
                     final BlockPos leaf = new BlockPos(topLog.getX() + x, topLog.getY() + y, topLog.getZ() + z);
-                    if (world.getBlockState(leaf).is(BlockTags.LEAVES))
+                    final BlockState leaves = world.getBlockState(leaf);
+                    if (leaves.is(BlockTags.LEAVES) || leaves.is(ModTags.hugeMushroomBlocks))
                     {
-                        if (world.getBlockState(leaf).getOptionalValue(LeavesBlock.PERSISTENT).orElse(false))
+                        if (leaves.getOptionalValue(LeavesBlock.PERSISTENT).orElse(false))
                         {
                             continue;
                         }
@@ -766,7 +767,7 @@ public class Tree
     {
         int locXMin = location.getX() - LEAVES_WIDTH;
         int locXMax = location.getX() + LEAVES_WIDTH;
-        final int locYMin = location.getY() + 2;
+        final int locYMin = location.getY() + 1;
         int locZMin = location.getZ() - LEAVES_WIDTH;
         int locZMax = location.getZ() + LEAVES_WIDTH;
         int temp;
@@ -789,10 +790,11 @@ public class Tree
                 for (int locZ = locZMin; locZ <= locZMax; locZ++)
                 {
                     final BlockPos leaf = new BlockPos(locX, locY, locZ);
-                    if (world.getBlockState(leaf).is(BlockTags.LEAVES) || world.getBlockState(leaf).is(BlockTags.WART_BLOCKS)
-                          || world.getBlockState(leaf).getBlock() == Blocks.SHROOMLIGHT)
+                    final BlockState block = world.getBlockState(leaf);
+                    if (block.is(BlockTags.LEAVES) || block.is(ModTags.hugeMushroomBlocks) ||
+                            block.is(BlockTags.WART_BLOCKS) || block.is(Blocks.SHROOMLIGHT))
                     {
-                        if (!world.getBlockState(leaf).getOptionalValue(LeavesBlock.PERSISTENT).orElse(false))
+                        if (!block.getOptionalValue(LeavesBlock.PERSISTENT).orElse(false))
                         {
                             leaves.add(leaf);
                         }

--- a/src/main/java/com/minecolonies/core/entity/pathfinding/pathjobs/PathJobFindTree.java
+++ b/src/main/java/com/minecolonies/core/entity/pathfinding/pathjobs/PathJobFindTree.java
@@ -3,6 +3,7 @@ package com.minecolonies.core.entity.pathfinding.pathjobs;
 import com.minecolonies.api.colony.IColony;
 import com.minecolonies.api.compatibility.Compatibility;
 import com.minecolonies.api.crafting.ItemStorage;
+import com.minecolonies.api.items.ModTags;
 import com.minecolonies.api.util.BlockPosUtil;
 import com.minecolonies.core.entity.ai.workers.util.Tree;
 import com.minecolonies.core.entity.pathfinding.MNode;
@@ -187,20 +188,20 @@ public class PathJobFindTree extends AbstractPathJob
     @Override
     protected boolean isPassable(@NotNull final BlockState block, final int x, final int y, final int z, final MNode parent, final boolean head)
     {
-        return super.isPassable(block, x, y, z, parent, head) || block.is(BlockTags.LEAVES) || Compatibility.isDynamicTrunkShell(block.getBlock());
+        return super.isPassable(block, x, y, z, parent, head) || isLeafLike(block);
     }
 
     @Override
     protected double modifyCost(double cost, final MNode parent, final boolean swimstart, final boolean swimming, final int x, final int y, final int z, final BlockState state)
     {
-        if (!state.isAir() && state.is(BlockTags.LEAVES))
+        if (!state.isAir() && isLeafLike(state))
         {
             cost *= PASSING_COST;
         }
         else
         {
             final BlockState above = cachedBlockLookup.getBlockState(x, y + 1, z);
-            if (!above.isAir() && above.is(BlockTags.LEAVES))
+            if (!above.isAir() && isLeafLike(above))
             {
                 cost *= PASSING_COST;
             }
@@ -212,5 +213,10 @@ public class PathJobFindTree extends AbstractPathJob
         }
 
         return cost;
+    }
+
+    private boolean isLeafLike(@NotNull final BlockState block)
+    {
+        return block.is(BlockTags.LEAVES) || Compatibility.isDynamicTrunkShell(block.getBlock()) || block.is(ModTags.hugeMushroomBlocks);
     }
 }

--- a/src/main/java/com/minecolonies/core/generation/defaults/DefaultBlockTagsProvider.java
+++ b/src/main/java/com/minecolonies/core/generation/defaults/DefaultBlockTagsProvider.java
@@ -164,9 +164,23 @@ public class DefaultBlockTagsProvider extends BlockTagsProvider
                 .add(Blocks.MANGROVE_LOG)
                 .add(Blocks.MANGROVE_ROOTS);
 
+        // sadly forge doesn't provide the block form of this tag, despite providing an item tag
+        tag(ModTags.mushroomBlocks)
+                .add(Blocks.BROWN_MUSHROOM)
+                .add(Blocks.RED_MUSHROOM);
+
+        tag(ModTags.hugeMushroomBlocks)
+                .add(Blocks.BROWN_MUSHROOM_BLOCK)
+                .add(Blocks.RED_MUSHROOM_BLOCK);
+
+        tag(ModTags.fungiBlocks)
+                .add(Blocks.WARPED_FUNGUS)
+                .add(Blocks.CRIMSON_FUNGUS);
+
         tag(ModTags.tree)
                 .addTag(BlockTags.LOGS)
-                .addTag(ModTags.mangroveTree);
+                .addTag(ModTags.mangroveTree)
+                .add(Blocks.MUSHROOM_STEM);
 
         tag(ModTags.colonyProtectionException)
                 .addOptional(new ResourceLocation("waystones:waystone"))

--- a/src/main/java/com/minecolonies/core/generation/defaults/DefaultItemTagsProvider.java
+++ b/src/main/java/com/minecolonies/core/generation/defaults/DefaultItemTagsProvider.java
@@ -136,9 +136,7 @@ public class DefaultItemTagsProvider extends ItemTagsProvider
           .add(Items.CORNFLOWER)
           .add(Items.LILY_OF_THE_VALLEY);
 
-        tag(ModTags.fungi)
-          .add(Items.WARPED_FUNGUS)
-          .add(Items.CRIMSON_FUNGUS);
+        copy(ModTags.fungiBlocks, ModTags.fungi);
 
         tag(ModTags.meshes)
           .add(ModItems.sifterMeshString)


### PR DESCRIPTION
Closes ldtteam/minecolonies-features#202
Closes [discord request](https://discord.com/channels/139070364159311872/1228515515945975901)

# Changes proposed in this pull request:
- Adds the ability to cut and replant overworld mushroom trees to the Forester (since they could already handle nether fungi trees).
    - You can plant the overworld mushrooms on whatever block you like (that they'll grow on), but podzol is the most recommended.  (Mycelium decays back to dirt, so is not sustainable; unlike nylium there's no magic restoration.)
    - As with any of the other tree types, you will need to plant and grow the first one yourself (unless there's a nearby mushroom biome to harvest); after that it should be self-sustaining unless they run out of saplings.
- Adds the overworld and nether mushroom "saplings" to the settings list, so that cutting can be disabled if desired.
    - Known (pre-existing) issue: if any forester in the colony has never cut down a particular overworld tree before the sapling was disabled, then they will still cut at least one down if available; the setting is only respected for the second and subsequent tree of that type.  This is due to threading limitations between the pathfinding system and the loot system.  The nether trees are not affected by this limitation.
- When the "break leaves" setting is enabled (or for overworld/nether mushroom trees, where it's forced regardless of the setting), the Forester will now break the leaves before breaking the logs, so the overall tree cutting occurs top-down.
- Includes leaf blocks only one block above the sapling in the breakable leaves list, since red mushrooms can generate that low.  (Jungle bushes can also generate that low, but only in worldgen and not as proper trees.)
- The internal sapling lookup cache is now based purely on block type rather than block state -- the previous implementation could cause spurious cache misses for entirely unrelated properties (like "waterlogged", and various facing directions of the mushroom blocks).  The state-based implementation predated the Great Flattening; there aren't any vanilla trees where different states of the same block drop different saplings, so this should not be needed any more.
    - For backwards compatibility, persistence of this cache is still state-based, but it will not preserve all historic states on upgrade.
- Attempts to use tags for more things to theoretically support additional mushroom tree types from mods, but some MineColonies-specific compatibility datapacks will still be required.

[x] Yes I tested this before submitting it.
[ ] I also did a multiplayer test.

Review please (could port)
