### PR TITLE
Farmer not tilling moss and other dirt tagged blocks

### DIFF
--- a/src/main/java/com/minecolonies/core/entity/ai/workers/production/agriculture/EntityAIWorkFarmer.java
+++ b/src/main/java/com/minecolonies/core/entity/ai/workers/production/agriculture/EntityAIWorkFarmer.java
@@ -41,10 +41,14 @@ import net.minecraft.world.item.BlockItem;
 import net.minecraft.world.item.Item;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.Items;
+import net.minecraft.world.item.context.UseOnContext;
 import net.minecraft.world.level.block.*;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.storage.loot.LootParams;
 import net.minecraft.world.level.storage.loot.parameters.LootContextParams;
+import net.minecraft.world.phys.BlockHitResult;
+import net.minecraft.world.phys.Vec3;
+import net.minecraftforge.common.ToolActions;
 import net.minecraftforge.network.PacketDistributor;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -360,6 +364,16 @@ public class EntityAIWorkFarmer extends AbstractEntityAICrafting<JobFarmer, Buil
         {
             return null;
         }
+
+        final BlockState blockState = world.getBlockState(position);
+        final BlockHitResult blockHitResult = new BlockHitResult(Vec3.ZERO, Direction.UP, position, false);
+        final UseOnContext useOnContext = new UseOnContext(world, null, InteractionHand.MAIN_HAND, getInventory().getHeldItem(InteractionHand.MAIN_HAND), blockHitResult);
+        final BlockState toolModifiedState = blockState.getToolModifiedState(useOnContext, ToolActions.HOE_TILL, true);
+        if (toolModifiedState == null || !toolModifiedState.is(Blocks.FARMLAND))
+        {
+            return null;
+        }
+
         return position;
     }
 


### PR DESCRIPTION
Closes #
Closes #
Closes #

# Changes proposed in this pull request:
- Utilize BlockState#getToolModifiedState to check whether any given block should turn into farmland, not relying on merely the dirt block tag. This makes things like moss, that shouldn't turn into farmland, not turn into farmland.


[X] Yes I tested this before submitting it.
[ ] I also did a multiplayer test.

Review please
