### PR TITLE
Fix food auditor for new food system

### DIFF
--- a/src/main/java/com/minecolonies/api/compatibility/CompatibilityManager.java
+++ b/src/main/java/com/minecolonies/api/compatibility/CompatibilityManager.java
@@ -655,6 +655,7 @@ public class CompatibilityManager implements ICompatibilityManager
             return;
         }
 
+        final Set<ItemStorage> tempDuplicates = new HashSet<>();
         final Set<ItemStorage> tempFlowers = new HashSet<>();
 
         final CreativeModeTab.ItemDisplayParameters tempDisplayParams = new CreativeModeTab.ItemDisplayParameters(level.enabledFeatures(), false, level.registryAccess());
@@ -666,7 +667,7 @@ public class CompatibilityManager implements ICompatibilityManager
             final Object2IntLinkedOpenHashMap<Item> mapping = new Object2IntLinkedOpenHashMap<>();
             for (final ItemStack item : stacks)
             {
-                if (mapping.addTo(item.getItem(), 1) > MAX_DEPTH)
+                if (!tempDuplicates.add(new ItemStorage(item)) || mapping.addTo(item.getItem(), 1) > MAX_DEPTH)
                 {
                     continue;
                 }

--- a/src/main/java/com/minecolonies/api/util/ItemStackUtils.java
+++ b/src/main/java/com/minecolonies/api/util/ItemStackUtils.java
@@ -9,7 +9,6 @@ import com.minecolonies.api.compatibility.Compatibility;
 import com.minecolonies.api.crafting.ItemStorage;
 import com.minecolonies.api.entity.citizen.AbstractEntityCitizen;
 import com.minecolonies.api.items.CheckedNbtKey;
-import com.minecolonies.api.items.IMinecoloniesFoodItem;
 import com.minecolonies.api.items.ModItems;
 import com.minecolonies.api.items.ModTags;
 import com.minecolonies.api.util.constant.IToolType;
@@ -49,7 +48,6 @@ import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 import static com.minecolonies.api.items.ModTags.fungi;
-import static com.minecolonies.api.research.util.ResearchConstants.SATURATION;
 import static com.minecolonies.api.util.constant.Constants.*;
 
 /**
@@ -1118,12 +1116,8 @@ public final class ItemStackUtils
     public static void consumeFood(final ItemStack foodStack, final AbstractEntityCitizen citizen, final Inventory inventory)
     {
         final ICitizenData citizenData = citizen.getCitizenData();
-        final FoodProperties itemFood = foodStack.getItem().getFoodProperties(foodStack, citizen);
         ItemStack itemUseReturn = foodStack.finishUsingItem(citizen.level(), citizen);
-        final int housingLevel = citizenData.getHomeBuilding() == null ? 0 : citizenData.getHomeBuilding().getBuildingLevel();
-        final double saturationNerf = foodStack.getItem() instanceof IMinecoloniesFoodItem ? 1.0 : (1.0 / (housingLevel + 1));
-
-        final double satIncrease = itemFood.getNutrition() * (1.0 + citizen.getCitizenColonyHandler().getColony().getResearchManager().getResearchEffects().getEffectStrength(SATURATION)) * saturationNerf;
+        final double satIncrease = FoodUtils.getFoodValue(foodStack, citizen);
 
         citizenData.increaseSaturation(satIncrease / 2.0);
 

--- a/src/main/java/com/minecolonies/core/compatibility/CraftingTagAuditor.java
+++ b/src/main/java/com/minecolonies/core/compatibility/CraftingTagAuditor.java
@@ -9,6 +9,8 @@ import com.minecolonies.api.crafting.IGenericRecipe;
 import com.minecolonies.api.crafting.ItemStorage;
 import com.minecolonies.api.crafting.ModCraftingTypes;
 import com.minecolonies.api.crafting.registry.CraftingType;
+import com.minecolonies.api.items.IMinecoloniesFoodItem;
+import com.minecolonies.api.util.FoodUtils;
 import com.minecolonies.api.util.ItemStackUtils;
 import com.minecolonies.api.util.Log;
 import com.minecolonies.core.colony.buildings.modules.AnimalHerdingModule;
@@ -32,6 +34,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.*;
 
+import static com.minecolonies.api.util.constant.Constants.MAX_BUILDING_LEVEL;
 import static com.minecolonies.api.util.constant.Constants.MOD_ID;
 
 /**
@@ -325,7 +328,11 @@ public class CraftingTagAuditor
                                     @NotNull final MinecraftServer server) throws IOException
     {
         writeItemHeaders(writer);
-        writer.write(",nutrition,maxlevel");
+        writer.write(",nutrition,maxlevel,tier");
+        for (int level = 0; level <= MAX_BUILDING_LEVEL; ++level)
+        {
+            writer.write(",actual" + level);
+        }
         writer.newLine();
 
         for (final ItemStack item : getAllItems())
@@ -340,10 +347,17 @@ public class CraftingTagAuditor
             writer.write(',');
             writer.write(Integer.toString(properties.getNutrition()));
             writer.write(',');
-
-            // minNutrition = getBuildingLevel() - 1
-            // maxLevel     = getNutrition()     + 1
-            writer.write(Integer.toString(Math.min(5, properties.getNutrition() + 1)));
+            writer.write(Integer.toString(FoodUtils.getBuildingLevelForFood(item)));
+            writer.write(',');
+            if (item.getItem() instanceof final IMinecoloniesFoodItem mcolFood)
+            {
+                writer.write(Integer.toString(mcolFood.getTier()));
+            }
+            for (int level = 0; level <= MAX_BUILDING_LEVEL; ++level)
+            {
+                writer.write(',');
+                writer.write(Double.toString(FoodUtils.getFoodValue(item, properties, level, 0)));
+            }
 
             writer.newLine();
         }

--- a/src/main/java/com/minecolonies/core/entity/ai/workers/service/EntityAIWorkCook.java
+++ b/src/main/java/com/minecolonies/core/entity/ai/workers/service/EntityAIWorkCook.java
@@ -203,10 +203,7 @@ public class EntityAIWorkCook extends AbstractEntityAIUsesFurnace<JobCook, Build
                 if (foodSlot != -1)
                 {
                     final ItemStack stack = worker.getInventoryCitizen().extractItem(foodSlot, 1, false);
-                    if (stack.isEdible())
-                    {
-                        citizenToServe.get(0).getCitizenData().increaseSaturation(stack.getItem().getFoodProperties(stack, worker).getNutrition() / 2.0);
-                    }
+                    citizenToServe.get(0).getCitizenData().increaseSaturation(FoodUtils.getFoodValue(stack, worker));
                     worker.getCitizenColonyHandler().getColony().getStatisticsManager().increment(FOOD_SERVED, worker.getCitizenColonyHandler().getColony().getDay());
                 }
             }


### PR DESCRIPTION
# Changes proposed in this pull request:
- Fixes duplicated items appearing in general item lists (due to a quirk of creative tab enumeration).
- Fixes cook force-feeding citizens (when their inventory is full) using outdated food value calculation.
- Updates the food audit output according to the new food system.
    - The rule to calculate `maxlevel` changed in the food update.  It now uses a common implementation.
    - Adds a `tier` column which contains the MineColonies food tier level (or empty for non-mcol food).
    - Adds `actual0`-`actual5` columns which contain the actual food value a colonist with the given residence level will gain.  (This does not include the research bonus.)
    - [Sample output with no extra mods](https://docs.google.com/spreadsheets/d/1i6EQuPuxVWDmH2Z9_CHiXOmDG5sXVF2cscHg6lwXs9o/edit?gid=1343555397#gid=1343555397)

## Known or suspected (pre-existing) issues not fixed in this pull request:
- When the cook force-feeds a citizen, container items are lost.
- The "amount of food to serve" by the cook is based on the raw food nutrition value, not actual value.
- The restaurant still requests food based on `rawNutrition >= (restaurantLevel - 1)`, which is very unrelated to actual food value.
- The restaurant UI hides items that fail `canEat(restaurantLevel)`, which notably is a `rawNutrition >= (restaurantLevel + 1)` check.
- There's a mismatch between `canEat` allowing any food for level 1-2 while the `Food` request does not.

(Some of these things might be fixed by #10054)

[x] Yes I tested this before submitting it.
[ ] I also did a multiplayer test.

Review please
