### PR TITLE
Fixed null pointer exception in client upon joining server

### DIFF
--- a/src/main/java/com/minecolonies/core/client/render/worldevent/WorldEventContext.java
+++ b/src/main/java/com/minecolonies/core/client/render/worldevent/WorldEventContext.java
@@ -93,6 +93,19 @@ public class WorldEventContext
      */
     public void checkNearbyColony(final Level level)
     {
+        /*
+        * This insures that the player is loaded in before anything is called.
+        * Preventing the nullpointer exception when a player joins the server.
+        */
+        while(clientPlayer == null) {
+            System.out.println("Waiting for player to load in.");
+            try {
+                Thread.sleep(1000);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                System.err.println("Thread is already sleeping");
+            }
+        }
         nearestColony = IColonyManager.getInstance().getClosestColonyView(level, clientPlayer.blockPosition());
     }
 }


### PR DESCRIPTION
# Changes proposed in this pull request:
**Fixed issue where a users attempts to join a server and encounters a null pointer exception**
- Forces thread to wait until client is loaded before calling methods that require player object.


[* ] Yes I tested this before submitting it.
[ ] I also did a multiplayer test.

Review please
