### PR TITLE
Central Courier Task Assignment

### DIFF
--- a/src/main/java/com/minecolonies/apiimp/initializer/ModBuildingsInitializer.java
+++ b/src/main/java/com/minecolonies/apiimp/initializer/ModBuildingsInitializer.java
@@ -177,7 +177,7 @@ public final class ModBuildingsInitializer
           .setBuildingViewProducer(() -> EmptyView::new)
           .setRegistryName(new ResourceLocation(Constants.MOD_ID, ModBuildings.DELIVERYMAN_ID))
           .addBuildingModuleProducer(COURIER_WORK)
-          .addBuildingModuleProducer(CRAFT_TASK_VIEW)
+          .addBuildingModuleProducer(COURIER_TASK_VIEW)
           .createBuildingEntry());
 
         ModBuildings.farmer = DEFERRED_REGISTER.register(ModBuildings.FARMER_ID, () -> new BuildingEntry.Builder()
@@ -372,6 +372,7 @@ public final class ModBuildingsInitializer
           .addBuildingModuleProducer(WAREHOUSE_COURIERS)
           .addBuildingModuleProducer(WAREHOUSE_OPTIONS)
           .addBuildingModuleProducer(MIN_STOCK)
+          .addBuildingModuleProducer(WAREHOUSE_REQUEST_QUEUE)
           .createBuildingEntry());
 
         ModBuildings.postBox = DEFERRED_REGISTER.register(ModBuildings.POSTBOX_ID, () -> new BuildingEntry.Builder()

--- a/src/main/java/com/minecolonies/core/client/gui/modules/WindowHutCrafterTaskModule.java
+++ b/src/main/java/com/minecolonies/core/client/gui/modules/WindowHutCrafterTaskModule.java
@@ -14,6 +14,7 @@ import com.minecolonies.api.colony.requestsystem.requestable.IStackBasedTask;
 import com.minecolonies.api.colony.requestsystem.requestable.deliveryman.IDeliverymanRequestable;
 import com.minecolonies.api.colony.requestsystem.token.IToken;
 import com.minecolonies.core.client.gui.AbstractModuleWindow;
+import com.minecolonies.core.colony.buildings.moduleviews.RequestTaskModuleView;
 import com.minecolonies.core.colony.buildings.moduleviews.WorkerBuildingModuleView;
 import com.minecolonies.core.colony.jobs.views.CrafterJobView;
 import com.minecolonies.core.colony.jobs.views.DmanJobView;
@@ -52,28 +53,7 @@ public class WindowHutCrafterTaskModule extends AbstractModuleWindow
     public void onOpened()
     {
         super.onOpened();
-        final List<IToken<?>> tasks = new ArrayList<>();
-
-
-        for (final WorkerBuildingModuleView moduleView : buildingView.getModuleViews(WorkerBuildingModuleView.class))
-        {
-            for (final int citizenId : moduleView.getAssignedCitizens())
-            {
-                ICitizenDataView citizen = buildingView.getColony().getCitizen(citizenId);
-                if (citizen != null)
-                {
-                    if (citizen.getJobView() instanceof CrafterJobView)
-                    {
-                        tasks.addAll(((CrafterJobView) citizen.getJobView()).getDataStore().getQueue());
-                    }
-                    else if (citizen.getJobView() instanceof DmanJobView)
-                    {
-                        tasks.addAll(((DmanJobView) citizen.getJobView()).getDataStore().getQueue());
-                    }
-                }
-            }
-        }
-
+        final List<IToken<?>> tasks =  buildingView.getModuleViewByType(RequestTaskModuleView.class).getTasks();
         findPaneOfTypeByID(LIST_TASKS, ScrollingList.class).setDataProvider(new ScrollingList.DataProvider()
         {
             @Override

--- a/src/main/java/com/minecolonies/core/client/gui/modules/WindowHutRequestTaskModule.java
+++ b/src/main/java/com/minecolonies/core/client/gui/modules/WindowHutRequestTaskModule.java
@@ -6,7 +6,6 @@ import com.ldtteam.blockui.controls.Image;
 import com.ldtteam.blockui.controls.ItemIcon;
 import com.ldtteam.blockui.controls.Text;
 import com.ldtteam.blockui.views.ScrollingList;
-import com.minecolonies.api.colony.ICitizenDataView;
 import com.minecolonies.api.colony.buildings.views.IBuildingView;
 import com.minecolonies.api.colony.requestsystem.request.IRequest;
 import com.minecolonies.api.colony.requestsystem.request.RequestState;
@@ -15,15 +14,11 @@ import com.minecolonies.api.colony.requestsystem.requestable.deliveryman.IDelive
 import com.minecolonies.api.colony.requestsystem.token.IToken;
 import com.minecolonies.core.client.gui.AbstractModuleWindow;
 import com.minecolonies.core.colony.buildings.moduleviews.RequestTaskModuleView;
-import com.minecolonies.core.colony.buildings.moduleviews.WorkerBuildingModuleView;
-import com.minecolonies.core.colony.jobs.views.CrafterJobView;
-import com.minecolonies.core.colony.jobs.views.DmanJobView;
 import net.minecraft.ChatFormatting;
 import net.minecraft.network.chat.Component;
 import net.minecraft.world.item.ItemStack;
 import org.jetbrains.annotations.NotNull;
 
-import java.util.ArrayList;
 import java.util.List;
 
 import static com.minecolonies.api.util.constant.TranslationConstants.COM_MINECOLONIES_COREMOD_ENTITY_DELIVERYMAN_PRIORITY;
@@ -32,7 +27,7 @@ import static com.minecolonies.api.util.constant.WindowConstants.*;
 /**
  * Task list module.
  */
-public class WindowHutCrafterTaskModule extends AbstractModuleWindow
+public class WindowHutRequestTaskModule extends AbstractModuleWindow
 {
     /**
      * Id of the the task list inside the GUI.
@@ -44,7 +39,7 @@ public class WindowHutCrafterTaskModule extends AbstractModuleWindow
      * @param view the building view.
      * @param name the layout file.
      */
-    public WindowHutCrafterTaskModule(final IBuildingView view, final String name)
+    public WindowHutRequestTaskModule(final IBuildingView view, final String name)
     {
         super(view, name);
     }

--- a/src/main/java/com/minecolonies/core/colony/buildings/modules/BuildingModules.java
+++ b/src/main/java/com/minecolonies/core/colony/buildings/modules/BuildingModules.java
@@ -39,9 +39,11 @@ public class BuildingModules
     public static final BuildingEntry.ModuleProducer<MinimumStockModule,MinimumStockModuleView> MIN_STOCK =
       new BuildingEntry.ModuleProducer<>("min_stock", MinimumStockModule::new, () -> MinimumStockModuleView::new);
     public static final BuildingEntry.ModuleProducer<BedHandlingModule, IBuildingModuleView> BED             = new BuildingEntry.ModuleProducer<>("bed", BedHandlingModule::new, null);
-    public static final BuildingEntry.ModuleProducer<FurnaceUserModule,IBuildingModuleView>    FURNACE         = new BuildingEntry.ModuleProducer<>("furnace", FurnaceUserModule::new, null);
-    public static final BuildingEntry.ModuleProducer<IBuildingModule,CrafterTaskModuleView>                                         CRAFT_TASK_VIEW = new BuildingEntry.ModuleProducer<>("craft_task_view", null, () -> CrafterTaskModuleView::new);
-    public static final BuildingEntry.ModuleProducer<SettingsModule,SettingsModuleView> SETTINGS_CRAFTER_RECIPE = new BuildingEntry.ModuleProducer<>("craft_settings",
+    public static final BuildingEntry.ModuleProducer<FurnaceUserModule,IBuildingModuleView>  FURNACE                 = new BuildingEntry.ModuleProducer<>("furnace", FurnaceUserModule::new, null);
+    public static final BuildingEntry.ModuleProducer<IBuildingModule, RequestTaskModuleView> CRAFT_TASK_VIEW         = new BuildingEntry.ModuleProducer<>("craft_task_view", null, () -> CrafterRequestTaskModuleView::new);
+    public static final BuildingEntry.ModuleProducer<IBuildingModule, RequestTaskModuleView> COURIER_TASK_VIEW         = new BuildingEntry.ModuleProducer<>("courier_task_view", null, () -> CourierRequestTaskModuleView::new);
+
+    public static final BuildingEntry.ModuleProducer<SettingsModule,SettingsModuleView>      SETTINGS_CRAFTER_RECIPE = new BuildingEntry.ModuleProducer<>("craft_settings",
       () -> new SettingsModule().with(AbstractCraftingBuildingModule.RECIPE_MODE, new CrafterRecipeSetting()),
       () -> SettingsModuleView::new);
     public static final BuildingEntry.ModuleProducer<EntityListModule,EntityListModuleView> GUARD_ENTITY_LIST       = new BuildingEntry.ModuleProducer<>("guard_entity_list",
@@ -357,6 +359,8 @@ public class BuildingModules
       new BuildingEntry.ModuleProducer<>("warehouse_couriers", CourierAssignmentModule::new, () -> CourierAssignmentModuleView::new);
     public static final BuildingEntry.ModuleProducer<WarehouseModule,WarehouseOptionsModuleView> WAREHOUSE_OPTIONS     =
       new BuildingEntry.ModuleProducer<>("warehouse_options", WarehouseModule::new, () -> WarehouseOptionsModuleView::new);
+    public static final BuildingEntry.ModuleProducer<WarehouseRequestQueueModule, WarehouseRequestTaskModuleView> WAREHOUSE_REQUEST_QUEUE     =
+      new BuildingEntry.ModuleProducer<>("warehouse_request_queue", WarehouseRequestQueueModule::new, () -> WarehouseRequestTaskModuleView::new);
 
     /**
      * Education

--- a/src/main/java/com/minecolonies/core/colony/buildings/modules/WarehouseRequestQueueModule.java
+++ b/src/main/java/com/minecolonies/core/colony/buildings/modules/WarehouseRequestQueueModule.java
@@ -1,0 +1,82 @@
+package com.minecolonies.core.colony.buildings.modules;
+
+import com.minecolonies.api.colony.buildings.modules.AbstractBuildingModule;
+import com.minecolonies.api.colony.buildings.modules.IPersistentModule;
+import com.minecolonies.api.colony.requestsystem.StandardFactoryController;
+import com.minecolonies.api.colony.requestsystem.token.IToken;
+import net.minecraft.nbt.CompoundTag;
+import net.minecraft.nbt.ListTag;
+import net.minecraft.nbt.Tag;
+import net.minecraft.network.FriendlyByteBuf;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static com.minecolonies.api.util.constant.NbtTagConstants.TAG_REQUEST;
+
+/**
+ * The class of the citizen hut.
+ */
+public class WarehouseRequestQueueModule extends AbstractBuildingModule implements IPersistentModule
+{
+    /**
+     * List of all beds.
+     */
+    @NotNull
+    private final List<IToken<?>> requestList = new ArrayList<>();
+
+    @Override
+    public void deserializeNBT(final CompoundTag compound)
+    {
+        final ListTag requestTagList = compound.getList(TAG_REQUEST, Tag.TAG_COMPOUND);
+        for (int i = 0; i < requestTagList.size(); ++i)
+        {
+            requestList.add(StandardFactoryController.getInstance().deserialize(requestTagList.getCompound(i)));
+        }
+    }
+
+    @Override
+    public void serializeNBT(final CompoundTag compound)
+    {
+        if (!requestList.isEmpty())
+        {
+            @NotNull final ListTag requestTagList = new ListTag();
+            for (@NotNull final IToken<?> token : requestList)
+            {
+                requestTagList.add(StandardFactoryController.getInstance().serialize(token));
+            }
+            compound.put(TAG_REQUEST, requestTagList);
+        }
+    }
+
+    @Override
+    public void serializeToView(final FriendlyByteBuf buf)
+    {
+        super.serializeToView(buf);
+        buf.writeInt(requestList.size());
+        for (final IToken<?> reqId : requestList)
+        {
+            StandardFactoryController.getInstance().serialize(buf, reqId);
+        }
+    }
+
+    /**
+     * Add request to warehouse queue.
+     * @param requestToken request to add.
+     */
+    public void addRequest(IToken<?> requestToken)
+    {
+        requestList.add(requestToken);
+        markDirty();
+    }
+
+    /**
+     * Get a mutable version of the request list.
+     * @return the mutable request list.
+     */
+    public List<IToken<?>> getMutableRequestList()
+    {
+        return requestList;
+    }
+}

--- a/src/main/java/com/minecolonies/core/colony/buildings/moduleviews/CourierRequestTaskModuleView.java
+++ b/src/main/java/com/minecolonies/core/colony/buildings/moduleviews/CourierRequestTaskModuleView.java
@@ -1,0 +1,33 @@
+package com.minecolonies.core.colony.buildings.moduleviews;
+
+import com.minecolonies.api.colony.ICitizenDataView;
+import com.minecolonies.api.colony.requestsystem.token.IToken;
+import com.minecolonies.core.colony.jobs.views.DmanJobView;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Courier task module to display tasks in the UI.
+ */
+public class CourierRequestTaskModuleView extends RequestTaskModuleView
+{
+    @Override
+    public List<IToken<?>> getTasks()
+    {
+        final List<IToken<?>> tasks = new ArrayList<>();
+        for (final WorkerBuildingModuleView moduleView : buildingView.getModuleViews(WorkerBuildingModuleView.class))
+        {
+            for (final int citizenId : moduleView.getAssignedCitizens())
+            {
+                ICitizenDataView citizen = buildingView.getColony().getCitizen(citizenId);
+                if (citizen != null && citizen.getJobView() instanceof DmanJobView)
+                {
+                    tasks.addAll(((DmanJobView) citizen.getJobView()).getDataStore().getQueue());
+                }
+            }
+        }
+
+        return tasks;
+    }
+}

--- a/src/main/java/com/minecolonies/core/colony/buildings/moduleviews/CrafterRequestTaskModuleView.java
+++ b/src/main/java/com/minecolonies/core/colony/buildings/moduleviews/CrafterRequestTaskModuleView.java
@@ -1,0 +1,33 @@
+package com.minecolonies.core.colony.buildings.moduleviews;
+
+import com.minecolonies.api.colony.ICitizenDataView;
+import com.minecolonies.api.colony.requestsystem.token.IToken;
+import com.minecolonies.core.colony.jobs.views.CrafterJobView;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Crafter task module to display tasks in the UI.
+ */
+public class CrafterRequestTaskModuleView extends RequestTaskModuleView
+{
+    @Override
+    public List<IToken<?>> getTasks()
+    {
+        final List<IToken<?>> tasks = new ArrayList<>();
+        for (final WorkerBuildingModuleView moduleView : buildingView.getModuleViews(WorkerBuildingModuleView.class))
+        {
+            for (final int citizenId : moduleView.getAssignedCitizens())
+            {
+                ICitizenDataView citizen = buildingView.getColony().getCitizen(citizenId);
+                if (citizen != null && citizen.getJobView() instanceof CrafterJobView)
+                {
+                    tasks.addAll(((CrafterJobView) citizen.getJobView()).getDataStore().getQueue());
+                }
+            }
+        }
+
+        return tasks;
+    }
+}

--- a/src/main/java/com/minecolonies/core/colony/buildings/moduleviews/RequestTaskModuleView.java
+++ b/src/main/java/com/minecolonies/core/colony/buildings/moduleviews/RequestTaskModuleView.java
@@ -4,7 +4,7 @@ import com.ldtteam.blockui.views.BOWindow;
 import com.minecolonies.api.colony.buildings.modules.AbstractBuildingModuleView;
 import com.minecolonies.api.colony.requestsystem.token.IToken;
 import com.minecolonies.api.util.constant.Constants;
-import com.minecolonies.core.client.gui.modules.WindowHutCrafterTaskModule;
+import com.minecolonies.core.client.gui.modules.WindowHutRequestTaskModule;
 import net.minecraft.network.FriendlyByteBuf;
 import net.minecraftforge.api.distmarker.Dist;
 import net.minecraftforge.api.distmarker.OnlyIn;
@@ -13,7 +13,7 @@ import org.jetbrains.annotations.NotNull;
 import java.util.List;
 
 /**
- * Crafter task module to display tasks in the UI.
+ * Request task module to display tasks in the UI.
  */
 public abstract class RequestTaskModuleView extends AbstractBuildingModuleView
 {
@@ -27,7 +27,7 @@ public abstract class RequestTaskModuleView extends AbstractBuildingModuleView
     @Override
     public BOWindow getWindow()
     {
-        return new WindowHutCrafterTaskModule(buildingView,Constants.MOD_ID + ":gui/layouthuts/layouttasklist.xml");
+        return new WindowHutRequestTaskModule(buildingView,Constants.MOD_ID + ":gui/layouthuts/layouttasklist.xml");
     }
 
     @Override

--- a/src/main/java/com/minecolonies/core/colony/buildings/moduleviews/RequestTaskModuleView.java
+++ b/src/main/java/com/minecolonies/core/colony/buildings/moduleviews/RequestTaskModuleView.java
@@ -2,6 +2,7 @@ package com.minecolonies.core.colony.buildings.moduleviews;
 
 import com.ldtteam.blockui.views.BOWindow;
 import com.minecolonies.api.colony.buildings.modules.AbstractBuildingModuleView;
+import com.minecolonies.api.colony.requestsystem.token.IToken;
 import com.minecolonies.api.util.constant.Constants;
 import com.minecolonies.core.client.gui.modules.WindowHutCrafterTaskModule;
 import net.minecraft.network.FriendlyByteBuf;
@@ -9,10 +10,12 @@ import net.minecraftforge.api.distmarker.Dist;
 import net.minecraftforge.api.distmarker.OnlyIn;
 import org.jetbrains.annotations.NotNull;
 
+import java.util.List;
+
 /**
  * Crafter task module to display tasks in the UI.
  */
-public class CrafterTaskModuleView extends AbstractBuildingModuleView
+public abstract class RequestTaskModuleView extends AbstractBuildingModuleView
 {
     @Override
     public void deserialize(@NotNull final FriendlyByteBuf buf)
@@ -38,4 +41,10 @@ public class CrafterTaskModuleView extends AbstractBuildingModuleView
     {
         return "com.minecolonies.coremod.gui.workerhuts.crafter.tasks";
     }
+
+    /**
+     * Get the specific task list.
+     * @return the task list.
+     */
+    public abstract List<IToken<?>> getTasks();
 }

--- a/src/main/java/com/minecolonies/core/colony/buildings/moduleviews/WarehouseOptionsModuleView.java
+++ b/src/main/java/com/minecolonies/core/colony/buildings/moduleviews/WarehouseOptionsModuleView.java
@@ -40,7 +40,7 @@ public class WarehouseOptionsModuleView extends AbstractBuildingModuleView
     @Override
     public String getIcon()
     {
-        return "info";
+        return "settings";
     }
 
     /**

--- a/src/main/java/com/minecolonies/core/colony/buildings/moduleviews/WarehouseRequestTaskModuleView.java
+++ b/src/main/java/com/minecolonies/core/colony/buildings/moduleviews/WarehouseRequestTaskModuleView.java
@@ -1,0 +1,38 @@
+package com.minecolonies.core.colony.buildings.moduleviews;
+
+import com.minecolonies.api.colony.requestsystem.StandardFactoryController;
+import com.minecolonies.api.colony.requestsystem.token.IToken;
+import net.minecraft.network.FriendlyByteBuf;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Warehouse task module to display tasks in the UI.
+ */
+public class WarehouseRequestTaskModuleView extends RequestTaskModuleView
+{
+    /**
+     * Warehouse tasks.
+     */
+    final List<IToken<?>> tasks = new ArrayList<>();
+
+    @Override
+    public List<IToken<?>> getTasks()
+    {
+        return tasks;
+    }
+
+    @Override
+    public void deserialize(final @NotNull FriendlyByteBuf buf)
+    {
+        tasks.clear();
+        super.deserialize(buf);
+        int size = buf.readInt();
+        for (int i = 0; i < size; i++)
+        {
+            tasks.add(StandardFactoryController.getInstance().deserialize(buf));
+        }
+    }
+}

--- a/src/main/java/com/minecolonies/core/colony/buildings/workerbuildings/BuildingWareHouse.java
+++ b/src/main/java/com/minecolonies/core/colony/buildings/workerbuildings/BuildingWareHouse.java
@@ -8,7 +8,6 @@ import com.minecolonies.api.colony.IColony;
 import com.minecolonies.api.colony.IColonyView;
 import com.minecolonies.api.colony.buildings.workerbuildings.IWareHouse;
 import com.minecolonies.api.colony.requestsystem.resolver.IRequestResolver;
-import com.minecolonies.api.colony.requestsystem.token.IToken;
 import com.minecolonies.api.tileentities.*;
 import com.minecolonies.api.util.constant.TypeConstants;
 import com.minecolonies.core.blocks.BlockMinecoloniesRack;
@@ -29,8 +28,6 @@ import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.entity.BlockEntity;
 import org.jetbrains.annotations.NotNull;
-
-import static com.ldtteam.structurize.placement.handlers.placement.PlacementHandlers.handleTileEntityPlacement;
 
 /**
  * Class of the warehouse building.

--- a/src/main/java/com/minecolonies/core/colony/buildings/workerbuildings/BuildingWareHouse.java
+++ b/src/main/java/com/minecolonies/core/colony/buildings/workerbuildings/BuildingWareHouse.java
@@ -8,6 +8,7 @@ import com.minecolonies.api.colony.IColony;
 import com.minecolonies.api.colony.IColonyView;
 import com.minecolonies.api.colony.buildings.workerbuildings.IWareHouse;
 import com.minecolonies.api.colony.requestsystem.resolver.IRequestResolver;
+import com.minecolonies.api.colony.requestsystem.token.IToken;
 import com.minecolonies.api.tileentities.*;
 import com.minecolonies.api.util.constant.TypeConstants;
 import com.minecolonies.core.blocks.BlockMinecoloniesRack;

--- a/src/main/java/com/minecolonies/core/colony/jobs/JobDeliveryman.java
+++ b/src/main/java/com/minecolonies/core/colony/jobs/JobDeliveryman.java
@@ -243,6 +243,7 @@ public class JobDeliveryman extends AbstractJob<EntityAIWorkDeliveryman, JobDeli
             }
 
             module.getMutableRequestList().removeAll(reqsToRemove);
+            module.markDirty();
 
             if (request == null)
             {

--- a/src/main/java/com/minecolonies/core/colony/jobs/JobDeliveryman.java
+++ b/src/main/java/com/minecolonies/core/colony/jobs/JobDeliveryman.java
@@ -205,8 +205,8 @@ public class JobDeliveryman extends AbstractJob<EntityAIWorkDeliveryman, JobDeli
                 return null;
             }
 
-            final WarehouseRequestQueueModule module = wareHouse.getFirstModuleOccurance(WarehouseRequestQueueModule.class);
-            if (module == null || module.getMutableRequestList().isEmpty())
+            final WarehouseRequestQueueModule module = wareHouse.getModule(BuildingModules.WAREHOUSE_REQUEST_QUEUE);
+            if (module.getMutableRequestList().isEmpty())
             {
                 return null;
             }

--- a/src/main/java/com/minecolonies/core/colony/requestsystem/resolvers/DeliverymenRequestResolver.java
+++ b/src/main/java/com/minecolonies/core/colony/requestsystem/resolvers/DeliverymenRequestResolver.java
@@ -12,6 +12,7 @@ import com.minecolonies.api.util.BlockPosUtil;
 import com.minecolonies.api.util.Log;
 import com.minecolonies.api.util.constant.TranslationConstants;
 import com.minecolonies.core.colony.Colony;
+import com.minecolonies.core.colony.buildings.modules.BuildingModules;
 import com.minecolonies.core.colony.buildings.modules.CourierAssignmentModule;
 import com.minecolonies.core.colony.buildings.modules.WarehouseRequestQueueModule;
 import com.minecolonies.core.colony.jobs.JobDeliveryman;
@@ -61,7 +62,7 @@ public abstract class DeliverymenRequestResolver<R extends IRequestable> extends
             return false;
         }
 
-       return !wareHouse.getFirstModuleOccurance(CourierAssignmentModule.class).getAssignedCitizen().isEmpty();
+       return !wareHouse.getModule(BuildingModules.WAREHOUSE_COURIERS).getAssignedCitizen().isEmpty();
     }
 
     @Override
@@ -92,16 +93,13 @@ public abstract class DeliverymenRequestResolver<R extends IRequestable> extends
             return;
         }
 
-        if (wareHouse.getFirstModuleOccurance(CourierAssignmentModule.class).getAssignedCitizen().isEmpty())
+        if (wareHouse.getModule(BuildingModules.WAREHOUSE_COURIERS).getAssignedCitizen().isEmpty())
         {
             return;
         }
 
-        final WarehouseRequestQueueModule module = wareHouse.getFirstModuleOccurance(WarehouseRequestQueueModule.class);
-        if (module != null)
-        {
-            module.addRequest(request.getId());
-        }
+        final WarehouseRequestQueueModule module = wareHouse.getModule(BuildingModules.WAREHOUSE_REQUEST_QUEUE);
+        module.addRequest(request.getId());
     }
 
     @Nullable
@@ -142,11 +140,8 @@ public abstract class DeliverymenRequestResolver<R extends IRequestable> extends
                 return;
             }
 
-            final WarehouseRequestQueueModule module = wareHouse.getFirstModuleOccurance(WarehouseRequestQueueModule.class);
-            if (module != null)
-            {
-                module.getMutableRequestList().remove(request.getId());
-            }
+            final WarehouseRequestQueueModule module = wareHouse.getModule(BuildingModules.WAREHOUSE_REQUEST_QUEUE);
+            module.getMutableRequestList().remove(request.getId());
         }
     }
 

--- a/src/main/resources/assets/minecolonies/gui/layouthuts/layouttasklist.xml
+++ b/src/main/resources/assets/minecolonies/gui/layouthuts/layouttasklist.xml
@@ -11,7 +11,7 @@
             <itemicon id="detailIcon" size="9 9" pos="80 1" color="black" visible="false"/>
             <label id="priority" size="130 9" pos="20 12" color="black"/>
 
-            <label id="requester" size="130 9" pos="2 22" color="black"/>
+            <label id="requester" size="150 9" pos="2 22" color="black"/>
         </box>
     </list>
 </window>


### PR DESCRIPTION
Closes #
Closes #
Closes #

# Changes proposed in this pull request:
- Move Assignment of Courier Tasks to Warehouse
- Couriers pick up to 5 tasks from there to handle (only if tasks go to same destination and its not pickups)
- Generify task list rendering code


[ x ] Yes I tested this before submitting it.
[ ] I also did a multiplayer test.

Review please
