### PR TITLE
Fix npe

### DIFF
--- a/src/main/java/com/minecolonies/core/items/ItemScepterLumberjack.java
+++ b/src/main/java/com/minecolonies/core/items/ItemScepterLumberjack.java
@@ -140,9 +140,8 @@ public class ItemScepterLumberjack extends AbstractItemMinecolonies implements I
         {
             final OverlayBox anchorBox = new OverlayBox(box.anchor(), RED_OVERLAY, 0.02f, true);
 
-            if (box.corners() != null)
+            if (box.corners() != null && box.corners().getA() != null && box.corners().getB() != null)
             {
-                assert box.corners().getA() != null && box.corners().getB() != null;
                 final AABB bounds = AABB.encapsulatingFullBlocks(box.corners().getA(), box.corners().getB().offset(1, 1, 1)).inflate(1);
                 // inflate(1) is due to implementation of BlockPosUtil.isInArea
 


### PR DESCRIPTION
Closes [discord report](https://discord.com/channels/472875599422291968/1274733488398139497/1276884030192877628)

# Changes proposed in this pull request:
- Fix NPE in forester tool when no existing zone is set

[ ] Yes I tested this before submitting it.
[ ] I also did a multiplayer test.

Review please

I didn't think too hard about how it got into this state -- in older versions it avoided this case some other way.  But this is more defensive anyway.