### PR TITLE
Add safeguard to mods messing with follow range

### DIFF
--- a/src/main/java/com/minecolonies/core/entity/pathfinding/pathjobs/AbstractPathJob.java
+++ b/src/main/java/com/minecolonies/core/entity/pathfinding/pathjobs/AbstractPathJob.java
@@ -165,8 +165,10 @@ public abstract class AbstractPathJob implements Callable<Path>, IPathJob
      * @param result path result.
      * @param entity the entity.
      */
-    public AbstractPathJob(final Level world, @NotNull final BlockPos start, final int range, final PathResult result, @Nullable final Mob entity)
+    public AbstractPathJob(final Level world, @NotNull final BlockPos start, int range, final PathResult result, @Nullable final Mob entity)
     {
+        range = Math.max(10, range);
+
         // 30% Extra range to account for heuristics/cost based less circular exploring
         final int minX = (int) (start.getX() - range * 1.3);
         final int minZ = (int) (start.getZ() - range * 1.3);
@@ -200,8 +202,9 @@ public abstract class AbstractPathJob implements Callable<Path>, IPathJob
      * @param result
      * @param entity
      */
-    protected AbstractPathJob(final LevelReader chunkCache, @NotNull final BlockPos start, final int range, final PathResult result, @Nullable final Mob entity)
+    protected AbstractPathJob(final LevelReader chunkCache, @NotNull final BlockPos start, int range, final PathResult result, @Nullable final Mob entity)
     {
+        range = Math.max(10, range);
         this.maxNodes = Math.min(MAX_NODES, range * range);
         nodesToVisit = new PriorityQueue<>(range * 2);
         this.start = new BlockPos(start);


### PR DESCRIPTION
Closes #
Closes #
Closes #

# Changes proposed in this pull request:
- Adds a minimum search range to pathfinding to avoid crashes on zero when other mods modify follow range
-
-


[ ] Yes I tested this before submitting it.
[ ] I also did a multiplayer test.

Review please
