### PR TITLE
Quarrier tweaks

### DIFF
--- a/src/main/java/com/minecolonies/core/entity/ai/workers/AbstractEntityAIStructure.java
+++ b/src/main/java/com/minecolonies/core/entity/ai/workers/AbstractEntityAIStructure.java
@@ -585,7 +585,7 @@ public abstract class AbstractEntityAIStructure<J extends AbstractJobStructure<?
      * @param handler
      * @return
      */
-    private boolean skipClearing(final BlueprintPositionInfo info, final BlockPos pos, final IStructureHandler handler)
+    protected boolean skipClearing(final BlueprintPositionInfo info, final BlockPos pos, final IStructureHandler handler)
     {
         if (info.getBlockInfo().getState().getBlock() == com.ldtteam.structurize.blocks.ModBlocks.blockFluidSubstitution.get())
         {

--- a/src/main/java/com/minecolonies/core/entity/ai/workers/production/EntityAIQuarrier.java
+++ b/src/main/java/com/minecolonies/core/entity/ai/workers/production/EntityAIQuarrier.java
@@ -360,6 +360,20 @@ public class EntityAIQuarrier extends AbstractEntityAIStructureWithWorkOrder<Job
     }
 
     @Override
+    protected boolean skipClearing(final BlueprintPositionInfo info, final BlockPos pos, final IStructureHandler handler)
+    {
+        if (super.skipClearing(info, pos, handler))
+        {
+            return true;
+        }
+        final BlockState state = handler.getWorld().getBlockState(pos);
+        // The blocks have been placed earlier by the quarrier. E.g. fences and walls can have the wrong blockstate
+        // (due to connecting to yet to be mined blocks), which means the block state is incorrect, and they would be mined by the quarrier,
+        // only to be replaced after the next restart. Instead, skip them now if the block itself is correct
+        return state.getBlock() == info.getBlockInfo().getState().getBlock();
+    }
+
+    @Override
     public boolean requestMaterials()
     {
         StructurePhasePlacementResult result;

--- a/src/main/java/com/minecolonies/core/entity/ai/workers/util/LayerBlueprintIterator.java
+++ b/src/main/java/com/minecolonies/core/entity/ai/workers/util/LayerBlueprintIterator.java
@@ -72,9 +72,12 @@ public class LayerBlueprintIterator extends AbstractBlueprintIteratorWrapper
      */
     public void setLayer(final int newLevel)
     {
-        layer = newLevel;
-        // Reset the blueprint, as we now need a new layer of the blueprint
-        handler.setLayerBlueprint();
+        if (layer != newLevel)
+        {
+            layer = newLevel;
+            // Reset the blueprint, as we now need a new layer of the blueprint
+            handler.setLayerBlueprint();
+        }
         delegate.setProgressPos(NULL_POS);
     }
 

--- a/src/main/java/com/minecolonies/core/entity/ai/workers/util/LayerBlueprintIterator.java
+++ b/src/main/java/com/minecolonies/core/entity/ai/workers/util/LayerBlueprintIterator.java
@@ -125,7 +125,7 @@ public class LayerBlueprintIterator extends AbstractBlueprintIteratorWrapper
     public BlockPos getSize()
     {
         final Blueprint blueprint = originalHandler.getBluePrint();
-        return new BlockPos(blueprint.getSizeX(), blueprint.getSizeY(), blueprint.getSizeY());
+        return new BlockPos(blueprint.getSizeX(), blueprint.getSizeY(), blueprint.getSizeZ());
     }
 
     @Override


### PR DESCRIPTION
Seems to mitigate #10026
Closes #
Closes #

# Changes proposed in this pull request:
- Don't remove blocks which were just placed 
  As the quarrier places blocks before breaking them, blocks like fences and walls could immediately be invalid because of the surrounding blocks that needed to be removed first
- Don't recalculate level when not needed. Apparently when walking towards where the quarrier was going to mine, they set the level on each citizen tick.
  It is a little wasteful to do the same calculation constantly over again, when the iterator, or its structure handler, has the result already
- Fix z-dimension of the iterator size
  This is the only thing that I could think of that could maybe have something to do with the issue, but I didn't see this being used anywhere, and it seemed to work fine before this change as well


[ ] Yes I tested this before submitting it.
[ ] I also did a multiplayer test.

Review please
