### PR TITLE
ship raid changes

### DIFF
--- a/src/main/java/com/minecolonies/api/colony/colonyEvents/IColonyStructureSpawnEvent.java
+++ b/src/main/java/com/minecolonies/api/colony/colonyEvents/IColonyStructureSpawnEvent.java
@@ -21,4 +21,10 @@ public interface IColonyStructureSpawnEvent extends IColonyEvent
      * Get the ship description for the schematic
      */
     String getShipDesc();
+
+    /**
+     * Set the max raider count.
+     * @param maxRaiderCount the count.
+     */
+    void setMaxRaiderCount(int maxRaiderCount);
 }

--- a/src/main/java/com/minecolonies/api/util/constant/TranslationConstants.java
+++ b/src/main/java/com/minecolonies/api/util/constant/TranslationConstants.java
@@ -194,6 +194,8 @@ public final class TranslationConstants
     @NonNls
     public static final String RAID_EVENT_MESSAGE_PIRATE                                            = "event.minecolonies.raidmessage_p";
     @NonNls
+    public static final String RAID_EVENT_MESSAGE_U_PIRATE                                          = "event.minecolonies.raidmessage_u";
+    @NonNls
     public static final String RAID_AMAZON                                                          = "com.minecolonies.coremod.raid.amazon.name";
     @NonNls
     public static final String RAID_EGYPTIAN                                                        = "com.minecolonies.coremod.raid.egyptian.name";
@@ -261,6 +263,10 @@ public final class TranslationConstants
     public static final String CMC_GUI_TOWNHALL_BUILDING_LEVEL                                      = "com.minecolonies.coremod.gui.townhall.buildinglevel";
     @NonNls
     public static final String PIRATES_SAILING_OFF_MESSAGE                                          = "com.minecolonies.coremod.pirates.sailing.away";
+    @NonNls
+    public static final String DROWNED_PIRATES_SAILING_OFF_MESSAGE                                  = "com.minecolonies.core.drowned_pirates.sailing.away";
+    @NonNls
+    public static final String STRUCTURE_SPAWNER_BREAKS                                             = "com.minecolonies.core.raidevent.spawnerbreaks";
     @NonNls
     public static final String ALL_PIRATE_SPAWNERS_DESTROYED_MESSAGE                                = "com.minecolonies.coremod.pirates.spawners.destroyed";
     @NonNls

--- a/src/main/java/com/minecolonies/core/colony/colonyEvents/raidEvents/AbstractShipRaidEvent.java
+++ b/src/main/java/com/minecolonies/core/colony/colonyEvents/raidEvents/AbstractShipRaidEvent.java
@@ -64,9 +64,9 @@ public abstract class AbstractShipRaidEvent implements IColonyRaidEvent, IColony
     public static final String TAG_POS           = "pos";
     public static final String TAG_SPAWNERS      = "spawners";
     public static final String TAG_SHIPSIZE      = "shipSize";
-    public static final String TAG_SHIPROTATION  = "shipRotation";
-    public static final String TAG_RAIDER_KILL_COUNT = "raiderKillCount";
-    public static final String TAG_MAX_RAIDER_COUNT  = "maxRaiderCount";
+    public static final String TAG_SHIPROTATION             = "shipRotation";
+    public static final String TAG_RAIDER_THRESHOLD_TRACKER = "raiderkillthresholdtracker";
+    public static final String TAG_MAX_RAIDER_COUNT         = "maxRaiderCount";
 
     /**
      * The max distance for spawning raiders when the ship is unloaded
@@ -161,7 +161,7 @@ public abstract class AbstractShipRaidEvent implements IColonyRaidEvent, IColony
     /**
      * Raider kill count.
      */
-    protected int raiderKillCount = 0;
+    protected int spawnerThresholdKillTracker = 0;
 
     /**
      * Create a new ship based raid event.
@@ -367,13 +367,14 @@ public abstract class AbstractShipRaidEvent implements IColonyRaidEvent, IColony
             status = EventStatus.WAITING;
             MessageUtils.format(ALL_PIRATES_KILLED_MESSAGE, colony.getName()).sendTo(colony).forManagers();
         }
-        raiderKillCount++;
+        spawnerThresholdKillTracker++;
 
-        if (!spawners.isEmpty() && raiderKillCount > maxRaiderCount/maxSpawners)
+        if (!spawners.isEmpty() && spawnerThresholdKillTracker > maxRaiderCount/maxSpawners)
         {
             MessageUtils.format(STRUCTURE_SPAWNER_BREAKS, colony.getName()).sendTo(colony).forManagers();
             colony.getWorld().removeBlock(spawners.remove(0), false);
             raidBar.setProgress((float) spawners.size() / maxSpawners);
+            spawnerThresholdKillTracker = 0;
             if (spawners.isEmpty())
             {
                 daysToGo = 1;
@@ -522,7 +523,7 @@ public abstract class AbstractShipRaidEvent implements IColonyRaidEvent, IColony
         compound.putInt(TAG_SHIPROTATION, shipRotation);
         BlockPosUtil.writePosListToNBT(compound, TAG_WAYPOINT, wayPoints);
         compound.putInt(TAG_MAX_RAIDER_COUNT, maxRaiderCount);
-        compound.putInt(TAG_RAIDER_KILL_COUNT, raiderKillCount);
+        compound.putInt(TAG_RAIDER_THRESHOLD_TRACKER, spawnerThresholdKillTracker);
         return compound;
     }
 
@@ -545,7 +546,7 @@ public abstract class AbstractShipRaidEvent implements IColonyRaidEvent, IColony
         shipRotation = compound.getInt(TAG_SHIPROTATION);
         wayPoints = BlockPosUtil.readPosListFromNBT(compound, TAG_WAYPOINT);
         maxRaiderCount = compound.getInt(TAG_MAX_RAIDER_COUNT);
-        raiderKillCount = compound.getInt(TAG_RAIDER_KILL_COUNT);
+        spawnerThresholdKillTracker = compound.getInt(TAG_RAIDER_THRESHOLD_TRACKER);
     }
 
     @Override

--- a/src/main/java/com/minecolonies/core/colony/colonyEvents/raidEvents/pirateEvent/DrownedPirateRaidEvent.java
+++ b/src/main/java/com/minecolonies/core/colony/colonyEvents/raidEvents/pirateEvent/DrownedPirateRaidEvent.java
@@ -16,14 +16,14 @@ import net.minecraft.nbt.CompoundTag;
 import net.minecraft.network.chat.Component;
 import net.minecraft.network.chat.MutableComponent;
 import net.minecraft.resources.ResourceLocation;
+import net.minecraft.world.entity.Entity;
 import net.minecraft.world.entity.EntityType;
 import net.minecraft.world.level.block.Mirror;
 import net.minecraft.world.level.pathfinder.Path;
 import org.jetbrains.annotations.NotNull;
 
 import static com.minecolonies.api.util.constant.Constants.STORAGE_STYLE;
-import static com.minecolonies.api.util.constant.TranslationConstants.RAID_EVENT_MESSAGE_PIRATE;
-import static com.minecolonies.api.util.constant.TranslationConstants.RAID_PIRATE;
+import static com.minecolonies.api.util.constant.TranslationConstants.*;
 
 /**
  * The Pirate raid event, spawns a ship with pirate spawners onboard.
@@ -109,7 +109,7 @@ public class DrownedPirateRaidEvent extends AbstractShipRaidEvent
 
             updateRaidBar();
 
-            MessageUtils.format(RAID_EVENT_MESSAGE_PIRATE + shipSize.messageID, BlockPosUtil.calcDirection(colony.getCenter(), spawnPoint), colony.getName())
+            MessageUtils.format(RAID_EVENT_MESSAGE_U_PIRATE + shipSize.messageID, BlockPosUtil.calcDirection(colony.getCenter(), spawnPoint), colony.getName())
               .withPriority(MessageUtils.MessagePriority.DANGER)
               .sendTo(colony).forManagers();
             colony.markDirty();
@@ -145,7 +145,7 @@ public class DrownedPirateRaidEvent extends AbstractShipRaidEvent
     @Override
     public EntityType<?> getArcherRaiderType()
     {
-        return ModEntities.DROWNED_ARCHERPIRATE;
+        return null;
     }
 
     @Override
@@ -158,5 +158,26 @@ public class DrownedPirateRaidEvent extends AbstractShipRaidEvent
     protected MutableComponent getDisplayName()
     {
         return Component.translatable(RAID_PIRATE);
+    }
+
+    @Override
+    protected void updateRaidBar()
+    {
+        super.updateRaidBar();
+        raidBar.setDarkenScreen(true);
+    }
+
+    @Override
+    public void onFinish()
+    {
+        MessageUtils.format(DROWNED_PIRATES_SAILING_OFF_MESSAGE, BlockPosUtil.calcDirection(colony.getCenter(), spawnPoint), colony.getName())
+          .sendTo(colony).forManagers();
+        for (final Entity entity : raiders.keySet())
+        {
+            entity.remove(Entity.RemovalReason.DISCARDED);
+        }
+
+        raidBar.setVisible(false);
+        raidBar.removeAllPlayers();
     }
 }

--- a/src/main/java/com/minecolonies/core/colony/managers/RaidManager.java
+++ b/src/main/java/com/minecolonies/core/colony/managers/RaidManager.java
@@ -343,6 +343,7 @@ public class RaidManager implements IRaiderManager
                 event.setShipSize(ShipSize.getShipForRaiderAmount(amount));
                 event.setShipRotation(shipRotation);
                 event.setSpawnPath(createSpawnPath(targetSpawnPoint, false));
+                event.setMaxRaiderCount(amount*2);
                 raidEvent = event;
                 colony.getEventManager().addEvent(event);
             }
@@ -355,6 +356,7 @@ public class RaidManager implements IRaiderManager
                 event.setShipSize(ShipSize.getShipForRaiderAmount(amount));
                 event.setShipRotation(shipRotation);
                 event.setSpawnPath(createSpawnPath(targetSpawnPoint, true));
+                event.setMaxRaiderCount(amount*2);
                 raidEvent = event;
                 colony.getEventManager().addEvent(event);
             }
@@ -366,6 +368,7 @@ public class RaidManager implements IRaiderManager
                 event.setShipSize(ShipSize.getShipForRaiderAmount(amount));
                 event.setShipRotation(shipRotation);
                 event.setSpawnPath(createSpawnPath(targetSpawnPoint, false));
+                event.setMaxRaiderCount(amount*2);
                 raidEvent = event;
                 colony.getEventManager().addEvent(event);
             }
@@ -391,9 +394,13 @@ public class RaidManager implements IRaiderManager
                 {
                     event = new PirateGroundRaidEvent(colony);
                 }
-                else
+                else if (raidType.isEmpty() || raidType.equals(BarbarianRaidEvent.BARBARIAN_RAID_EVENT_TYPE_ID))
                 {
                     event = new BarbarianRaidEvent(colony);
+                }
+                else
+                {
+                    return RaidSpawnResult.NO_SPAWN_POINT;
                 }
 
                 event.setSpawnPoint(targetSpawnPoint);

--- a/src/main/resources/assets/minecolonies/lang/manual_en_us.json
+++ b/src/main/resources/assets/minecolonies/lang/manual_en_us.json
@@ -958,6 +958,11 @@
   "event.minecolonies.raidmessage_p3": "Arr Comrade! There's some darn pirates from the %s comin' for %s tonight! They sailed 'ere and will continue attacking until we destroy their caravel.",
   "event.minecolonies.raidmessage_p4": "A huge horde of pirates are sailin' %s of %s and they're not here to play! Their rigorous waves will hit us unless we destroy their galleon!",
 
+  "event.minecolonies.raidmessage_u1": "A mysterious sunken shipwreck has been been spotted to the %s of %s! It is a small sloop, you should consider destroying it.",
+  "event.minecolonies.raidmessage_u2": "Citizens report rumors of drowned pirates closing in %s of %s! There also seems to be a sunk ship there, better destroy it.",
+  "event.minecolonies.raidmessage_u3": "Arrglglglgl! There's some darn drowned pirates from the %s comin' for %s tonight! There is even a sunk ship 'ere and will continue attacking until we destroy their caravel.",
+  "event.minecolonies.raidmessage_u4": "A huge horde of drowned pirates are swimming' %s of %s and they're not here to play! Their rigorous waves will hit us unless we destroy their sunken galleon!",
+
   "com.minecolonies.coremod.raid.amazon.name": "Amazons",
   "com.minecolonies.coremod.raid.egyptian.name": "Mummies",
   "com.minecolonies.coremod.raid.barbarian.name": "Barbarians",
@@ -1088,6 +1093,8 @@
   "item.minecolonies.mercegg": "Mercenary Spawn Egg",
 
   "com.minecolonies.coremod.pirates.sailing.away": "A pirate ship %s of %s just sailed away to search for another victim.",
+  "com.minecolonies.core.drowned_pirates.sailing.away": "The sunk shipwreck %s of %s mysteriously disappears back into the depths of the ocean.",
+
   "com.minecolonies.coremod.cook.serve.player": "%s: Here Governor, take this food!",
 
   "item.minecolonies.santa_hat": "Santa Hat",
@@ -2581,5 +2588,6 @@
   "death.attack.entity.minecolonies.drownedarcherpirate": "%s was pierced from the depths by a drowned Pirate Archer",
   "entity.minecolonies.drownedchiefpirate": "Drowned Pirate Chief",
   "death.attack.entity.minecolonies.drownedchiefpirate": "%s was put to a watery grave by a drowned Pirate Chief",
-  "com.minecolonies.core.exit_interactions": "Exit Interactions"
+  "com.minecolonies.core.exit_interactions": "Exit Interactions",
+  "com.minecolonies.core.raidevent.spawnerbreaks": "One of the spawners of the raid misteriously broke, it seems you hit some sort of limit"
 }


### PR DESCRIPTION




Closes #
Closes #
Closes #

# Changes proposed in this pull request:
- Update raid messages for drowned raiders
- No archer raiders for drowned raids
- Auto break spawners when reaching a limit of killed ship raiders
-  dont create a barbarian event as fallback when a specific one is requested


[ ] Yes I tested this before submitting it.
[ ] I also did a multiplayer test.

Review please
