### PR TITLE
Fixes crash if rack next to hut

### DIFF
--- a/src/main/java/com/minecolonies/core/blocks/BlockMinecoloniesRack.java
+++ b/src/main/java/com/minecolonies/core/blocks/BlockMinecoloniesRack.java
@@ -175,7 +175,8 @@ public class BlockMinecoloniesRack extends AbstractBlockMinecoloniesRack<BlockMi
       @NotNull final BlockPos neighbourPos)
     {
         final BlockEntity bEntity1 = level.getBlockEntity(pos);
-        BlockEntity bEntity2 = level.getBlockEntity(neighbourPos);
+        // ignore buildings/graves since for some weird reason they're also rack entities
+        final BlockEntity bEntity2 = neighbourState.hasProperty(VARIANT) ? level.getBlockEntity(neighbourPos) : null;
 
         if (pos.subtract(neighbourPos).getY() != 0)
         {
@@ -183,15 +184,9 @@ public class BlockMinecoloniesRack extends AbstractBlockMinecoloniesRack<BlockMi
         }
 
         // Is this a double chest and our connection is being removed.
-        if (bEntity1 instanceof TileEntityRack)
+        if (bEntity1 instanceof final TileEntityRack myRack)
         {
-            // ignore buildings/graves since for some weird reason they're also rack entities
-            if (!neighbourState.hasProperty(VARIANT))
-            {
-                bEntity2 = null;
-            }
-
-            if (bEntity2 == null && state.getValue(VARIANT).isDoubleVariant() && pos.relative(state.getValue(FACING)).equals(neighbourPos))
+            if (!(bEntity2 instanceof TileEntityRack) && state.getValue(VARIANT).isDoubleVariant() && pos.relative(state.getValue(FACING)).equals(neighbourPos))
             {
                 // Reset to single
                 return state.setValue(VARIANT, ((TileEntityRack) bEntity1).isEmpty() ? RackType.DEFAULT : RackType.FULL);
@@ -202,7 +197,7 @@ public class BlockMinecoloniesRack extends AbstractBlockMinecoloniesRack<BlockMi
             {
                 if (neighbourState.getValue(VARIANT) == RackType.EMPTYAIR)
                 {
-                    return state.setValue(VARIANT, ((TileEntityRack) bEntity1).isEmpty() ? RackType.DEFAULTDOUBLE : RackType.FULLDOUBLE)
+                    return state.setValue(VARIANT, myRack.isEmpty() ? RackType.DEFAULTDOUBLE : RackType.FULLDOUBLE)
                       .setValue(FACING, BY_NORMAL.get(neighbourPos.subtract(pos).asLong()));
                 }
                 else

--- a/src/main/java/com/minecolonies/core/blocks/BlockMinecoloniesRack.java
+++ b/src/main/java/com/minecolonies/core/blocks/BlockMinecoloniesRack.java
@@ -186,7 +186,7 @@ public class BlockMinecoloniesRack extends AbstractBlockMinecoloniesRack<BlockMi
         if (bEntity1 instanceof TileEntityRack)
         {
             // ignore buildings/graves since for some weird reason they're also rack entities
-            if (bEntity2 instanceof TileEntityRack && !neighbourState.hasProperty(VARIANT))
+            if (!neighbourState.hasProperty(VARIANT))
             {
                 bEntity2 = null;
             }

--- a/src/main/java/com/minecolonies/core/blocks/BlockMinecoloniesRack.java
+++ b/src/main/java/com/minecolonies/core/blocks/BlockMinecoloniesRack.java
@@ -175,7 +175,7 @@ public class BlockMinecoloniesRack extends AbstractBlockMinecoloniesRack<BlockMi
       @NotNull final BlockPos neighbourPos)
     {
         final BlockEntity bEntity1 = level.getBlockEntity(pos);
-        final BlockEntity bEntity2 = level.getBlockEntity(neighbourPos);
+        BlockEntity bEntity2 = level.getBlockEntity(neighbourPos);
 
         if (pos.subtract(neighbourPos).getY() != 0)
         {
@@ -185,13 +185,19 @@ public class BlockMinecoloniesRack extends AbstractBlockMinecoloniesRack<BlockMi
         // Is this a double chest and our connection is being removed.
         if (bEntity1 instanceof TileEntityRack)
         {
+            // ignore buildings/graves since for some weird reason they're also rack entities
+            if (bEntity2 instanceof TileEntityRack && !neighbourState.hasProperty(VARIANT))
+            {
+                bEntity2 = null;
+            }
+
             if (bEntity2 == null && state.getValue(VARIANT).isDoubleVariant() && pos.relative(state.getValue(FACING)).equals(neighbourPos))
             {
                 // Reset to single
                 return state.setValue(VARIANT, ((TileEntityRack) bEntity1).isEmpty() ? RackType.DEFAULT : RackType.FULL);
             }
             // If its not a double variant and the new neighbor is neither, then connect.
-            else if (bEntity2 instanceof TileEntityRack && !state.getValue(VARIANT).isDoubleVariant() && neighbourState.hasProperty(VARIANT) && neighbourState.getValue(VARIANT)
+            else if (bEntity2 instanceof TileEntityRack && !state.getValue(VARIANT).isDoubleVariant() && neighbourState.getValue(VARIANT)
               .isDoubleVariant() && neighbourState.getValue(FACING).equals(BY_NORMAL.get(((neighbourPos.subtract(pos)).asLong())).getOpposite()))
             {
                 if (neighbourState.getValue(VARIANT) == RackType.EMPTYAIR)


### PR DESCRIPTION
Closes [crash report](https://discord.com/channels/139070364159311872/1125094832143077456/1263979022925168831)

# Changes proposed in this pull request:
- Fixes a crash when a rack is next to a hut or grave.

[ ] Yes I tested this before submitting it.
[ ] I also did a multiplayer test.

Review please

(The actual crash occurs in the test after the diff, where it failed to check if the `VARIANT` property exists.  But just adding that check seemed like it would still misbehave as it would avoid updating the shape entirely instead of resetting it to single rack if needed, so I did this instead.)