### PR TITLE
Fix tools with damage value not being used in crafting recipes

### DIFF
--- a/src/main/java/com/minecolonies/api/crafting/RecipeStorage.java
+++ b/src/main/java/com/minecolonies/api/crafting/RecipeStorage.java
@@ -252,14 +252,14 @@ public class RecipeStorage implements IRecipeStorage
      */
     private void calculateTools()
     {
-        for (int index = 0; index < this.cleanedInput.size(); index++)
+        for (int index = 0; index < cleanedInput.size(); index++)
         {
-            final ItemStorage item = this.cleanedInput.get(index);
+            final ItemStorage item = cleanedInput.get(index);
             for (ItemStack result : getSecondaryOutputs())
             {
                 if (ItemStackUtils.compareItemStacksIgnoreStackSize(item.getItemStack(), result, false, true) && result.isDamageableItem())
                 {
-                    this.cleanedInput.set(index, new ImmutableItemStorage(new ItemStorage(item.getItemStack(), item.getAmount(), true)));
+                    cleanedInput.set(index, new ImmutableItemStorage(new ItemStorage(item.getItemStack(), item.getAmount(), true)));
                     tools.add(result);
                     secondaryOutputs.remove(result);
                     break;

--- a/src/main/java/com/minecolonies/api/crafting/RecipeStorage.java
+++ b/src/main/java/com/minecolonies/api/crafting/RecipeStorage.java
@@ -252,15 +252,14 @@ public class RecipeStorage implements IRecipeStorage
      */
     private void calculateTools()
     {
-        final List<ItemStorage> cleaned = getCleanedInput();
-        for (int index = 0; index < cleaned.size(); index++)
+        for (int index = 0; index < this.cleanedInput.size(); index++)
         {
-            final ItemStorage item = cleaned.get(index);
+            final ItemStorage item = this.cleanedInput.get(index);
             for (ItemStack result : getSecondaryOutputs())
             {
                 if (ItemStackUtils.compareItemStacksIgnoreStackSize(item.getItemStack(), result, false, true) && result.isDamageableItem())
                 {
-                    cleaned.set(index, new ImmutableItemStorage(new ItemStorage(item.getItemStack(), item.getAmount(), true)));
+                    this.cleanedInput.set(index, new ImmutableItemStorage(new ItemStorage(item.getItemStack(), item.getAmount(), true)));
                     tools.add(result);
                     secondaryOutputs.remove(result);
                     break;

--- a/src/main/java/com/minecolonies/api/crafting/RecipeStorage.java
+++ b/src/main/java/com/minecolonies/api/crafting/RecipeStorage.java
@@ -252,12 +252,15 @@ public class RecipeStorage implements IRecipeStorage
      */
     private void calculateTools()
     {
-        for(ItemStorage item : getCleanedInput())
+        final List<ItemStorage> cleaned = getCleanedInput();
+        for (int index = 0; index < cleaned.size(); index++)
         {
-            for(ItemStack result: getSecondaryOutputs())
+            final ItemStorage item = cleaned.get(index);
+            for (ItemStack result : getSecondaryOutputs())
             {
-                if(ItemStackUtils.compareItemStacksIgnoreStackSize(item.getItemStack(), result, false, true) && result.isDamageableItem())
+                if (ItemStackUtils.compareItemStacksIgnoreStackSize(item.getItemStack(), result, false, true) && result.isDamageableItem())
                 {
+                    cleaned.set(index, new ImmutableItemStorage(new ItemStorage(item.getItemStack(), item.getAmount(), true)));
                     tools.add(result);
                     secondaryOutputs.remove(result);
                     break;


### PR DESCRIPTION
Closes #9764 

# Changes proposed in this pull request:
- When tools are detected in crafting recipes, modify the input item to not match on damage


[X] Yes I tested this before submitting it.
[ ] I also did a multiplayer test.

Review please
