### PR TITLE
Avoid nearby colony lookup on each frame

### DIFF
--- a/src/main/java/com/minecolonies/core/client/render/worldevent/WorldEventContext.java
+++ b/src/main/java/com/minecolonies/core/client/render/worldevent/WorldEventContext.java
@@ -9,6 +9,7 @@ import net.minecraft.client.multiplayer.ClientLevel;
 import net.minecraft.client.player.LocalPlayer;
 import net.minecraft.client.renderer.MultiBufferSource.BufferSource;
 import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.level.Level;
 import net.minecraft.world.phys.Vec3;
 
 import net.minecraftforge.client.event.RenderLevelStageEvent;
@@ -51,7 +52,6 @@ public class WorldEventContext
         clientLevel = Minecraft.getInstance().level;
         clientPlayer = Minecraft.getInstance().player;
         mainHandItem = clientPlayer.getMainHandItem();
-        nearestColony = IColonyManager.getInstance().getClosestColonyView(clientLevel, clientPlayer.blockPosition());
         clientRenderDist = Minecraft.getInstance().options.renderDistance().get();
 
         final Vec3 cameraPos = Minecraft.getInstance().gameRenderer.getMainCamera().getPosition();
@@ -84,5 +84,15 @@ public class WorldEventContext
     boolean hasNearestColony()
     {
         return nearestColony != null;
+    }
+
+    /**
+     * Checks for a nearby colony
+     *
+     * @param level
+     */
+    public void checkNearbyColony(final Level level)
+    {
+        nearestColony = IColonyManager.getInstance().getClosestColonyView(level, clientPlayer.blockPosition());
     }
 }

--- a/src/main/java/com/minecolonies/core/event/ClientEventHandler.java
+++ b/src/main/java/com/minecolonies/core/event/ClientEventHandler.java
@@ -13,6 +13,7 @@ import com.minecolonies.api.colony.buildings.modules.ICraftingBuildingModule;
 import com.minecolonies.api.colony.buildings.registry.BuildingEntry;
 import com.minecolonies.api.research.IGlobalResearch;
 import com.minecolonies.api.util.InventoryUtils;
+import com.minecolonies.api.util.constant.ColonyConstants;
 import com.minecolonies.api.util.constant.Constants;
 import com.minecolonies.api.util.constant.TranslationConstants;
 import com.minecolonies.core.client.gui.WindowBuildingBrowser;
@@ -44,6 +45,7 @@ import net.minecraftforge.client.event.CustomizeGuiOverlayEvent;
 import net.minecraftforge.client.event.RenderLevelStageEvent;
 import net.minecraftforge.client.event.sound.PlaySoundEvent;
 import net.minecraftforge.common.util.Lazy;
+import net.minecraftforge.event.TickEvent;
 import net.minecraftforge.event.entity.player.ItemTooltipEvent;
 import net.minecraftforge.event.entity.player.PlayerInteractEvent;
 import net.minecraftforge.eventbus.api.EventPriority;
@@ -75,6 +77,15 @@ public class ClientEventHandler
     public static void renderWorldLastEvent(@NotNull final RenderLevelStageEvent event)
     {
         WorldEventContext.INSTANCE.renderWorldLastEvent(event);
+    }
+
+    @SubscribeEvent(priority = EventPriority.LOWEST)
+    public static void onwWorldTick(@NotNull final TickEvent.LevelTickEvent event)
+    {
+        if (event.level.isClientSide && event.phase == TickEvent.Phase.END && ColonyConstants.rand.nextInt(20) == 0)
+        {
+            WorldEventContext.INSTANCE.checkNearbyColony(event.level);
+        }
     }
 
     @SubscribeEvent


### PR DESCRIPTION
Closes #
Closes #
Closes #

# Changes proposed in this pull request:
- Avoid nearby colony lookup on each frame


[x ] Yes I tested this before submitting it.
[ ] I also did a multiplayer test.

Review please
