### PR TITLE
Consolidate itemstack serialization

### DIFF
--- a/src/datagen/generated/minecolonies/data/minecolonies/colony/quests/general/alchemy.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/colony/quests/general/alchemy.json
@@ -62,9 +62,11 @@
     {
       "type": "minecolonies:delivery",
       "details": {
-        "item": "minecraft:rotten_flesh",
+        "item": {
+          "count": 3,
+          "id": "minecraft:rotten_flesh"
+        },
         "next-objective": 2,
-        "qty": 3,
         "target": 0
       }
     },
@@ -112,9 +114,11 @@
     {
       "type": "minecolonies:delivery",
       "details": {
-        "item": "minecraft:rotten_flesh",
+        "item": {
+          "count": 3,
+          "id": "minecraft:rotten_flesh"
+        },
         "next-objective": 5,
-        "qty": 3,
         "target": 0
       }
     },
@@ -149,9 +153,11 @@
     {
       "type": "minecolonies:delivery",
       "details": {
-        "item": "minecraft:spider_eye",
+        "item": {
+          "count": 2,
+          "id": "minecraft:spider_eye"
+        },
         "next-objective": 7,
-        "qty": 2,
         "target": 0
       }
     },
@@ -186,9 +192,10 @@
     {
       "type": "minecolonies:delivery",
       "details": {
-        "item": "minecraft:gunpowder",
+        "item": {
+          "id": "minecraft:gunpowder"
+        },
         "next-objective": 9,
-        "qty": 1,
         "target": 0
       }
     },
@@ -229,17 +236,18 @@
     {
       "type": "minecolonies:item",
       "details": {
-        "components": {
-          "minecraft:item_name": "{\"translate\":\"com.minecolonies.alchemyquestpotion.name\"}",
-          "minecraft:lore": [
-            "{\"translate\":\"com.minecolonies.alchemyquestpotion.lore\"}"
-          ],
-          "minecraft:potion_contents": {
-            "potion": "minecraft:poison"
-          }
-        },
-        "item": "minecraft:potion",
-        "qty": 1
+        "item": {
+          "components": {
+            "minecraft:item_name": "{\"translate\":\"com.minecolonies.alchemyquestpotion.name\"}",
+            "minecraft:lore": [
+              "{\"translate\":\"com.minecolonies.alchemyquestpotion.lore\"}"
+            ],
+            "minecraft:potion_contents": {
+              "potion": "minecraft:poison"
+            }
+          },
+          "id": "minecraft:potion"
+        }
       }
     },
     {

--- a/src/datagen/generated/minecolonies/data/minecolonies/colony/quests/general/cookies.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/colony/quests/general/cookies.json
@@ -48,18 +48,21 @@
     {
       "type": "minecolonies:delivery",
       "details": {
-        "item": "minecraft:wheat",
+        "item": {
+          "count": 2,
+          "id": "minecraft:wheat"
+        },
         "next-objective": 2,
-        "qty": 2,
         "target": 0
       }
     },
     {
       "type": "minecolonies:delivery",
       "details": {
-        "item": "minecraft:cocoa_beans",
+        "item": {
+          "id": "minecraft:cocoa_beans"
+        },
         "next-objective": 3,
-        "qty": 1,
         "target": 0
       }
     },
@@ -127,9 +130,11 @@
     {
       "type": "minecolonies:delivery",
       "details": {
-        "item": "minecraft:cookie",
+        "item": {
+          "count": 8,
+          "id": "minecraft:cookie"
+        },
         "next-objective": 7,
-        "qty": 8,
         "target": 1
       }
     },
@@ -199,15 +204,18 @@
     {
       "type": "minecolonies:item",
       "details": {
-        "item": "minecraft:cookie",
-        "qty": 8
+        "item": {
+          "count": 8,
+          "id": "minecraft:cookie"
+        }
       }
     },
     {
       "type": "minecolonies:item",
       "details": {
-        "item": "minecraft:emerald",
-        "qty": 1
+        "item": {
+          "id": "minecraft:emerald"
+        }
       }
     },
     {

--- a/src/datagen/generated/minecolonies/data/minecolonies/colony/quests/general/hungrycourier.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/colony/quests/general/hungrycourier.json
@@ -58,9 +58,10 @@
     {
       "type": "minecolonies:delivery",
       "details": {
-        "item": "minecraft:baked_potato",
+        "item": {
+          "id": "minecraft:baked_potato"
+        },
         "next-objective": 2,
-        "qty": 1,
         "target": 0
       }
     },
@@ -88,8 +89,9 @@
     {
       "type": "minecolonies:item",
       "details": {
-        "item": "minecraft:gold_ingot",
-        "qty": 1
+        "item": {
+          "id": "minecraft:gold_ingot"
+        }
       }
     },
     {

--- a/src/datagen/generated/minecolonies/data/minecolonies/colony/quests/general/thezombiemenace1.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/colony/quests/general/thezombiemenace1.json
@@ -64,8 +64,10 @@
     {
       "type": "minecolonies:item",
       "details": {
-        "item": "minecraft:iron_ingot",
-        "qty": 2
+        "item": {
+          "count": 2,
+          "id": "minecraft:iron_ingot"
+        }
       }
     },
     {

--- a/src/datagen/generated/minecolonies/data/minecolonies/colony/quests/general/thezombiemenace2.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/colony/quests/general/thezombiemenace2.json
@@ -66,8 +66,9 @@
     {
       "type": "minecolonies:item",
       "details": {
-        "item": "minecraft:diamond",
-        "qty": 1
+        "item": {
+          "id": "minecraft:diamond"
+        }
       }
     },
     {

--- a/src/datagen/generated/minecolonies/data/minecolonies/colony/quests/guides/buildergoggles.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/colony/quests/guides/buildergoggles.json
@@ -32,9 +32,10 @@
     {
       "type": "minecolonies:delivery",
       "details": {
-        "item": "minecolonies:build_goggles",
+        "item": {
+          "id": "minecolonies:build_goggles"
+        },
         "next-objective": 2,
-        "qty": 1,
         "target": 0
       }
     },
@@ -63,8 +64,9 @@
     {
       "type": "minecolonies:item",
       "details": {
-        "item": "minecolonies:build_goggles",
-        "qty": 1
+        "item": {
+          "id": "minecolonies:build_goggles"
+        }
       }
     }
   ],

--- a/src/datagen/generated/minecolonies/data/minecolonies/colony/quests/guides/clipboard.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/colony/quests/guides/clipboard.json
@@ -32,9 +32,10 @@
     {
       "type": "minecolonies:delivery",
       "details": {
-        "item": "minecolonies:clipboard",
+        "item": {
+          "id": "minecolonies:clipboard"
+        },
         "next-objective": 2,
-        "qty": 1,
         "target": 0
       }
     },
@@ -63,8 +64,9 @@
     {
       "type": "minecolonies:item",
       "details": {
-        "item": "minecolonies:clipboard",
-        "qty": 1
+        "item": {
+          "id": "minecolonies:clipboard"
+        }
       }
     }
   ],

--- a/src/datagen/generated/minecolonies/data/minecolonies/colony/quests/guides/rallybanner.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/colony/quests/guides/rallybanner.json
@@ -75,10 +75,11 @@
     {
       "type": "minecolonies:delivery",
       "details": {
-        "item": "minecolonies:banner_rally_guards",
+        "item": {
+          "id": "minecolonies:banner_rally_guards"
+        },
         "nbt-mode": "any",
         "next-objective": 4,
-        "qty": 1,
         "target": 0
       }
     },
@@ -107,8 +108,9 @@
     {
       "type": "minecolonies:item",
       "details": {
-        "item": "minecolonies:banner_rally_guards",
-        "qty": 1
+        "item": {
+          "id": "minecolonies:banner_rally_guards"
+        }
       }
     }
   ],

--- a/src/datagen/generated/minecolonies/data/minecolonies/colony/quests/guides/resourcescroll.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/colony/quests/guides/resourcescroll.json
@@ -32,9 +32,10 @@
     {
       "type": "minecolonies:delivery",
       "details": {
-        "item": "minecolonies:resourcescroll",
+        "item": {
+          "id": "minecolonies:resourcescroll"
+        },
         "next-objective": 2,
-        "qty": 1,
         "target": 0
       }
     },
@@ -63,8 +64,9 @@
     {
       "type": "minecolonies:item",
       "details": {
-        "item": "minecolonies:resourcescroll",
-        "qty": 1
+        "item": {
+          "id": "minecolonies:resourcescroll"
+        }
       }
     }
   ],

--- a/src/datagen/generated/minecolonies/data/minecolonies/colony/quests/romance/aromanticgesture.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/colony/quests/romance/aromanticgesture.json
@@ -49,9 +49,10 @@
     {
       "type": "minecolonies:delivery",
       "details": {
-        "item": "minecraft:poppy",
+        "item": {
+          "id": "minecraft:poppy"
+        },
         "next-objective": 2,
-        "qty": 1,
         "target": 1
       }
     },
@@ -89,8 +90,9 @@
     {
       "type": "minecolonies:item",
       "details": {
-        "item": "minecraft:diamond",
-        "qty": 1
+        "item": {
+          "id": "minecraft:diamond"
+        }
       }
     },
     {

--- a/src/datagen/generated/minecolonies/data/minecolonies/colony/quests/romance/atokenofapp.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/colony/quests/romance/atokenofapp.json
@@ -72,9 +72,10 @@
     {
       "type": "minecolonies:delivery",
       "details": {
-        "item": "minecraft:dandelion",
+        "item": {
+          "id": "minecraft:dandelion"
+        },
         "next-objective": 3,
-        "qty": 1,
         "target": 1
       }
     },
@@ -104,8 +105,9 @@
     {
       "type": "minecolonies:item",
       "details": {
-        "item": "minecraft:emerald",
-        "qty": 1
+        "item": {
+          "id": "minecraft:emerald"
+        }
       }
     },
     {

--- a/src/datagen/generated/minecolonies/data/minecolonies/colony/quests/template/questtemplate.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/colony/quests/template/questtemplate.json
@@ -62,18 +62,20 @@
     {
       "type": "minecolonies:delivery",
       "details": {
-        "item": "minecraft:apple",
+        "item": {
+          "id": "minecraft:apple"
+        },
         "next-objective": 3,
-        "qty": 1,
         "target": 0
       }
     },
     {
       "type": "minecolonies:delivery",
       "details": {
-        "item": "minecraft:baked_potato",
+        "item": {
+          "id": "minecraft:baked_potato"
+        },
         "next-objective": 3,
-        "qty": 1,
         "target": 0
       }
     },
@@ -128,8 +130,9 @@
     {
       "type": "minecolonies:item",
       "details": {
-        "item": "minecraft:gold_ingot",
-        "qty": 1
+        "item": {
+          "id": "minecraft:gold_ingot"
+        }
       }
     },
     {

--- a/src/datagen/generated/minecolonies/data/minecolonies/colony/quests/tutorial/builder.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/colony/quests/tutorial/builder.json
@@ -256,8 +256,10 @@
     {
       "type": "minecolonies:item",
       "details": {
-        "item": "minecraft:cobblestone",
-        "qty": 32
+        "item": {
+          "count": 32,
+          "id": "minecraft:cobblestone"
+        }
       }
     }
   ],

--- a/src/datagen/generated/minecolonies/data/minecolonies/colony/quests/tutorial/builder2.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/colony/quests/tutorial/builder2.json
@@ -99,8 +99,10 @@
     {
       "type": "minecolonies:item",
       "details": {
-        "item": "minecraft:lantern",
-        "qty": 8
+        "item": {
+          "count": 8,
+          "id": "minecraft:lantern"
+        }
       }
     }
   ],

--- a/src/datagen/generated/minecolonies/data/minecolonies/colony/quests/tutorial/farm.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/colony/quests/tutorial/farm.json
@@ -233,8 +233,10 @@
     {
       "type": "minecolonies:item",
       "details": {
-        "item": "minecraft:wheat_seeds",
-        "qty": 32
+        "item": {
+          "count": 32,
+          "id": "minecraft:wheat_seeds"
+        }
       }
     }
   ],

--- a/src/datagen/generated/minecolonies/data/minecolonies/colony/quests/tutorial/forester.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/colony/quests/tutorial/forester.json
@@ -159,8 +159,10 @@
     {
       "type": "minecolonies:item",
       "details": {
-        "item": "minecraft:torch",
-        "qty": 32
+        "item": {
+          "count": 32,
+          "id": "minecraft:torch"
+        }
       }
     }
   ],

--- a/src/datagen/generated/minecolonies/data/minecolonies/colony/quests/tutorial/hospital.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/colony/quests/tutorial/hospital.json
@@ -128,15 +128,19 @@
     {
       "type": "minecolonies:item",
       "details": {
-        "item": "minecraft:carrot",
-        "qty": 8
+        "item": {
+          "count": 8,
+          "id": "minecraft:carrot"
+        }
       }
     },
     {
       "type": "minecolonies:item",
       "details": {
-        "item": "minecraft:potato",
-        "qty": 8
+        "item": {
+          "count": 8,
+          "id": "minecraft:potato"
+        }
       }
     }
   ],

--- a/src/datagen/generated/minecolonies/data/minecolonies/colony/quests/tutorial/housing.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/colony/quests/tutorial/housing.json
@@ -143,8 +143,10 @@
     {
       "type": "minecolonies:item",
       "details": {
-        "item": "minecraft:white_wool",
-        "qty": 16
+        "item": {
+          "count": 16,
+          "id": "minecraft:white_wool"
+        }
       }
     }
   ],

--- a/src/datagen/generated/minecolonies/data/minecolonies/colony/quests/tutorial/housing2.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/colony/quests/tutorial/housing2.json
@@ -99,8 +99,10 @@
     {
       "type": "minecolonies:item",
       "details": {
-        "item": "minecolonies:blockminecoloniesrack",
-        "qty": 8
+        "item": {
+          "count": 8,
+          "id": "minecolonies:blockminecoloniesrack"
+        }
       }
     }
   ],

--- a/src/datagen/generated/minecolonies/data/minecolonies/colony/quests/tutorial/military/barracks.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/colony/quests/tutorial/military/barracks.json
@@ -128,8 +128,10 @@
     {
       "type": "minecolonies:item",
       "details": {
-        "item": "minecraft:iron_sword",
-        "qty": 2
+        "item": {
+          "count": 2,
+          "id": "minecraft:iron_sword"
+        }
       }
     }
   ],

--- a/src/datagen/generated/minecolonies/data/minecolonies/colony/quests/tutorial/military/guards.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/colony/quests/tutorial/military/guards.json
@@ -159,8 +159,9 @@
     {
       "type": "minecolonies:item",
       "details": {
-        "item": "minecraft:iron_block",
-        "qty": 1
+        "item": {
+          "id": "minecraft:iron_block"
+        }
       }
     }
   ],

--- a/src/datagen/generated/minecolonies/data/minecolonies/colony/quests/tutorial/military/guards2.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/colony/quests/tutorial/military/guards2.json
@@ -71,29 +71,33 @@
     {
       "type": "minecolonies:item",
       "details": {
-        "item": "minecraft:chainmail_helmet",
-        "qty": 1
+        "item": {
+          "id": "minecraft:chainmail_helmet"
+        }
       }
     },
     {
       "type": "minecolonies:item",
       "details": {
-        "item": "minecraft:chainmail_chestplate",
-        "qty": 1
+        "item": {
+          "id": "minecraft:chainmail_chestplate"
+        }
       }
     },
     {
       "type": "minecolonies:item",
       "details": {
-        "item": "minecraft:chainmail_leggings",
-        "qty": 1
+        "item": {
+          "id": "minecraft:chainmail_leggings"
+        }
       }
     },
     {
       "type": "minecolonies:item",
       "details": {
-        "item": "minecraft:chainmail_boots",
-        "qty": 1
+        "item": {
+          "id": "minecraft:chainmail_boots"
+        }
       }
     }
   ],

--- a/src/datagen/generated/minecolonies/data/minecolonies/colony/quests/tutorial/military/torches.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/colony/quests/tutorial/military/torches.json
@@ -57,15 +57,17 @@
     {
       "type": "minecolonies:item",
       "details": {
-        "item": "minecraft:iron_sword",
-        "qty": 1
+        "item": {
+          "id": "minecraft:iron_sword"
+        }
       }
     },
     {
       "type": "minecolonies:item",
       "details": {
-        "item": "minecraft:bow",
-        "qty": 1
+        "item": {
+          "id": "minecraft:bow"
+        }
       }
     }
   ],

--- a/src/datagen/generated/minecolonies/data/minecolonies/colony/quests/tutorial/military/zombies.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/colony/quests/tutorial/military/zombies.json
@@ -59,29 +59,33 @@
     {
       "type": "minecolonies:item",
       "details": {
-        "item": "minecraft:leather_chestplate",
-        "qty": 1
+        "item": {
+          "id": "minecraft:leather_chestplate"
+        }
       }
     },
     {
       "type": "minecolonies:item",
       "details": {
-        "item": "minecraft:leather_boots",
-        "qty": 1
+        "item": {
+          "id": "minecraft:leather_boots"
+        }
       }
     },
     {
       "type": "minecolonies:item",
       "details": {
-        "item": "minecraft:leather_helmet",
-        "qty": 1
+        "item": {
+          "id": "minecraft:leather_helmet"
+        }
       }
     },
     {
       "type": "minecolonies:item",
       "details": {
-        "item": "minecraft:leather_leggings",
-        "qty": 1
+        "item": {
+          "id": "minecraft:leather_leggings"
+        }
       }
     }
   ],

--- a/src/datagen/generated/minecolonies/data/minecolonies/colony/quests/tutorial/mine.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/colony/quests/tutorial/mine.json
@@ -168,8 +168,10 @@
     {
       "type": "minecolonies:item",
       "details": {
-        "item": "minecraft:ladder",
-        "qty": 32
+        "item": {
+          "count": 32,
+          "id": "minecraft:ladder"
+        }
       }
     }
   ],

--- a/src/datagen/generated/minecolonies/data/minecolonies/colony/quests/tutorial/restaurant.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/colony/quests/tutorial/restaurant.json
@@ -143,8 +143,10 @@
     {
       "type": "minecolonies:item",
       "details": {
-        "item": "minecraft:coal",
-        "qty": 16
+        "item": {
+          "count": 16,
+          "id": "minecraft:coal"
+        }
       }
     }
   ],

--- a/src/datagen/generated/minecolonies/data/minecolonies/colony/quests/tutorial/sawmill.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/colony/quests/tutorial/sawmill.json
@@ -137,8 +137,10 @@
     {
       "type": "minecolonies:item",
       "details": {
-        "item": "minecraft:diamond",
-        "qty": 3
+        "item": {
+          "count": 3,
+          "id": "minecraft:diamond"
+        }
       }
     }
   ],

--- a/src/datagen/generated/minecolonies/data/minecolonies/colony/quests/tutorial/tavern.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/colony/quests/tutorial/tavern.json
@@ -159,8 +159,10 @@
     {
       "type": "minecolonies:item",
       "details": {
-        "item": "minecraft:baked_potato",
-        "qty": 32
+        "item": {
+          "count": 32,
+          "id": "minecraft:baked_potato"
+        }
       }
     }
   ],

--- a/src/datagen/generated/minecolonies/data/minecolonies/colony/quests/tutorial/tieredfood.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/colony/quests/tutorial/tieredfood.json
@@ -83,15 +83,19 @@
     {
       "type": "minecolonies:item",
       "details": {
-        "item": "minecolonies:garlic",
-        "qty": 8
+        "item": {
+          "count": 8,
+          "id": "minecolonies:garlic"
+        }
       }
     },
     {
       "type": "minecolonies:item",
       "details": {
-        "item": "minecolonies:onion",
-        "qty": 8
+        "item": {
+          "count": 8,
+          "id": "minecolonies:onion"
+        }
       }
     }
   ],

--- a/src/datagen/generated/minecolonies/data/minecolonies/colony/quests/tutorial/university.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/colony/quests/tutorial/university.json
@@ -108,8 +108,10 @@
     {
       "type": "minecolonies:item",
       "details": {
-        "item": "minecraft:book",
-        "qty": 8
+        "item": {
+          "count": 8,
+          "id": "minecraft:book"
+        }
       }
     }
   ],

--- a/src/datagen/generated/minecolonies/data/minecolonies/colony/quests/tutorial/warehouse.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/colony/quests/tutorial/warehouse.json
@@ -158,29 +158,37 @@
     {
       "type": "minecolonies:item",
       "details": {
-        "item": "minecraft:stone_pickaxe",
-        "qty": 2
+        "item": {
+          "count": 2,
+          "id": "minecraft:stone_pickaxe"
+        }
       }
     },
     {
       "type": "minecolonies:item",
       "details": {
-        "item": "minecraft:stone_axe",
-        "qty": 2
+        "item": {
+          "count": 2,
+          "id": "minecraft:stone_axe"
+        }
       }
     },
     {
       "type": "minecolonies:item",
       "details": {
-        "item": "minecraft:stone_shovel",
-        "qty": 2
+        "item": {
+          "count": 2,
+          "id": "minecraft:stone_shovel"
+        }
       }
     },
     {
       "type": "minecolonies:item",
       "details": {
-        "item": "minecraft:stone_hoe",
-        "qty": 2
+        "item": {
+          "count": 2,
+          "id": "minecraft:stone_hoe"
+        }
       }
     }
   ],

--- a/src/datagen/generated/minecolonies/data/minecolonies/colony/quests/tutorial/welcome.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/colony/quests/tutorial/welcome.json
@@ -240,8 +240,9 @@
     {
       "type": "minecolonies:item",
       "details": {
-        "item": "minecolonies:questlog",
-        "qty": 1
+        "item": {
+          "id": "minecolonies:questlog"
+        }
       }
     },
     {

--- a/src/datagen/generated/minecolonies/data/minecolonies/crafterrecipes/alchemist/magicpotion.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/crafterrecipes/alchemist/magicpotion.json
@@ -3,14 +3,16 @@
   "crafter": "alchemist_crafting",
   "inputs": [
     {
-      "item": "minecolonies:mistletoe"
+      "id": "minecolonies:mistletoe"
     },
     {
-      "item": "minecolonies:large_water_bottle"
+      "id": "minecolonies:large_water_bottle"
     }
   ],
   "intermediate": "minecraft:air",
   "research-id": "minecolonies:effects/consumepotions",
-  "result": "minecolonies:magicpotion",
+  "result": {
+    "id": "minecolonies:magicpotion"
+  },
   "show-tooltip": true
 }

--- a/src/datagen/generated/minecolonies/data/minecolonies/crafterrecipes/baker/bread.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/crafterrecipes/baker/bread.json
@@ -3,9 +3,11 @@
   "crafter": "baker_smelting",
   "inputs": [
     {
-      "item": "minecolonies:bread_dough"
+      "id": "minecolonies:bread_dough"
     }
   ],
   "intermediate": "minecraft:furnace",
-  "result": "minecraft:bread"
+  "result": {
+    "id": "minecraft:bread"
+  }
 }

--- a/src/datagen/generated/minecolonies/data/minecolonies/crafterrecipes/baker/bread_dough.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/crafterrecipes/baker/bread_dough.json
@@ -4,11 +4,13 @@
   "inputs": [
     {
       "count": 3,
-      "item": "minecraft:wheat"
+      "id": "minecraft:wheat"
     }
   ],
   "intermediate": "minecraft:air",
   "max-building-level": 2,
-  "result": "minecolonies:bread_dough",
+  "result": {
+    "id": "minecolonies:bread_dough"
+  },
   "show-tooltip": true
 }

--- a/src/datagen/generated/minecolonies/data/minecolonies/crafterrecipes/baker/bread_dough3.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/crafterrecipes/baker/bread_dough3.json
@@ -1,18 +1,20 @@
 {
   "type": "recipe",
-  "count": 2,
   "crafter": "baker_crafting",
   "inputs": [
     {
-      "item": "minecraft:wheat"
+      "id": "minecraft:wheat"
     },
     {
-      "item": "minecolonies:large_water_bottle"
+      "id": "minecolonies:large_water_bottle"
     }
   ],
   "intermediate": "minecraft:air",
   "loot-table": "minecolonies:recipes/large_bottle",
   "min-building-level": 3,
-  "result": "minecolonies:bread_dough",
+  "result": {
+    "count": 2,
+    "id": "minecolonies:bread_dough"
+  },
   "show-tooltip": true
 }

--- a/src/datagen/generated/minecolonies/data/minecolonies/crafterrecipes/baker/cake.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/crafterrecipes/baker/cake.json
@@ -3,10 +3,12 @@
   "crafter": "baker_smelting",
   "inputs": [
     {
-      "item": "minecolonies:cake_batter"
+      "id": "minecolonies:cake_batter"
     }
   ],
   "intermediate": "minecraft:furnace",
   "min-building-level": 4,
-  "result": "minecraft:cake"
+  "result": {
+    "id": "minecraft:cake"
+  }
 }

--- a/src/datagen/generated/minecolonies/data/minecolonies/crafterrecipes/baker/cake_batter.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/crafterrecipes/baker/cake_batter.json
@@ -4,22 +4,24 @@
   "inputs": [
     {
       "count": 3,
-      "item": "minecraft:wheat"
+      "id": "minecraft:wheat"
     },
     {
       "count": 3,
-      "item": "minecolonies:large_milk_bottle"
+      "id": "minecolonies:large_milk_bottle"
     },
     {
       "count": 2,
-      "item": "minecraft:sugar"
+      "id": "minecraft:sugar"
     },
     {
-      "item": "minecraft:egg"
+      "id": "minecraft:egg"
     }
   ],
   "intermediate": "minecraft:air",
   "min-building-level": 4,
-  "result": "minecolonies:cake_batter",
+  "result": {
+    "id": "minecolonies:cake_batter"
+  },
   "show-tooltip": true
 }

--- a/src/datagen/generated/minecolonies/data/minecolonies/crafterrecipes/baker/chorus_bread.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/crafterrecipes/baker/chorus_bread.json
@@ -1,18 +1,20 @@
 {
   "type": "recipe",
-  "count": 4,
   "crafter": "baker_crafting",
   "inputs": [
     {
       "count": 8,
-      "item": "minecraft:wheat"
+      "id": "minecraft:wheat"
     },
     {
-      "item": "minecraft:chorus_fruit"
+      "id": "minecraft:chorus_fruit"
     }
   ],
   "intermediate": "minecraft:air",
   "research-id": "minecolonies:effects/knowledgeoftheendunlock",
-  "result": "minecolonies:chorus_bread",
+  "result": {
+    "count": 4,
+    "id": "minecolonies:chorus_bread"
+  },
   "show-tooltip": true
 }

--- a/src/datagen/generated/minecolonies/data/minecolonies/crafterrecipes/baker/cookie.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/crafterrecipes/baker/cookie.json
@@ -3,10 +3,12 @@
   "crafter": "baker_smelting",
   "inputs": [
     {
-      "item": "minecolonies:cookie_dough"
+      "id": "minecolonies:cookie_dough"
     }
   ],
   "intermediate": "minecraft:furnace",
   "min-building-level": 2,
-  "result": "minecraft:cookie"
+  "result": {
+    "id": "minecraft:cookie"
+  }
 }

--- a/src/datagen/generated/minecolonies/data/minecolonies/crafterrecipes/baker/cookie_dough.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/crafterrecipes/baker/cookie_dough.json
@@ -1,19 +1,21 @@
 {
   "type": "recipe",
-  "count": 8,
   "crafter": "baker_crafting",
   "inputs": [
     {
       "count": 2,
-      "item": "minecraft:wheat"
+      "id": "minecraft:wheat"
     },
     {
       "count": 2,
-      "item": "minecraft:cocoa_beans"
+      "id": "minecraft:cocoa_beans"
     }
   ],
   "intermediate": "minecraft:air",
   "min-building-level": 2,
-  "result": "minecolonies:cookie_dough",
+  "result": {
+    "count": 8,
+    "id": "minecolonies:cookie_dough"
+  },
   "show-tooltip": true
 }

--- a/src/datagen/generated/minecolonies/data/minecolonies/crafterrecipes/baker/flatbread.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/crafterrecipes/baker/flatbread.json
@@ -3,16 +3,18 @@
   "crafter": "baker_crafting",
   "inputs": [
     {
-      "item": "minecolonies:durum"
+      "id": "minecolonies:durum"
     },
     {
-      "item": "minecolonies:durum"
+      "id": "minecolonies:durum"
     },
     {
-      "item": "minecolonies:large_water_bottle"
+      "id": "minecolonies:large_water_bottle"
     }
   ],
   "intermediate": "minecraft:air",
   "min-building-level": 1,
-  "result": "minecolonies:flatbread"
+  "result": {
+    "id": "minecolonies:flatbread"
+  }
 }

--- a/src/datagen/generated/minecolonies/data/minecolonies/crafterrecipes/baker/golden_bread.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/crafterrecipes/baker/golden_bread.json
@@ -1,18 +1,20 @@
 {
   "type": "recipe",
-  "count": 4,
   "crafter": "baker_crafting",
   "inputs": [
     {
       "count": 8,
-      "item": "minecraft:wheat"
+      "id": "minecraft:wheat"
     },
     {
-      "item": "minecraft:gold_ingot"
+      "id": "minecraft:gold_ingot"
     }
   ],
   "intermediate": "minecraft:air",
   "min-building-level": 5,
-  "result": "minecolonies:golden_bread",
+  "result": {
+    "count": 4,
+    "id": "minecolonies:golden_bread"
+  },
   "show-tooltip": true
 }

--- a/src/datagen/generated/minecolonies/data/minecolonies/crafterrecipes/baker/lembas_scone.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/crafterrecipes/baker/lembas_scone.json
@@ -3,16 +3,18 @@
   "crafter": "baker_crafting",
   "inputs": [
     {
-      "item": "minecolonies:durum"
+      "id": "minecolonies:durum"
     },
     {
-      "item": "minecolonies:butter"
+      "id": "minecolonies:butter"
     },
     {
-      "item": "minecraft:honey_bottle"
+      "id": "minecraft:honey_bottle"
     }
   ],
   "intermediate": "minecraft:air",
   "min-building-level": 1,
-  "result": "minecolonies:lembas_scone"
+  "result": {
+    "id": "minecolonies:lembas_scone"
+  }
 }

--- a/src/datagen/generated/minecolonies/data/minecolonies/crafterrecipes/baker/manchet.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/crafterrecipes/baker/manchet.json
@@ -3,10 +3,12 @@
   "crafter": "baker_smelting",
   "inputs": [
     {
-      "item": "minecolonies:manchet_dough"
+      "id": "minecolonies:manchet_dough"
     }
   ],
   "intermediate": "minecraft:furnace",
   "min-building-level": 1,
-  "result": "minecolonies:manchet_bread"
+  "result": {
+    "id": "minecolonies:manchet_bread"
+  }
 }

--- a/src/datagen/generated/minecolonies/data/minecolonies/crafterrecipes/baker/manchet_dough.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/crafterrecipes/baker/manchet_dough.json
@@ -1,19 +1,21 @@
 {
   "type": "recipe",
-  "count": 2,
   "crafter": "baker_crafting",
   "inputs": [
     {
-      "item": "minecolonies:durum"
+      "id": "minecolonies:durum"
     },
     {
-      "item": "minecolonies:durum"
+      "id": "minecolonies:durum"
     },
     {
-      "item": "minecolonies:butter"
+      "id": "minecolonies:butter"
     }
   ],
   "intermediate": "minecraft:air",
   "min-building-level": 1,
-  "result": "minecolonies:manchet_dough"
+  "result": {
+    "count": 2,
+    "id": "minecolonies:manchet_dough"
+  }
 }

--- a/src/datagen/generated/minecolonies/data/minecolonies/crafterrecipes/baker/milky_bread.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/crafterrecipes/baker/milky_bread.json
@@ -1,18 +1,20 @@
 {
   "type": "recipe",
-  "count": 4,
   "crafter": "baker_crafting",
   "inputs": [
     {
       "count": 8,
-      "item": "minecraft:wheat"
+      "id": "minecraft:wheat"
     },
     {
-      "item": "minecolonies:large_milk_bottle"
+      "id": "minecolonies:large_milk_bottle"
     }
   ],
   "intermediate": "minecraft:air",
   "min-building-level": 4,
-  "result": "minecolonies:milky_bread",
+  "result": {
+    "count": 4,
+    "id": "minecolonies:milky_bread"
+  },
   "show-tooltip": true
 }

--- a/src/datagen/generated/minecolonies/data/minecolonies/crafterrecipes/baker/muffin.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/crafterrecipes/baker/muffin.json
@@ -3,10 +3,12 @@
   "crafter": "baker_smelting",
   "inputs": [
     {
-      "item": "minecolonies:muffin_dough"
+      "id": "minecolonies:muffin_dough"
     }
   ],
   "intermediate": "minecraft:furnace",
   "min-building-level": 1,
-  "result": "minecolonies:muffin"
+  "result": {
+    "id": "minecolonies:muffin"
+  }
 }

--- a/src/datagen/generated/minecolonies/data/minecolonies/crafterrecipes/baker/muffin_dough.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/crafterrecipes/baker/muffin_dough.json
@@ -1,25 +1,27 @@
 {
   "type": "recipe",
-  "count": 2,
   "crafter": "baker_crafting",
   "inputs": [
     {
-      "item": "minecolonies:durum"
+      "id": "minecolonies:durum"
     },
     {
-      "item": "minecolonies:durum"
+      "id": "minecolonies:durum"
     },
     {
-      "item": "minecolonies:butter"
+      "id": "minecolonies:butter"
     },
     {
-      "item": "minecraft:sugar"
+      "id": "minecraft:sugar"
     },
     {
-      "item": "minecraft:sweet_berries"
+      "id": "minecraft:sweet_berries"
     }
   ],
   "intermediate": "minecraft:air",
   "min-building-level": 1,
-  "result": "minecolonies:muffin_dough"
+  "result": {
+    "count": 2,
+    "id": "minecolonies:muffin_dough"
+  }
 }

--- a/src/datagen/generated/minecolonies/data/minecolonies/crafterrecipes/baker/pumpkin_pie.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/crafterrecipes/baker/pumpkin_pie.json
@@ -3,10 +3,12 @@
   "crafter": "baker_smelting",
   "inputs": [
     {
-      "item": "minecolonies:raw_pumpkin_pie"
+      "id": "minecolonies:raw_pumpkin_pie"
     }
   ],
   "intermediate": "minecraft:furnace",
   "min-building-level": 3,
-  "result": "minecraft:pumpkin_pie"
+  "result": {
+    "id": "minecraft:pumpkin_pie"
+  }
 }

--- a/src/datagen/generated/minecolonies/data/minecolonies/crafterrecipes/baker/raw_pumpkin_pie.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/crafterrecipes/baker/raw_pumpkin_pie.json
@@ -3,17 +3,19 @@
   "crafter": "baker_crafting",
   "inputs": [
     {
-      "item": "minecraft:pumpkin"
+      "id": "minecraft:pumpkin"
     },
     {
-      "item": "minecraft:sugar"
+      "id": "minecraft:sugar"
     },
     {
-      "item": "minecraft:egg"
+      "id": "minecraft:egg"
     }
   ],
   "intermediate": "minecraft:air",
   "min-building-level": 3,
-  "result": "minecolonies:raw_pumpkin_pie",
+  "result": {
+    "id": "minecolonies:raw_pumpkin_pie"
+  },
   "show-tooltip": true
 }

--- a/src/datagen/generated/minecolonies/data/minecolonies/crafterrecipes/baker/scake_batter.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/crafterrecipes/baker/scake_batter.json
@@ -4,22 +4,24 @@
   "inputs": [
     {
       "count": 3,
-      "item": "minecraft:wheat"
+      "id": "minecraft:wheat"
     },
     {
       "count": 3,
-      "item": "minecolonies:large_soy_milk_bottle"
+      "id": "minecolonies:large_soy_milk_bottle"
     },
     {
       "count": 2,
-      "item": "minecraft:sugar"
+      "id": "minecraft:sugar"
     },
     {
-      "item": "minecraft:egg"
+      "id": "minecraft:egg"
     }
   ],
   "intermediate": "minecraft:air",
   "min-building-level": 4,
-  "result": "minecolonies:cake_batter",
+  "result": {
+    "id": "minecolonies:cake_batter"
+  },
   "show-tooltip": true
 }

--- a/src/datagen/generated/minecolonies/data/minecolonies/crafterrecipes/baker/smilky_bread.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/crafterrecipes/baker/smilky_bread.json
@@ -1,18 +1,20 @@
 {
   "type": "recipe",
-  "count": 4,
   "crafter": "baker_crafting",
   "inputs": [
     {
       "count": 8,
-      "item": "minecraft:wheat"
+      "id": "minecraft:wheat"
     },
     {
-      "item": "minecolonies:large_soy_milk_bottle"
+      "id": "minecolonies:large_soy_milk_bottle"
     }
   ],
   "intermediate": "minecraft:air",
   "min-building-level": 4,
-  "result": "minecolonies:milky_bread",
+  "result": {
+    "count": 4,
+    "id": "minecolonies:milky_bread"
+  },
   "show-tooltip": true
 }

--- a/src/datagen/generated/minecolonies/data/minecolonies/crafterrecipes/baker/sugary_bread.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/crafterrecipes/baker/sugary_bread.json
@@ -1,18 +1,20 @@
 {
   "type": "recipe",
-  "count": 4,
   "crafter": "baker_crafting",
   "inputs": [
     {
       "count": 8,
-      "item": "minecraft:wheat"
+      "id": "minecraft:wheat"
     },
     {
-      "item": "minecraft:honey_bottle"
+      "id": "minecraft:honey_bottle"
     }
   ],
   "intermediate": "minecraft:air",
   "min-building-level": 3,
-  "result": "minecolonies:sugary_bread",
+  "result": {
+    "count": 4,
+    "id": "minecolonies:sugary_bread"
+  },
   "show-tooltip": true
 }

--- a/src/datagen/generated/minecolonies/data/minecolonies/crafterrecipes/baker/water_bottle.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/crafterrecipes/baker/water_bottle.json
@@ -3,10 +3,17 @@
   "crafter": "baker_crafting",
   "inputs": [
     {
-      "item": "minecraft:glass_bottle"
+      "id": "minecraft:glass_bottle"
     }
   ],
   "intermediate": "minecraft:air",
   "min-building-level": 3,
-  "result": "minecraft:potion{\"minecraft:potion_contents\":{\"potion\":\"minecraft:water\"}}"
+  "result": {
+    "components": {
+      "minecraft:potion_contents": {
+        "potion": "minecraft:water"
+      }
+    },
+    "id": "minecraft:potion"
+  }
 }

--- a/src/datagen/generated/minecolonies/data/minecolonies/crafterrecipes/baker/water_jug.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/crafterrecipes/baker/water_jug.json
@@ -3,9 +3,11 @@
   "crafter": "baker_crafting",
   "inputs": [
     {
-      "item": "minecolonies:large_empty_bottle"
+      "id": "minecolonies:large_empty_bottle"
     }
   ],
   "intermediate": "minecraft:air",
-  "result": "minecolonies:large_water_bottle"
+  "result": {
+    "id": "minecolonies:large_water_bottle"
+  }
 }

--- a/src/datagen/generated/minecolonies/data/minecolonies/crafterrecipes/blacksmith/netherite_axe.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/crafterrecipes/blacksmith/netherite_axe.json
@@ -2,29 +2,31 @@
   "type": "recipe",
   "additional-output": [
     {
-      "item": "minecraft:netherite_upgrade_smithing_template"
+      "id": "minecraft:netherite_upgrade_smithing_template"
     }
   ],
   "crafter": "blacksmith_crafting",
   "inputs": [
     {
-      "item": "minecraft:diamond_axe"
+      "id": "minecraft:diamond_axe"
     },
     {
-      "item": "minecraft:netherite_upgrade_smithing_template"
+      "id": "minecraft:netherite_upgrade_smithing_template"
     },
     {
-      "item": "minecraft:netherite_ingot"
+      "id": "minecraft:netherite_ingot"
     },
     {
       "count": 7,
-      "item": "minecraft:diamond"
+      "id": "minecraft:diamond"
     },
     {
-      "item": "minecraft:netherrack"
+      "id": "minecraft:netherrack"
     }
   ],
   "intermediate": "minecraft:air",
   "min-building-level": 4,
-  "result": "minecraft:netherite_axe"
+  "result": {
+    "id": "minecraft:netherite_axe"
+  }
 }

--- a/src/datagen/generated/minecolonies/data/minecolonies/crafterrecipes/blacksmith/netherite_boots.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/crafterrecipes/blacksmith/netherite_boots.json
@@ -2,29 +2,31 @@
   "type": "recipe",
   "additional-output": [
     {
-      "item": "minecraft:netherite_upgrade_smithing_template"
+      "id": "minecraft:netherite_upgrade_smithing_template"
     }
   ],
   "crafter": "blacksmith_crafting",
   "inputs": [
     {
-      "item": "minecraft:diamond_boots"
+      "id": "minecraft:diamond_boots"
     },
     {
-      "item": "minecraft:netherite_upgrade_smithing_template"
+      "id": "minecraft:netherite_upgrade_smithing_template"
     },
     {
-      "item": "minecraft:netherite_ingot"
+      "id": "minecraft:netherite_ingot"
     },
     {
       "count": 7,
-      "item": "minecraft:diamond"
+      "id": "minecraft:diamond"
     },
     {
-      "item": "minecraft:netherrack"
+      "id": "minecraft:netherrack"
     }
   ],
   "intermediate": "minecraft:air",
   "min-building-level": 4,
-  "result": "minecraft:netherite_boots"
+  "result": {
+    "id": "minecraft:netherite_boots"
+  }
 }

--- a/src/datagen/generated/minecolonies/data/minecolonies/crafterrecipes/blacksmith/netherite_chestplate.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/crafterrecipes/blacksmith/netherite_chestplate.json
@@ -2,29 +2,31 @@
   "type": "recipe",
   "additional-output": [
     {
-      "item": "minecraft:netherite_upgrade_smithing_template"
+      "id": "minecraft:netherite_upgrade_smithing_template"
     }
   ],
   "crafter": "blacksmith_crafting",
   "inputs": [
     {
-      "item": "minecraft:diamond_chestplate"
+      "id": "minecraft:diamond_chestplate"
     },
     {
-      "item": "minecraft:netherite_upgrade_smithing_template"
+      "id": "minecraft:netherite_upgrade_smithing_template"
     },
     {
-      "item": "minecraft:netherite_ingot"
+      "id": "minecraft:netherite_ingot"
     },
     {
       "count": 7,
-      "item": "minecraft:diamond"
+      "id": "minecraft:diamond"
     },
     {
-      "item": "minecraft:netherrack"
+      "id": "minecraft:netherrack"
     }
   ],
   "intermediate": "minecraft:air",
   "min-building-level": 4,
-  "result": "minecraft:netherite_chestplate"
+  "result": {
+    "id": "minecraft:netherite_chestplate"
+  }
 }

--- a/src/datagen/generated/minecolonies/data/minecolonies/crafterrecipes/blacksmith/netherite_helmet.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/crafterrecipes/blacksmith/netherite_helmet.json
@@ -2,29 +2,31 @@
   "type": "recipe",
   "additional-output": [
     {
-      "item": "minecraft:netherite_upgrade_smithing_template"
+      "id": "minecraft:netherite_upgrade_smithing_template"
     }
   ],
   "crafter": "blacksmith_crafting",
   "inputs": [
     {
-      "item": "minecraft:diamond_helmet"
+      "id": "minecraft:diamond_helmet"
     },
     {
-      "item": "minecraft:netherite_upgrade_smithing_template"
+      "id": "minecraft:netherite_upgrade_smithing_template"
     },
     {
-      "item": "minecraft:netherite_ingot"
+      "id": "minecraft:netherite_ingot"
     },
     {
       "count": 7,
-      "item": "minecraft:diamond"
+      "id": "minecraft:diamond"
     },
     {
-      "item": "minecraft:netherrack"
+      "id": "minecraft:netherrack"
     }
   ],
   "intermediate": "minecraft:air",
   "min-building-level": 4,
-  "result": "minecraft:netherite_helmet"
+  "result": {
+    "id": "minecraft:netherite_helmet"
+  }
 }

--- a/src/datagen/generated/minecolonies/data/minecolonies/crafterrecipes/blacksmith/netherite_hoe.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/crafterrecipes/blacksmith/netherite_hoe.json
@@ -2,29 +2,31 @@
   "type": "recipe",
   "additional-output": [
     {
-      "item": "minecraft:netherite_upgrade_smithing_template"
+      "id": "minecraft:netherite_upgrade_smithing_template"
     }
   ],
   "crafter": "blacksmith_crafting",
   "inputs": [
     {
-      "item": "minecraft:diamond_hoe"
+      "id": "minecraft:diamond_hoe"
     },
     {
-      "item": "minecraft:netherite_upgrade_smithing_template"
+      "id": "minecraft:netherite_upgrade_smithing_template"
     },
     {
-      "item": "minecraft:netherite_ingot"
+      "id": "minecraft:netherite_ingot"
     },
     {
       "count": 7,
-      "item": "minecraft:diamond"
+      "id": "minecraft:diamond"
     },
     {
-      "item": "minecraft:netherrack"
+      "id": "minecraft:netherrack"
     }
   ],
   "intermediate": "minecraft:air",
   "min-building-level": 4,
-  "result": "minecraft:netherite_hoe"
+  "result": {
+    "id": "minecraft:netherite_hoe"
+  }
 }

--- a/src/datagen/generated/minecolonies/data/minecolonies/crafterrecipes/blacksmith/netherite_leggings.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/crafterrecipes/blacksmith/netherite_leggings.json
@@ -2,29 +2,31 @@
   "type": "recipe",
   "additional-output": [
     {
-      "item": "minecraft:netherite_upgrade_smithing_template"
+      "id": "minecraft:netherite_upgrade_smithing_template"
     }
   ],
   "crafter": "blacksmith_crafting",
   "inputs": [
     {
-      "item": "minecraft:diamond_leggings"
+      "id": "minecraft:diamond_leggings"
     },
     {
-      "item": "minecraft:netherite_upgrade_smithing_template"
+      "id": "minecraft:netherite_upgrade_smithing_template"
     },
     {
-      "item": "minecraft:netherite_ingot"
+      "id": "minecraft:netherite_ingot"
     },
     {
       "count": 7,
-      "item": "minecraft:diamond"
+      "id": "minecraft:diamond"
     },
     {
-      "item": "minecraft:netherrack"
+      "id": "minecraft:netherrack"
     }
   ],
   "intermediate": "minecraft:air",
   "min-building-level": 4,
-  "result": "minecraft:netherite_leggings"
+  "result": {
+    "id": "minecraft:netherite_leggings"
+  }
 }

--- a/src/datagen/generated/minecolonies/data/minecolonies/crafterrecipes/blacksmith/netherite_pickaxe.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/crafterrecipes/blacksmith/netherite_pickaxe.json
@@ -2,29 +2,31 @@
   "type": "recipe",
   "additional-output": [
     {
-      "item": "minecraft:netherite_upgrade_smithing_template"
+      "id": "minecraft:netherite_upgrade_smithing_template"
     }
   ],
   "crafter": "blacksmith_crafting",
   "inputs": [
     {
-      "item": "minecraft:diamond_pickaxe"
+      "id": "minecraft:diamond_pickaxe"
     },
     {
-      "item": "minecraft:netherite_upgrade_smithing_template"
+      "id": "minecraft:netherite_upgrade_smithing_template"
     },
     {
-      "item": "minecraft:netherite_ingot"
+      "id": "minecraft:netherite_ingot"
     },
     {
       "count": 7,
-      "item": "minecraft:diamond"
+      "id": "minecraft:diamond"
     },
     {
-      "item": "minecraft:netherrack"
+      "id": "minecraft:netherrack"
     }
   ],
   "intermediate": "minecraft:air",
   "min-building-level": 4,
-  "result": "minecraft:netherite_pickaxe"
+  "result": {
+    "id": "minecraft:netherite_pickaxe"
+  }
 }

--- a/src/datagen/generated/minecolonies/data/minecolonies/crafterrecipes/blacksmith/netherite_shovel.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/crafterrecipes/blacksmith/netherite_shovel.json
@@ -2,29 +2,31 @@
   "type": "recipe",
   "additional-output": [
     {
-      "item": "minecraft:netherite_upgrade_smithing_template"
+      "id": "minecraft:netherite_upgrade_smithing_template"
     }
   ],
   "crafter": "blacksmith_crafting",
   "inputs": [
     {
-      "item": "minecraft:diamond_shovel"
+      "id": "minecraft:diamond_shovel"
     },
     {
-      "item": "minecraft:netherite_upgrade_smithing_template"
+      "id": "minecraft:netherite_upgrade_smithing_template"
     },
     {
-      "item": "minecraft:netherite_ingot"
+      "id": "minecraft:netherite_ingot"
     },
     {
       "count": 7,
-      "item": "minecraft:diamond"
+      "id": "minecraft:diamond"
     },
     {
-      "item": "minecraft:netherrack"
+      "id": "minecraft:netherrack"
     }
   ],
   "intermediate": "minecraft:air",
   "min-building-level": 4,
-  "result": "minecraft:netherite_shovel"
+  "result": {
+    "id": "minecraft:netherite_shovel"
+  }
 }

--- a/src/datagen/generated/minecolonies/data/minecolonies/crafterrecipes/blacksmith/netherite_sword.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/crafterrecipes/blacksmith/netherite_sword.json
@@ -2,29 +2,31 @@
   "type": "recipe",
   "additional-output": [
     {
-      "item": "minecraft:netherite_upgrade_smithing_template"
+      "id": "minecraft:netherite_upgrade_smithing_template"
     }
   ],
   "crafter": "blacksmith_crafting",
   "inputs": [
     {
-      "item": "minecraft:diamond_sword"
+      "id": "minecraft:diamond_sword"
     },
     {
-      "item": "minecraft:netherite_upgrade_smithing_template"
+      "id": "minecraft:netherite_upgrade_smithing_template"
     },
     {
-      "item": "minecraft:netherite_ingot"
+      "id": "minecraft:netherite_ingot"
     },
     {
       "count": 7,
-      "item": "minecraft:diamond"
+      "id": "minecraft:diamond"
     },
     {
-      "item": "minecraft:netherrack"
+      "id": "minecraft:netherrack"
     }
   ],
   "intermediate": "minecraft:air",
   "min-building-level": 4,
-  "result": "minecraft:netherite_sword"
+  "result": {
+    "id": "minecraft:netherite_sword"
+  }
 }

--- a/src/datagen/generated/minecolonies/data/minecolonies/crafterrecipes/blacksmith/plate_armor_boots.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/crafterrecipes/blacksmith/plate_armor_boots.json
@@ -4,18 +4,20 @@
   "inputs": [
     {
       "count": 3,
-      "item": "minecraft:iron_ingot"
+      "id": "minecraft:iron_ingot"
     },
     {
-      "item": "minecraft:leather"
+      "id": "minecraft:leather"
     },
     {
-      "item": "minecraft:coal"
+      "id": "minecraft:coal"
     }
   ],
   "intermediate": "minecraft:air",
   "min-building-level": 4,
   "research-id": "minecolonies:effects/platearmorunlock",
-  "result": "minecolonies:plate_armor_boots",
+  "result": {
+    "id": "minecolonies:plate_armor_boots"
+  },
   "show-tooltip": true
 }

--- a/src/datagen/generated/minecolonies/data/minecolonies/crafterrecipes/blacksmith/plate_armor_chest.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/crafterrecipes/blacksmith/plate_armor_chest.json
@@ -4,19 +4,21 @@
   "inputs": [
     {
       "count": 7,
-      "item": "minecraft:iron_ingot"
+      "id": "minecraft:iron_ingot"
     },
     {
-      "item": "minecraft:leather"
+      "id": "minecraft:leather"
     },
     {
       "count": 3,
-      "item": "minecraft:coal"
+      "id": "minecraft:coal"
     }
   ],
   "intermediate": "minecraft:air",
   "min-building-level": 4,
   "research-id": "minecolonies:effects/platearmorunlock",
-  "result": "minecolonies:plate_armor_chest",
+  "result": {
+    "id": "minecolonies:plate_armor_chest"
+  },
   "show-tooltip": true
 }

--- a/src/datagen/generated/minecolonies/data/minecolonies/crafterrecipes/blacksmith/plate_armor_helmet.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/crafterrecipes/blacksmith/plate_armor_helmet.json
@@ -4,18 +4,20 @@
   "inputs": [
     {
       "count": 4,
-      "item": "minecraft:iron_ingot"
+      "id": "minecraft:iron_ingot"
     },
     {
-      "item": "minecraft:leather"
+      "id": "minecraft:leather"
     },
     {
-      "item": "minecraft:coal"
+      "id": "minecraft:coal"
     }
   ],
   "intermediate": "minecraft:air",
   "min-building-level": 4,
   "research-id": "minecolonies:effects/platearmorunlock",
-  "result": "minecolonies:plate_armor_helmet",
+  "result": {
+    "id": "minecolonies:plate_armor_helmet"
+  },
   "show-tooltip": true
 }

--- a/src/datagen/generated/minecolonies/data/minecolonies/crafterrecipes/blacksmith/plate_armor_legs.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/crafterrecipes/blacksmith/plate_armor_legs.json
@@ -4,19 +4,21 @@
   "inputs": [
     {
       "count": 6,
-      "item": "minecraft:iron_ingot"
+      "id": "minecraft:iron_ingot"
     },
     {
-      "item": "minecraft:leather"
+      "id": "minecraft:leather"
     },
     {
       "count": 4,
-      "item": "minecraft:coal"
+      "id": "minecraft:coal"
     }
   ],
   "intermediate": "minecraft:air",
   "min-building-level": 4,
   "research-id": "minecolonies:effects/platearmorunlock",
-  "result": "minecolonies:plate_armor_legs",
+  "result": {
+    "id": "minecolonies:plate_armor_legs"
+  },
   "show-tooltip": true
 }

--- a/src/datagen/generated/minecolonies/data/minecolonies/crafterrecipes/blacksmith/sifter_mesh_iron.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/crafterrecipes/blacksmith/sifter_mesh_iron.json
@@ -3,11 +3,13 @@
   "crafter": "blacksmith_crafting",
   "inputs": [
     {
-      "item": "minecraft:iron_ingot"
+      "id": "minecraft:iron_ingot"
     }
   ],
   "intermediate": "minecraft:air",
   "research-id": "minecolonies:effects/sifterironunlock",
-  "result": "minecolonies:sifter_mesh_iron",
+  "result": {
+    "id": "minecolonies:sifter_mesh_iron"
+  },
   "show-tooltip": true
 }

--- a/src/datagen/generated/minecolonies/data/minecolonies/crafterrecipes/chef/butter.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/crafterrecipes/chef/butter.json
@@ -2,16 +2,18 @@
   "type": "recipe",
   "additional-output": [
     {
-      "item": "minecolonies:large_empty_bottle"
+      "id": "minecolonies:large_empty_bottle"
     }
   ],
   "crafter": "chef_crafting",
   "inputs": [
     {
-      "item": "minecolonies:large_milk_bottle"
+      "id": "minecolonies:large_milk_bottle"
     }
   ],
   "intermediate": "minecraft:air",
   "min-building-level": 1,
-  "result": "minecolonies:butter"
+  "result": {
+    "id": "minecolonies:butter"
+  }
 }

--- a/src/datagen/generated/minecolonies/data/minecolonies/crafterrecipes/chef/cabochis.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/crafterrecipes/chef/cabochis.json
@@ -3,19 +3,21 @@
   "crafter": "chef_crafting",
   "inputs": [
     {
-      "item": "minecolonies:onion"
+      "id": "minecolonies:onion"
     },
     {
-      "item": "minecolonies:cabbage"
+      "id": "minecolonies:cabbage"
     },
     {
-      "item": "minecraft:bowl"
+      "id": "minecraft:bowl"
     },
     {
-      "item": "minecolonies:manchet_bread"
+      "id": "minecolonies:manchet_bread"
     }
   ],
   "intermediate": "minecraft:air",
   "min-building-level": 1,
-  "result": "minecolonies:cabochis"
+  "result": {
+    "id": "minecolonies:cabochis"
+  }
 }

--- a/src/datagen/generated/minecolonies/data/minecolonies/crafterrecipes/chef/cheddar_cheese.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/crafterrecipes/chef/cheddar_cheese.json
@@ -2,16 +2,18 @@
   "type": "recipe",
   "additional-output": [
     {
-      "item": "minecolonies:large_empty_bottle"
+      "id": "minecolonies:large_empty_bottle"
     }
   ],
   "crafter": "chef_crafting",
   "inputs": [
     {
-      "item": "minecolonies:large_milk_bottle"
+      "id": "minecolonies:large_milk_bottle"
     }
   ],
   "intermediate": "minecraft:air",
   "min-building-level": 1,
-  "result": "minecolonies:cheddar_cheese"
+  "result": {
+    "id": "minecolonies:cheddar_cheese"
+  }
 }

--- a/src/datagen/generated/minecolonies/data/minecolonies/crafterrecipes/chef/congee.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/crafterrecipes/chef/congee.json
@@ -3,19 +3,21 @@
   "crafter": "chef_crafting",
   "inputs": [
     {
-      "item": "minecolonies:cooked_rice"
+      "id": "minecolonies:cooked_rice"
     },
     {
-      "item": "minecolonies:garlic"
+      "id": "minecolonies:garlic"
     },
     {
-      "item": "minecraft:bowl"
+      "id": "minecraft:bowl"
     },
     {
-      "item": "minecolonies:cabbage"
+      "id": "minecolonies:cabbage"
     }
   ],
   "intermediate": "minecraft:air",
   "min-building-level": 1,
-  "result": "minecolonies:congee"
+  "result": {
+    "id": "minecolonies:congee"
+  }
 }

--- a/src/datagen/generated/minecolonies/data/minecolonies/crafterrecipes/chef/cooked_rice.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/crafterrecipes/chef/cooked_rice.json
@@ -3,13 +3,15 @@
   "crafter": "chef_crafting",
   "inputs": [
     {
-      "item": "minecolonies:rice"
+      "id": "minecolonies:rice"
     },
     {
-      "item": "minecraft:bowl"
+      "id": "minecraft:bowl"
     }
   ],
   "intermediate": "minecraft:air",
   "min-building-level": 1,
-  "result": "minecolonies:cooked_rice"
+  "result": {
+    "id": "minecolonies:cooked_rice"
+  }
 }

--- a/src/datagen/generated/minecolonies/data/minecolonies/crafterrecipes/chef/eggplant_dolma.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/crafterrecipes/chef/eggplant_dolma.json
@@ -3,25 +3,27 @@
   "crafter": "chef_crafting",
   "inputs": [
     {
-      "item": "minecolonies:eggplant"
+      "id": "minecolonies:eggplant"
     },
     {
-      "item": "minecolonies:feta_cheese"
+      "id": "minecolonies:feta_cheese"
     },
     {
-      "item": "minecolonies:garlic"
+      "id": "minecolonies:garlic"
     },
     {
-      "item": "minecolonies:tomato"
+      "id": "minecolonies:tomato"
     },
     {
-      "item": "minecolonies:durum"
+      "id": "minecolonies:durum"
     },
     {
-      "item": "minecolonies:onion"
+      "id": "minecolonies:onion"
     }
   ],
   "intermediate": "minecraft:air",
   "min-building-level": 1,
-  "result": "minecolonies:eggplant_dolma"
+  "result": {
+    "id": "minecolonies:eggplant_dolma"
+  }
 }

--- a/src/datagen/generated/minecolonies/data/minecolonies/crafterrecipes/chef/feta_cheese.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/crafterrecipes/chef/feta_cheese.json
@@ -2,16 +2,18 @@
   "type": "recipe",
   "additional-output": [
     {
-      "item": "minecolonies:large_empty_bottle"
+      "id": "minecolonies:large_empty_bottle"
     }
   ],
   "crafter": "chef_crafting",
   "inputs": [
     {
-      "item": "minecolonies:large_milk_bottle"
+      "id": "minecolonies:large_milk_bottle"
     }
   ],
   "intermediate": "minecraft:air",
   "min-building-level": 1,
-  "result": "minecolonies:feta_cheese"
+  "result": {
+    "id": "minecolonies:feta_cheese"
+  }
 }

--- a/src/datagen/generated/minecolonies/data/minecolonies/crafterrecipes/chef/hand_pie.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/crafterrecipes/chef/hand_pie.json
@@ -3,22 +3,24 @@
   "crafter": "chef_crafting",
   "inputs": [
     {
-      "item": "minecolonies:durum"
+      "id": "minecolonies:durum"
     },
     {
-      "item": "minecolonies:garlic"
+      "id": "minecolonies:garlic"
     },
     {
-      "item": "minecraft:brown_mushroom"
+      "id": "minecraft:brown_mushroom"
     },
     {
-      "item": "minecolonies:onion"
+      "id": "minecolonies:onion"
     },
     {
-      "item": "minecraft:mutton"
+      "id": "minecraft:mutton"
     }
   ],
   "intermediate": "minecraft:air",
   "min-building-level": 1,
-  "result": "minecolonies:hand_pie"
+  "result": {
+    "id": "minecolonies:hand_pie"
+  }
 }

--- a/src/datagen/generated/minecolonies/data/minecolonies/crafterrecipes/chef/lamb_stew.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/crafterrecipes/chef/lamb_stew.json
@@ -3,34 +3,36 @@
   "crafter": "chef_crafting",
   "inputs": [
     {
-      "item": "minecolonies:onion"
+      "id": "minecolonies:onion"
     },
     {
-      "item": "minecolonies:garlic"
+      "id": "minecolonies:garlic"
     },
     {
-      "item": "minecraft:carrot"
+      "id": "minecraft:carrot"
     },
     {
-      "item": "minecraft:potato"
+      "id": "minecraft:potato"
     },
     {
-      "item": "minecraft:carrot"
+      "id": "minecraft:carrot"
     },
     {
-      "item": "minecraft:potato"
+      "id": "minecraft:potato"
     },
     {
-      "item": "minecraft:brown_mushroom"
+      "id": "minecraft:brown_mushroom"
     },
     {
-      "item": "minecolonies:cabbage"
+      "id": "minecolonies:cabbage"
     },
     {
-      "item": "minecraft:mutton"
+      "id": "minecraft:mutton"
     }
   ],
   "intermediate": "minecraft:air",
   "min-building-level": 1,
-  "result": "minecolonies:lamb_stew"
+  "result": {
+    "id": "minecolonies:lamb_stew"
+  }
 }

--- a/src/datagen/generated/minecolonies/data/minecolonies/crafterrecipes/chef/pasta_plain.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/crafterrecipes/chef/pasta_plain.json
@@ -3,19 +3,21 @@
   "crafter": "chef_crafting",
   "inputs": [
     {
-      "item": "minecolonies:raw_noodle"
+      "id": "minecolonies:raw_noodle"
     },
     {
-      "item": "minecolonies:butter"
+      "id": "minecolonies:butter"
     },
     {
-      "item": "minecraft:bowl"
+      "id": "minecraft:bowl"
     },
     {
-      "item": "minecolonies:garlic"
+      "id": "minecolonies:garlic"
     }
   ],
   "intermediate": "minecraft:air",
   "min-building-level": 1,
-  "result": "minecolonies:pasta_plain"
+  "result": {
+    "id": "minecolonies:pasta_plain"
+  }
 }

--- a/src/datagen/generated/minecolonies/data/minecolonies/crafterrecipes/chef/pasta_tomato.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/crafterrecipes/chef/pasta_tomato.json
@@ -3,25 +3,27 @@
   "crafter": "chef_crafting",
   "inputs": [
     {
-      "item": "minecolonies:raw_noodle"
+      "id": "minecolonies:raw_noodle"
     },
     {
-      "item": "minecolonies:tomato"
+      "id": "minecolonies:tomato"
     },
     {
-      "item": "minecolonies:tomato"
+      "id": "minecolonies:tomato"
     },
     {
-      "item": "minecolonies:onion"
+      "id": "minecolonies:onion"
     },
     {
-      "item": "minecraft:bowl"
+      "id": "minecraft:bowl"
     },
     {
-      "item": "minecolonies:garlic"
+      "id": "minecolonies:garlic"
     }
   ],
   "intermediate": "minecraft:air",
   "min-building-level": 1,
-  "result": "minecolonies:pasta_tomato"
+  "result": {
+    "id": "minecolonies:pasta_tomato"
+  }
 }

--- a/src/datagen/generated/minecolonies/data/minecolonies/crafterrecipes/chef/pepper_hummus.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/crafterrecipes/chef/pepper_hummus.json
@@ -1,25 +1,27 @@
 {
   "type": "recipe",
-  "count": 2,
   "crafter": "chef_crafting",
   "inputs": [
     {
-      "item": "minecolonies:bell_pepper"
+      "id": "minecolonies:bell_pepper"
     },
     {
-      "item": "minecolonies:bell_pepper"
+      "id": "minecolonies:bell_pepper"
     },
     {
-      "item": "minecolonies:garlic"
+      "id": "minecolonies:garlic"
     },
     {
-      "item": "minecolonies:chickpea"
+      "id": "minecolonies:chickpea"
     },
     {
-      "item": "minecolonies:chickpea"
+      "id": "minecolonies:chickpea"
     }
   ],
   "intermediate": "minecraft:air",
   "min-building-level": 1,
-  "result": "minecolonies:pepper_hummus"
+  "result": {
+    "count": 2,
+    "id": "minecolonies:pepper_hummus"
+  }
 }

--- a/src/datagen/generated/minecolonies/data/minecolonies/crafterrecipes/chef/pita_hummus.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/crafterrecipes/chef/pita_hummus.json
@@ -3,25 +3,27 @@
   "crafter": "chef_crafting",
   "inputs": [
     {
-      "item": "minecolonies:flatbread"
+      "id": "minecolonies:flatbread"
     },
     {
-      "item": "minecolonies:chickpea"
+      "id": "minecolonies:chickpea"
     },
     {
-      "item": "minecolonies:chickpea"
+      "id": "minecolonies:chickpea"
     },
     {
-      "item": "minecolonies:eggplant"
+      "id": "minecolonies:eggplant"
     },
     {
-      "item": "minecolonies:onion"
+      "id": "minecolonies:onion"
     },
     {
-      "item": "minecolonies:garlic"
+      "id": "minecolonies:garlic"
     }
   ],
   "intermediate": "minecraft:air",
   "min-building-level": 1,
-  "result": "minecolonies:pita_hummus"
+  "result": {
+    "id": "minecolonies:pita_hummus"
+  }
 }

--- a/src/datagen/generated/minecolonies/data/minecolonies/crafterrecipes/chef/pottage.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/crafterrecipes/chef/pottage.json
@@ -3,25 +3,27 @@
   "crafter": "chef_crafting",
   "inputs": [
     {
-      "item": "minecolonies:durum"
+      "id": "minecolonies:durum"
     },
     {
-      "item": "minecolonies:onion"
+      "id": "minecolonies:onion"
     },
     {
-      "item": "minecraft:bowl"
+      "id": "minecraft:bowl"
     },
     {
-      "item": "minecraft:potato"
+      "id": "minecraft:potato"
     },
     {
-      "item": "minecraft:carrot"
+      "id": "minecraft:carrot"
     },
     {
-      "item": "minecolonies:garlic"
+      "id": "minecolonies:garlic"
     }
   ],
   "intermediate": "minecraft:air",
   "min-building-level": 1,
-  "result": "minecolonies:pottage"
+  "result": {
+    "id": "minecolonies:pottage"
+  }
 }

--- a/src/datagen/generated/minecolonies/data/minecolonies/crafterrecipes/chef/raw_noodle.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/crafterrecipes/chef/raw_noodle.json
@@ -3,10 +3,12 @@
   "crafter": "chef_crafting",
   "inputs": [
     {
-      "item": "minecolonies:durum"
+      "id": "minecolonies:durum"
     }
   ],
   "intermediate": "minecraft:air",
   "min-building-level": 1,
-  "result": "minecolonies:raw_noodle"
+  "result": {
+    "id": "minecolonies:raw_noodle"
+  }
 }

--- a/src/datagen/generated/minecolonies/data/minecolonies/crafterrecipes/chef/rice_ball.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/crafterrecipes/chef/rice_ball.json
@@ -1,19 +1,21 @@
 {
   "type": "recipe",
-  "count": 2,
   "crafter": "chef_crafting",
   "inputs": [
     {
-      "item": "minecolonies:tofu"
+      "id": "minecolonies:tofu"
     },
     {
-      "item": "minecraft:dried_kelp"
+      "id": "minecraft:dried_kelp"
     },
     {
-      "item": "minecolonies:cooked_rice"
+      "id": "minecolonies:cooked_rice"
     }
   ],
   "intermediate": "minecraft:air",
   "min-building-level": 1,
-  "result": "minecolonies:rice_ball"
+  "result": {
+    "count": 2,
+    "id": "minecolonies:rice_ball"
+  }
 }

--- a/src/datagen/generated/minecolonies/data/minecolonies/crafterrecipes/chef/soy_milk.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/crafterrecipes/chef/soy_milk.json
@@ -3,19 +3,21 @@
   "crafter": "chef_crafting",
   "inputs": [
     {
-      "item": "minecolonies:large_water_bottle"
+      "id": "minecolonies:large_water_bottle"
     },
     {
-      "item": "minecolonies:soybean"
+      "id": "minecolonies:soybean"
     },
     {
-      "item": "minecolonies:soybean"
+      "id": "minecolonies:soybean"
     },
     {
-      "item": "minecolonies:soybean"
+      "id": "minecolonies:soybean"
     }
   ],
   "intermediate": "minecraft:air",
   "min-building-level": 1,
-  "result": "minecolonies:large_soy_milk_bottle"
+  "result": {
+    "id": "minecolonies:large_soy_milk_bottle"
+  }
 }

--- a/src/datagen/generated/minecolonies/data/minecolonies/crafterrecipes/chef/stew_trencher.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/crafterrecipes/chef/stew_trencher.json
@@ -3,19 +3,21 @@
   "crafter": "chef_crafting",
   "inputs": [
     {
-      "item": "minecolonies:manchet_bread"
+      "id": "minecolonies:manchet_bread"
     },
     {
-      "item": "minecolonies:tomato"
+      "id": "minecolonies:tomato"
     },
     {
-      "item": "minecolonies:cabbage"
+      "id": "minecolonies:cabbage"
     },
     {
-      "item": "minecolonies:onion"
+      "id": "minecolonies:onion"
     }
   ],
   "intermediate": "minecraft:air",
   "min-building-level": 1,
-  "result": "minecolonies:stew_trencher"
+  "result": {
+    "id": "minecolonies:stew_trencher"
+  }
 }

--- a/src/datagen/generated/minecolonies/data/minecolonies/crafterrecipes/chef/stuffed_pepper.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/crafterrecipes/chef/stuffed_pepper.json
@@ -3,25 +3,27 @@
   "crafter": "chef_crafting",
   "inputs": [
     {
-      "item": "minecolonies:cooked_rice"
+      "id": "minecolonies:cooked_rice"
     },
     {
-      "item": "minecolonies:bell_pepper"
+      "id": "minecolonies:bell_pepper"
     },
     {
-      "item": "minecolonies:tomato"
+      "id": "minecolonies:tomato"
     },
     {
-      "item": "minecraft:carrot"
+      "id": "minecraft:carrot"
     },
     {
-      "item": "minecolonies:garlic"
+      "id": "minecolonies:garlic"
     },
     {
-      "item": "minecolonies:eggplant"
+      "id": "minecolonies:eggplant"
     }
   ],
   "intermediate": "minecraft:air",
   "min-building-level": 1,
-  "result": "minecolonies:stuffed_pepper"
+  "result": {
+    "id": "minecolonies:stuffed_pepper"
+  }
 }

--- a/src/datagen/generated/minecolonies/data/minecolonies/crafterrecipes/chef/stuffed_pita.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/crafterrecipes/chef/stuffed_pita.json
@@ -3,22 +3,24 @@
   "crafter": "chef_crafting",
   "inputs": [
     {
-      "item": "minecolonies:flatbread"
+      "id": "minecolonies:flatbread"
     },
     {
-      "item": "minecolonies:tomato"
+      "id": "minecolonies:tomato"
     },
     {
-      "item": "minecolonies:onion"
+      "id": "minecolonies:onion"
     },
     {
-      "item": "minecolonies:eggplant"
+      "id": "minecolonies:eggplant"
     },
     {
-      "item": "minecolonies:garlic"
+      "id": "minecolonies:garlic"
     }
   ],
   "intermediate": "minecraft:air",
   "min-building-level": 1,
-  "result": "minecolonies:stuffed_pita"
+  "result": {
+    "id": "minecolonies:stuffed_pita"
+  }
 }

--- a/src/datagen/generated/minecolonies/data/minecolonies/crafterrecipes/chef/sushi_roll.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/crafterrecipes/chef/sushi_roll.json
@@ -1,25 +1,27 @@
 {
   "type": "recipe",
-  "count": 2,
   "crafter": "chef_crafting",
   "inputs": [
     {
-      "item": "minecolonies:cooked_rice"
+      "id": "minecolonies:cooked_rice"
     },
     {
-      "item": "minecraft:salmon"
+      "id": "minecraft:salmon"
     },
     {
-      "item": "minecolonies:garlic"
+      "id": "minecolonies:garlic"
     },
     {
-      "item": "minecraft:dried_kelp"
+      "id": "minecraft:dried_kelp"
     },
     {
-      "item": "minecolonies:onion"
+      "id": "minecolonies:onion"
     }
   ],
   "intermediate": "minecraft:air",
   "min-building-level": 1,
-  "result": "minecolonies:sushi_roll"
+  "result": {
+    "count": 2,
+    "id": "minecolonies:sushi_roll"
+  }
 }

--- a/src/datagen/generated/minecolonies/data/minecolonies/crafterrecipes/chef/tofu.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/crafterrecipes/chef/tofu.json
@@ -3,13 +3,15 @@
   "crafter": "chef_crafting",
   "inputs": [
     {
-      "item": "minecolonies:soybean"
+      "id": "minecolonies:soybean"
     },
     {
-      "item": "minecolonies:soybean"
+      "id": "minecolonies:soybean"
     }
   ],
   "intermediate": "minecraft:air",
   "min-building-level": 1,
-  "result": "minecolonies:tofu"
+  "result": {
+    "id": "minecolonies:tofu"
+  }
 }

--- a/src/datagen/generated/minecolonies/data/minecolonies/crafterrecipes/concretemixer/black_concrete.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/crafterrecipes/concretemixer/black_concrete.json
@@ -3,9 +3,11 @@
   "crafter": "concretemixer_custom",
   "inputs": [
     {
-      "item": "minecraft:black_concrete_powder"
+      "id": "minecraft:black_concrete_powder"
     }
   ],
   "intermediate": "minecraft:air",
-  "result": "minecraft:black_concrete"
+  "result": {
+    "id": "minecraft:black_concrete"
+  }
 }

--- a/src/datagen/generated/minecolonies/data/minecolonies/crafterrecipes/concretemixer/black_concrete_powder.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/crafterrecipes/concretemixer/black_concrete_powder.json
@@ -1,20 +1,22 @@
 {
   "type": "recipe",
-  "count": 8,
   "crafter": "concretemixer_custom",
   "inputs": [
     {
       "count": 4,
-      "item": "minecraft:sand"
+      "id": "minecraft:sand"
     },
     {
       "count": 4,
-      "item": "minecraft:gravel"
+      "id": "minecraft:gravel"
     },
     {
-      "item": "minecraft:black_dye"
+      "id": "minecraft:black_dye"
     }
   ],
   "intermediate": "minecraft:air",
-  "result": "minecraft:black_concrete_powder"
+  "result": {
+    "count": 8,
+    "id": "minecraft:black_concrete_powder"
+  }
 }

--- a/src/datagen/generated/minecolonies/data/minecolonies/crafterrecipes/concretemixer/blue_concrete.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/crafterrecipes/concretemixer/blue_concrete.json
@@ -3,9 +3,11 @@
   "crafter": "concretemixer_custom",
   "inputs": [
     {
-      "item": "minecraft:blue_concrete_powder"
+      "id": "minecraft:blue_concrete_powder"
     }
   ],
   "intermediate": "minecraft:air",
-  "result": "minecraft:blue_concrete"
+  "result": {
+    "id": "minecraft:blue_concrete"
+  }
 }

--- a/src/datagen/generated/minecolonies/data/minecolonies/crafterrecipes/concretemixer/blue_concrete_powder.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/crafterrecipes/concretemixer/blue_concrete_powder.json
@@ -1,20 +1,22 @@
 {
   "type": "recipe",
-  "count": 8,
   "crafter": "concretemixer_custom",
   "inputs": [
     {
       "count": 4,
-      "item": "minecraft:sand"
+      "id": "minecraft:sand"
     },
     {
       "count": 4,
-      "item": "minecraft:gravel"
+      "id": "minecraft:gravel"
     },
     {
-      "item": "minecraft:blue_dye"
+      "id": "minecraft:blue_dye"
     }
   ],
   "intermediate": "minecraft:air",
-  "result": "minecraft:blue_concrete_powder"
+  "result": {
+    "count": 8,
+    "id": "minecraft:blue_concrete_powder"
+  }
 }

--- a/src/datagen/generated/minecolonies/data/minecolonies/crafterrecipes/concretemixer/brown_concrete.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/crafterrecipes/concretemixer/brown_concrete.json
@@ -3,9 +3,11 @@
   "crafter": "concretemixer_custom",
   "inputs": [
     {
-      "item": "minecraft:brown_concrete_powder"
+      "id": "minecraft:brown_concrete_powder"
     }
   ],
   "intermediate": "minecraft:air",
-  "result": "minecraft:brown_concrete"
+  "result": {
+    "id": "minecraft:brown_concrete"
+  }
 }

--- a/src/datagen/generated/minecolonies/data/minecolonies/crafterrecipes/concretemixer/brown_concrete_powder.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/crafterrecipes/concretemixer/brown_concrete_powder.json
@@ -1,20 +1,22 @@
 {
   "type": "recipe",
-  "count": 8,
   "crafter": "concretemixer_custom",
   "inputs": [
     {
       "count": 4,
-      "item": "minecraft:sand"
+      "id": "minecraft:sand"
     },
     {
       "count": 4,
-      "item": "minecraft:gravel"
+      "id": "minecraft:gravel"
     },
     {
-      "item": "minecraft:brown_dye"
+      "id": "minecraft:brown_dye"
     }
   ],
   "intermediate": "minecraft:air",
-  "result": "minecraft:brown_concrete_powder"
+  "result": {
+    "count": 8,
+    "id": "minecraft:brown_concrete_powder"
+  }
 }

--- a/src/datagen/generated/minecolonies/data/minecolonies/crafterrecipes/concretemixer/cyan_concrete.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/crafterrecipes/concretemixer/cyan_concrete.json
@@ -3,9 +3,11 @@
   "crafter": "concretemixer_custom",
   "inputs": [
     {
-      "item": "minecraft:cyan_concrete_powder"
+      "id": "minecraft:cyan_concrete_powder"
     }
   ],
   "intermediate": "minecraft:air",
-  "result": "minecraft:cyan_concrete"
+  "result": {
+    "id": "minecraft:cyan_concrete"
+  }
 }

--- a/src/datagen/generated/minecolonies/data/minecolonies/crafterrecipes/concretemixer/cyan_concrete_powder.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/crafterrecipes/concretemixer/cyan_concrete_powder.json
@@ -1,20 +1,22 @@
 {
   "type": "recipe",
-  "count": 8,
   "crafter": "concretemixer_custom",
   "inputs": [
     {
       "count": 4,
-      "item": "minecraft:sand"
+      "id": "minecraft:sand"
     },
     {
       "count": 4,
-      "item": "minecraft:gravel"
+      "id": "minecraft:gravel"
     },
     {
-      "item": "minecraft:cyan_dye"
+      "id": "minecraft:cyan_dye"
     }
   ],
   "intermediate": "minecraft:air",
-  "result": "minecraft:cyan_concrete_powder"
+  "result": {
+    "count": 8,
+    "id": "minecraft:cyan_concrete_powder"
+  }
 }

--- a/src/datagen/generated/minecolonies/data/minecolonies/crafterrecipes/concretemixer/gray_concrete.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/crafterrecipes/concretemixer/gray_concrete.json
@@ -3,9 +3,11 @@
   "crafter": "concretemixer_custom",
   "inputs": [
     {
-      "item": "minecraft:gray_concrete_powder"
+      "id": "minecraft:gray_concrete_powder"
     }
   ],
   "intermediate": "minecraft:air",
-  "result": "minecraft:gray_concrete"
+  "result": {
+    "id": "minecraft:gray_concrete"
+  }
 }

--- a/src/datagen/generated/minecolonies/data/minecolonies/crafterrecipes/concretemixer/gray_concrete_powder.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/crafterrecipes/concretemixer/gray_concrete_powder.json
@@ -1,20 +1,22 @@
 {
   "type": "recipe",
-  "count": 8,
   "crafter": "concretemixer_custom",
   "inputs": [
     {
       "count": 4,
-      "item": "minecraft:sand"
+      "id": "minecraft:sand"
     },
     {
       "count": 4,
-      "item": "minecraft:gravel"
+      "id": "minecraft:gravel"
     },
     {
-      "item": "minecraft:gray_dye"
+      "id": "minecraft:gray_dye"
     }
   ],
   "intermediate": "minecraft:air",
-  "result": "minecraft:gray_concrete_powder"
+  "result": {
+    "count": 8,
+    "id": "minecraft:gray_concrete_powder"
+  }
 }

--- a/src/datagen/generated/minecolonies/data/minecolonies/crafterrecipes/concretemixer/green_concrete.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/crafterrecipes/concretemixer/green_concrete.json
@@ -3,9 +3,11 @@
   "crafter": "concretemixer_custom",
   "inputs": [
     {
-      "item": "minecraft:green_concrete_powder"
+      "id": "minecraft:green_concrete_powder"
     }
   ],
   "intermediate": "minecraft:air",
-  "result": "minecraft:green_concrete"
+  "result": {
+    "id": "minecraft:green_concrete"
+  }
 }

--- a/src/datagen/generated/minecolonies/data/minecolonies/crafterrecipes/concretemixer/green_concrete_powder.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/crafterrecipes/concretemixer/green_concrete_powder.json
@@ -1,20 +1,22 @@
 {
   "type": "recipe",
-  "count": 8,
   "crafter": "concretemixer_custom",
   "inputs": [
     {
       "count": 4,
-      "item": "minecraft:sand"
+      "id": "minecraft:sand"
     },
     {
       "count": 4,
-      "item": "minecraft:gravel"
+      "id": "minecraft:gravel"
     },
     {
-      "item": "minecraft:green_dye"
+      "id": "minecraft:green_dye"
     }
   ],
   "intermediate": "minecraft:air",
-  "result": "minecraft:green_concrete_powder"
+  "result": {
+    "count": 8,
+    "id": "minecraft:green_concrete_powder"
+  }
 }

--- a/src/datagen/generated/minecolonies/data/minecolonies/crafterrecipes/concretemixer/light_blue_concrete.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/crafterrecipes/concretemixer/light_blue_concrete.json
@@ -3,9 +3,11 @@
   "crafter": "concretemixer_custom",
   "inputs": [
     {
-      "item": "minecraft:light_blue_concrete_powder"
+      "id": "minecraft:light_blue_concrete_powder"
     }
   ],
   "intermediate": "minecraft:air",
-  "result": "minecraft:light_blue_concrete"
+  "result": {
+    "id": "minecraft:light_blue_concrete"
+  }
 }

--- a/src/datagen/generated/minecolonies/data/minecolonies/crafterrecipes/concretemixer/light_blue_concrete_powder.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/crafterrecipes/concretemixer/light_blue_concrete_powder.json
@@ -1,20 +1,22 @@
 {
   "type": "recipe",
-  "count": 8,
   "crafter": "concretemixer_custom",
   "inputs": [
     {
       "count": 4,
-      "item": "minecraft:sand"
+      "id": "minecraft:sand"
     },
     {
       "count": 4,
-      "item": "minecraft:gravel"
+      "id": "minecraft:gravel"
     },
     {
-      "item": "minecraft:light_blue_dye"
+      "id": "minecraft:light_blue_dye"
     }
   ],
   "intermediate": "minecraft:air",
-  "result": "minecraft:light_blue_concrete_powder"
+  "result": {
+    "count": 8,
+    "id": "minecraft:light_blue_concrete_powder"
+  }
 }

--- a/src/datagen/generated/minecolonies/data/minecolonies/crafterrecipes/concretemixer/light_gray_concrete.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/crafterrecipes/concretemixer/light_gray_concrete.json
@@ -3,9 +3,11 @@
   "crafter": "concretemixer_custom",
   "inputs": [
     {
-      "item": "minecraft:light_gray_concrete_powder"
+      "id": "minecraft:light_gray_concrete_powder"
     }
   ],
   "intermediate": "minecraft:air",
-  "result": "minecraft:light_gray_concrete"
+  "result": {
+    "id": "minecraft:light_gray_concrete"
+  }
 }

--- a/src/datagen/generated/minecolonies/data/minecolonies/crafterrecipes/concretemixer/light_gray_concrete_powder.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/crafterrecipes/concretemixer/light_gray_concrete_powder.json
@@ -1,20 +1,22 @@
 {
   "type": "recipe",
-  "count": 8,
   "crafter": "concretemixer_custom",
   "inputs": [
     {
       "count": 4,
-      "item": "minecraft:sand"
+      "id": "minecraft:sand"
     },
     {
       "count": 4,
-      "item": "minecraft:gravel"
+      "id": "minecraft:gravel"
     },
     {
-      "item": "minecraft:light_gray_dye"
+      "id": "minecraft:light_gray_dye"
     }
   ],
   "intermediate": "minecraft:air",
-  "result": "minecraft:light_gray_concrete_powder"
+  "result": {
+    "count": 8,
+    "id": "minecraft:light_gray_concrete_powder"
+  }
 }

--- a/src/datagen/generated/minecolonies/data/minecolonies/crafterrecipes/concretemixer/lime_concrete.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/crafterrecipes/concretemixer/lime_concrete.json
@@ -3,9 +3,11 @@
   "crafter": "concretemixer_custom",
   "inputs": [
     {
-      "item": "minecraft:lime_concrete_powder"
+      "id": "minecraft:lime_concrete_powder"
     }
   ],
   "intermediate": "minecraft:air",
-  "result": "minecraft:lime_concrete"
+  "result": {
+    "id": "minecraft:lime_concrete"
+  }
 }

--- a/src/datagen/generated/minecolonies/data/minecolonies/crafterrecipes/concretemixer/lime_concrete_powder.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/crafterrecipes/concretemixer/lime_concrete_powder.json
@@ -1,20 +1,22 @@
 {
   "type": "recipe",
-  "count": 8,
   "crafter": "concretemixer_custom",
   "inputs": [
     {
       "count": 4,
-      "item": "minecraft:sand"
+      "id": "minecraft:sand"
     },
     {
       "count": 4,
-      "item": "minecraft:gravel"
+      "id": "minecraft:gravel"
     },
     {
-      "item": "minecraft:lime_dye"
+      "id": "minecraft:lime_dye"
     }
   ],
   "intermediate": "minecraft:air",
-  "result": "minecraft:lime_concrete_powder"
+  "result": {
+    "count": 8,
+    "id": "minecraft:lime_concrete_powder"
+  }
 }

--- a/src/datagen/generated/minecolonies/data/minecolonies/crafterrecipes/concretemixer/magenta_concrete.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/crafterrecipes/concretemixer/magenta_concrete.json
@@ -3,9 +3,11 @@
   "crafter": "concretemixer_custom",
   "inputs": [
     {
-      "item": "minecraft:magenta_concrete_powder"
+      "id": "minecraft:magenta_concrete_powder"
     }
   ],
   "intermediate": "minecraft:air",
-  "result": "minecraft:magenta_concrete"
+  "result": {
+    "id": "minecraft:magenta_concrete"
+  }
 }

--- a/src/datagen/generated/minecolonies/data/minecolonies/crafterrecipes/concretemixer/magenta_concrete_powder.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/crafterrecipes/concretemixer/magenta_concrete_powder.json
@@ -1,20 +1,22 @@
 {
   "type": "recipe",
-  "count": 8,
   "crafter": "concretemixer_custom",
   "inputs": [
     {
       "count": 4,
-      "item": "minecraft:sand"
+      "id": "minecraft:sand"
     },
     {
       "count": 4,
-      "item": "minecraft:gravel"
+      "id": "minecraft:gravel"
     },
     {
-      "item": "minecraft:magenta_dye"
+      "id": "minecraft:magenta_dye"
     }
   ],
   "intermediate": "minecraft:air",
-  "result": "minecraft:magenta_concrete_powder"
+  "result": {
+    "count": 8,
+    "id": "minecraft:magenta_concrete_powder"
+  }
 }

--- a/src/datagen/generated/minecolonies/data/minecolonies/crafterrecipes/concretemixer/orange_concrete.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/crafterrecipes/concretemixer/orange_concrete.json
@@ -3,9 +3,11 @@
   "crafter": "concretemixer_custom",
   "inputs": [
     {
-      "item": "minecraft:orange_concrete_powder"
+      "id": "minecraft:orange_concrete_powder"
     }
   ],
   "intermediate": "minecraft:air",
-  "result": "minecraft:orange_concrete"
+  "result": {
+    "id": "minecraft:orange_concrete"
+  }
 }

--- a/src/datagen/generated/minecolonies/data/minecolonies/crafterrecipes/concretemixer/orange_concrete_powder.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/crafterrecipes/concretemixer/orange_concrete_powder.json
@@ -1,20 +1,22 @@
 {
   "type": "recipe",
-  "count": 8,
   "crafter": "concretemixer_custom",
   "inputs": [
     {
       "count": 4,
-      "item": "minecraft:sand"
+      "id": "minecraft:sand"
     },
     {
       "count": 4,
-      "item": "minecraft:gravel"
+      "id": "minecraft:gravel"
     },
     {
-      "item": "minecraft:orange_dye"
+      "id": "minecraft:orange_dye"
     }
   ],
   "intermediate": "minecraft:air",
-  "result": "minecraft:orange_concrete_powder"
+  "result": {
+    "count": 8,
+    "id": "minecraft:orange_concrete_powder"
+  }
 }

--- a/src/datagen/generated/minecolonies/data/minecolonies/crafterrecipes/concretemixer/pink_concrete.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/crafterrecipes/concretemixer/pink_concrete.json
@@ -3,9 +3,11 @@
   "crafter": "concretemixer_custom",
   "inputs": [
     {
-      "item": "minecraft:pink_concrete_powder"
+      "id": "minecraft:pink_concrete_powder"
     }
   ],
   "intermediate": "minecraft:air",
-  "result": "minecraft:pink_concrete"
+  "result": {
+    "id": "minecraft:pink_concrete"
+  }
 }

--- a/src/datagen/generated/minecolonies/data/minecolonies/crafterrecipes/concretemixer/pink_concrete_powder.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/crafterrecipes/concretemixer/pink_concrete_powder.json
@@ -1,20 +1,22 @@
 {
   "type": "recipe",
-  "count": 8,
   "crafter": "concretemixer_custom",
   "inputs": [
     {
       "count": 4,
-      "item": "minecraft:sand"
+      "id": "minecraft:sand"
     },
     {
       "count": 4,
-      "item": "minecraft:gravel"
+      "id": "minecraft:gravel"
     },
     {
-      "item": "minecraft:pink_dye"
+      "id": "minecraft:pink_dye"
     }
   ],
   "intermediate": "minecraft:air",
-  "result": "minecraft:pink_concrete_powder"
+  "result": {
+    "count": 8,
+    "id": "minecraft:pink_concrete_powder"
+  }
 }

--- a/src/datagen/generated/minecolonies/data/minecolonies/crafterrecipes/concretemixer/purple_concrete.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/crafterrecipes/concretemixer/purple_concrete.json
@@ -3,9 +3,11 @@
   "crafter": "concretemixer_custom",
   "inputs": [
     {
-      "item": "minecraft:purple_concrete_powder"
+      "id": "minecraft:purple_concrete_powder"
     }
   ],
   "intermediate": "minecraft:air",
-  "result": "minecraft:purple_concrete"
+  "result": {
+    "id": "minecraft:purple_concrete"
+  }
 }

--- a/src/datagen/generated/minecolonies/data/minecolonies/crafterrecipes/concretemixer/purple_concrete_powder.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/crafterrecipes/concretemixer/purple_concrete_powder.json
@@ -1,20 +1,22 @@
 {
   "type": "recipe",
-  "count": 8,
   "crafter": "concretemixer_custom",
   "inputs": [
     {
       "count": 4,
-      "item": "minecraft:sand"
+      "id": "minecraft:sand"
     },
     {
       "count": 4,
-      "item": "minecraft:gravel"
+      "id": "minecraft:gravel"
     },
     {
-      "item": "minecraft:purple_dye"
+      "id": "minecraft:purple_dye"
     }
   ],
   "intermediate": "minecraft:air",
-  "result": "minecraft:purple_concrete_powder"
+  "result": {
+    "count": 8,
+    "id": "minecraft:purple_concrete_powder"
+  }
 }

--- a/src/datagen/generated/minecolonies/data/minecolonies/crafterrecipes/concretemixer/red_concrete.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/crafterrecipes/concretemixer/red_concrete.json
@@ -3,9 +3,11 @@
   "crafter": "concretemixer_custom",
   "inputs": [
     {
-      "item": "minecraft:red_concrete_powder"
+      "id": "minecraft:red_concrete_powder"
     }
   ],
   "intermediate": "minecraft:air",
-  "result": "minecraft:red_concrete"
+  "result": {
+    "id": "minecraft:red_concrete"
+  }
 }

--- a/src/datagen/generated/minecolonies/data/minecolonies/crafterrecipes/concretemixer/red_concrete_powder.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/crafterrecipes/concretemixer/red_concrete_powder.json
@@ -1,20 +1,22 @@
 {
   "type": "recipe",
-  "count": 8,
   "crafter": "concretemixer_custom",
   "inputs": [
     {
       "count": 4,
-      "item": "minecraft:sand"
+      "id": "minecraft:sand"
     },
     {
       "count": 4,
-      "item": "minecraft:gravel"
+      "id": "minecraft:gravel"
     },
     {
-      "item": "minecraft:red_dye"
+      "id": "minecraft:red_dye"
     }
   ],
   "intermediate": "minecraft:air",
-  "result": "minecraft:red_concrete_powder"
+  "result": {
+    "count": 8,
+    "id": "minecraft:red_concrete_powder"
+  }
 }

--- a/src/datagen/generated/minecolonies/data/minecolonies/crafterrecipes/concretemixer/white_concrete.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/crafterrecipes/concretemixer/white_concrete.json
@@ -3,9 +3,11 @@
   "crafter": "concretemixer_custom",
   "inputs": [
     {
-      "item": "minecraft:white_concrete_powder"
+      "id": "minecraft:white_concrete_powder"
     }
   ],
   "intermediate": "minecraft:air",
-  "result": "minecraft:white_concrete"
+  "result": {
+    "id": "minecraft:white_concrete"
+  }
 }

--- a/src/datagen/generated/minecolonies/data/minecolonies/crafterrecipes/concretemixer/white_concrete_powder.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/crafterrecipes/concretemixer/white_concrete_powder.json
@@ -1,20 +1,22 @@
 {
   "type": "recipe",
-  "count": 8,
   "crafter": "concretemixer_custom",
   "inputs": [
     {
       "count": 4,
-      "item": "minecraft:sand"
+      "id": "minecraft:sand"
     },
     {
       "count": 4,
-      "item": "minecraft:gravel"
+      "id": "minecraft:gravel"
     },
     {
-      "item": "minecraft:white_dye"
+      "id": "minecraft:white_dye"
     }
   ],
   "intermediate": "minecraft:air",
-  "result": "minecraft:white_concrete_powder"
+  "result": {
+    "count": 8,
+    "id": "minecraft:white_concrete_powder"
+  }
 }

--- a/src/datagen/generated/minecolonies/data/minecolonies/crafterrecipes/concretemixer/yellow_concrete.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/crafterrecipes/concretemixer/yellow_concrete.json
@@ -3,9 +3,11 @@
   "crafter": "concretemixer_custom",
   "inputs": [
     {
-      "item": "minecraft:yellow_concrete_powder"
+      "id": "minecraft:yellow_concrete_powder"
     }
   ],
   "intermediate": "minecraft:air",
-  "result": "minecraft:yellow_concrete"
+  "result": {
+    "id": "minecraft:yellow_concrete"
+  }
 }

--- a/src/datagen/generated/minecolonies/data/minecolonies/crafterrecipes/concretemixer/yellow_concrete_powder.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/crafterrecipes/concretemixer/yellow_concrete_powder.json
@@ -1,20 +1,22 @@
 {
   "type": "recipe",
-  "count": 8,
   "crafter": "concretemixer_custom",
   "inputs": [
     {
       "count": 4,
-      "item": "minecraft:sand"
+      "id": "minecraft:sand"
     },
     {
       "count": 4,
-      "item": "minecraft:gravel"
+      "id": "minecraft:gravel"
     },
     {
-      "item": "minecraft:yellow_dye"
+      "id": "minecraft:yellow_dye"
     }
   ],
   "intermediate": "minecraft:air",
-  "result": "minecraft:yellow_concrete_powder"
+  "result": {
+    "count": 8,
+    "id": "minecraft:yellow_concrete_powder"
+  }
 }

--- a/src/datagen/generated/minecolonies/data/minecolonies/crafterrecipes/crusher/bonemeal1.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/crafterrecipes/crusher/bonemeal1.json
@@ -1,13 +1,15 @@
 {
   "type": "recipe",
-  "count": 3,
   "crafter": "crusher_custom",
   "inputs": [
     {
-      "item": "minecraft:bone"
+      "id": "minecraft:bone"
     }
   ],
   "intermediate": "minecraft:air",
   "not-research-id": "minecolonies:effects/crushing11unlock",
-  "result": "minecraft:bone_meal"
+  "result": {
+    "count": 3,
+    "id": "minecraft:bone_meal"
+  }
 }

--- a/src/datagen/generated/minecolonies/data/minecolonies/crafterrecipes/crusher/bonemeal2.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/crafterrecipes/crusher/bonemeal2.json
@@ -1,13 +1,15 @@
 {
   "type": "recipe",
-  "count": 5,
   "crafter": "crusher_custom",
   "inputs": [
     {
-      "item": "minecraft:bone"
+      "id": "minecraft:bone"
     }
   ],
   "intermediate": "minecraft:air",
   "research-id": "minecolonies:effects/crushing11unlock",
-  "result": "minecraft:bone_meal"
+  "result": {
+    "count": 5,
+    "id": "minecraft:bone_meal"
+  }
 }

--- a/src/datagen/generated/minecolonies/data/minecolonies/crafterrecipes/crusher/bonemeal3.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/crafterrecipes/crusher/bonemeal3.json
@@ -1,12 +1,14 @@
 {
   "type": "recipe",
-  "count": 9,
   "crafter": "crusher_custom",
   "inputs": [
     {
-      "item": "minecraft:bone_block"
+      "id": "minecraft:bone_block"
     }
   ],
   "intermediate": "minecraft:air",
-  "result": "minecraft:bone_meal"
+  "result": {
+    "count": 9,
+    "id": "minecraft:bone_meal"
+  }
 }

--- a/src/datagen/generated/minecolonies/data/minecolonies/crafterrecipes/crusher/clay1.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/crafterrecipes/crusher/clay1.json
@@ -4,10 +4,12 @@
   "inputs": [
     {
       "count": 2,
-      "item": "minecraft:sand"
+      "id": "minecraft:sand"
     }
   ],
   "intermediate": "minecraft:air",
   "not-research-id": "minecolonies:effects/crushing11unlock",
-  "result": "minecraft:clay"
+  "result": {
+    "id": "minecraft:clay"
+  }
 }

--- a/src/datagen/generated/minecolonies/data/minecolonies/crafterrecipes/crusher/clay2.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/crafterrecipes/crusher/clay2.json
@@ -3,10 +3,12 @@
   "crafter": "crusher_custom",
   "inputs": [
     {
-      "item": "minecraft:sand"
+      "id": "minecraft:sand"
     }
   ],
   "intermediate": "minecraft:air",
   "research-id": "minecolonies:effects/crushing11unlock",
-  "result": "minecraft:clay"
+  "result": {
+    "id": "minecraft:clay"
+  }
 }

--- a/src/datagen/generated/minecolonies/data/minecolonies/crafterrecipes/crusher/clay_ball.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/crafterrecipes/crusher/clay_ball.json
@@ -1,12 +1,14 @@
 {
   "type": "recipe",
-  "count": 4,
   "crafter": "crusher_custom",
   "inputs": [
     {
-      "item": "minecraft:clay"
+      "id": "minecraft:clay"
     }
   ],
   "intermediate": "minecraft:air",
-  "result": "minecraft:clay_ball"
+  "result": {
+    "count": 4,
+    "id": "minecraft:clay_ball"
+  }
 }

--- a/src/datagen/generated/minecolonies/data/minecolonies/crafterrecipes/crusher/cobble.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/crafterrecipes/crusher/cobble.json
@@ -4,11 +4,13 @@
   "inputs": [
     {
       "count": 2,
-      "item": "minecraft:tuff"
+      "id": "minecraft:tuff"
     }
   ],
   "intermediate": "minecraft:air",
   "not-research-id": "minecolonies:effects/crushing11unlock",
   "research-id": "minecolonies:effects/knowledgeofthedepthsunlock",
-  "result": "minecraft:cobblestone"
+  "result": {
+    "id": "minecraft:cobblestone"
+  }
 }

--- a/src/datagen/generated/minecolonies/data/minecolonies/crafterrecipes/crusher/cobble2.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/crafterrecipes/crusher/cobble2.json
@@ -3,7 +3,7 @@
   "crafter": "crusher_custom",
   "inputs": [
     {
-      "item": "minecraft:tuff"
+      "id": "minecraft:tuff"
     }
   ],
   "intermediate": "minecraft:air",
@@ -11,5 +11,7 @@
     "minecolonies:effects/knowledgeofthedepthsunlock",
     "minecolonies:effects/crushing11unlock"
   ],
-  "result": "minecraft:cobblestone"
+  "result": {
+    "id": "minecraft:cobblestone"
+  }
 }

--- a/src/datagen/generated/minecolonies/data/minecolonies/crafterrecipes/crusher/gravel1.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/crafterrecipes/crusher/gravel1.json
@@ -4,11 +4,13 @@
   "inputs": [
     {
       "count": 2,
-      "item": "minecraft:cobblestone"
+      "id": "minecraft:cobblestone"
     }
   ],
   "intermediate": "minecraft:air",
   "loot-table": "minecolonies:recipes/gravel",
   "not-research-id": "minecolonies:effects/crushing11unlock",
-  "result": "minecraft:gravel"
+  "result": {
+    "id": "minecraft:gravel"
+  }
 }

--- a/src/datagen/generated/minecolonies/data/minecolonies/crafterrecipes/crusher/gravel2.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/crafterrecipes/crusher/gravel2.json
@@ -3,11 +3,13 @@
   "crafter": "crusher_custom",
   "inputs": [
     {
-      "item": "minecraft:cobblestone"
+      "id": "minecraft:cobblestone"
     }
   ],
   "intermediate": "minecraft:air",
   "loot-table": "minecolonies:recipes/gravel",
   "research-id": "minecolonies:effects/crushing11unlock",
-  "result": "minecraft:gravel"
+  "result": {
+    "id": "minecraft:gravel"
+  }
 }

--- a/src/datagen/generated/minecolonies/data/minecolonies/crafterrecipes/crusher/sand1.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/crafterrecipes/crusher/sand1.json
@@ -4,10 +4,12 @@
   "inputs": [
     {
       "count": 2,
-      "item": "minecraft:gravel"
+      "id": "minecraft:gravel"
     }
   ],
   "intermediate": "minecraft:air",
   "not-research-id": "minecolonies:effects/crushing11unlock",
-  "result": "minecraft:sand"
+  "result": {
+    "id": "minecraft:sand"
+  }
 }

--- a/src/datagen/generated/minecolonies/data/minecolonies/crafterrecipes/crusher/sand2.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/crafterrecipes/crusher/sand2.json
@@ -3,10 +3,12 @@
   "crafter": "crusher_custom",
   "inputs": [
     {
-      "item": "minecraft:gravel"
+      "id": "minecraft:gravel"
     }
   ],
   "intermediate": "minecraft:air",
   "research-id": "minecolonies:effects/crushing11unlock",
-  "result": "minecraft:sand"
+  "result": {
+    "id": "minecraft:sand"
+  }
 }

--- a/src/datagen/generated/minecolonies/data/minecolonies/crafterrecipes/crusher/tuff.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/crafterrecipes/crusher/tuff.json
@@ -4,11 +4,13 @@
   "inputs": [
     {
       "count": 2,
-      "item": "minecraft:cobbled_deepslate"
+      "id": "minecraft:cobbled_deepslate"
     }
   ],
   "intermediate": "minecraft:air",
   "not-research-id": "minecolonies:effects/crushing11unlock",
   "research-id": "minecolonies:effects/knowledgeofthedepthsunlock",
-  "result": "minecraft:tuff"
+  "result": {
+    "id": "minecraft:tuff"
+  }
 }

--- a/src/datagen/generated/minecolonies/data/minecolonies/crafterrecipes/crusher/tuff2.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/crafterrecipes/crusher/tuff2.json
@@ -3,7 +3,7 @@
   "crafter": "crusher_custom",
   "inputs": [
     {
-      "item": "minecraft:cobbled_deepslate"
+      "id": "minecraft:cobbled_deepslate"
     }
   ],
   "intermediate": "minecraft:air",
@@ -11,5 +11,7 @@
     "minecolonies:effects/knowledgeofthedepthsunlock",
     "minecolonies:effects/crushing11unlock"
   ],
-  "result": "minecraft:tuff"
+  "result": {
+    "id": "minecraft:tuff"
+  }
 }

--- a/src/datagen/generated/minecolonies/data/minecolonies/crafterrecipes/dyer/black_dye.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/crafterrecipes/dyer/black_dye.json
@@ -3,10 +3,12 @@
   "crafter": "dyer_crafting",
   "inputs": [
     {
-      "item": "minecraft:charcoal"
+      "id": "minecraft:charcoal"
     }
   ],
   "intermediate": "minecraft:air",
   "min-building-level": 2,
-  "result": "minecraft:black_dye"
+  "result": {
+    "id": "minecraft:black_dye"
+  }
 }

--- a/src/datagen/generated/minecolonies/data/minecolonies/crafterrecipes/dyer/dark_prismarine.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/crafterrecipes/dyer/dark_prismarine.json
@@ -1,17 +1,19 @@
 {
   "type": "recipe",
-  "count": 4,
   "crafter": "dyer_crafting",
   "inputs": [
     {
       "count": 4,
-      "item": "minecraft:prismarine"
+      "id": "minecraft:prismarine"
     },
     {
-      "item": "minecraft:black_dye"
+      "id": "minecraft:black_dye"
     }
   ],
   "intermediate": "minecraft:air",
   "min-building-level": 3,
-  "result": "minecraft:dark_prismarine"
+  "result": {
+    "count": 4,
+    "id": "minecraft:dark_prismarine"
+  }
 }

--- a/src/datagen/generated/minecolonies/data/minecolonies/crafterrecipes/dyer/red_sand.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/crafterrecipes/dyer/red_sand.json
@@ -1,16 +1,18 @@
 {
   "type": "recipe",
-  "count": 4,
   "crafter": "dyer_crafting",
   "inputs": [
     {
       "count": 4,
-      "item": "minecraft:sand"
+      "id": "minecraft:sand"
     },
     {
-      "item": "minecraft:red_dye"
+      "id": "minecraft:red_dye"
     }
   ],
   "intermediate": "minecraft:air",
-  "result": "minecraft:red_sand"
+  "result": {
+    "count": 4,
+    "id": "minecraft:red_sand"
+  }
 }

--- a/src/datagen/generated/minecolonies/data/minecolonies/crafterrecipes/enchanter/scroll_area_tp.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/crafterrecipes/enchanter/scroll_area_tp.json
@@ -4,11 +4,13 @@
   "inputs": [
     {
       "count": 3,
-      "item": "minecolonies:scroll_tp"
+      "id": "minecolonies:scroll_tp"
     }
   ],
   "intermediate": "minecraft:air",
   "min-building-level": 2,
-  "result": "minecolonies:scroll_area_tp",
+  "result": {
+    "id": "minecolonies:scroll_area_tp"
+  },
   "show-tooltip": true
 }

--- a/src/datagen/generated/minecolonies/data/minecolonies/crafterrecipes/enchanter/scroll_guard_help.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/crafterrecipes/enchanter/scroll_guard_help.json
@@ -1,25 +1,27 @@
 {
   "type": "recipe",
-  "count": 2,
   "crafter": "enchanter_custom",
   "inputs": [
     {
-      "item": "minecolonies:scroll_tp"
+      "id": "minecolonies:scroll_tp"
     },
     {
       "count": 5,
-      "item": "minecraft:lapis_lazuli"
+      "id": "minecraft:lapis_lazuli"
     },
     {
-      "item": "minecraft:ender_pearl"
+      "id": "minecraft:ender_pearl"
     },
     {
-      "item": "minecraft:paper"
+      "id": "minecraft:paper"
     }
   ],
   "intermediate": "minecraft:air",
   "min-building-level": 3,
   "research-id": "minecolonies:effects/morescrollsunlock",
-  "result": "minecolonies:scroll_guard_help",
+  "result": {
+    "count": 2,
+    "id": "minecolonies:scroll_guard_help"
+  },
   "show-tooltip": true
 }

--- a/src/datagen/generated/minecolonies/data/minecolonies/crafterrecipes/enchanter/scroll_highlight.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/crafterrecipes/enchanter/scroll_highlight.json
@@ -1,24 +1,26 @@
 {
   "type": "recipe",
-  "count": 5,
   "crafter": "enchanter_custom",
   "inputs": [
     {
       "count": 3,
-      "item": "minecolonies:scroll_tp"
+      "id": "minecolonies:scroll_tp"
     },
     {
       "count": 6,
-      "item": "minecraft:glowstone_dust"
+      "id": "minecraft:glowstone_dust"
     },
     {
       "count": 2,
-      "item": "minecraft:paper"
+      "id": "minecraft:paper"
     }
   ],
   "intermediate": "minecraft:air",
   "min-building-level": 3,
   "research-id": "minecolonies:effects/morescrollsunlock",
-  "result": "minecolonies:scroll_highlight",
+  "result": {
+    "count": 5,
+    "id": "minecolonies:scroll_highlight"
+  },
   "show-tooltip": true
 }

--- a/src/datagen/generated/minecolonies/data/minecolonies/crafterrecipes/enchanter/scroll_tp.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/crafterrecipes/enchanter/scroll_tp.json
@@ -1,20 +1,22 @@
 {
   "type": "recipe",
-  "count": 3,
   "crafter": "enchanter_custom",
   "inputs": [
     {
       "count": 3,
-      "item": "minecraft:paper"
+      "id": "minecraft:paper"
     },
     {
-      "item": "minecraft:compass"
+      "id": "minecraft:compass"
     },
     {
-      "item": "structurize:sceptergold"
+      "id": "structurize:sceptergold"
     }
   ],
   "intermediate": "minecraft:air",
-  "result": "minecolonies:scroll_tp",
+  "result": {
+    "count": 3,
+    "id": "minecolonies:scroll_tp"
+  },
   "show-tooltip": true
 }

--- a/src/datagen/generated/minecolonies/data/minecolonies/crafterrecipes/enchanter/tome1.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/crafterrecipes/enchanter/tome1.json
@@ -2,13 +2,13 @@
   "type": "recipe",
   "additional-output": [
     {
-      "item": "minecraft:enchanted_book"
+      "id": "minecraft:enchanted_book"
     }
   ],
   "crafter": "enchanter_custom",
   "inputs": [
     {
-      "item": "minecolonies:ancienttome",
+      "id": "minecolonies:ancienttome",
       "matchType": "ignore"
     }
   ],

--- a/src/datagen/generated/minecolonies/data/minecolonies/crafterrecipes/enchanter/tome2.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/crafterrecipes/enchanter/tome2.json
@@ -2,13 +2,13 @@
   "type": "recipe",
   "additional-output": [
     {
-      "item": "minecraft:enchanted_book"
+      "id": "minecraft:enchanted_book"
     }
   ],
   "crafter": "enchanter_custom",
   "inputs": [
     {
-      "item": "minecolonies:ancienttome",
+      "id": "minecolonies:ancienttome",
       "matchType": "ignore"
     }
   ],

--- a/src/datagen/generated/minecolonies/data/minecolonies/crafterrecipes/enchanter/tome3.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/crafterrecipes/enchanter/tome3.json
@@ -2,13 +2,13 @@
   "type": "recipe",
   "additional-output": [
     {
-      "item": "minecraft:enchanted_book"
+      "id": "minecraft:enchanted_book"
     }
   ],
   "crafter": "enchanter_custom",
   "inputs": [
     {
-      "item": "minecolonies:ancienttome",
+      "id": "minecolonies:ancienttome",
       "matchType": "ignore"
     }
   ],

--- a/src/datagen/generated/minecolonies/data/minecolonies/crafterrecipes/enchanter/tome4.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/crafterrecipes/enchanter/tome4.json
@@ -2,13 +2,13 @@
   "type": "recipe",
   "additional-output": [
     {
-      "item": "minecraft:enchanted_book"
+      "id": "minecraft:enchanted_book"
     }
   ],
   "crafter": "enchanter_custom",
   "inputs": [
     {
-      "item": "minecolonies:ancienttome",
+      "id": "minecolonies:ancienttome",
       "matchType": "ignore"
     }
   ],

--- a/src/datagen/generated/minecolonies/data/minecolonies/crafterrecipes/enchanter/tome5.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/crafterrecipes/enchanter/tome5.json
@@ -2,13 +2,13 @@
   "type": "recipe",
   "additional-output": [
     {
-      "item": "minecraft:enchanted_book"
+      "id": "minecraft:enchanted_book"
     }
   ],
   "crafter": "enchanter_custom",
   "inputs": [
     {
-      "item": "minecolonies:ancienttome",
+      "id": "minecolonies:ancienttome",
       "matchType": "ignore"
     }
   ],

--- a/src/datagen/generated/minecolonies/data/minecolonies/crafterrecipes/farmer/carved_pumpkin.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/crafterrecipes/farmer/carved_pumpkin.json
@@ -3,10 +3,12 @@
   "crafter": "farmer_crafting",
   "inputs": [
     {
-      "item": "minecraft:pumpkin"
+      "id": "minecraft:pumpkin"
     }
   ],
   "intermediate": "minecraft:air",
-  "result": "minecraft:carved_pumpkin",
+  "result": {
+    "id": "minecraft:carved_pumpkin"
+  },
   "tool": "shears"
 }

--- a/src/datagen/generated/minecolonies/data/minecolonies/crafterrecipes/farmer/mud.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/crafterrecipes/farmer/mud.json
@@ -3,13 +3,15 @@
   "crafter": "farmer_crafting",
   "inputs": [
     {
-      "item": "minecraft:dirt"
+      "id": "minecraft:dirt"
     },
     {
-      "item": "minecolonies:large_water_bottle"
+      "id": "minecolonies:large_water_bottle"
     }
   ],
   "intermediate": "minecraft:air",
   "loot-table": "minecolonies:recipes/large_bottle",
-  "result": "minecraft:mud"
+  "result": {
+    "id": "minecraft:mud"
+  }
 }

--- a/src/datagen/generated/minecolonies/data/minecolonies/crafterrecipes/fletcher/flint.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/crafterrecipes/fletcher/flint.json
@@ -4,9 +4,11 @@
   "inputs": [
     {
       "count": 3,
-      "item": "minecraft:gravel"
+      "id": "minecraft:gravel"
     }
   ],
   "intermediate": "minecraft:air",
-  "result": "minecraft:flint"
+  "result": {
+    "id": "minecraft:flint"
+  }
 }

--- a/src/datagen/generated/minecolonies/data/minecolonies/crafterrecipes/fletcher/sifter_mesh_string.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/crafterrecipes/fletcher/sifter_mesh_string.json
@@ -3,11 +3,13 @@
   "crafter": "fletcher_crafting",
   "inputs": [
     {
-      "item": "minecraft:string"
+      "id": "minecraft:string"
     }
   ],
   "intermediate": "minecraft:air",
   "research-id": "minecolonies:effects/sifterstringunlock",
-  "result": "minecolonies:sifter_mesh_string",
+  "result": {
+    "id": "minecolonies:sifter_mesh_string"
+  },
   "show-tooltip": true
 }

--- a/src/datagen/generated/minecolonies/data/minecolonies/crafterrecipes/fletcher/string.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/crafterrecipes/fletcher/string.json
@@ -1,12 +1,14 @@
 {
   "type": "recipe",
-  "count": 4,
   "crafter": "fletcher_crafting",
   "inputs": [
     {
-      "item": "minecraft:white_wool"
+      "id": "minecraft:white_wool"
     }
   ],
   "intermediate": "minecraft:air",
-  "result": "minecraft:string"
+  "result": {
+    "count": 4,
+    "id": "minecraft:string"
+  }
 }

--- a/src/datagen/generated/minecolonies/data/minecolonies/crafterrecipes/lumberjack/strip_bamboo_block.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/crafterrecipes/lumberjack/strip_bamboo_block.json
@@ -3,10 +3,12 @@
   "crafter": "lumberjack_custom",
   "inputs": [
     {
-      "item": "minecraft:bamboo_block"
+      "id": "minecraft:bamboo_block"
     }
   ],
   "intermediate": "minecraft:air",
-  "result": "minecraft:stripped_bamboo_block",
+  "result": {
+    "id": "minecraft:stripped_bamboo_block"
+  },
   "tool": "axe"
 }

--- a/src/datagen/generated/minecolonies/data/minecolonies/crafterrecipes/mechanic/deoxidize_exposed_copper.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/crafterrecipes/mechanic/deoxidize_exposed_copper.json
@@ -3,10 +3,12 @@
   "crafter": "mechanic_crafting",
   "inputs": [
     {
-      "item": "minecraft:exposed_copper"
+      "id": "minecraft:exposed_copper"
     }
   ],
   "intermediate": "minecraft:air",
-  "result": "minecraft:copper_block",
+  "result": {
+    "id": "minecraft:copper_block"
+  },
   "tool": "axe"
 }

--- a/src/datagen/generated/minecolonies/data/minecolonies/crafterrecipes/mechanic/deoxidize_exposed_cut_copper.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/crafterrecipes/mechanic/deoxidize_exposed_cut_copper.json
@@ -3,10 +3,12 @@
   "crafter": "mechanic_crafting",
   "inputs": [
     {
-      "item": "minecraft:exposed_cut_copper"
+      "id": "minecraft:exposed_cut_copper"
     }
   ],
   "intermediate": "minecraft:air",
-  "result": "minecraft:cut_copper",
+  "result": {
+    "id": "minecraft:cut_copper"
+  },
   "tool": "axe"
 }

--- a/src/datagen/generated/minecolonies/data/minecolonies/crafterrecipes/mechanic/deoxidize_oxidized_copper.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/crafterrecipes/mechanic/deoxidize_oxidized_copper.json
@@ -3,10 +3,12 @@
   "crafter": "mechanic_crafting",
   "inputs": [
     {
-      "item": "minecraft:oxidized_copper"
+      "id": "minecraft:oxidized_copper"
     }
   ],
   "intermediate": "minecraft:air",
-  "result": "minecraft:weathered_copper",
+  "result": {
+    "id": "minecraft:weathered_copper"
+  },
   "tool": "axe"
 }

--- a/src/datagen/generated/minecolonies/data/minecolonies/crafterrecipes/mechanic/deoxidize_oxidized_cut_copper.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/crafterrecipes/mechanic/deoxidize_oxidized_cut_copper.json
@@ -3,10 +3,12 @@
   "crafter": "mechanic_crafting",
   "inputs": [
     {
-      "item": "minecraft:oxidized_cut_copper"
+      "id": "minecraft:oxidized_cut_copper"
     }
   ],
   "intermediate": "minecraft:air",
-  "result": "minecraft:weathered_cut_copper",
+  "result": {
+    "id": "minecraft:weathered_cut_copper"
+  },
   "tool": "axe"
 }

--- a/src/datagen/generated/minecolonies/data/minecolonies/crafterrecipes/mechanic/deoxidize_weathered_copper.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/crafterrecipes/mechanic/deoxidize_weathered_copper.json
@@ -3,10 +3,12 @@
   "crafter": "mechanic_crafting",
   "inputs": [
     {
-      "item": "minecraft:weathered_copper"
+      "id": "minecraft:weathered_copper"
     }
   ],
   "intermediate": "minecraft:air",
-  "result": "minecraft:exposed_copper",
+  "result": {
+    "id": "minecraft:exposed_copper"
+  },
   "tool": "axe"
 }

--- a/src/datagen/generated/minecolonies/data/minecolonies/crafterrecipes/mechanic/deoxidize_weathered_cut_copper.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/crafterrecipes/mechanic/deoxidize_weathered_cut_copper.json
@@ -3,10 +3,12 @@
   "crafter": "mechanic_crafting",
   "inputs": [
     {
-      "item": "minecraft:weathered_cut_copper"
+      "id": "minecraft:weathered_cut_copper"
     }
   ],
   "intermediate": "minecraft:air",
-  "result": "minecraft:exposed_cut_copper",
+  "result": {
+    "id": "minecraft:exposed_cut_copper"
+  },
   "tool": "axe"
 }

--- a/src/datagen/generated/minecolonies/data/minecolonies/crafterrecipes/mechanic/gate_iron.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/crafterrecipes/mechanic/gate_iron.json
@@ -4,10 +4,12 @@
   "inputs": [
     {
       "count": 5,
-      "item": "minecraft:iron_nugget"
+      "id": "minecraft:iron_nugget"
     }
   ],
   "intermediate": "minecraft:air",
-  "result": "minecolonies:gate_iron",
+  "result": {
+    "id": "minecolonies:gate_iron"
+  },
   "show-tooltip": true
 }

--- a/src/datagen/generated/minecolonies/data/minecolonies/crafterrecipes/mechanic/gate_wood.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/crafterrecipes/mechanic/gate_wood.json
@@ -4,10 +4,12 @@
   "inputs": [
     {
       "count": 5,
-      "item": "minecraft:oak_log"
+      "id": "minecraft:oak_log"
     }
   ],
   "intermediate": "minecraft:air",
-  "result": "minecolonies:gate_wood",
+  "result": {
+    "id": "minecolonies:gate_wood"
+  },
   "show-tooltip": true
 }

--- a/src/datagen/generated/minecolonies/data/minecolonies/crafterrecipes/mechanic/lantern.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/crafterrecipes/mechanic/lantern.json
@@ -4,16 +4,18 @@
   "inputs": [
     {
       "count": 3,
-      "item": "minecraft:iron_nugget"
+      "id": "minecraft:iron_nugget"
     },
     {
-      "item": "minecraft:glass_bottle"
+      "id": "minecraft:glass_bottle"
     },
     {
-      "item": "minecraft:torch"
+      "id": "minecraft:torch"
     }
   ],
   "intermediate": "minecraft:air",
   "min-building-level": 3,
-  "result": "minecraft:lantern"
+  "result": {
+    "id": "minecraft:lantern"
+  }
 }

--- a/src/datagen/generated/minecolonies/data/minecolonies/crafterrecipes/mechanic/rails.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/crafterrecipes/mechanic/rails.json
@@ -1,18 +1,20 @@
 {
   "type": "recipe",
-  "count": 16,
   "crafter": "mechanic_crafting",
   "inputs": [
     {
       "count": 5,
-      "item": "minecraft:stick"
+      "id": "minecraft:stick"
     },
     {
       "count": 2,
-      "item": "minecraft:iron_ingot"
+      "id": "minecraft:iron_ingot"
     }
   ],
   "intermediate": "minecraft:air",
   "min-building-level": 3,
-  "result": "minecraft:rail"
+  "result": {
+    "count": 16,
+    "id": "minecraft:rail"
+  }
 }

--- a/src/datagen/generated/minecolonies/data/minecolonies/crafterrecipes/mechanic/sifter_mesh_diamond.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/crafterrecipes/mechanic/sifter_mesh_diamond.json
@@ -3,11 +3,13 @@
   "crafter": "mechanic_crafting",
   "inputs": [
     {
-      "item": "minecraft:diamond"
+      "id": "minecraft:diamond"
     }
   ],
   "intermediate": "minecraft:air",
   "research-id": "minecolonies:effects/sifterdiamondunlock",
-  "result": "minecolonies:sifter_mesh_diamond",
+  "result": {
+    "id": "minecolonies:sifter_mesh_diamond"
+  },
   "show-tooltip": true
 }

--- a/src/datagen/generated/minecolonies/data/minecolonies/crafterrecipes/mechanic/soul_lantern.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/crafterrecipes/mechanic/soul_lantern.json
@@ -4,16 +4,18 @@
   "inputs": [
     {
       "count": 3,
-      "item": "minecraft:iron_nugget"
+      "id": "minecraft:iron_nugget"
     },
     {
-      "item": "minecraft:glass_bottle"
+      "id": "minecraft:glass_bottle"
     },
     {
-      "item": "minecraft:soul_torch"
+      "id": "minecraft:soul_torch"
     }
   ],
   "intermediate": "minecraft:air",
   "min-building-level": 3,
-  "result": "minecraft:soul_lantern"
+  "result": {
+    "id": "minecraft:soul_lantern"
+  }
 }

--- a/src/datagen/generated/minecolonies/data/minecolonies/crafterrecipes/netherworker/lava.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/crafterrecipes/netherworker/lava.json
@@ -3,9 +3,11 @@
   "crafter": "netherworker_custom",
   "inputs": [
     {
-      "item": "minecraft:bucket"
+      "id": "minecraft:bucket"
     }
   ],
   "intermediate": "minecraft:air",
-  "result": "minecraft:lava_bucket"
+  "result": {
+    "id": "minecraft:lava_bucket"
+  }
 }

--- a/src/datagen/generated/minecolonies/data/minecolonies/crafterrecipes/netherworker/trip1.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/crafterrecipes/netherworker/trip1.json
@@ -2,58 +2,58 @@
   "type": "recipe",
   "additional-output": [
     {
-      "item": "minecraft:netherrack"
+      "id": "minecraft:netherrack"
     },
     {
-      "item": "minecraft:nether_quartz_ore"
+      "id": "minecraft:nether_quartz_ore"
     },
     {
-      "item": "minecraft:rotten_flesh"
+      "id": "minecraft:rotten_flesh"
     },
     {
-      "item": "minecraft:gold_nugget"
+      "id": "minecraft:gold_nugget"
     },
     {
-      "item": "minecraft:soul_sand"
+      "id": "minecraft:soul_sand"
     },
     {
-      "item": "minecraft:gravel"
+      "id": "minecraft:gravel"
     },
     {
-      "item": "minecraft:soul_soil"
+      "id": "minecraft:soul_soil"
     },
     {
-      "item": "minecraft:porkchop"
+      "id": "minecraft:porkchop"
     },
     {
-      "item": "minecraft:leather"
+      "id": "minecraft:leather"
     },
     {
-      "item": "minecraft:gunpowder"
+      "id": "minecraft:gunpowder"
     },
     {
-      "item": "minecraft:ghast_tear"
+      "id": "minecraft:ghast_tear"
     },
     {
-      "item": "minecraft:ender_pearl"
+      "id": "minecraft:ender_pearl"
     },
     {
-      "item": "minecraft:magma_cream"
+      "id": "minecraft:magma_cream"
     }
   ],
   "crafter": "netherworker_custom",
   "inputs": [
     {
       "count": 64,
-      "item": "minecraft:cobblestone"
+      "id": "minecraft:cobblestone"
     },
     {
       "count": 32,
-      "item": "minecraft:torch"
+      "id": "minecraft:torch"
     },
     {
       "count": 16,
-      "item": "minecraft:ladder"
+      "id": "minecraft:ladder"
     }
   ],
   "intermediate": "minecraft:air",

--- a/src/datagen/generated/minecolonies/data/minecolonies/crafterrecipes/netherworker/trip2.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/crafterrecipes/netherworker/trip2.json
@@ -2,79 +2,79 @@
   "type": "recipe",
   "additional-output": [
     {
-      "item": "minecraft:rotten_flesh"
+      "id": "minecraft:rotten_flesh"
     },
     {
-      "item": "minecraft:gold_nugget"
+      "id": "minecraft:gold_nugget"
     },
     {
-      "item": "minecraft:netherrack"
+      "id": "minecraft:netherrack"
     },
     {
-      "item": "minecraft:nether_quartz_ore"
+      "id": "minecraft:nether_quartz_ore"
     },
     {
-      "item": "minecraft:soul_sand"
+      "id": "minecraft:soul_sand"
     },
     {
-      "item": "minecraft:gravel"
+      "id": "minecraft:gravel"
     },
     {
-      "item": "minecraft:brown_mushroom"
+      "id": "minecraft:brown_mushroom"
     },
     {
-      "item": "minecraft:red_mushroom"
+      "id": "minecraft:red_mushroom"
     },
     {
-      "item": "minecraft:soul_soil"
+      "id": "minecraft:soul_soil"
     },
     {
-      "item": "minecraft:glowstone"
+      "id": "minecraft:glowstone"
     },
     {
-      "item": "minecraft:crimson_nylium"
+      "id": "minecraft:crimson_nylium"
     },
     {
-      "item": "minecraft:crimson_fungus"
+      "id": "minecraft:crimson_fungus"
     },
     {
-      "item": "minecraft:crimson_stem"
+      "id": "minecraft:crimson_stem"
     },
     {
-      "item": "minecraft:porkchop"
+      "id": "minecraft:porkchop"
     },
     {
-      "item": "minecraft:nether_wart"
+      "id": "minecraft:nether_wart"
     },
     {
-      "item": "minecraft:leather"
+      "id": "minecraft:leather"
     },
     {
-      "item": "minecraft:gunpowder"
+      "id": "minecraft:gunpowder"
     },
     {
-      "item": "minecraft:ghast_tear"
+      "id": "minecraft:ghast_tear"
     },
     {
-      "item": "minecraft:ender_pearl"
+      "id": "minecraft:ender_pearl"
     },
     {
-      "item": "minecraft:magma_cream"
+      "id": "minecraft:magma_cream"
     }
   ],
   "crafter": "netherworker_custom",
   "inputs": [
     {
       "count": 64,
-      "item": "minecraft:cobblestone"
+      "id": "minecraft:cobblestone"
     },
     {
       "count": 32,
-      "item": "minecraft:torch"
+      "id": "minecraft:torch"
     },
     {
       "count": 16,
-      "item": "minecraft:ladder"
+      "id": "minecraft:ladder"
     }
   ],
   "intermediate": "minecraft:air",

--- a/src/datagen/generated/minecolonies/data/minecolonies/crafterrecipes/netherworker/trip3.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/crafterrecipes/netherworker/trip3.json
@@ -2,100 +2,100 @@
   "type": "recipe",
   "additional-output": [
     {
-      "item": "minecraft:rotten_flesh"
+      "id": "minecraft:rotten_flesh"
     },
     {
-      "item": "minecraft:gold_nugget"
+      "id": "minecraft:gold_nugget"
     },
     {
-      "item": "minecraft:netherrack"
+      "id": "minecraft:netherrack"
     },
     {
-      "item": "minecraft:nether_quartz_ore"
+      "id": "minecraft:nether_quartz_ore"
     },
     {
-      "item": "minecraft:soul_sand"
+      "id": "minecraft:soul_sand"
     },
     {
-      "item": "minecraft:gravel"
+      "id": "minecraft:gravel"
     },
     {
-      "item": "minecraft:brown_mushroom"
+      "id": "minecraft:brown_mushroom"
     },
     {
-      "item": "minecraft:red_mushroom"
+      "id": "minecraft:red_mushroom"
     },
     {
-      "item": "minecraft:soul_soil"
+      "id": "minecraft:soul_soil"
     },
     {
-      "item": "minecraft:porkchop"
+      "id": "minecraft:porkchop"
     },
     {
-      "item": "minecraft:glowstone"
+      "id": "minecraft:glowstone"
     },
     {
-      "item": "minecraft:crimson_nylium"
+      "id": "minecraft:crimson_nylium"
     },
     {
-      "item": "minecraft:crimson_fungus"
+      "id": "minecraft:crimson_fungus"
     },
     {
-      "item": "minecraft:crimson_stem"
+      "id": "minecraft:crimson_stem"
     },
     {
-      "item": "minecraft:basalt"
+      "id": "minecraft:basalt"
     },
     {
-      "item": "minecraft:warped_nylium"
+      "id": "minecraft:warped_nylium"
     },
     {
-      "item": "minecraft:warped_fungus"
+      "id": "minecraft:warped_fungus"
     },
     {
-      "item": "minecraft:warped_stem"
+      "id": "minecraft:warped_stem"
     },
     {
-      "item": "minecraft:leather"
+      "id": "minecraft:leather"
     },
     {
-      "item": "minecraft:nether_wart"
+      "id": "minecraft:nether_wart"
     },
     {
-      "item": "minecraft:gunpowder"
+      "id": "minecraft:gunpowder"
     },
     {
-      "item": "minecraft:ochre_froglight"
+      "id": "minecraft:ochre_froglight"
     },
     {
-      "item": "minecraft:ghast_tear"
+      "id": "minecraft:ghast_tear"
     },
     {
-      "item": "minecraft:ender_pearl"
+      "id": "minecraft:ender_pearl"
     },
     {
-      "item": "minecraft:pearlescent_froglight"
+      "id": "minecraft:pearlescent_froglight"
     },
     {
-      "item": "minecraft:verdant_froglight"
+      "id": "minecraft:verdant_froglight"
     },
     {
-      "item": "minecraft:magma_cream"
+      "id": "minecraft:magma_cream"
     }
   ],
   "crafter": "netherworker_custom",
   "inputs": [
     {
       "count": 64,
-      "item": "minecraft:cobblestone"
+      "id": "minecraft:cobblestone"
     },
     {
       "count": 32,
-      "item": "minecraft:torch"
+      "id": "minecraft:torch"
     },
     {
       "count": 16,
-      "item": "minecraft:ladder"
+      "id": "minecraft:ladder"
     }
   ],
   "intermediate": "minecraft:air",

--- a/src/datagen/generated/minecolonies/data/minecolonies/crafterrecipes/netherworker/trip4.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/crafterrecipes/netherworker/trip4.json
@@ -2,106 +2,106 @@
   "type": "recipe",
   "additional-output": [
     {
-      "item": "minecraft:rotten_flesh"
+      "id": "minecraft:rotten_flesh"
     },
     {
-      "item": "minecraft:gold_nugget"
+      "id": "minecraft:gold_nugget"
     },
     {
-      "item": "minecraft:netherrack"
+      "id": "minecraft:netherrack"
     },
     {
-      "item": "minecraft:nether_quartz_ore"
+      "id": "minecraft:nether_quartz_ore"
     },
     {
-      "item": "minecraft:soul_sand"
+      "id": "minecraft:soul_sand"
     },
     {
-      "item": "minecraft:gravel"
+      "id": "minecraft:gravel"
     },
     {
-      "item": "minecraft:brown_mushroom"
+      "id": "minecraft:brown_mushroom"
     },
     {
-      "item": "minecraft:red_mushroom"
+      "id": "minecraft:red_mushroom"
     },
     {
-      "item": "minecraft:soul_soil"
+      "id": "minecraft:soul_soil"
     },
     {
-      "item": "minecraft:porkchop"
+      "id": "minecraft:porkchop"
     },
     {
-      "item": "minecraft:glowstone"
+      "id": "minecraft:glowstone"
     },
     {
-      "item": "minecraft:crimson_nylium"
+      "id": "minecraft:crimson_nylium"
     },
     {
-      "item": "minecraft:crimson_fungus"
+      "id": "minecraft:crimson_fungus"
     },
     {
-      "item": "minecraft:crimson_stem"
+      "id": "minecraft:crimson_stem"
     },
     {
-      "item": "minecraft:basalt"
+      "id": "minecraft:basalt"
     },
     {
-      "item": "minecraft:warped_nylium"
+      "id": "minecraft:warped_nylium"
     },
     {
-      "item": "minecraft:warped_fungus"
+      "id": "minecraft:warped_fungus"
     },
     {
-      "item": "minecraft:warped_stem"
+      "id": "minecraft:warped_stem"
     },
     {
-      "item": "minecraft:nether_gold_ore"
+      "id": "minecraft:nether_gold_ore"
     },
     {
-      "item": "minecraft:blackstone"
+      "id": "minecraft:blackstone"
     },
     {
-      "item": "minecraft:leather"
+      "id": "minecraft:leather"
     },
     {
-      "item": "minecraft:nether_wart"
+      "id": "minecraft:nether_wart"
     },
     {
-      "item": "minecraft:gunpowder"
+      "id": "minecraft:gunpowder"
     },
     {
-      "item": "minecraft:ochre_froglight"
+      "id": "minecraft:ochre_froglight"
     },
     {
-      "item": "minecraft:ghast_tear"
+      "id": "minecraft:ghast_tear"
     },
     {
-      "item": "minecraft:ender_pearl"
+      "id": "minecraft:ender_pearl"
     },
     {
-      "item": "minecraft:pearlescent_froglight"
+      "id": "minecraft:pearlescent_froglight"
     },
     {
-      "item": "minecraft:verdant_froglight"
+      "id": "minecraft:verdant_froglight"
     },
     {
-      "item": "minecraft:magma_cream"
+      "id": "minecraft:magma_cream"
     }
   ],
   "crafter": "netherworker_custom",
   "inputs": [
     {
       "count": 64,
-      "item": "minecraft:cobblestone"
+      "id": "minecraft:cobblestone"
     },
     {
       "count": 32,
-      "item": "minecraft:torch"
+      "id": "minecraft:torch"
     },
     {
       "count": 16,
-      "item": "minecraft:ladder"
+      "id": "minecraft:ladder"
     }
   ],
   "intermediate": "minecraft:air",

--- a/src/datagen/generated/minecolonies/data/minecolonies/crafterrecipes/netherworker/trip5.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/crafterrecipes/netherworker/trip5.json
@@ -2,109 +2,109 @@
   "type": "recipe",
   "additional-output": [
     {
-      "item": "minecraft:rotten_flesh"
+      "id": "minecraft:rotten_flesh"
     },
     {
-      "item": "minecraft:gold_nugget"
+      "id": "minecraft:gold_nugget"
     },
     {
-      "item": "minecraft:netherrack"
+      "id": "minecraft:netherrack"
     },
     {
-      "item": "minecraft:nether_quartz_ore"
+      "id": "minecraft:nether_quartz_ore"
     },
     {
-      "item": "minecraft:soul_sand"
+      "id": "minecraft:soul_sand"
     },
     {
-      "item": "minecraft:gravel"
+      "id": "minecraft:gravel"
     },
     {
-      "item": "minecraft:brown_mushroom"
+      "id": "minecraft:brown_mushroom"
     },
     {
-      "item": "minecraft:red_mushroom"
+      "id": "minecraft:red_mushroom"
     },
     {
-      "item": "minecraft:soul_soil"
+      "id": "minecraft:soul_soil"
     },
     {
-      "item": "minecraft:porkchop"
+      "id": "minecraft:porkchop"
     },
     {
-      "item": "minecraft:glowstone"
+      "id": "minecraft:glowstone"
     },
     {
-      "item": "minecraft:crimson_nylium"
+      "id": "minecraft:crimson_nylium"
     },
     {
-      "item": "minecraft:crimson_fungus"
+      "id": "minecraft:crimson_fungus"
     },
     {
-      "item": "minecraft:crimson_stem"
+      "id": "minecraft:crimson_stem"
     },
     {
-      "item": "minecraft:basalt"
+      "id": "minecraft:basalt"
     },
     {
-      "item": "minecraft:warped_nylium"
+      "id": "minecraft:warped_nylium"
     },
     {
-      "item": "minecraft:warped_fungus"
+      "id": "minecraft:warped_fungus"
     },
     {
-      "item": "minecraft:warped_stem"
+      "id": "minecraft:warped_stem"
     },
     {
-      "item": "minecraft:nether_gold_ore"
+      "id": "minecraft:nether_gold_ore"
     },
     {
-      "item": "minecraft:blackstone"
+      "id": "minecraft:blackstone"
     },
     {
-      "item": "minecraft:leather"
+      "id": "minecraft:leather"
     },
     {
-      "item": "minecraft:nether_wart"
+      "id": "minecraft:nether_wart"
     },
     {
-      "item": "minecraft:gunpowder"
+      "id": "minecraft:gunpowder"
     },
     {
-      "item": "minecraft:ochre_froglight"
+      "id": "minecraft:ochre_froglight"
     },
     {
-      "item": "minecraft:ghast_tear"
+      "id": "minecraft:ghast_tear"
     },
     {
-      "item": "minecraft:ender_pearl"
+      "id": "minecraft:ender_pearl"
     },
     {
-      "item": "minecraft:pearlescent_froglight"
+      "id": "minecraft:pearlescent_froglight"
     },
     {
-      "item": "minecraft:verdant_froglight"
+      "id": "minecraft:verdant_froglight"
     },
     {
-      "item": "minecraft:ancient_debris"
+      "id": "minecraft:ancient_debris"
     },
     {
-      "item": "minecraft:magma_cream"
+      "id": "minecraft:magma_cream"
     }
   ],
   "crafter": "netherworker_custom",
   "inputs": [
     {
       "count": 64,
-      "item": "minecraft:cobblestone"
+      "id": "minecraft:cobblestone"
     },
     {
       "count": 32,
-      "item": "minecraft:torch"
+      "id": "minecraft:torch"
     },
     {
       "count": 16,
-      "item": "minecraft:ladder"
+      "id": "minecraft:ladder"
     }
   ],
   "intermediate": "minecraft:air",

--- a/src/datagen/generated/minecolonies/data/minecolonies/crafterrecipes/sifter/diamond/dirt.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/crafterrecipes/sifter/diamond/dirt.json
@@ -2,52 +2,52 @@
   "type": "recipe",
   "additional-output": [
     {
-      "item": "minecolonies:sifter_mesh_diamond"
+      "id": "minecolonies:sifter_mesh_diamond"
     },
     {
-      "item": "minecraft:wheat_seeds"
+      "id": "minecraft:wheat_seeds"
     },
     {
-      "item": "minecraft:oak_sapling"
+      "id": "minecraft:oak_sapling"
     },
     {
-      "item": "minecraft:birch_sapling"
+      "id": "minecraft:birch_sapling"
     },
     {
-      "item": "minecraft:spruce_sapling"
+      "id": "minecraft:spruce_sapling"
     },
     {
-      "item": "minecraft:jungle_sapling"
+      "id": "minecraft:jungle_sapling"
     },
     {
-      "item": "minecraft:carrot"
+      "id": "minecraft:carrot"
     },
     {
-      "item": "minecraft:potato"
+      "id": "minecraft:potato"
     },
     {
-      "item": "minecraft:pumpkin_seeds"
+      "id": "minecraft:pumpkin_seeds"
     },
     {
-      "item": "minecraft:melon_seeds"
+      "id": "minecraft:melon_seeds"
     },
     {
-      "item": "minecraft:beetroot_seeds"
+      "id": "minecraft:beetroot_seeds"
     },
     {
-      "item": "minecraft:dark_oak_sapling"
+      "id": "minecraft:dark_oak_sapling"
     },
     {
-      "item": "minecraft:acacia_sapling"
+      "id": "minecraft:acacia_sapling"
     }
   ],
   "crafter": "sifter_custom",
   "inputs": [
     {
-      "item": "minecraft:dirt"
+      "id": "minecraft:dirt"
     },
     {
-      "item": "minecolonies:sifter_mesh_diamond"
+      "id": "minecolonies:sifter_mesh_diamond"
     }
   ],
   "intermediate": "minecraft:air",

--- a/src/datagen/generated/minecolonies/data/minecolonies/crafterrecipes/sifter/diamond/gravel.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/crafterrecipes/sifter/diamond/gravel.json
@@ -2,40 +2,40 @@
   "type": "recipe",
   "additional-output": [
     {
-      "item": "minecolonies:sifter_mesh_diamond"
+      "id": "minecolonies:sifter_mesh_diamond"
     },
     {
-      "item": "minecraft:redstone"
+      "id": "minecraft:redstone"
     },
     {
-      "item": "minecraft:iron_nugget"
+      "id": "minecraft:iron_nugget"
     },
     {
-      "item": "minecraft:coal"
+      "id": "minecraft:coal"
     },
     {
-      "item": "minecraft:lapis_lazuli"
+      "id": "minecraft:lapis_lazuli"
     },
     {
-      "item": "minecraft:iron_ingot"
+      "id": "minecraft:iron_ingot"
     },
     {
-      "item": "minecraft:gold_ingot"
+      "id": "minecraft:gold_ingot"
     },
     {
-      "item": "minecraft:emerald"
+      "id": "minecraft:emerald"
     },
     {
-      "item": "minecraft:diamond"
+      "id": "minecraft:diamond"
     }
   ],
   "crafter": "sifter_custom",
   "inputs": [
     {
-      "item": "minecraft:gravel"
+      "id": "minecraft:gravel"
     },
     {
-      "item": "minecolonies:sifter_mesh_diamond"
+      "id": "minecolonies:sifter_mesh_diamond"
     }
   ],
   "intermediate": "minecraft:air",

--- a/src/datagen/generated/minecolonies/data/minecolonies/crafterrecipes/sifter/diamond/sand.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/crafterrecipes/sifter/diamond/sand.json
@@ -2,28 +2,28 @@
   "type": "recipe",
   "additional-output": [
     {
-      "item": "minecolonies:sifter_mesh_diamond"
+      "id": "minecolonies:sifter_mesh_diamond"
     },
     {
-      "item": "minecraft:cactus"
+      "id": "minecraft:cactus"
     },
     {
-      "item": "minecraft:sugar_cane"
+      "id": "minecraft:sugar_cane"
     },
     {
-      "item": "minecraft:gold_nugget"
+      "id": "minecraft:gold_nugget"
     },
     {
-      "item": "minecraft:cocoa_beans"
+      "id": "minecraft:cocoa_beans"
     }
   ],
   "crafter": "sifter_custom",
   "inputs": [
     {
-      "item": "minecraft:sand"
+      "id": "minecraft:sand"
     },
     {
-      "item": "minecolonies:sifter_mesh_diamond"
+      "id": "minecolonies:sifter_mesh_diamond"
     }
   ],
   "intermediate": "minecraft:air",

--- a/src/datagen/generated/minecolonies/data/minecolonies/crafterrecipes/sifter/diamond/soul_sand.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/crafterrecipes/sifter/diamond/soul_sand.json
@@ -2,34 +2,34 @@
   "type": "recipe",
   "additional-output": [
     {
-      "item": "minecolonies:sifter_mesh_diamond"
+      "id": "minecolonies:sifter_mesh_diamond"
     },
     {
-      "item": "minecraft:nether_wart"
+      "id": "minecraft:nether_wart"
     },
     {
-      "item": "minecraft:quartz"
+      "id": "minecraft:quartz"
     },
     {
-      "item": "minecraft:glowstone_dust"
+      "id": "minecraft:glowstone_dust"
     },
     {
-      "item": "minecraft:blaze_powder"
+      "id": "minecraft:blaze_powder"
     },
     {
-      "item": "minecraft:magma_cream"
+      "id": "minecraft:magma_cream"
     },
     {
-      "item": "minecraft:player_head"
+      "id": "minecraft:player_head"
     }
   ],
   "crafter": "sifter_custom",
   "inputs": [
     {
-      "item": "minecraft:soul_sand"
+      "id": "minecraft:soul_sand"
     },
     {
-      "item": "minecolonies:sifter_mesh_diamond"
+      "id": "minecolonies:sifter_mesh_diamond"
     }
   ],
   "intermediate": "minecraft:air",

--- a/src/datagen/generated/minecolonies/data/minecolonies/crafterrecipes/sifter/flint/dirt.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/crafterrecipes/sifter/flint/dirt.json
@@ -2,37 +2,37 @@
   "type": "recipe",
   "additional-output": [
     {
-      "item": "minecolonies:sifter_mesh_flint"
+      "id": "minecolonies:sifter_mesh_flint"
     },
     {
-      "item": "minecraft:wheat_seeds"
+      "id": "minecraft:wheat_seeds"
     },
     {
-      "item": "minecraft:oak_sapling"
+      "id": "minecraft:oak_sapling"
     },
     {
-      "item": "minecraft:birch_sapling"
+      "id": "minecraft:birch_sapling"
     },
     {
-      "item": "minecraft:spruce_sapling"
+      "id": "minecraft:spruce_sapling"
     },
     {
-      "item": "minecraft:jungle_sapling"
+      "id": "minecraft:jungle_sapling"
     },
     {
-      "item": "minecraft:carrot"
+      "id": "minecraft:carrot"
     },
     {
-      "item": "minecraft:potato"
+      "id": "minecraft:potato"
     }
   ],
   "crafter": "sifter_custom",
   "inputs": [
     {
-      "item": "minecraft:dirt"
+      "id": "minecraft:dirt"
     },
     {
-      "item": "minecolonies:sifter_mesh_flint"
+      "id": "minecolonies:sifter_mesh_flint"
     }
   ],
   "intermediate": "minecraft:air",

--- a/src/datagen/generated/minecolonies/data/minecolonies/crafterrecipes/sifter/flint/gravel.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/crafterrecipes/sifter/flint/gravel.json
@@ -2,28 +2,28 @@
   "type": "recipe",
   "additional-output": [
     {
-      "item": "minecolonies:sifter_mesh_flint"
+      "id": "minecolonies:sifter_mesh_flint"
     },
     {
-      "item": "minecraft:iron_nugget"
+      "id": "minecraft:iron_nugget"
     },
     {
-      "item": "minecraft:flint"
+      "id": "minecraft:flint"
     },
     {
-      "item": "minecraft:coal"
+      "id": "minecraft:coal"
     },
     {
-      "item": "minecraft:redstone"
+      "id": "minecraft:redstone"
     }
   ],
   "crafter": "sifter_custom",
   "inputs": [
     {
-      "item": "minecraft:gravel"
+      "id": "minecraft:gravel"
     },
     {
-      "item": "minecolonies:sifter_mesh_flint"
+      "id": "minecolonies:sifter_mesh_flint"
     }
   ],
   "intermediate": "minecraft:air",

--- a/src/datagen/generated/minecolonies/data/minecolonies/crafterrecipes/sifter/flint/sand.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/crafterrecipes/sifter/flint/sand.json
@@ -2,25 +2,25 @@
   "type": "recipe",
   "additional-output": [
     {
-      "item": "minecolonies:sifter_mesh_flint"
+      "id": "minecolonies:sifter_mesh_flint"
     },
     {
-      "item": "minecraft:cactus"
+      "id": "minecraft:cactus"
     },
     {
-      "item": "minecraft:sugar_cane"
+      "id": "minecraft:sugar_cane"
     },
     {
-      "item": "minecraft:gold_nugget"
+      "id": "minecraft:gold_nugget"
     }
   ],
   "crafter": "sifter_custom",
   "inputs": [
     {
-      "item": "minecraft:sand"
+      "id": "minecraft:sand"
     },
     {
-      "item": "minecolonies:sifter_mesh_flint"
+      "id": "minecolonies:sifter_mesh_flint"
     }
   ],
   "intermediate": "minecraft:air",

--- a/src/datagen/generated/minecolonies/data/minecolonies/crafterrecipes/sifter/flint/soul_sand.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/crafterrecipes/sifter/flint/soul_sand.json
@@ -2,25 +2,25 @@
   "type": "recipe",
   "additional-output": [
     {
-      "item": "minecolonies:sifter_mesh_flint"
+      "id": "minecolonies:sifter_mesh_flint"
     },
     {
-      "item": "minecraft:nether_wart"
+      "id": "minecraft:nether_wart"
     },
     {
-      "item": "minecraft:quartz"
+      "id": "minecraft:quartz"
     },
     {
-      "item": "minecraft:glowstone_dust"
+      "id": "minecraft:glowstone_dust"
     }
   ],
   "crafter": "sifter_custom",
   "inputs": [
     {
-      "item": "minecraft:soul_sand"
+      "id": "minecraft:soul_sand"
     },
     {
-      "item": "minecolonies:sifter_mesh_flint"
+      "id": "minecolonies:sifter_mesh_flint"
     }
   ],
   "intermediate": "minecraft:air",

--- a/src/datagen/generated/minecolonies/data/minecolonies/crafterrecipes/sifter/iron/dirt.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/crafterrecipes/sifter/iron/dirt.json
@@ -2,52 +2,52 @@
   "type": "recipe",
   "additional-output": [
     {
-      "item": "minecolonies:sifter_mesh_iron"
+      "id": "minecolonies:sifter_mesh_iron"
     },
     {
-      "item": "minecraft:wheat_seeds"
+      "id": "minecraft:wheat_seeds"
     },
     {
-      "item": "minecraft:oak_sapling"
+      "id": "minecraft:oak_sapling"
     },
     {
-      "item": "minecraft:birch_sapling"
+      "id": "minecraft:birch_sapling"
     },
     {
-      "item": "minecraft:spruce_sapling"
+      "id": "minecraft:spruce_sapling"
     },
     {
-      "item": "minecraft:jungle_sapling"
+      "id": "minecraft:jungle_sapling"
     },
     {
-      "item": "minecraft:carrot"
+      "id": "minecraft:carrot"
     },
     {
-      "item": "minecraft:potato"
+      "id": "minecraft:potato"
     },
     {
-      "item": "minecraft:pumpkin_seeds"
+      "id": "minecraft:pumpkin_seeds"
     },
     {
-      "item": "minecraft:melon_seeds"
+      "id": "minecraft:melon_seeds"
     },
     {
-      "item": "minecraft:beetroot_seeds"
+      "id": "minecraft:beetroot_seeds"
     },
     {
-      "item": "minecraft:dark_oak_sapling"
+      "id": "minecraft:dark_oak_sapling"
     },
     {
-      "item": "minecraft:acacia_sapling"
+      "id": "minecraft:acacia_sapling"
     }
   ],
   "crafter": "sifter_custom",
   "inputs": [
     {
-      "item": "minecraft:dirt"
+      "id": "minecraft:dirt"
     },
     {
-      "item": "minecolonies:sifter_mesh_iron"
+      "id": "minecolonies:sifter_mesh_iron"
     }
   ],
   "intermediate": "minecraft:air",

--- a/src/datagen/generated/minecolonies/data/minecolonies/crafterrecipes/sifter/iron/gravel.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/crafterrecipes/sifter/iron/gravel.json
@@ -2,40 +2,40 @@
   "type": "recipe",
   "additional-output": [
     {
-      "item": "minecolonies:sifter_mesh_iron"
+      "id": "minecolonies:sifter_mesh_iron"
     },
     {
-      "item": "minecraft:redstone"
+      "id": "minecraft:redstone"
     },
     {
-      "item": "minecraft:iron_nugget"
+      "id": "minecraft:iron_nugget"
     },
     {
-      "item": "minecraft:coal"
+      "id": "minecraft:coal"
     },
     {
-      "item": "minecraft:lapis_lazuli"
+      "id": "minecraft:lapis_lazuli"
     },
     {
-      "item": "minecraft:iron_ingot"
+      "id": "minecraft:iron_ingot"
     },
     {
-      "item": "minecraft:gold_ingot"
+      "id": "minecraft:gold_ingot"
     },
     {
-      "item": "minecraft:emerald"
+      "id": "minecraft:emerald"
     },
     {
-      "item": "minecraft:diamond"
+      "id": "minecraft:diamond"
     }
   ],
   "crafter": "sifter_custom",
   "inputs": [
     {
-      "item": "minecraft:gravel"
+      "id": "minecraft:gravel"
     },
     {
-      "item": "minecolonies:sifter_mesh_iron"
+      "id": "minecolonies:sifter_mesh_iron"
     }
   ],
   "intermediate": "minecraft:air",

--- a/src/datagen/generated/minecolonies/data/minecolonies/crafterrecipes/sifter/iron/sand.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/crafterrecipes/sifter/iron/sand.json
@@ -2,28 +2,28 @@
   "type": "recipe",
   "additional-output": [
     {
-      "item": "minecolonies:sifter_mesh_iron"
+      "id": "minecolonies:sifter_mesh_iron"
     },
     {
-      "item": "minecraft:cactus"
+      "id": "minecraft:cactus"
     },
     {
-      "item": "minecraft:sugar_cane"
+      "id": "minecraft:sugar_cane"
     },
     {
-      "item": "minecraft:gold_nugget"
+      "id": "minecraft:gold_nugget"
     },
     {
-      "item": "minecraft:cocoa_beans"
+      "id": "minecraft:cocoa_beans"
     }
   ],
   "crafter": "sifter_custom",
   "inputs": [
     {
-      "item": "minecraft:sand"
+      "id": "minecraft:sand"
     },
     {
-      "item": "minecolonies:sifter_mesh_iron"
+      "id": "minecolonies:sifter_mesh_iron"
     }
   ],
   "intermediate": "minecraft:air",

--- a/src/datagen/generated/minecolonies/data/minecolonies/crafterrecipes/sifter/iron/soul_sand.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/crafterrecipes/sifter/iron/soul_sand.json
@@ -2,31 +2,31 @@
   "type": "recipe",
   "additional-output": [
     {
-      "item": "minecolonies:sifter_mesh_iron"
+      "id": "minecolonies:sifter_mesh_iron"
     },
     {
-      "item": "minecraft:nether_wart"
+      "id": "minecraft:nether_wart"
     },
     {
-      "item": "minecraft:quartz"
+      "id": "minecraft:quartz"
     },
     {
-      "item": "minecraft:glowstone_dust"
+      "id": "minecraft:glowstone_dust"
     },
     {
-      "item": "minecraft:blaze_powder"
+      "id": "minecraft:blaze_powder"
     },
     {
-      "item": "minecraft:magma_cream"
+      "id": "minecraft:magma_cream"
     }
   ],
   "crafter": "sifter_custom",
   "inputs": [
     {
-      "item": "minecraft:soul_sand"
+      "id": "minecraft:soul_sand"
     },
     {
-      "item": "minecolonies:sifter_mesh_iron"
+      "id": "minecolonies:sifter_mesh_iron"
     }
   ],
   "intermediate": "minecraft:air",

--- a/src/datagen/generated/minecolonies/data/minecolonies/crafterrecipes/sifter/string/dirt.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/crafterrecipes/sifter/string/dirt.json
@@ -2,31 +2,31 @@
   "type": "recipe",
   "additional-output": [
     {
-      "item": "minecolonies:sifter_mesh_string"
+      "id": "minecolonies:sifter_mesh_string"
     },
     {
-      "item": "minecraft:wheat_seeds"
+      "id": "minecraft:wheat_seeds"
     },
     {
-      "item": "minecraft:oak_sapling"
+      "id": "minecraft:oak_sapling"
     },
     {
-      "item": "minecraft:birch_sapling"
+      "id": "minecraft:birch_sapling"
     },
     {
-      "item": "minecraft:spruce_sapling"
+      "id": "minecraft:spruce_sapling"
     },
     {
-      "item": "minecraft:jungle_sapling"
+      "id": "minecraft:jungle_sapling"
     }
   ],
   "crafter": "sifter_custom",
   "inputs": [
     {
-      "item": "minecraft:dirt"
+      "id": "minecraft:dirt"
     },
     {
-      "item": "minecolonies:sifter_mesh_string"
+      "id": "minecolonies:sifter_mesh_string"
     }
   ],
   "intermediate": "minecraft:air",

--- a/src/datagen/generated/minecolonies/data/minecolonies/crafterrecipes/sifter/string/gravel.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/crafterrecipes/sifter/string/gravel.json
@@ -2,25 +2,25 @@
   "type": "recipe",
   "additional-output": [
     {
-      "item": "minecolonies:sifter_mesh_string"
+      "id": "minecolonies:sifter_mesh_string"
     },
     {
-      "item": "minecraft:iron_nugget"
+      "id": "minecraft:iron_nugget"
     },
     {
-      "item": "minecraft:flint"
+      "id": "minecraft:flint"
     },
     {
-      "item": "minecraft:coal"
+      "id": "minecraft:coal"
     }
   ],
   "crafter": "sifter_custom",
   "inputs": [
     {
-      "item": "minecraft:gravel"
+      "id": "minecraft:gravel"
     },
     {
-      "item": "minecolonies:sifter_mesh_string"
+      "id": "minecolonies:sifter_mesh_string"
     }
   ],
   "intermediate": "minecraft:air",

--- a/src/datagen/generated/minecolonies/data/minecolonies/crafterrecipes/sifter/string/sand.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/crafterrecipes/sifter/string/sand.json
@@ -2,22 +2,22 @@
   "type": "recipe",
   "additional-output": [
     {
-      "item": "minecolonies:sifter_mesh_string"
+      "id": "minecolonies:sifter_mesh_string"
     },
     {
-      "item": "minecraft:cactus"
+      "id": "minecraft:cactus"
     },
     {
-      "item": "minecraft:sugar_cane"
+      "id": "minecraft:sugar_cane"
     }
   ],
   "crafter": "sifter_custom",
   "inputs": [
     {
-      "item": "minecraft:sand"
+      "id": "minecraft:sand"
     },
     {
-      "item": "minecolonies:sifter_mesh_string"
+      "id": "minecolonies:sifter_mesh_string"
     }
   ],
   "intermediate": "minecraft:air",

--- a/src/datagen/generated/minecolonies/data/minecolonies/crafterrecipes/sifter/string/soul_sand.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/crafterrecipes/sifter/string/soul_sand.json
@@ -2,22 +2,22 @@
   "type": "recipe",
   "additional-output": [
     {
-      "item": "minecolonies:sifter_mesh_string"
+      "id": "minecolonies:sifter_mesh_string"
     },
     {
-      "item": "minecraft:nether_wart"
+      "id": "minecraft:nether_wart"
     },
     {
-      "item": "minecraft:quartz"
+      "id": "minecraft:quartz"
     }
   ],
   "crafter": "sifter_custom",
   "inputs": [
     {
-      "item": "minecraft:soul_sand"
+      "id": "minecraft:soul_sand"
     },
     {
-      "item": "minecolonies:sifter_mesh_string"
+      "id": "minecolonies:sifter_mesh_string"
     }
   ],
   "intermediate": "minecraft:air",

--- a/src/datagen/generated/minecolonies/data/minecolonies/crafterrecipes/stonemason/end_stone.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/crafterrecipes/stonemason/end_stone.json
@@ -1,17 +1,19 @@
 {
   "type": "recipe",
-  "count": 8,
   "crafter": "stonemason_crafting",
   "inputs": [
     {
       "count": 8,
-      "item": "minecraft:sandstone"
+      "id": "minecraft:sandstone"
     },
     {
-      "item": "minecraft:ender_pearl"
+      "id": "minecraft:ender_pearl"
     }
   ],
   "intermediate": "minecraft:air",
   "research-id": "minecolonies:effects/knowledgeoftheendunlock",
-  "result": "minecraft:end_stone"
+  "result": {
+    "count": 8,
+    "id": "minecraft:end_stone"
+  }
 }

--- a/src/datagen/generated/minecolonies/data/minecolonies/crafterrecipes/stonemason/prismarine.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/crafterrecipes/stonemason/prismarine.json
@@ -3,12 +3,14 @@
   "crafter": "stonemason_crafting",
   "inputs": [
     {
-      "item": "minecraft:cobblestone"
+      "id": "minecraft:cobblestone"
     },
     {
-      "item": "minecraft:prismarine_shard"
+      "id": "minecraft:prismarine_shard"
     }
   ],
   "intermediate": "minecraft:air",
-  "result": "minecraft:prismarine"
+  "result": {
+    "id": "minecraft:prismarine"
+  }
 }

--- a/src/datagen/generated/minecolonies/data/minecolonies/crafterrecipes/stonemason/prismarine_bricks.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/crafterrecipes/stonemason/prismarine_bricks.json
@@ -3,12 +3,14 @@
   "crafter": "stonemason_crafting",
   "inputs": [
     {
-      "item": "minecraft:stone_bricks"
+      "id": "minecraft:stone_bricks"
     },
     {
-      "item": "minecraft:prismarine_shard"
+      "id": "minecraft:prismarine_shard"
     }
   ],
   "intermediate": "minecraft:air",
-  "result": "minecraft:prismarine_bricks"
+  "result": {
+    "id": "minecraft:prismarine_bricks"
+  }
 }

--- a/src/datagen/generated/minecolonies/data/minecolonies/crafterrecipes/stonemason/red_sandstone.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/crafterrecipes/stonemason/red_sandstone.json
@@ -3,12 +3,14 @@
   "crafter": "stonemason_crafting",
   "inputs": [
     {
-      "item": "minecraft:cobblestone"
+      "id": "minecraft:cobblestone"
     },
     {
-      "item": "minecraft:red_sand"
+      "id": "minecraft:red_sand"
     }
   ],
   "intermediate": "minecraft:air",
-  "result": "minecraft:red_sandstone"
+  "result": {
+    "id": "minecraft:red_sandstone"
+  }
 }

--- a/src/datagen/generated/minecolonies/data/minecolonies/crafterrecipes/stonemason/sandstone.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/crafterrecipes/stonemason/sandstone.json
@@ -3,12 +3,14 @@
   "crafter": "stonemason_crafting",
   "inputs": [
     {
-      "item": "minecraft:cobblestone"
+      "id": "minecraft:cobblestone"
     },
     {
-      "item": "minecraft:sand"
+      "id": "minecraft:sand"
     }
   ],
   "intermediate": "minecraft:air",
-  "result": "minecraft:sandstone"
+  "result": {
+    "id": "minecraft:sandstone"
+  }
 }

--- a/src/datagen/generated/minecolonies/data/minecolonies/crafterrecipes/stonemason/sifter_mesh_flint.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/crafterrecipes/stonemason/sifter_mesh_flint.json
@@ -3,11 +3,13 @@
   "crafter": "stonemason_crafting",
   "inputs": [
     {
-      "item": "minecraft:flint"
+      "id": "minecraft:flint"
     }
   ],
   "intermediate": "minecraft:air",
   "research-id": "minecolonies:effects/sifterflintunlock",
-  "result": "minecolonies:sifter_mesh_flint",
+  "result": {
+    "id": "minecolonies:sifter_mesh_flint"
+  },
   "show-tooltip": true
 }

--- a/src/main/java/com/minecolonies/api/crafting/ItemStorage.java
+++ b/src/main/java/com/minecolonies/api/crafting/ItemStorage.java
@@ -4,7 +4,6 @@ import com.google.gson.JsonObject;
 import com.minecolonies.api.util.ItemStackUtils;
 import com.minecolonies.api.util.Utils;
 import net.minecraft.core.HolderLookup;
-import net.minecraft.core.component.DataComponentPatch;
 import net.minecraft.world.item.Item;
 import net.minecraft.world.item.ItemStack;
 import org.jetbrains.annotations.NotNull;
@@ -128,29 +127,27 @@ public class ItemStorage
      * 
      * @param jObject the JSON Object to parse
      */
-    public ItemStorage(@NotNull final HolderLookup.Provider provider, @NotNull final JsonObject jObject)
+    public ItemStorage(@NotNull final HolderLookup.Provider provider, @NotNull JsonObject jObject)
     {
-        if (jObject.has(ITEM_PROP))
+        // storage amount can be larger than is valid for ItemStack.
+        if (jObject.has(COUNT_PROP))
         {
-            final ItemStack parsedStack = ItemStackUtils.idToItemStack(jObject.get(ITEM_PROP).getAsString(), provider);
-            if(jObject.has(COUNT_PROP))
-            {
-                parsedStack.setCount(jObject.get(COUNT_PROP).getAsInt());
-                this.amount = jObject.get(COUNT_PROP).getAsInt();
-            }
-            else
-            {
-                this.amount = parsedStack.getCount();
-            }
-            if (jObject.has(TAG_PROP))
-            {
-                parsedStack.applyComponents(Utils.deserializeCodecMessFromJson(DataComponentPatch.CODEC, provider, jObject.get(TAG_PROP)));
-            }
-            this.stack = parsedStack;
-            if(jObject.has(MATCHTYPE_PROP))
+            this.amount = jObject.get(COUNT_PROP).getAsInt();
+            jObject = jObject.deepCopy();
+            jObject.remove(COUNT_PROP);
+        }
+        else
+        {
+            this.amount = 1;
+        }
+
+        if (jObject.has("id"))
+        {
+            this.stack = Utils.deserializeCodecMessFromJson(ItemStack.OPTIONAL_CODEC, provider, jObject);
+            if (jObject.has(MATCHTYPE_PROP))
             {
                 String matchType = jObject.get(MATCHTYPE_PROP).getAsString();
-                if(matchType.equals(MATCH_NBTIGNORE))
+                if (matchType.equals(MATCH_NBTIGNORE))
                 {
                     this.shouldIgnoreNBTValue = true;
                 }
@@ -163,7 +160,7 @@ public class ItemStorage
             {
                 this.shouldIgnoreNBTValue = false;
             }
-            this.shouldIgnoreDamageValue= true;
+            this.shouldIgnoreDamageValue = true;
         }
         else
         {

--- a/src/main/java/com/minecolonies/api/quests/QuestParseConstant.java
+++ b/src/main/java/com/minecolonies/api/quests/QuestParseConstant.java
@@ -15,7 +15,6 @@ public class QuestParseConstant
     public static final String NEXT_OBJ_KEY   = "next-objective";
     public static final String BLOCK_KEY = "block";
     public static final String ITEM_KEY = "item";
-    public static final String COMPONENTS_KEY = "components";
     public static final String NBT_MODE_KEY = "nbt-mode";
     public static final String UNLOCKS_REWARDS_KEY = "unlocks-rewards";
     public static final String ENTITY_TYPE_KEY = "entity-type";

--- a/src/main/java/com/minecolonies/api/util/ItemStackUtils.java
+++ b/src/main/java/com/minecolonies/api/util/ItemStackUtils.java
@@ -980,29 +980,25 @@ public final class ItemStackUtils
     }
 
     /**
-     * Parses an item string (formatted for {@link #idToItemStack}) that may
-     * contain replaceable template components:
+     * Parses an item id that may contain replaceable template components:
      *
      * <pre>
      *     [NS]           => {@code baseItemId.getNamespace()}
      *     [PATH]         => {@code baseItemId.getPath()}
      *     [PATH:foo=bar] => {@code baseItemId.getPath()} but with "foo" replaced with "bar"</pre>
      *
-     * @param value      the value to parse
+     * @param itemId     the id to parse
      * @param baseItemId the base item id to use to fill in the components
      * @return a tuple of (boolean, result), where the boolean is false if result didn't resolve to a valid item
      */
     @NotNull
-    public static Tuple<Boolean, String> parseIdTemplate(@Nullable final String value,
+    public static Tuple<Boolean, String> parseIdTemplate(@Nullable String itemId,
                                                          @NotNull final ResourceLocation baseItemId)
     {
-        if (value == null)
+        if (itemId == null)
         {
             return new Tuple<>(false, null);
         }
-
-        final int nbtIndex = value.indexOf('{');
-        String itemId = nbtIndex < 0 ? value : value.substring(0, nbtIndex);
 
         itemId = itemId.replace("[NS]", baseItemId.getNamespace());
         itemId = TEMPLATE_PATH_PATTERN.matcher(itemId).replaceAll(m ->
@@ -1014,8 +1010,7 @@ public final class ItemStackUtils
             return baseItemId.getPath();
         });
 
-        return new Tuple<>(BuiltInRegistries.ITEM.containsKey(ResourceLocation.parse(itemId)),
-                itemId + (nbtIndex >= 0 ? value.substring(nbtIndex) : ""));
+        return new Tuple<>(BuiltInRegistries.ITEM.containsKey(ResourceLocation.parse(itemId)), itemId);
     }
 
     /**

--- a/src/main/java/com/minecolonies/api/util/constant/NbtTagConstants.java
+++ b/src/main/java/com/minecolonies/api/util/constant/NbtTagConstants.java
@@ -714,7 +714,6 @@ public final class NbtTagConstants
     public static final String ITEM_PROP       = "item";
     public static final String MATCHTYPE_PROP  = "matchType";
     public static final String MATCH_NBTIGNORE = "ignore";
-    public static final String TAG_PROP        = "tag";
 
     /**
      * Version tag.

--- a/src/main/java/com/minecolonies/core/generation/CustomRecipeProvider.java
+++ b/src/main/java/com/minecolonies/core/generation/CustomRecipeProvider.java
@@ -10,7 +10,6 @@ import com.minecolonies.api.util.constant.IToolType;
 import com.minecolonies.api.util.constant.ToolType;
 import com.minecolonies.core.colony.crafting.CustomRecipe;
 import net.minecraft.core.HolderLookup;
-import net.minecraft.core.component.DataComponentPatch;
 import net.minecraft.core.registries.BuiltInRegistries;
 import net.minecraft.data.CachedOutput;
 import net.minecraft.data.DataProvider;
@@ -117,12 +116,7 @@ public abstract class CustomRecipeProvider implements DataProvider
         public CustomRecipeBuilder result(@NotNull final ItemStack result)
         {
             final JsonObject jsonItemStack = stackAsJson(result);
-
-            this.json.addProperty(CustomRecipe.RECIPE_RESULT_PROP, jsonItemStack.get(ITEM_PROP).getAsString());
-            if (jsonItemStack.has(COUNT_PROP))
-            {
-                this.json.add(COUNT_PROP, jsonItemStack.get(COUNT_PROP));
-            }
+            this.json.add(CustomRecipe.RECIPE_RESULT_PROP, jsonItemStack);
             return this;
         }
 
@@ -259,18 +253,12 @@ public abstract class CustomRecipeProvider implements DataProvider
         @NotNull
         private JsonObject stackAsJson(final ItemStack stack)
         {
-            final JsonObject jsonItemStack = new JsonObject();
-            String name = BuiltInRegistries.ITEM.getKey(stack.getItem()).toString();
-            if (!stack.isComponentsPatchEmpty())
+            final JsonObject json = Utils.serializeCodecMessToJson(ItemStack.OPTIONAL_CODEC, provider, stack).getAsJsonObject();
+            if (stack.getCount() == 1)
             {
-                name += Utils.serializeCodecMessToJson(DataComponentPatch.CODEC, provider, stack.getComponentsPatch());
+                json.remove(COUNT_PROP);
             }
-            jsonItemStack.addProperty(ITEM_PROP, name);
-            if (stack.getCount() != 1)
-            {
-                jsonItemStack.addProperty(COUNT_PROP, stack.getCount());
-            }
-            return jsonItemStack;
+            return json;
         }
 
         @NotNull
@@ -291,11 +279,7 @@ public abstract class CustomRecipeProvider implements DataProvider
             for (final ItemStorage itemStorage : itemStorages)
             {
                 final JsonObject jsonItemStorage = stackAsJson(itemStorage.getItemStack());
-                if (itemStorage.getAmount() == 1)
-                {
-                    jsonItemStorage.remove(COUNT_PROP);
-                }
-                else
+                if (itemStorage.getAmount() != 1)
                 {
                     jsonItemStorage.addProperty(COUNT_PROP, itemStorage.getAmount());
                 }

--- a/src/main/java/com/minecolonies/core/quests/objectives/DeliveryObjectiveTemplateTemplate.java
+++ b/src/main/java/com/minecolonies/core/quests/objectives/DeliveryObjectiveTemplateTemplate.java
@@ -9,11 +9,8 @@ import com.minecolonies.api.util.InventoryUtils;
 import com.minecolonies.api.util.ItemStackUtils;
 import com.minecolonies.api.util.Utils;
 import net.minecraft.core.HolderLookup;
-import net.minecraft.core.component.DataComponentPatch;
-import net.minecraft.core.registries.BuiltInRegistries;
 import net.minecraft.network.chat.Component;
 import net.minecraft.network.chat.Style;
-import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.item.ItemStack;
 import net.neoforged.neoforge.items.wrapper.InvWrapper;
@@ -98,15 +95,10 @@ public class DeliveryObjectiveTemplateTemplate extends DialogueObjectiveTemplate
     {
         JsonObject details = jsonObject.getAsJsonObject(DETAILS_KEY);
         final int target = details.get(TARGET_KEY).getAsInt();
-        final int quantity = details.get(QUANTITY_KEY).getAsInt();
-        final ItemStack item = BuiltInRegistries.ITEM.get(ResourceLocation.parse(details.get(ITEM_KEY).getAsString())).getDefaultInstance();
-        if (details.has(COMPONENTS_KEY))
-        {
-            item.applyComponents(Utils.deserializeCodecMessFromJson(DataComponentPatch.CODEC, provider, details.getAsJsonObject(COMPONENTS_KEY)));
-        }
+        final ItemStack item = Utils.deserializeCodecMessFromJson(ItemStack.CODEC, provider, details.get(ITEM_KEY));
         final int nextObj = details.has(NEXT_OBJ_KEY) ? details.get(NEXT_OBJ_KEY).getAsInt() : -1;
         final String nbtMode = details.has(NBT_MODE_KEY) ? details.get(NBT_MODE_KEY).getAsString() : "";
-        return new DeliveryObjectiveTemplateTemplate(target, item, quantity, nextObj, parseRewards(jsonObject), nbtMode);
+        return new DeliveryObjectiveTemplateTemplate(target, item, item.getCount(), nextObj, parseRewards(jsonObject), nbtMode);
     }
 
     @Override

--- a/src/main/java/com/minecolonies/core/quests/rewards/ItemRewardTemplate.java
+++ b/src/main/java/com/minecolonies/core/quests/rewards/ItemRewardTemplate.java
@@ -6,14 +6,12 @@ import com.minecolonies.api.quests.IQuestInstance;
 import com.minecolonies.api.quests.IQuestRewardTemplate;
 import com.minecolonies.api.util.Utils;
 import net.minecraft.core.HolderLookup;
-import net.minecraft.core.component.DataComponentPatch;
-import net.minecraft.core.registries.BuiltInRegistries;
-import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.item.ItemStack;
 import org.jetbrains.annotations.NotNull;
 
-import static com.minecolonies.api.quests.QuestParseConstant.*;
+import static com.minecolonies.api.quests.QuestParseConstant.DETAILS_KEY;
+import static com.minecolonies.api.quests.QuestParseConstant.ITEM_KEY;
 
 /**
  * Item based quest reward.
@@ -42,13 +40,7 @@ public class ItemRewardTemplate implements IQuestRewardTemplate
     public static IQuestRewardTemplate createReward(@NotNull final HolderLookup.Provider provider, final JsonObject jsonObject)
     {
         JsonObject details = jsonObject.getAsJsonObject(DETAILS_KEY);
-        final int quantity = details.get(QUANTITY_KEY).getAsInt();
-        final ItemStack item = BuiltInRegistries.ITEM.get(ResourceLocation.parse(details.get(ITEM_KEY).getAsString())).getDefaultInstance();
-        if (details.has(COMPONENTS_KEY))
-        {
-            item.applyComponents(Utils.deserializeCodecMessFromJson(DataComponentPatch.CODEC, provider, details.getAsJsonObject(COMPONENTS_KEY)));
-        }
-        item.setCount(quantity);
+        final ItemStack item = Utils.deserializeCodecMessFromJson(ItemStack.CODEC, provider, details.get(ITEM_KEY));
         return new ItemRewardTemplate(item);
     }
     @Override

--- a/src/main/resources/data/minecolonies/colony/quests/general/alchemy.json
+++ b/src/main/resources/data/minecolonies/colony/quests/general/alchemy.json
@@ -90,8 +90,10 @@
       "type": "minecolonies:delivery",
       "details": {
         "target": 0,
-        "item": "minecraft:rotten_flesh",
-        "qty": 3,
+        "item": {
+          "id": "minecraft:rotten_flesh",
+          "count": 3
+        },
         "next-objective": 2
       }
     },
@@ -137,8 +139,10 @@
       "type": "minecolonies:delivery",
       "details": {
         "target": 0,
-        "item": "minecraft:rotten_flesh",
-        "qty": 3,
+        "item": {
+          "id": "minecraft:rotten_flesh",
+          "count": 3
+        },
         "next-objective": 5
       }
     },
@@ -174,8 +178,10 @@
       "type": "minecolonies:delivery",
       "details": {
         "target": 0,
-        "item": "minecraft:spider_eye",
-        "qty": 2,
+        "item": {
+          "id": "minecraft:spider_eye",
+          "count": 2
+        },
         "next-objective": 7
       }
     },
@@ -211,8 +217,9 @@
       "type": "minecolonies:delivery",
       "details": {
         "target": 0,
-        "item": "minecraft:gunpowder",
-        "qty": 1,
+        "item": {
+          "id": "minecraft:gunpowder"
+        },
         "next-objective": 9
       }
     },
@@ -250,12 +257,13 @@
     {
       "type": "minecolonies:item",
       "details": {
-        "item": "minecraft:potion",
-        "qty": 1,
-        "components": {
-          "minecraft:item_name": "{\"translate\":\"com.minecolonies.alchemyquestpotion.name\"}",
-          "minecraft:lore": ["{\"translate\":\"com.minecolonies.alchemyquestpotion.lore\"}"],
-          "minecraft:potion_contents": { "potion": "minecraft:poison" }
+        "item": {
+          "id": "minecraft:potion",
+          "components": {
+            "minecraft:item_name": "{\"translate\":\"com.minecolonies.alchemyquestpotion.name\"}",
+            "minecraft:lore": ["{\"translate\":\"com.minecolonies.alchemyquestpotion.lore\"}"],
+            "minecraft:potion_contents": { "potion": "minecraft:poison" }
+          }
         }
       }
     },

--- a/src/main/resources/data/minecolonies/colony/quests/general/cookies.json
+++ b/src/main/resources/data/minecolonies/colony/quests/general/cookies.json
@@ -84,8 +84,10 @@
       "type": "minecolonies:delivery",
       "details": {
         "target": 0,
-        "item": "minecraft:wheat",
-        "qty": 2,
+        "item": {
+          "id": "minecraft:wheat",
+          "count": 2
+        },
         "next-objective": 2
       }
     },
@@ -93,8 +95,9 @@
       "type": "minecolonies:delivery",
       "details": {
         "target": 0,
-        "item": "minecraft:cocoa_beans",
-        "qty": 1,
+        "item": {
+          "id": "minecraft:cocoa_beans"
+        },
         "next-objective": 3
       }
     },
@@ -161,8 +164,10 @@
       "type": "minecolonies:delivery",
       "details": {
         "target": 1,
-        "item": "minecraft:cookie",
-        "qty": 8,
+        "item": {
+          "id": "minecraft:cookie",
+          "count": 8
+        },
         "next-objective": 7
       }
     },
@@ -227,15 +232,18 @@
     {
       "type": "minecolonies:item",
       "details": {
-        "item": "minecraft:cookie",
-        "qty": 8
+        "item": {
+          "id": "minecraft:cookie",
+          "count": 8
+        }
       }
     },
     {
       "type": "minecolonies:item",
       "details": {
-        "item": "minecraft:emerald",
-        "qty": 1
+        "item": {
+          "id": "minecraft:emerald"
+        }
       }
     },
     {

--- a/src/main/resources/data/minecolonies/colony/quests/general/hungrycourier.json
+++ b/src/main/resources/data/minecolonies/colony/quests/general/hungrycourier.json
@@ -86,8 +86,9 @@
       "type": "minecolonies:delivery",
       "details": {
         "target": 0,
-        "item": "minecraft:baked_potato",
-        "qty": 1,
+        "item": {
+          "id": "minecraft:baked_potato"
+        },
         "next-objective": 2
       }
     },
@@ -111,8 +112,9 @@
     {
       "type": "minecolonies:item",
       "details": {
-        "item": "minecraft:gold_ingot",
-        "qty": 1
+        "item": {
+          "id": "minecraft:gold_ingot"
+        }
       }
     },
     {

--- a/src/main/resources/data/minecolonies/colony/quests/general/thezombiemenace1.json
+++ b/src/main/resources/data/minecolonies/colony/quests/general/thezombiemenace1.json
@@ -87,8 +87,10 @@
     {
       "type": "minecolonies:item",
       "details": {
-        "item": "minecraft:iron_ingot",
-        "qty": 2
+        "item": {
+          "id": "minecraft:iron_ingot",
+          "count": 2
+        }
       }
     },
     {

--- a/src/main/resources/data/minecolonies/colony/quests/general/thezombiemenace2.json
+++ b/src/main/resources/data/minecolonies/colony/quests/general/thezombiemenace2.json
@@ -89,8 +89,9 @@
     {
       "type": "minecolonies:item",
       "details": {
-        "item": "minecraft:diamond",
-        "qty": 1
+        "item": {
+          "id": "minecraft:diamond"
+        }
       }
     },
     {

--- a/src/main/resources/data/minecolonies/colony/quests/guides/buildergoggles.json
+++ b/src/main/resources/data/minecolonies/colony/quests/guides/buildergoggles.json
@@ -58,8 +58,9 @@
       "type": "minecolonies:delivery",
       "details": {
         "target": 0,
-        "item": "minecolonies:build_goggles",
-        "qty": 1,
+        "item": {
+          "id": "minecolonies:build_goggles"
+        },
         "next-objective": 2
       }
     },
@@ -83,8 +84,9 @@
     {
       "type": "minecolonies:item",
       "details": {
-        "item": "minecolonies:build_goggles",
-        "qty": 1
+        "item": {
+          "id": "minecolonies:build_goggles"
+        }
       }
     }
   ]

--- a/src/main/resources/data/minecolonies/colony/quests/guides/clipboard.json
+++ b/src/main/resources/data/minecolonies/colony/quests/guides/clipboard.json
@@ -58,8 +58,9 @@
       "type": "minecolonies:delivery",
       "details": {
         "target": 0,
-        "item": "minecolonies:clipboard",
-        "qty": 1,
+        "item": {
+          "id": "minecolonies:clipboard"
+        },
         "next-objective": 2
       }
     },
@@ -83,8 +84,9 @@
     {
       "type": "minecolonies:item",
       "details": {
-        "item": "minecolonies:clipboard",
-        "qty": 1
+        "item": {
+          "id": "minecolonies:clipboard"
+        }
       }
     }
   ]

--- a/src/main/resources/data/minecolonies/colony/quests/guides/rallybanner.json
+++ b/src/main/resources/data/minecolonies/colony/quests/guides/rallybanner.json
@@ -101,9 +101,10 @@
       "type": "minecolonies:delivery",
       "details": {
         "target": 0,
-        "item": "minecolonies:banner_rally_guards",
+        "item": {
+          "id": "minecolonies:banner_rally_guards"
+        },
         "nbt-mode": "any",
-        "qty": 1,
         "next-objective": 4
       }
     },
@@ -127,8 +128,9 @@
     {
       "type": "minecolonies:item",
       "details": {
-        "item": "minecolonies:banner_rally_guards",
-        "qty": 1
+        "item": {
+          "id": "minecolonies:banner_rally_guards"
+        }
       }
     }
   ]

--- a/src/main/resources/data/minecolonies/colony/quests/guides/resourcescroll.json
+++ b/src/main/resources/data/minecolonies/colony/quests/guides/resourcescroll.json
@@ -58,8 +58,9 @@
       "type": "minecolonies:delivery",
       "details": {
         "target": 0,
-        "item": "minecolonies:resourcescroll",
-        "qty": 1,
+        "item": {
+          "id": "minecolonies:resourcescroll"
+        },
         "next-objective": 2
       }
     },
@@ -83,8 +84,9 @@
     {
       "type": "minecolonies:item",
       "details": {
-        "item": "minecolonies:resourcescroll",
-        "qty": 1
+        "item": {
+          "id": "minecolonies:resourcescroll"
+        }
       }
     }
   ]

--- a/src/main/resources/data/minecolonies/colony/quests/romance/aromanticgesture.json
+++ b/src/main/resources/data/minecolonies/colony/quests/romance/aromanticgesture.json
@@ -77,8 +77,9 @@
       "type": "minecolonies:delivery",
       "details": {
         "target": 1,
-        "item": "minecraft:poppy",
-        "qty": 1,
+        "item": {
+          "id": "minecraft:poppy"
+        },
         "next-objective": 2
       }
     },
@@ -111,8 +112,9 @@
     {
       "type": "minecolonies:item",
       "details": {
-        "item": "minecraft:diamond",
-        "qty": 1
+        "item": {
+          "id": "minecraft:diamond"
+        }
       }
     },
     {

--- a/src/main/resources/data/minecolonies/colony/quests/romance/atokenofapp.json
+++ b/src/main/resources/data/minecolonies/colony/quests/romance/atokenofapp.json
@@ -102,8 +102,9 @@
       "type": "minecolonies:delivery",
       "details": {
         "target": 1,
-        "item": "minecraft:dandelion",
-        "qty": 1,
+        "item": {
+          "id": "minecraft:dandelion"
+        },
         "next-objective": 3
       }
     },
@@ -127,8 +128,9 @@
     {
       "type": "minecolonies:item",
       "details": {
-        "item": "minecraft:emerald",
-        "qty": 1
+        "item": {
+          "id": "minecraft:emerald"
+        }
       }
     },
     {

--- a/src/main/resources/data/minecolonies/colony/quests/template/questtemplate.json
+++ b/src/main/resources/data/minecolonies/colony/quests/template/questtemplate.json
@@ -110,8 +110,9 @@
       "type": "minecolonies:delivery",
       "details": {
         "target": 0,
-        "item": "minecraft:apple",
-        "qty": 1,
+        "item": {
+          "id": "minecraft:apple"
+        },
         "next-objective": 3
       }
     },
@@ -119,8 +120,9 @@
       "type": "minecolonies:delivery",
       "details": {
         "target": 0,
-        "item": "minecraft:baked_potato",
-        "qty": 1,
+        "item": {
+          "id": "minecraft:baked_potato"
+        },
         "next-objective": 3
       }
     },
@@ -167,8 +169,9 @@
     {
       "type": "minecolonies:item",
       "details": {
-        "item": "minecraft:gold_ingot",
-        "qty": 1
+        "item": {
+          "id": "minecraft:gold_ingot"
+        }
       }
     },
     {

--- a/src/main/resources/data/minecolonies/colony/quests/tutorial/builder.json
+++ b/src/main/resources/data/minecolonies/colony/quests/tutorial/builder.json
@@ -274,8 +274,10 @@
     {
       "type": "minecolonies:item",
       "details": {
-        "item": "minecraft:cobblestone",
-        "qty": 32
+        "item": {
+          "id": "minecraft:cobblestone",
+          "count": 32
+        }
       }
     }
   ]

--- a/src/main/resources/data/minecolonies/colony/quests/tutorial/builder2.json
+++ b/src/main/resources/data/minecolonies/colony/quests/tutorial/builder2.json
@@ -114,8 +114,10 @@
     {
       "type": "minecolonies:item",
       "details": {
-        "item": "minecraft:lantern",
-        "qty": 8
+        "item": {
+          "id": "minecraft:lantern",
+          "count": 8
+        }
       }
     }
   ]

--- a/src/main/resources/data/minecolonies/colony/quests/tutorial/farm.json
+++ b/src/main/resources/data/minecolonies/colony/quests/tutorial/farm.json
@@ -248,8 +248,10 @@
     {
       "type": "minecolonies:item",
       "details": {
-        "item": "minecraft:wheat_seeds",
-        "qty": 32
+        "item": {
+          "id": "minecraft:wheat_seeds",
+          "count": 32
+        }
       }
     }
   ]

--- a/src/main/resources/data/minecolonies/colony/quests/tutorial/forester.json
+++ b/src/main/resources/data/minecolonies/colony/quests/tutorial/forester.json
@@ -174,8 +174,10 @@
     {
       "type": "minecolonies:item",
       "details": {
-        "item": "minecraft:torch",
-        "qty": 32
+        "item": {
+          "id": "minecraft:torch",
+          "count": 32
+        }
       }
     }
   ]

--- a/src/main/resources/data/minecolonies/colony/quests/tutorial/hospital.json
+++ b/src/main/resources/data/minecolonies/colony/quests/tutorial/hospital.json
@@ -142,15 +142,19 @@
     {
       "type": "minecolonies:item",
       "details": {
-        "item": "minecraft:carrot",
-        "qty": 8
+        "item": {
+          "id": "minecraft:carrot",
+          "count": 8
+        }
       }
     },
     {
       "type": "minecolonies:item",
       "details": {
-        "item": "minecraft:potato",
-        "qty": 8
+        "item": {
+          "id": "minecraft:potato",
+          "count": 8
+        }
       }
     }
   ]

--- a/src/main/resources/data/minecolonies/colony/quests/tutorial/housing.json
+++ b/src/main/resources/data/minecolonies/colony/quests/tutorial/housing.json
@@ -158,8 +158,10 @@
     {
       "type": "minecolonies:item",
       "details": {
-        "item": "minecraft:white_wool",
-        "qty": 16
+        "item": {
+          "id": "minecraft:white_wool",
+          "count": 16
+        }
       }
     }
   ]

--- a/src/main/resources/data/minecolonies/colony/quests/tutorial/housing2.json
+++ b/src/main/resources/data/minecolonies/colony/quests/tutorial/housing2.json
@@ -114,8 +114,10 @@
     {
       "type": "minecolonies:item",
       "details": {
-        "item": "minecolonies:blockminecoloniesrack",
-        "qty": 8
+        "item": {
+          "id": "minecolonies:blockminecoloniesrack",
+          "count": 8
+        }
       }
     }
   ]

--- a/src/main/resources/data/minecolonies/colony/quests/tutorial/military/barracks.json
+++ b/src/main/resources/data/minecolonies/colony/quests/tutorial/military/barracks.json
@@ -143,8 +143,10 @@
     {
       "type": "minecolonies:item",
       "details": {
-        "item": "minecraft:iron_sword",
-        "qty": 2
+        "item": {
+          "id": "minecraft:iron_sword",
+          "count": 2
+        }
       }
     }
   ]

--- a/src/main/resources/data/minecolonies/colony/quests/tutorial/military/guards.json
+++ b/src/main/resources/data/minecolonies/colony/quests/tutorial/military/guards.json
@@ -174,8 +174,9 @@
     {
       "type": "minecolonies:item",
       "details": {
-        "item": "minecraft:iron_block",
-        "qty": 1
+        "item": {
+          "id": "minecraft:iron_block"
+        }
       }
     }
   ]

--- a/src/main/resources/data/minecolonies/colony/quests/tutorial/military/guards2.json
+++ b/src/main/resources/data/minecolonies/colony/quests/tutorial/military/guards2.json
@@ -83,29 +83,33 @@
     {
       "type": "minecolonies:item",
       "details": {
-        "item": "minecraft:chainmail_helmet",
-        "qty": 1
+        "item": {
+          "id": "minecraft:chainmail_helmet"
+        }
       }
     },
     {
       "type": "minecolonies:item",
       "details": {
-        "item": "minecraft:chainmail_chestplate",
-        "qty": 1
+        "item": {
+          "id": "minecraft:chainmail_chestplate"
+        }
       }
     },
     {
       "type": "minecolonies:item",
       "details": {
-        "item": "minecraft:chainmail_leggings",
-        "qty": 1
+        "item": {
+          "id": "minecraft:chainmail_leggings"
+        }
       }
     },
     {
       "type": "minecolonies:item",
       "details": {
-        "item": "minecraft:chainmail_boots",
-        "qty": 1
+        "item": {
+          "id": "minecraft:chainmail_boots"
+        }
       }
     }
   ]

--- a/src/main/resources/data/minecolonies/colony/quests/tutorial/military/torches.json
+++ b/src/main/resources/data/minecolonies/colony/quests/tutorial/military/torches.json
@@ -60,15 +60,17 @@
     {
       "type": "minecolonies:item",
       "details": {
-        "item": "minecraft:iron_sword",
-        "qty": 1
+        "item": {
+          "id": "minecraft:iron_sword"
+        }
       }
     },
     {
       "type": "minecolonies:item",
       "details": {
-        "item": "minecraft:bow",
-        "qty": 1
+        "item": {
+          "id": "minecraft:bow"
+        }
       }
     }
   ]

--- a/src/main/resources/data/minecolonies/colony/quests/tutorial/military/zombies.json
+++ b/src/main/resources/data/minecolonies/colony/quests/tutorial/military/zombies.json
@@ -71,29 +71,33 @@
     {
       "type": "minecolonies:item",
       "details": {
-        "item": "minecraft:leather_chestplate",
-        "qty": 1
+        "item": {
+          "id": "minecraft:leather_chestplate"
+        }
       }
     },
     {
       "type": "minecolonies:item",
       "details": {
-        "item": "minecraft:leather_boots",
-        "qty": 1
+        "item": {
+          "id": "minecraft:leather_boots"
+        }
       }
     },
     {
       "type": "minecolonies:item",
       "details": {
-        "item": "minecraft:leather_helmet",
-        "qty": 1
+        "item": {
+          "id": "minecraft:leather_helmet"
+        }
       }
     },
     {
       "type": "minecolonies:item",
       "details": {
-        "item": "minecraft:leather_leggings",
-        "qty": 1
+        "item": {
+          "id": "minecraft:leather_leggings"
+        }
       }
     }
   ]

--- a/src/main/resources/data/minecolonies/colony/quests/tutorial/mine.json
+++ b/src/main/resources/data/minecolonies/colony/quests/tutorial/mine.json
@@ -183,8 +183,10 @@
     {
       "type": "minecolonies:item",
       "details": {
-        "item": "minecraft:ladder",
-        "qty": 32
+        "item": {
+          "id": "minecraft:ladder",
+          "count": 32
+        }
       }
     }
   ]

--- a/src/main/resources/data/minecolonies/colony/quests/tutorial/restaurant.json
+++ b/src/main/resources/data/minecolonies/colony/quests/tutorial/restaurant.json
@@ -158,8 +158,10 @@
     {
       "type": "minecolonies:item",
       "details": {
-        "item": "minecraft:coal",
-        "qty": 16
+        "item": {
+          "id": "minecraft:coal",
+          "count": 16
+        }
       }
     }
   ]

--- a/src/main/resources/data/minecolonies/colony/quests/tutorial/sawmill.json
+++ b/src/main/resources/data/minecolonies/colony/quests/tutorial/sawmill.json
@@ -151,8 +151,10 @@
     {
       "type": "minecolonies:item",
       "details": {
-        "item": "minecraft:diamond",
-        "qty": 3
+        "item": {
+          "id": "minecraft:diamond",
+          "count": 3
+        }
       }
     }
   ]

--- a/src/main/resources/data/minecolonies/colony/quests/tutorial/tavern.json
+++ b/src/main/resources/data/minecolonies/colony/quests/tutorial/tavern.json
@@ -174,8 +174,10 @@
     {
       "type": "minecolonies:item",
       "details": {
-        "item": "minecraft:baked_potato",
-        "qty": 32
+        "item": {
+          "id": "minecraft:baked_potato",
+          "count": 32
+        }
       }
     }
   ]

--- a/src/main/resources/data/minecolonies/colony/quests/tutorial/tieredfood.json
+++ b/src/main/resources/data/minecolonies/colony/quests/tutorial/tieredfood.json
@@ -108,15 +108,19 @@
     {
       "type": "minecolonies:item",
       "details": {
-        "item": "minecolonies:garlic",
-        "qty": 8
+        "item": {
+          "id": "minecolonies:garlic",
+          "count": 8
+        }
       }
     },
     {
       "type": "minecolonies:item",
       "details": {
-        "item": "minecolonies:onion",
-        "qty": 8
+        "item": {
+          "id": "minecolonies:onion",
+          "count": 8
+        }
       }
     }
   ]

--- a/src/main/resources/data/minecolonies/colony/quests/tutorial/university.json
+++ b/src/main/resources/data/minecolonies/colony/quests/tutorial/university.json
@@ -123,8 +123,10 @@
     {
       "type": "minecolonies:item",
       "details": {
-        "item": "minecraft:book",
-        "qty": 8
+        "item": {
+          "id": "minecraft:book",
+          "count": 8
+        }
       }
     }
   ]

--- a/src/main/resources/data/minecolonies/colony/quests/tutorial/warehouse.json
+++ b/src/main/resources/data/minecolonies/colony/quests/tutorial/warehouse.json
@@ -170,29 +170,37 @@
     {
       "type": "minecolonies:item",
       "details": {
-        "item": "minecraft:stone_pickaxe",
-        "qty": 2
+        "item": {
+          "id": "minecraft:stone_pickaxe",
+          "count": 2
+        }
       }
     },
     {
       "type": "minecolonies:item",
       "details": {
-        "item": "minecraft:stone_axe",
-        "qty": 2
+        "item": {
+          "id": "minecraft:stone_axe",
+          "count": 2
+        }
       }
     },
     {
       "type": "minecolonies:item",
       "details": {
-        "item": "minecraft:stone_shovel",
-        "qty": 2
+        "item": {
+          "id": "minecraft:stone_shovel",
+          "count": 2
+        }
       }
     },
     {
       "type": "minecolonies:item",
       "details": {
-        "item": "minecraft:stone_hoe",
-        "qty": 2
+        "item": {
+          "id": "minecraft:stone_hoe",
+          "count": 2
+        }
       }
     }
   ]

--- a/src/main/resources/data/minecolonies/colony/quests/tutorial/welcome.json
+++ b/src/main/resources/data/minecolonies/colony/quests/tutorial/welcome.json
@@ -243,8 +243,9 @@
     {
       "type": "minecolonies:item",
       "details": {
-        "item": "minecolonies:questlog",
-        "qty": 1
+        "item": {
+          "id": "minecolonies:questlog"
+        }
       }
     },
     {

--- a/src/main/resources/data/minecolonies/crafterrecipes/lumberjack/strip_logs.json
+++ b/src/main/resources/data/minecolonies/crafterrecipes/lumberjack/strip_logs.json
@@ -9,18 +9,18 @@
     "crafter": "lumberjack_custom",
     "inputs": [
       {
-        "item": "[NS]:[PATH]"
+        "id": "[NS]:[PATH]"
       }
     ],
     "alternate-output": [
       {
-        "item": "[NS]:stripped_[PATH]"
+        "id": "[NS]:stripped_[PATH]"
       },
       {
-        "item": "[NS]:[PATH:_log=_wood]"
+        "id": "[NS]:[PATH:_log=_wood]"
       },
       {
-        "item": "[NS]:stripped_[PATH:_log=_wood]"
+        "id": "[NS]:stripped_[PATH:_log=_wood]"
       }
     ],
     "intermediate": "minecraft:air",

--- a/src/main/resources/data/minecolonies/crafterrecipes/lumberjack/strip_stems.json
+++ b/src/main/resources/data/minecolonies/crafterrecipes/lumberjack/strip_stems.json
@@ -9,24 +9,24 @@
     "crafter": "lumberjack_custom",
     "inputs": [
       {
-        "item": "[NS]:[PATH]"
+        "id": "[NS]:[PATH]"
       }
     ],
     "alternate-output": [
       {
-        "item": "[NS]:stripped_[PATH]"
+        "id": "[NS]:stripped_[PATH]"
       },
       {
-        "item": "[NS]:[PATH:_stem=_hyphae]"
+        "id": "[NS]:[PATH:_stem=_hyphae]"
       },
       {
-        "item": "[NS]:stripped_[PATH:_stem=_hyphae]"
+        "id": "[NS]:stripped_[PATH:_stem=_hyphae]"
       },
       {
-        "item": "[NS]:[PATH:_stem=_wood]"
+        "id": "[NS]:[PATH:_stem=_wood]"
       },
       {
-        "item": "[NS]:stripped_[PATH:_stem=_wood]"
+        "id": "[NS]:stripped_[PATH:_stem=_wood]"
       }
     ],
     "intermediate": "minecraft:air",


### PR DESCRIPTION
# Changes proposed in this pull request:
- Make recipes and quests use vanilla item serialization to improve compatibility

[x] Yes I tested this before submitting it.
[ ] I also did a multiplayer test.

Review please (do not backport)

This is of course a breaking change for existing datapacks, but there was already a break for any items with NBT.
I didn't test the quests beyond checking there were no errors logged on startup, but the code looks sane to me.