### PR TITLE
Don't treat domum items as equivalent when reporting resource deliveries

### DIFF
--- a/src/main/java/com/minecolonies/core/client/gui/WindowResourceList.java
+++ b/src/main/java/com/minecolonies/core/client/gui/WindowResourceList.java
@@ -109,7 +109,7 @@ public class WindowResourceList extends AbstractWindowSkeleton
             resource.setAmountInDelivery(0);
             for (final Delivery delivery : deliveries)
             {
-                if (ItemStackUtils.compareItemStacksIgnoreStackSize(resource.getItemStack(), delivery.getStack(), false, false))
+                if (ItemStackUtils.compareItemStacksIgnoreStackSize(resource.getItemStack(), delivery.getStack(), false, true))
                 {
                     resource.setAmountInDelivery(resource.getAmountInDelivery() + delivery.getStack().getCount());
                 }


### PR DESCRIPTION
Closes [discord report](https://discord.com/channels/139070364159311872/1003402487417548801/1263043040369709066)

# Changes proposed in this pull request:
- Don't confuse separate Domum items (and similar) when reporting deliveries in resource scrolls.

[ ] Yes I tested this before submitting it.
[ ] I also did a multiplayer test.

Review please
