### PR TITLE
Food related fixe

### DIFF
--- a/src/main/java/com/minecolonies/api/util/FoodUtils.java
+++ b/src/main/java/com/minecolonies/api/util/FoodUtils.java
@@ -1,5 +1,6 @@
 package com.minecolonies.api.util;
 
+import net.minecraft.world.food.FoodProperties;
 import net.minecraft.world.item.ItemStack;
 
 import static com.minecolonies.api.util.constant.Constants.MAX_BUILDING_LEVEL;
@@ -17,7 +18,12 @@ public class FoodUtils
      */
     public static boolean canEat(final ItemStack stack, final int buildingLevel)
     {
-        return buildingLevel < 3 || stack.getItem().getFoodProperties(stack, null).getNutrition() >= buildingLevel + 1;
+        if (buildingLevel < 3)
+        {
+            return stack.getItem().getFoodProperties(stack, null) != null;
+        }
+        final FoodProperties foodProperties = stack.getItem().getFoodProperties(stack, null);
+        return foodProperties != null && stack.getItem().getFoodProperties(stack, null).getNutrition() >= buildingLevel + 1;
     }
 
     /**

--- a/src/main/java/com/minecolonies/api/util/FoodUtils.java
+++ b/src/main/java/com/minecolonies/api/util/FoodUtils.java
@@ -23,7 +23,7 @@ public class FoodUtils
             return stack.getItem().getFoodProperties(stack, null) != null;
         }
         final FoodProperties foodProperties = stack.getItem().getFoodProperties(stack, null);
-        return foodProperties != null && stack.getItem().getFoodProperties(stack, null).getNutrition() >= buildingLevel + 1;
+        return foodProperties != null && foodProperties.getNutrition() >= buildingLevel + 1;
     }
 
     /**

--- a/src/main/java/com/minecolonies/api/util/ItemStackUtils.java
+++ b/src/main/java/com/minecolonies/api/util/ItemStackUtils.java
@@ -11,6 +11,7 @@ import com.minecolonies.api.entity.citizen.AbstractEntityCitizen;
 import com.minecolonies.api.items.CheckedNbtKey;
 import com.minecolonies.api.items.IMinecoloniesFoodItem;
 import com.minecolonies.api.items.ModItems;
+import com.minecolonies.api.items.ModTags;
 import com.minecolonies.api.util.constant.IToolType;
 import com.minecolonies.api.util.constant.ToolType;
 import com.minecolonies.core.util.AdvancementUtils;
@@ -111,7 +112,7 @@ public final class ItemStackUtils
       {
           final FoodProperties foodProperties = stack.isEdible() ? stack.getFoodProperties(null) : null;
           return ItemStackUtils.isNotEmpty(stack) && foodProperties != null && foodProperties.getNutrition() > 0
-                     && foodProperties.getSaturationModifier() > 0;
+                     && foodProperties.getSaturationModifier() > 0 && !stack.is(ModTags.excludedFood);
       };
 
     /**

--- a/src/main/java/com/minecolonies/api/util/constant/TranslationConstants.java
+++ b/src/main/java/com/minecolonies/api/util/constant/TranslationConstants.java
@@ -408,7 +408,9 @@ public final class TranslationConstants
     @NonNls
     public static final String CROP_TOOLTIP                                                         = "com.minecolonies.core.item.crop.tooltip";
     @NonNls
-    public static final String FOOD_TOOLTIP                                                         = "com.minecolonies.core.item.food.tooltip";
+    public static final String FOOD_TOOLTIP                                                         = "com.minecolonies.core.item.food.tooltip.";
+    @NonNls
+    public static final String TIER_TOOLTIP                                                         = "com.minecolonies.core.item.food.tooltip.tier.";
     @NonNls
     public static final String BIOME_TOOLTIP                                                        = "com.minecolonies.core.item.crop.tooltip.biome";
     @NonNls
@@ -651,6 +653,9 @@ public final class TranslationConstants
     public static final String PACK_DESC                                          = "com.minecolonies.coremod.gui.colony.packdesc";
     @NonNls
     public static final String FOOD_QUALITY_TOOLTIP                               = "com.minecolonies.core.gui.restaurant.foodquality";
+    @NonNls
+    public static final String NOKITCHEN                                          = ".nokitchen";
+
     //<editor-fold desc="Partial keys">
 
     @NonNls

--- a/src/main/java/com/minecolonies/apiimp/initializer/InteractionValidatorInitializer.java
+++ b/src/main/java/com/minecolonies/apiimp/initializer/InteractionValidatorInitializer.java
@@ -261,8 +261,10 @@ public class InteractionValidatorInitializer
           citizen -> !(citizen.getJob() instanceof AbstractJobGuard) && ((ITimeBasedHappinessModifier)citizen.getCitizenHappinessHandler().getModifier(SLEPTTONIGHT)).getDays() <= 0);
 
         InteractionValidatorRegistry.registerStandardPredicate(Component.translatable(NO + HADDECENTFOOD),
-          citizen -> ((ITimeBasedHappinessModifier)citizen.getCitizenHappinessHandler().getModifier(HADDECENTFOOD)).getDays() <= 0);
+          citizen -> ((ITimeBasedHappinessModifier)citizen.getCitizenHappinessHandler().getModifier(HADDECENTFOOD)).getDays() <= 0 && citizen.getHomeBuilding() != null && citizen.getHomeBuilding().getBuildingLevel() > 2 && citizen.getColony().getBuildingManager().getFirstBuildingMatching(b -> b instanceof BuildingKitchen) != null);
 
+        InteractionValidatorRegistry.registerStandardPredicate(Component.translatable(NO + HADDECENTFOOD + NOKITCHEN),
+          citizen -> ((ITimeBasedHappinessModifier)citizen.getCitizenHappinessHandler().getModifier(HADDECENTFOOD)).getDays() <= 0 && citizen.getHomeBuilding() != null && citizen.getHomeBuilding().getBuildingLevel() > 2 && citizen.getColony().getBuildingManager().getFirstBuildingMatching(b -> b instanceof BuildingKitchen) == null);
 
         InteractionValidatorRegistry.registerStandardPredicate(Component.translatable(COM_MINECOLONIES_COREMOD_BEEKEEPER_NOFLOWERS),
           citizen -> citizen.getWorkBuilding() instanceof BuildingBeekeeper

--- a/src/main/java/com/minecolonies/apiimp/initializer/InteractionValidatorInitializer.java
+++ b/src/main/java/com/minecolonies/apiimp/initializer/InteractionValidatorInitializer.java
@@ -4,6 +4,7 @@ import com.google.common.collect.ImmutableList;
 import com.minecolonies.api.colony.IColony;
 import com.minecolonies.api.colony.IColonyManager;
 import com.minecolonies.api.colony.buildings.IBuilding;
+import com.minecolonies.api.colony.buildings.ModBuildings;
 import com.minecolonies.api.colony.interactionhandling.InteractionValidatorRegistry;
 import com.minecolonies.api.colony.requestsystem.request.RequestUtils;
 import com.minecolonies.api.crafting.ItemStorage;
@@ -261,10 +262,10 @@ public class InteractionValidatorInitializer
           citizen -> !(citizen.getJob() instanceof AbstractJobGuard) && ((ITimeBasedHappinessModifier)citizen.getCitizenHappinessHandler().getModifier(SLEPTTONIGHT)).getDays() <= 0);
 
         InteractionValidatorRegistry.registerStandardPredicate(Component.translatable(NO + HADDECENTFOOD),
-          citizen -> ((ITimeBasedHappinessModifier)citizen.getCitizenHappinessHandler().getModifier(HADDECENTFOOD)).getDays() <= 0 && citizen.getHomeBuilding() != null && citizen.getHomeBuilding().getBuildingLevel() > 2 && citizen.getColony().getBuildingManager().getFirstBuildingMatching(b -> b instanceof BuildingKitchen) != null);
+          citizen -> ((ITimeBasedHappinessModifier)citizen.getCitizenHappinessHandler().getModifier(HADDECENTFOOD)).getDays() <= 0 && citizen.getHomeBuilding() != null && citizen.getHomeBuilding().getBuildingLevel() > 2 && citizen.getColony().getBuildingManager().getFirstBuildingMatching(b -> b.getBuildingType() == ModBuildings.kitchen.get()) != null);
 
         InteractionValidatorRegistry.registerStandardPredicate(Component.translatable(NO + HADDECENTFOOD + NOKITCHEN),
-          citizen -> ((ITimeBasedHappinessModifier)citizen.getCitizenHappinessHandler().getModifier(HADDECENTFOOD)).getDays() <= 0 && citizen.getHomeBuilding() != null && citizen.getHomeBuilding().getBuildingLevel() > 2 && citizen.getColony().getBuildingManager().getFirstBuildingMatching(b -> b instanceof BuildingKitchen) == null);
+          citizen -> ((ITimeBasedHappinessModifier)citizen.getCitizenHappinessHandler().getModifier(HADDECENTFOOD)).getDays() <= 0 && citizen.getHomeBuilding() != null && citizen.getHomeBuilding().getBuildingLevel() > 2 && citizen.getColony().getBuildingManager().getFirstBuildingMatching(b -> b.getBuildingType() == ModBuildings.kitchen.get()) == null);
 
         InteractionValidatorRegistry.registerStandardPredicate(Component.translatable(COM_MINECOLONIES_COREMOD_BEEKEEPER_NOFLOWERS),
           citizen -> citizen.getWorkBuilding() instanceof BuildingBeekeeper

--- a/src/main/java/com/minecolonies/core/client/gui/modules/FoodItemListModuleWindow.java
+++ b/src/main/java/com/minecolonies/core/client/gui/modules/FoodItemListModuleWindow.java
@@ -37,7 +37,7 @@ public class FoodItemListModuleWindow extends ItemListModuleWindow
       final IItemListModuleView moduleView)
     {
         super(res, building, moduleView);
-        groupedItemList.removeIf(c -> c.getItemStack().is(ModTags.excludedFood) || !FoodUtils.canEat(c.getItemStack(), building.getBuildingLevel()));
+        groupedItemList.removeIf(c -> c.getItemStack().is(ModTags.excludedFood) || !FoodUtils.canEat(c.getItemStack(), building.getBuildingLevel() - 1));
     }
 
     @Override

--- a/src/main/java/com/minecolonies/core/colony/buildings/workerbuildings/BuildingNetherWorker.java
+++ b/src/main/java/com/minecolonies/core/colony/buildings/workerbuildings/BuildingNetherWorker.java
@@ -296,20 +296,6 @@ public class BuildingNetherWorker extends AbstractBuilding
         return PERIOD_DAYS;
     }
 
-    /**
-     * On initial construction or reset request, excludes the tagged food by default.
-     *
-     * @param listModule The food exclusion module.
-     */
-    public static void onResetFoodExclusionList(final ItemListModule listModule)
-    {
-        listModule.clearItems();
-        for (final Item item : ForgeRegistries.ITEMS.tags().getTag(ModTags.excludedFood))
-        {
-            listModule.addItem(new ItemStorage(new ItemStack(item)));
-        }
-    }
-
     @Override
     public void onPlacement()
     {

--- a/src/main/java/com/minecolonies/core/entity/ai/workers/service/EntityAIWorkCook.java
+++ b/src/main/java/com/minecolonies/core/entity/ai/workers/service/EntityAIWorkCook.java
@@ -397,7 +397,7 @@ public class EntityAIWorkCook extends AbstractEntityAIUsesFurnace<JobCook, Build
                     return null;
                 }
             }
-            return new Food(STACKSIZE, blockedItems, building.getBuildingLevel() - 1);
+            return new Food(STACKSIZE, blockedItems, building.getBuildingLevel());
         }
         return new Food(STACKSIZE, building.getBuildingLevel());
     }

--- a/src/main/java/com/minecolonies/core/entity/ai/workers/service/EntityAIWorkCook.java
+++ b/src/main/java/com/minecolonies/core/entity/ai/workers/service/EntityAIWorkCook.java
@@ -144,7 +144,7 @@ public class EntityAIWorkCook extends AbstractEntityAIUsesFurnace<JobCook, Build
         }
         final int buildingLimit = Math.max(1, building.getBuildingLevel() * building.getBuildingLevel()) * SLOT_PER_LINE;
         return InventoryUtils.getCountFromBuildingWithLimit(building,
-          ItemStackUtils.CAN_EAT.and(stack -> FoodUtils.canEat(stack, building.getBuildingLevel())),
+          ItemStackUtils.CAN_EAT.and(stack -> FoodUtils.canEat(stack, building.getBuildingLevel() - 1)),
           stack -> stack.getMaxStackSize() * 6) > buildingLimit;
     }
 
@@ -385,7 +385,7 @@ public class EntityAIWorkCook extends AbstractEntityAIUsesFurnace<JobCook, Build
             }
         }
 
-        blockedItems.removeIf(item -> item.getItemStack().getFoodProperties(worker) == null || !FoodUtils.canEat(item.getItemStack(), building.getBuildingLevel()));
+        blockedItems.removeIf(item -> item.getItemStack().getFoodProperties(worker) == null || !FoodUtils.canEat(item.getItemStack(), building.getBuildingLevel() - 1));
         if (!blockedItems.isEmpty())
         {
             if (IColonyManager.getInstance().getCompatibilityManager().getEdibles(building.getBuildingLevel() - 1).size() <= blockedItems.size())
@@ -399,6 +399,6 @@ public class EntityAIWorkCook extends AbstractEntityAIUsesFurnace<JobCook, Build
             }
             return new Food(STACKSIZE, blockedItems, building.getBuildingLevel() - 1);
         }
-        return new Food(STACKSIZE, building.getBuildingLevel() - 1);
+        return new Food(STACKSIZE, building.getBuildingLevel());
     }
 }

--- a/src/main/java/com/minecolonies/core/entity/citizen/citizenhandlers/CitizenHappinessHandler.java
+++ b/src/main/java/com/minecolonies/core/entity/citizen/citizenhandlers/CitizenHappinessHandler.java
@@ -76,7 +76,7 @@ public class CitizenHappinessHandler implements ICitizenHappinessHandler
           new Tuple<>(IDLE_AT_JOB_COMPLAINS_DAYS, 0.5), new Tuple<>(IDLE_AT_JOB_DEMANDS_DAYS, 0.1)));
 
         addModifier(new ExpirationBasedHappinessModifier(SLEPTTONIGHT, 1.5, new DynamicHappinessSupplier(SLEPTTONIGHT_FUNCTION), 3, true));
-        addModifier(new ExpirationBasedHappinessModifier(HADDECENTFOOD, 3.0, new DynamicHappinessSupplier(FOOD_FUNCTION), 5, true));
+        addModifier(new ExpirationBasedHappinessModifier(HADDECENTFOOD, 3.0, new DynamicHappinessSupplier(FOOD_FUNCTION), 7, true));
     }
 
     /**

--- a/src/main/java/com/minecolonies/core/items/ItemBowlFood.java
+++ b/src/main/java/com/minecolonies/core/items/ItemBowlFood.java
@@ -44,7 +44,8 @@ public class ItemBowlFood extends BowlFoodItem implements IMinecoloniesFoodItem
     @Override
     public void appendHoverText(@NotNull final ItemStack stack, @Nullable final Level worldIn, @NotNull final List<Component> tooltip, @NotNull final TooltipFlag flagIn)
     {
-        tooltip.add(Component.translatable(TranslationConstants.FOOD_TOOLTIP + "." + this.producer));
+        tooltip.add(Component.translatable(TranslationConstants.FOOD_TOOLTIP + this.producer));
+        tooltip.add(Component.translatable(TranslationConstants.TIER_TOOLTIP + this.tier));
     }
 
     @Override

--- a/src/main/java/com/minecolonies/core/items/ItemFood.java
+++ b/src/main/java/com/minecolonies/core/items/ItemFood.java
@@ -44,7 +44,8 @@ public class ItemFood extends Item implements IMinecoloniesFoodItem
     @Override
     public void appendHoverText(@NotNull final ItemStack stack, @Nullable final Level worldIn, @NotNull final List<Component> tooltip, @NotNull final TooltipFlag flagIn)
     {
-        tooltip.add(Component.translatable(TranslationConstants.FOOD_TOOLTIP + "." + this.producer));
+        tooltip.add(Component.translatable(TranslationConstants.FOOD_TOOLTIP + this.producer));
+        tooltip.add(Component.translatable(TranslationConstants.TIER_TOOLTIP + this.tier));
     }
 
     @Override

--- a/src/main/resources/assets/minecolonies/lang/manual_en_us.json
+++ b/src/main/resources/assets/minecolonies/lang/manual_en_us.json
@@ -2650,7 +2650,12 @@
 
   "com.minecolonies.core.item.food.tooltip.chef": "Ask a Chef in a Cookery to cook this for you",
   "com.minecolonies.core.item.food.tooltip.baker": "Ask a Baker in a Bakery to prepare this for you",
-  "com.minecolonies.coremod.entity.citizen.no.food": "I didn't have a decent meal in at least 5 days. The restaurant has a menu of food tiers!",
+  "com.minecolonies.coremod.entity.citizen.no.food": "I haven't had a decent meal in at least a week. If you're not sure what kind of food I'd like to eat, verify the food list in the restaurant for the appropriate food tiers!",
+  "com.minecolonies.coremod.entity.citizen.no.food.nokitchen": "I haven't had a decent meal in at least a week. If you're not sure what kind of food I'd like to eat, verify the food list in the restaurant for the appropriate food tiers! The assistant cook demanded their own kitchen, so you might need to build a Cookery to produce these sophisticated meals!",
+  "com.minecolonies.core.item.food.tooltip.tier.1": "This food is somewhat acceptable for your citizens.",
+  "com.minecolonies.core.item.food.tooltip.tier.2": "This food will keep your citizens satisfied.",
+  "com.minecolonies.core.item.food.tooltip.tier.3": "This food will make your citizens happy for sure!",
+
   "com.minecolonies.core.gui.restaurant.foodquality": "Eaten up to Residence level: %d",
   "com.minecolonies.coremod.gui.townhall.happiness.desc.food": "Didn't have at least a tier 2 meal recently",
   "com.minecolonies.coremod.gui.townhall.happiness.desc.greatfood": "Had a tier 3 meal recently.",


### PR DESCRIPTION
Closes #10050
Closes #9944
Closes #

# Changes proposed in this pull request:
- Restaurant is consistent about the food that it doesnt request and doesnt display in the UI
- Add a cookery notice to the interaction if it doesn't exist
- Interaction only show for citizens at > level 2 buildings
- Happiness factor is now 7 days (week)
- Added tooltip to minecol food 
- Only request building level foods

[ x ] Yes I tested this before submitting it.
[ ] I also did a multiplayer test.

Review please
