### PR TITLE
Fix enum naming for direction for raids

### DIFF
--- a/src/main/java/com/minecolonies/core/colony/events/raid/AbstractShipRaidEvent.java
+++ b/src/main/java/com/minecolonies/core/colony/events/raid/AbstractShipRaidEvent.java
@@ -211,7 +211,7 @@ public abstract class AbstractShipRaidEvent implements IColonyRaidEvent, IColony
 
             updateRaidBar();
 
-            MessageUtils.format(RAID_EVENT_MESSAGE_PIRATE + shipSize.messageID, BlockPosUtil.calcDirection(colony.getCenter(), spawnPoint), colony.getName())
+            MessageUtils.format(RAID_EVENT_MESSAGE_PIRATE + shipSize.messageID, BlockPosUtil.calcDirection(colony.getCenter(), spawnPoint).getLongText(), colony.getName())
               .withPriority(MessagePriority.DANGER)
               .sendTo(colony).forManagers();
             colony.markDirty();
@@ -320,7 +320,7 @@ public abstract class AbstractShipRaidEvent implements IColonyRaidEvent, IColony
     @Override
     public void onFinish()
     {
-        MessageUtils.format(PIRATES_SAILING_OFF_MESSAGE, BlockPosUtil.calcDirection(colony.getCenter(), spawnPoint), colony.getName())
+        MessageUtils.format(PIRATES_SAILING_OFF_MESSAGE, BlockPosUtil.calcDirection(colony.getCenter(), spawnPoint).getLongText(), colony.getName())
           .sendTo(colony).forManagers();
         for (final Entity entity : raiders.keySet())
         {

--- a/src/main/java/com/minecolonies/core/colony/events/raid/HordeRaidEvent.java
+++ b/src/main/java/com/minecolonies/core/colony/events/raid/HordeRaidEvent.java
@@ -379,7 +379,7 @@ public abstract class HordeRaidEvent implements IColonyRaidEvent, IColonyCampFir
 
         updateRaidBar();
 
-        MessageUtils.format(RAID_EVENT_MESSAGE + horde.getMessageID(), BlockPosUtil.calcDirection(colony.getCenter(), spawnPoint), colony.getName())
+        MessageUtils.format(RAID_EVENT_MESSAGE + horde.getMessageID(), BlockPosUtil.calcDirection(colony.getCenter(), spawnPoint).getLongText(), colony.getName())
           .withPriority(MessagePriority.DANGER)
           .sendTo(colony)
           .forManagers();

--- a/src/main/java/com/minecolonies/core/colony/events/raid/pirateEvent/DrownedPirateRaidEvent.java
+++ b/src/main/java/com/minecolonies/core/colony/events/raid/pirateEvent/DrownedPirateRaidEvent.java
@@ -109,7 +109,7 @@ public class DrownedPirateRaidEvent extends AbstractShipRaidEvent
 
             updateRaidBar();
 
-            MessageUtils.format(RAID_EVENT_MESSAGE_U_PIRATE + shipSize.messageID, BlockPosUtil.calcDirection(colony.getCenter(), spawnPoint), colony.getName())
+            MessageUtils.format(RAID_EVENT_MESSAGE_U_PIRATE + shipSize.messageID, BlockPosUtil.calcDirection(colony.getCenter(), spawnPoint).getLongText(), colony.getName())
               .withPriority(MessageUtils.MessagePriority.DANGER)
               .sendTo(colony).forManagers();
             colony.markDirty();
@@ -170,7 +170,7 @@ public class DrownedPirateRaidEvent extends AbstractShipRaidEvent
     @Override
     public void onFinish()
     {
-        MessageUtils.format(DROWNED_PIRATES_SAILING_OFF_MESSAGE, BlockPosUtil.calcDirection(colony.getCenter(), spawnPoint), colony.getName())
+        MessageUtils.format(DROWNED_PIRATES_SAILING_OFF_MESSAGE, BlockPosUtil.calcDirection(colony.getCenter(), spawnPoint).getLongText(), colony.getName())
           .sendTo(colony).forManagers();
         for (final Entity entity : raiders.keySet())
         {


### PR DESCRIPTION
Closes [discord report](https://discord.com/channels/472875599422291968/1253362214409343157) using enum name instead of component

# Changes proposed in this pull request:
- Fix all usages of the direction to actually show the display text

[X] Yes I tested this before submitting it.
[ ] I also did a multiplayer test.

Review please
