### PR TITLE
Exclude "excluded_food" from ISFOOD check

### DIFF
--- a/src/api/java/com/minecolonies/api/util/ItemStackUtils.java
+++ b/src/api/java/com/minecolonies/api/util/ItemStackUtils.java
@@ -7,6 +7,7 @@ import com.minecolonies.api.compatibility.Compatibility;
 import com.minecolonies.api.crafting.ItemStorage;
 import com.minecolonies.api.entity.citizen.AbstractEntityCitizen;
 import com.minecolonies.api.items.ModItems;
+import com.minecolonies.api.items.ModTags;
 import com.minecolonies.api.util.constant.IToolType;
 import com.minecolonies.api.util.constant.ToolType;
 import com.mojang.brigadier.exceptions.CommandSyntaxException;
@@ -87,7 +88,7 @@ public final class ItemStackUtils
      */
     public static final Predicate<ItemStack> ISFOOD =
       stack -> ItemStackUtils.isNotEmpty(stack) && stack.isEdible() && stack.getItem().getFoodProperties() != null && stack.getItem().getFoodProperties().getNutrition() > 0
-                 && stack.getItem().getFoodProperties().getSaturationModifier() > 0;
+                 && stack.getItem().getFoodProperties().getSaturationModifier() > 0 && !stack.is(ModTags.excludedFood);
 
     /**
      * Predicate describing things which work in the furnace.


### PR DESCRIPTION
Closes [discord report](https://discord.com/channels/139070364159311872/1264243072015798343) Food check not ignoring TFC spoiled items

# Changes proposed in this pull request:
- One-time backport to 1.18.2 to allow excluded food from being ignored in the ISFOOD check


[X] Yes I tested this before submitting it.
[ ] I also did a multiplayer test.

Review please
