### PR TITLE
sound manager rework

### DIFF
--- a/src/main/java/com/minecolonies/api/colony/IColonyManager.java
+++ b/src/main/java/com/minecolonies/api/colony/IColonyManager.java
@@ -5,6 +5,7 @@ import com.minecolonies.api.colony.buildings.IBuilding;
 import com.minecolonies.api.colony.buildings.views.IBuildingView;
 import com.minecolonies.api.compatibility.ICompatibilityManager;
 import com.minecolonies.api.crafting.IRecipeManager;
+import com.minecolonies.api.sounds.SoundManager;
 import net.minecraft.core.BlockPos;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.network.FriendlyByteBuf;
@@ -425,4 +426,10 @@ public interface IColonyManager
      * @param pos the pos to open it at.
      */
     void openReactivationWindow(final BlockPos pos);
+
+    /**
+     * Get the sound manager from the colony manager.
+     * @return the sound manager.
+     */
+    SoundManager getSoundManager();
 }

--- a/src/main/java/com/minecolonies/api/colony/IColonyManager.java
+++ b/src/main/java/com/minecolonies/api/colony/IColonyManager.java
@@ -426,10 +426,4 @@ public interface IColonyManager
      * @param pos the pos to open it at.
      */
     void openReactivationWindow(final BlockPos pos);
-
-    /**
-     * Get the sound manager from the colony manager.
-     * @return the sound manager.
-     */
-    SoundManager getSoundManager();
 }

--- a/src/main/java/com/minecolonies/api/entity/citizen/AbstractCivilianEntity.java
+++ b/src/main/java/com/minecolonies/api/entity/citizen/AbstractCivilianEntity.java
@@ -2,10 +2,9 @@ package com.minecolonies.api.entity.citizen;
 
 import com.minecolonies.api.colony.ICivilianData;
 import com.minecolonies.api.entity.other.AbstractFastMinecoloniesEntity;
-import com.minecolonies.api.sounds.SoundManager;
-import net.minecraft.client.multiplayer.ClientLevel;
 import net.minecraft.core.BlockPos;
 import net.minecraft.server.level.ServerPlayer;
+import net.minecraft.sounds.SoundEvent;
 import net.minecraft.world.entity.Entity;
 import net.minecraft.world.entity.EntityType;
 import net.minecraft.world.entity.PathfinderMob;
@@ -23,19 +22,9 @@ import static com.minecolonies.api.util.constant.Constants.TICKS_SECOND;
 public abstract class AbstractCivilianEntity extends AbstractFastMinecoloniesEntity implements Npc
 {
     /**
-     * Whether this entity can be stuck for stuckhandling
-     */
-    private boolean canBeStuck = true;
-
-    /**
      * Time after which the next player collision is possible
      */
     protected long nextPlayerCollisionTime = 0;
-
-    /**
-     * Sound manager of the civilian.
-     */
-    private SoundManager soundManager;
 
     /**
      * Create a new instance.
@@ -45,10 +34,6 @@ public abstract class AbstractCivilianEntity extends AbstractFastMinecoloniesEnt
     protected AbstractCivilianEntity(final EntityType<? extends PathfinderMob> type, final Level worldIn)
     {
         super(type, worldIn);
-        if (worldIn.isClientSide)
-        {
-            soundManager = new SoundManager((ClientLevel) worldIn);
-        }
     }
 
     /**
@@ -83,16 +68,6 @@ public abstract class AbstractCivilianEntity extends AbstractFastMinecoloniesEnt
      * @param id the id to set.
      */
     public abstract void setCitizenId(int id);
-
-    @Override
-    public void tick()
-    {
-        super.tick();
-        if (level().isClientSide)
-        {
-            soundManager.tick();
-        }
-    }
 
     @Override
     public boolean checkBedExists()
@@ -140,14 +115,22 @@ public abstract class AbstractCivilianEntity extends AbstractFastMinecoloniesEnt
     }
 
     /**
-     * Get the sound manager.
+     * Queue a sound at the citizen.
      *
-     * @return the sound manager.
+     * @param soundEvent  the sound event to play.
+     * @param length      the length of the event.
+     * @param repetitions the number of times to play it.
      */
-    public SoundManager getSoundManager()
-    {
-        return soundManager;
-    }
+    public abstract void queueSound(@NotNull final SoundEvent soundEvent, final BlockPos pos, final int length, final int repetitions);
+
+    /**
+     * Queue a sound at the citizen.
+     *
+     * @param soundEvent  the sound event to play.
+     * @param length      the length of the event.
+     * @param repetitions the number of times to play it.
+     */
+    public abstract void queueSound(@NotNull final SoundEvent soundEvent, final BlockPos pos, final int length, final int repetitions, final float volume, final float pitch);
 
     @Override
     public String toString()

--- a/src/main/java/com/minecolonies/api/entity/citizen/AbstractEntityCitizen.java
+++ b/src/main/java/com/minecolonies/api/entity/citizen/AbstractEntityCitizen.java
@@ -32,7 +32,6 @@ import net.minecraft.network.syncher.EntityDataSerializers;
 import net.minecraft.network.syncher.SynchedEntityData;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.server.level.ServerLevel;
-import net.minecraft.sounds.SoundEvent;
 import net.minecraft.util.RandomSource;
 import net.minecraft.world.InteractionHand;
 import net.minecraft.world.InteractionResult;
@@ -762,24 +761,6 @@ public abstract class AbstractEntityCitizen extends AbstractCivilianEntity imple
     {
         return false;
     }
-
-    /**
-     * Queue a sound at the citizen.
-     *
-     * @param soundEvent  the sound event to play.
-     * @param length      the length of the event.
-     * @param repetitions the number of times to play it.
-     */
-    public abstract void queueSound(@NotNull final SoundEvent soundEvent, final BlockPos pos, final int length, final int repetitions);
-
-    /**
-     * Queue a sound at the citizen.
-     *
-     * @param soundEvent  the sound event to play.
-     * @param length      the length of the event.
-     * @param repetitions the number of times to play it.
-     */
-    public abstract void queueSound(@NotNull final SoundEvent soundEvent, final BlockPos pos, final int length, final int repetitions, final float volume, final float pitch);
 
     /**
      * Get the entities state controller

--- a/src/main/java/com/minecolonies/api/sounds/SoundManager.java
+++ b/src/main/java/com/minecolonies/api/sounds/SoundManager.java
@@ -20,12 +20,12 @@ public class SoundManager
     /**
      * The queue to play from.
      */
-    private final Map<UUID, Deque<TimedSound>> soundQueue = new HashMap<>();
+    private static final Map<UUID, Deque<TimedSound>> soundQueue = new HashMap<>();
 
     /**
      * Tick the sound queue to play a sound.
      */
-    public void tick()
+    public static void tick()
     {
         if (soundQueue.isEmpty())
         {
@@ -78,7 +78,7 @@ public class SoundManager
      * @param pitch       the pitch to play it with.
      * @param volume      the volume to play it at.
      */
-    public void addToQueue(
+    public static void addToQueue(
       final UUID uuid,
       final SoundEvent soundEvent,
       final SoundSource source,

--- a/src/main/java/com/minecolonies/api/sounds/SoundManager.java
+++ b/src/main/java/com/minecolonies/api/sounds/SoundManager.java
@@ -1,13 +1,11 @@
 package com.minecolonies.api.sounds;
 
 import net.minecraft.client.Minecraft;
-import net.minecraft.client.multiplayer.ClientLevel;
 import net.minecraft.core.BlockPos;
 import net.minecraft.sounds.SoundEvent;
 import net.minecraft.sounds.SoundSource;
 
-import java.util.ArrayDeque;
-import java.util.Deque;
+import java.util.*;
 
 /**
  * This is a sound manager that allows playing a queue of sounds, for a specific time with length between a series of sounds.
@@ -15,23 +13,14 @@ import java.util.Deque;
 public class SoundManager
 {
     /**
+     * Max concurrent sounds.
+     */
+    private static final int MAX_CONCURRENT_SOUNDS = 5;
+
+    /**
      * The queue to play from.
      */
-    private final Deque<TimedSound> soundQueue = new ArrayDeque<>();
-
-    /**
-     * The client level.
-     */
-    private final ClientLevel level;
-
-    /**
-     * Create a new instance of the sound manager.
-     * @param level the client level it belongs to.
-     */
-    public SoundManager(final ClientLevel level)
-    {
-        this.level = level;
-    }
+    private final Map<UUID, Deque<TimedSound>> soundQueue = new HashMap<>();
 
     /**
      * Tick the sound queue to play a sound.
@@ -43,36 +32,64 @@ public class SoundManager
             return;
         }
 
-        final TimedSound instance = soundQueue.peek();
-        if (instance.timeout <= 0)
+        int playedSounds = 1;
+        for (final Map.Entry<UUID, Deque<TimedSound>> entries : soundQueue.entrySet())
         {
-            level.playSound(Minecraft.getInstance().player, instance.pos, instance.soundEvent, instance.source, instance.volume, instance.pitch);
-            instance.timeout = instance.length;
-            instance.repetitions--;
-            if (instance.repetitions < 0)
+            if (entries.getValue().isEmpty())
             {
-                soundQueue.pop();
+                continue;
             }
-        }
-        else
-        {
-            instance.timeout--;
+            final TimedSound instance = entries.getValue().peek();
+            if (instance.timeout <= 0)
+            {
+                Minecraft.getInstance().player.level.playSound(Minecraft.getInstance().player,
+                  instance.pos,
+                  instance.soundEvent,
+                  instance.source,
+                  instance.volume,
+                  instance.pitch);
+                instance.timeout = instance.length;
+                instance.repetitions--;
+                if (instance.repetitions < 0)
+                {
+                    entries.getValue().pop();
+                }
+            }
+            else
+            {
+                instance.timeout--;
+            }
+            playedSounds++;
+            if (playedSounds >= MAX_CONCURRENT_SOUNDS)
+            {
+                break;
+            }
         }
     }
 
     /**
      * Add a new sound to the queue.
-     * @param soundEvent the sound event to play.
-     * @param source the sound source.
+     *
+     * @param soundEvent  the sound event to play.
+     * @param source      the sound source.
      * @param repetitions the number of repetitions of it.
-     * @param length the length of it.
-     * @param pos the pos to play it at.
-     * @param pitch the pitch to play it with.
-     * @param volume the volume to play it at.
+     * @param length      the length of it.
+     * @param pos         the pos to play it at.
+     * @param pitch       the pitch to play it with.
+     * @param volume      the volume to play it at.
      */
-    public void addToQueue(final SoundEvent soundEvent, final SoundSource source, final int repetitions, final int length, final BlockPos pos, final float volume, final float pitch)
+    public void addToQueue(
+      final UUID uuid,
+      final SoundEvent soundEvent,
+      final SoundSource source,
+      final int repetitions,
+      final int length,
+      final BlockPos pos,
+      final float volume,
+      final float pitch)
     {
-        soundQueue.add(new TimedSound(soundEvent, source, repetitions, length, pos, volume, pitch));
+        final Deque<TimedSound> queue = soundQueue.computeIfAbsent(uuid, k -> new ArrayDeque<>());
+        queue.add(new TimedSound(soundEvent, source, repetitions, length, pos, volume, pitch));
     }
 
     /**
@@ -80,12 +97,12 @@ public class SoundManager
      */
     public static class TimedSound
     {
-        final SoundEvent soundEvent;
+        final SoundEvent  soundEvent;
         final SoundSource source;
-        final int length;
-        final BlockPos pos;
-        final float volume;
-        final float pitch;
+        final int         length;
+        final BlockPos    pos;
+        final float       volume;
+        final float       pitch;
 
         int repetitions;
         int timeout = 0;

--- a/src/main/java/com/minecolonies/api/util/SoundUtils.java
+++ b/src/main/java/com/minecolonies/api/util/SoundUtils.java
@@ -36,7 +36,7 @@ public final class SoundUtils
     /**
      * Standard pitch value.
      */
-    public static final double PITCH = 1.0D;
+    public static final float PITCH = 1.0f;
 
     /**
      * Random object.
@@ -291,12 +291,19 @@ public final class SoundUtils
         final SoundEvent event = citizenData.isFemale() ? CITIZEN_SOUND_EVENTS.get(jobDesc).get(type).get(citizenData.getVoiceProfile()).getB() : CITIZEN_SOUND_EVENTS.get(jobDesc).get(type).get(citizenData.getVoiceProfile()).getA();
         if (chance > rand.nextDouble() * ONE_HUNDRED)
         {
-            worldIn.playSound(null,
-              position,
-              event,
-              SoundSource.NEUTRAL,
-              (float) volume,
-              (float) PITCH);
+            if (worldIn.isClientSide || !citizenData.getEntity().isPresent())
+            {
+                worldIn.playSound(null,
+                  position,
+                  event,
+                  SoundSource.NEUTRAL,
+                  (float) volume,
+                  PITCH);
+            }
+            else
+            {
+              citizenData.getEntity().get().queueSound(event, position, 60, 0, (float) volume, PITCH);
+            }
         }
     }
 

--- a/src/main/java/com/minecolonies/core/client/render/CitizenArmorLayer.java
+++ b/src/main/java/com/minecolonies/core/client/render/CitizenArmorLayer.java
@@ -79,6 +79,11 @@ public class CitizenArmorLayer<T extends AbstractEntityCitizen, M extends Humano
             return;
         }
 
+        if (citizen.isInvisible())
+        {
+            return;
+        }
+
         final ICitizenDataView citizenDataView = citizen.getCitizenDataView();
         if (citizenDataView.getCustomTextureUUID() != null )
         {

--- a/src/main/java/com/minecolonies/core/colony/ColonyManager.java
+++ b/src/main/java/com/minecolonies/core/colony/ColonyManager.java
@@ -11,6 +11,7 @@ import com.minecolonies.api.colony.permissions.ColonyPlayer;
 import com.minecolonies.api.compatibility.CompatibilityManager;
 import com.minecolonies.api.compatibility.ICompatibilityManager;
 import com.minecolonies.api.crafting.IRecipeManager;
+import com.minecolonies.api.sounds.SoundManager;
 import com.minecolonies.api.util.BlockPosUtil;
 import com.minecolonies.api.util.ColonyUtils;
 import com.minecolonies.api.util.DamageSourceKeys;
@@ -42,7 +43,6 @@ import java.util.*;
 import static com.minecolonies.api.util.constant.ColonyManagerConstants.*;
 import static com.minecolonies.api.util.constant.Constants.BLOCKS_PER_CHUNK;
 import static com.minecolonies.api.util.constant.NbtTagConstants.TAG_COMPATABILITY_MANAGER;
-import static com.minecolonies.api.util.constant.NbtTagConstants.TAG_UUID;
 import static com.minecolonies.core.MineColonies.COLONY_MANAGER_CAP;
 import static com.minecolonies.core.MineColonies.getConfig;
 
@@ -77,6 +77,11 @@ public final class ColonyManager implements IColonyManager
      * If the manager finished loading already.
      */
     private boolean capLoaded = false;
+
+    /**
+     * Client side sound manager.
+     */
+    private SoundManager clientSoundManager;
 
     @Override
     public IColony createColony(@NotNull final Level w, final BlockPos pos, @NotNull final Player player, @NotNull final String colonyName, @NotNull final String pack)
@@ -584,10 +589,20 @@ public final class ColonyManager implements IColonyManager
     @Override
     public void onClientTick(@NotNull final TickEvent.ClientTickEvent event)
     {
-        if (event.phase == TickEvent.Phase.END && Minecraft.getInstance().level == null && !colonyViews.isEmpty())
+        if (event.phase == TickEvent.Phase.END)
         {
-            //  Player has left the game, clear the Colony View cache
-            colonyViews.clear();
+            if (Minecraft.getInstance().level == null && !colonyViews.isEmpty())
+            {
+                //  Player has left the game, clear the Colony View cache
+                colonyViews.clear();
+            }
+
+
+            if (clientSoundManager == null)
+            {
+                clientSoundManager = new SoundManager();
+            }
+            clientSoundManager.tick();
         }
     }
 
@@ -823,5 +838,15 @@ public final class ColonyManager implements IColonyManager
     public void resetColonyViews()
     {
         colonyViews.clear();
+    }
+
+    @Override
+    public SoundManager getSoundManager()
+    {
+        if (clientSoundManager == null)
+        {
+            clientSoundManager = new SoundManager();
+        }
+        return clientSoundManager;
     }
 }

--- a/src/main/java/com/minecolonies/core/colony/ColonyManager.java
+++ b/src/main/java/com/minecolonies/core/colony/ColonyManager.java
@@ -839,14 +839,4 @@ public final class ColonyManager implements IColonyManager
     {
         colonyViews.clear();
     }
-
-    @Override
-    public SoundManager getSoundManager()
-    {
-        if (clientSoundManager == null)
-        {
-            clientSoundManager = new SoundManager();
-        }
-        return clientSoundManager;
-    }
 }

--- a/src/main/java/com/minecolonies/core/entity/ai/workers/util/BuildingStructureHandler.java
+++ b/src/main/java/com/minecolonies/core/entity/ai/workers/util/BuildingStructureHandler.java
@@ -202,7 +202,7 @@ public class BuildingStructureHandler<J extends AbstractJobStructure<?, J>, B ex
         final BlockState state = getBluePrint().getBlockState(pos);
         if (building != null)
         {
-            building.registerBlockPosition(getBluePrint().getBlockState(pos), worldPos, this.getWorld());
+            building.registerBlockPosition(state, worldPos, this.getWorld());
         }
 
         if (placement)
@@ -218,6 +218,8 @@ public class BuildingStructureHandler<J extends AbstractJobStructure<?, J>, B ex
                   .getStatisticsManager()
                   .increment(BLOCKS_PLACED, structureAI.getWorker().getCitizenColonyHandler().getColony().getDay());
             }
+
+            structureAI.getWorker().queueSound(state.getSoundType().getPlaceSound(), worldPos, 10, 0);
         }
 
         if (state.getBlock() == ModBlocks.blockWayPoint)

--- a/src/main/java/com/minecolonies/core/network/messages/client/colony/PlaySoundForCitizenMessage.java
+++ b/src/main/java/com/minecolonies/core/network/messages/client/colony/PlaySoundForCitizenMessage.java
@@ -1,5 +1,6 @@
 package com.minecolonies.core.network.messages.client.colony;
 
+import com.minecolonies.api.colony.IColonyManager;
 import com.minecolonies.api.entity.citizen.AbstractCivilianEntity;
 import com.minecolonies.api.network.IMessage;
 import net.minecraft.client.Minecraft;
@@ -188,7 +189,7 @@ public class PlaySoundForCitizenMessage implements IMessage
         final Entity entity = Minecraft.getInstance().level.getEntity(this.entityid);
         if (entity instanceof AbstractCivilianEntity)
         {
-            ((AbstractCivilianEntity) entity).getSoundManager().addToQueue(this.soundEvent, this.soundSource, this.repetitions, this.length, this.pos, this.volume, this.pitch);
+            IColonyManager.getInstance().getSoundManager().addToQueue(entity.getUUID(), this.soundEvent, this.soundSource, this.repetitions, this.length, this.pos, this.volume, this.pitch);
         }
     }
 }

--- a/src/main/java/com/minecolonies/core/network/messages/client/colony/PlaySoundForCitizenMessage.java
+++ b/src/main/java/com/minecolonies/core/network/messages/client/colony/PlaySoundForCitizenMessage.java
@@ -3,6 +3,7 @@ package com.minecolonies.core.network.messages.client.colony;
 import com.minecolonies.api.colony.IColonyManager;
 import com.minecolonies.api.entity.citizen.AbstractCivilianEntity;
 import com.minecolonies.api.network.IMessage;
+import com.minecolonies.api.sounds.SoundManager;
 import net.minecraft.client.Minecraft;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.registries.Registries;
@@ -189,7 +190,7 @@ public class PlaySoundForCitizenMessage implements IMessage
         final Entity entity = Minecraft.getInstance().level.getEntity(this.entityid);
         if (entity instanceof AbstractCivilianEntity)
         {
-            IColonyManager.getInstance().getSoundManager().addToQueue(entity.getUUID(), this.soundEvent, this.soundSource, this.repetitions, this.length, this.pos, this.volume, this.pitch);
+            SoundManager.addToQueue(entity.getUUID(), this.soundEvent, this.soundSource, this.repetitions, this.length, this.pos, this.volume, this.pitch);
         }
     }
 }


### PR DESCRIPTION
Closes #
Closes #
Closes #

# Changes proposed in this pull request:
- Sound Manager Rework:
-> One central sound manager per client
-> Schedule normal citizen sounds there too
-> Max concurrent sounds
-> Builder also now plays normal block place sounds.


[ x ] Yes I tested this before submitting it.
[ ] I also did a multiplayer test.

Review please
