### PR TITLE
Fix pepper hummus

### DIFF
--- a/src/datagen/generated/minecolonies/data/minecolonies/compatibility/itemnbtmatching.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/compatibility/itemnbtmatching.json
@@ -1108,6 +1108,9 @@
     "item": "minecolonies:pasta_tomato"
   },
   {
+    "item": "minecolonies:pepper_hummus"
+  },
+  {
     "checkednbtkeys": [
       {
         "key": "Enchantments"

--- a/src/datagen/generated/minecolonies/data/minecolonies/crafterrecipes/baker/flatbread.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/crafterrecipes/baker/flatbread.json
@@ -14,6 +14,6 @@
   ],
   "intermediate": "minecraft:air",
   "loot-table": "minecolonies:recipes/large_bottle",
-  "min-building-level": 1,
-  "result": "minecolonies:flatbread"
+  "result": "minecolonies:flatbread",
+  "show-tooltip": true
 }

--- a/src/datagen/generated/minecolonies/data/minecolonies/crafterrecipes/baker/lembas_scone.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/crafterrecipes/baker/lembas_scone.json
@@ -14,6 +14,6 @@
   ],
   "intermediate": "minecraft:air",
   "loot-table": "minecolonies:recipes/glass_bottle",
-  "min-building-level": 1,
-  "result": "minecolonies:lembas_scone"
+  "result": "minecolonies:lembas_scone",
+  "show-tooltip": true
 }

--- a/src/datagen/generated/minecolonies/data/minecolonies/crafterrecipes/baker/manchet.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/crafterrecipes/baker/manchet.json
@@ -7,6 +7,6 @@
     }
   ],
   "intermediate": "minecraft:furnace",
-  "min-building-level": 1,
-  "result": "minecolonies:manchet_bread"
+  "result": "minecolonies:manchet_bread",
+  "show-tooltip": true
 }

--- a/src/datagen/generated/minecolonies/data/minecolonies/crafterrecipes/baker/manchet_dough.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/crafterrecipes/baker/manchet_dough.json
@@ -14,6 +14,6 @@
     }
   ],
   "intermediate": "minecraft:air",
-  "min-building-level": 1,
-  "result": "minecolonies:manchet_dough"
+  "result": "minecolonies:manchet_dough",
+  "show-tooltip": true
 }

--- a/src/datagen/generated/minecolonies/data/minecolonies/crafterrecipes/baker/muffin.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/crafterrecipes/baker/muffin.json
@@ -7,6 +7,6 @@
     }
   ],
   "intermediate": "minecraft:furnace",
-  "min-building-level": 1,
-  "result": "minecolonies:muffin"
+  "result": "minecolonies:muffin",
+  "show-tooltip": true
 }

--- a/src/datagen/generated/minecolonies/data/minecolonies/crafterrecipes/baker/muffin_dough.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/crafterrecipes/baker/muffin_dough.json
@@ -20,6 +20,6 @@
     }
   ],
   "intermediate": "minecraft:air",
-  "min-building-level": 1,
-  "result": "minecolonies:muffin_dough"
+  "result": "minecolonies:muffin_dough",
+  "show-tooltip": true
 }

--- a/src/datagen/generated/minecolonies/data/minecolonies/crafterrecipes/chef/butter.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/crafterrecipes/chef/butter.json
@@ -12,6 +12,6 @@
     }
   ],
   "intermediate": "minecraft:air",
-  "min-building-level": 1,
-  "result": "minecolonies:butter"
+  "result": "minecolonies:butter",
+  "show-tooltip": true
 }

--- a/src/datagen/generated/minecolonies/data/minecolonies/crafterrecipes/chef/cabochis.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/crafterrecipes/chef/cabochis.json
@@ -16,6 +16,6 @@
     }
   ],
   "intermediate": "minecraft:air",
-  "min-building-level": 1,
-  "result": "minecolonies:cabochis"
+  "result": "minecolonies:cabochis",
+  "show-tooltip": true
 }

--- a/src/datagen/generated/minecolonies/data/minecolonies/crafterrecipes/chef/cheddar_cheese.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/crafterrecipes/chef/cheddar_cheese.json
@@ -12,6 +12,6 @@
     }
   ],
   "intermediate": "minecraft:air",
-  "min-building-level": 1,
-  "result": "minecolonies:cheddar_cheese"
+  "result": "minecolonies:cheddar_cheese",
+  "show-tooltip": true
 }

--- a/src/datagen/generated/minecolonies/data/minecolonies/crafterrecipes/chef/congee.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/crafterrecipes/chef/congee.json
@@ -16,6 +16,6 @@
     }
   ],
   "intermediate": "minecraft:air",
-  "min-building-level": 1,
-  "result": "minecolonies:congee"
+  "result": "minecolonies:congee",
+  "show-tooltip": true
 }

--- a/src/datagen/generated/minecolonies/data/minecolonies/crafterrecipes/chef/cooked_rice.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/crafterrecipes/chef/cooked_rice.json
@@ -10,6 +10,6 @@
     }
   ],
   "intermediate": "minecraft:air",
-  "min-building-level": 1,
-  "result": "minecolonies:cooked_rice"
+  "result": "minecolonies:cooked_rice",
+  "show-tooltip": true
 }

--- a/src/datagen/generated/minecolonies/data/minecolonies/crafterrecipes/chef/eggplant_dolma.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/crafterrecipes/chef/eggplant_dolma.json
@@ -22,6 +22,6 @@
     }
   ],
   "intermediate": "minecraft:air",
-  "min-building-level": 1,
-  "result": "minecolonies:eggplant_dolma"
+  "result": "minecolonies:eggplant_dolma",
+  "show-tooltip": true
 }

--- a/src/datagen/generated/minecolonies/data/minecolonies/crafterrecipes/chef/feta_cheese.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/crafterrecipes/chef/feta_cheese.json
@@ -12,6 +12,6 @@
     }
   ],
   "intermediate": "minecraft:air",
-  "min-building-level": 1,
-  "result": "minecolonies:feta_cheese"
+  "result": "minecolonies:feta_cheese",
+  "show-tooltip": true
 }

--- a/src/datagen/generated/minecolonies/data/minecolonies/crafterrecipes/chef/hand_pie.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/crafterrecipes/chef/hand_pie.json
@@ -19,6 +19,6 @@
     }
   ],
   "intermediate": "minecraft:air",
-  "min-building-level": 1,
-  "result": "minecolonies:hand_pie"
+  "result": "minecolonies:hand_pie",
+  "show-tooltip": true
 }

--- a/src/datagen/generated/minecolonies/data/minecolonies/crafterrecipes/chef/lamb_stew.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/crafterrecipes/chef/lamb_stew.json
@@ -31,6 +31,6 @@
     }
   ],
   "intermediate": "minecraft:air",
-  "min-building-level": 1,
-  "result": "minecolonies:lamb_stew"
+  "result": "minecolonies:lamb_stew",
+  "show-tooltip": true
 }

--- a/src/datagen/generated/minecolonies/data/minecolonies/crafterrecipes/chef/pasta_plain.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/crafterrecipes/chef/pasta_plain.json
@@ -16,6 +16,6 @@
     }
   ],
   "intermediate": "minecraft:air",
-  "min-building-level": 1,
-  "result": "minecolonies:pasta_plain"
+  "result": "minecolonies:pasta_plain",
+  "show-tooltip": true
 }

--- a/src/datagen/generated/minecolonies/data/minecolonies/crafterrecipes/chef/pasta_tomato.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/crafterrecipes/chef/pasta_tomato.json
@@ -22,6 +22,6 @@
     }
   ],
   "intermediate": "minecraft:air",
-  "min-building-level": 1,
-  "result": "minecolonies:pasta_tomato"
+  "result": "minecolonies:pasta_tomato",
+  "show-tooltip": true
 }

--- a/src/datagen/generated/minecolonies/data/minecolonies/crafterrecipes/chef/pepper_hummus.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/crafterrecipes/chef/pepper_hummus.json
@@ -20,6 +20,6 @@
     }
   ],
   "intermediate": "minecraft:air",
-  "min-building-level": 1,
-  "result": "minecolonies:pepper_hummus"
+  "result": "minecolonies:pepper_hummus",
+  "show-tooltip": true
 }

--- a/src/datagen/generated/minecolonies/data/minecolonies/crafterrecipes/chef/pita_hummus.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/crafterrecipes/chef/pita_hummus.json
@@ -22,6 +22,6 @@
     }
   ],
   "intermediate": "minecraft:air",
-  "min-building-level": 1,
-  "result": "minecolonies:pita_hummus"
+  "result": "minecolonies:pita_hummus",
+  "show-tooltip": true
 }

--- a/src/datagen/generated/minecolonies/data/minecolonies/crafterrecipes/chef/pottage.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/crafterrecipes/chef/pottage.json
@@ -22,6 +22,6 @@
     }
   ],
   "intermediate": "minecraft:air",
-  "min-building-level": 1,
-  "result": "minecolonies:pottage"
+  "result": "minecolonies:pottage",
+  "show-tooltip": true
 }

--- a/src/datagen/generated/minecolonies/data/minecolonies/crafterrecipes/chef/raw_noodle.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/crafterrecipes/chef/raw_noodle.json
@@ -7,6 +7,6 @@
     }
   ],
   "intermediate": "minecraft:air",
-  "min-building-level": 1,
-  "result": "minecolonies:raw_noodle"
+  "result": "minecolonies:raw_noodle",
+  "show-tooltip": true
 }

--- a/src/datagen/generated/minecolonies/data/minecolonies/crafterrecipes/chef/rice_ball.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/crafterrecipes/chef/rice_ball.json
@@ -14,6 +14,6 @@
     }
   ],
   "intermediate": "minecraft:air",
-  "min-building-level": 1,
-  "result": "minecolonies:rice_ball"
+  "result": "minecolonies:rice_ball",
+  "show-tooltip": true
 }

--- a/src/datagen/generated/minecolonies/data/minecolonies/crafterrecipes/chef/soy_milk.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/crafterrecipes/chef/soy_milk.json
@@ -16,6 +16,6 @@
     }
   ],
   "intermediate": "minecraft:air",
-  "min-building-level": 1,
-  "result": "minecolonies:large_soy_milk_bottle"
+  "result": "minecolonies:large_soy_milk_bottle",
+  "show-tooltip": true
 }

--- a/src/datagen/generated/minecolonies/data/minecolonies/crafterrecipes/chef/stew_trencher.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/crafterrecipes/chef/stew_trencher.json
@@ -16,6 +16,6 @@
     }
   ],
   "intermediate": "minecraft:air",
-  "min-building-level": 1,
-  "result": "minecolonies:stew_trencher"
+  "result": "minecolonies:stew_trencher",
+  "show-tooltip": true
 }

--- a/src/datagen/generated/minecolonies/data/minecolonies/crafterrecipes/chef/stuffed_pepper.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/crafterrecipes/chef/stuffed_pepper.json
@@ -22,6 +22,6 @@
     }
   ],
   "intermediate": "minecraft:air",
-  "min-building-level": 1,
-  "result": "minecolonies:stuffed_pepper"
+  "result": "minecolonies:stuffed_pepper",
+  "show-tooltip": true
 }

--- a/src/datagen/generated/minecolonies/data/minecolonies/crafterrecipes/chef/stuffed_pita.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/crafterrecipes/chef/stuffed_pita.json
@@ -19,6 +19,6 @@
     }
   ],
   "intermediate": "minecraft:air",
-  "min-building-level": 1,
-  "result": "minecolonies:stuffed_pita"
+  "result": "minecolonies:stuffed_pita",
+  "show-tooltip": true
 }

--- a/src/datagen/generated/minecolonies/data/minecolonies/crafterrecipes/chef/sushi_roll.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/crafterrecipes/chef/sushi_roll.json
@@ -20,6 +20,6 @@
     }
   ],
   "intermediate": "minecraft:air",
-  "min-building-level": 1,
-  "result": "minecolonies:sushi_roll"
+  "result": "minecolonies:sushi_roll",
+  "show-tooltip": true
 }

--- a/src/datagen/generated/minecolonies/data/minecolonies/crafterrecipes/chef/tofu.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/crafterrecipes/chef/tofu.json
@@ -10,6 +10,6 @@
     }
   ],
   "intermediate": "minecraft:air",
-  "min-building-level": 1,
-  "result": "minecolonies:tofu"
+  "result": "minecolonies:tofu",
+  "show-tooltip": true
 }

--- a/src/main/java/com/minecolonies/api/creativetab/ModCreativeTabs.java
+++ b/src/main/java/com/minecolonies/api/creativetab/ModCreativeTabs.java
@@ -114,28 +114,41 @@ public final class ModCreativeTabs
               output.accept(crop);
           }
 
+          // bottles
+          output.accept(ModItems.large_empty_bottle);
+          output.accept(ModItems.large_water_bottle);
+          output.accept(ModItems.large_milk_bottle);
+          output.accept(ModItems.large_soy_milk_bottle);
+
+          // ingredients
           output.accept(ModItems.breadDough);
           output.accept(ModItems.cookieDough);
           output.accept(ModItems.cakeBatter);
           output.accept(ModItems.rawPumpkinPie);
+          output.accept(ModItems.muffin_dough);
+          output.accept(ModItems.manchet_dough);
+          output.accept(ModItems.raw_noodle);
+          output.accept(ModItems.butter);
 
+          // baker products
           output.accept(ModItems.milkyBread);
           output.accept(ModItems.sugaryBread);
           output.accept(ModItems.goldenBread);
           output.accept(ModItems.chorusBread);
+          output.accept(ModItems.flatbread);
+          output.accept(ModItems.lembas_scone);
+          output.accept(ModItems.manchet_bread);
+          output.accept(ModItems.muffin);
 
-          output.accept(ModItems.butter);
+          // chef products
           output.accept(ModItems.cabochis);
           output.accept(ModItems.cheddar_cheese);
           output.accept(ModItems.congee);
           output.accept(ModItems.cooked_rice);
           output.accept(ModItems.eggplant_dolma);
           output.accept(ModItems.feta_cheese);
-          output.accept(ModItems.flatbread);
           output.accept(ModItems.hand_pie);
           output.accept(ModItems.lamb_stew);
-          output.accept(ModItems.lembas_scone);
-          output.accept(ModItems.manchet_bread);
           output.accept(ModItems.pasta_plain);
           output.accept(ModItems.pasta_tomato);
           output.accept(ModItems.pepper_hummus);
@@ -147,16 +160,6 @@ public final class ModCreativeTabs
           output.accept(ModItems.stuffed_pita);
           output.accept(ModItems.sushi_roll);
           output.accept(ModItems.tofu);
-
-          output.accept(ModItems.large_water_bottle);
-          output.accept(ModItems.large_milk_bottle);
-          output.accept(ModItems.large_soy_milk_bottle);
-          output.accept(ModItems.large_empty_bottle);
-
-          output.accept(ModItems.muffin);
-          output.accept(ModItems.muffin_dough);
-          output.accept(ModItems.manchet_dough);
-          output.accept(ModItems.raw_noodle);
       }).build());
 
     /**

--- a/src/main/java/com/minecolonies/api/creativetab/ModCreativeTabs.java
+++ b/src/main/java/com/minecolonies/api/creativetab/ModCreativeTabs.java
@@ -138,6 +138,7 @@ public final class ModCreativeTabs
           output.accept(ModItems.manchet_bread);
           output.accept(ModItems.pasta_plain);
           output.accept(ModItems.pasta_tomato);
+          output.accept(ModItems.pepper_hummus);
           output.accept(ModItems.pita_hummus);
           output.accept(ModItems.pottage);
           output.accept(ModItems.rice_ball);

--- a/src/main/java/com/minecolonies/api/util/constant/TranslationConstants.java
+++ b/src/main/java/com/minecolonies/api/util/constant/TranslationConstants.java
@@ -408,8 +408,6 @@ public final class TranslationConstants
     @NonNls
     public static final String CROP_TOOLTIP                                                         = "com.minecolonies.core.item.crop.tooltip";
     @NonNls
-    public static final String FOOD_TOOLTIP                                                         = "com.minecolonies.core.item.food.tooltip.";
-    @NonNls
     public static final String TIER_TOOLTIP                                                         = "com.minecolonies.core.item.food.tooltip.tier.";
     @NonNls
     public static final String BIOME_TOOLTIP                                                        = "com.minecolonies.core.item.crop.tooltip.biome";

--- a/src/main/java/com/minecolonies/apiimp/initializer/ModItemsInitializer.java
+++ b/src/main/java/com/minecolonies/apiimp/initializer/ModItemsInitializer.java
@@ -1,7 +1,6 @@
 package com.minecolonies.apiimp.initializer;
 
 import com.minecolonies.api.blocks.ModBlocks;
-import com.minecolonies.api.colony.jobs.ModJobs;
 import com.minecolonies.api.entity.ModEntities;
 import com.minecolonies.api.items.ModItems;
 import com.minecolonies.api.util.constant.Constants;
@@ -135,53 +134,53 @@ public final class ModItemsInitializer
         ModItems.scanAnalyzer = new ItemScanAnalyzer("scan_analyzer", new Item.Properties());
 
         // Tier 1 Food Items
-        ModItems.cheddar_cheese = new ItemFood((new Item.Properties()).food(new FoodProperties.Builder().nutrition(4).saturationMod(0.6F).build()), ModJobs.CHEF_ID.getPath(), 1);
-        ModItems.feta_cheese = new ItemFood((new Item.Properties()).food(new FoodProperties.Builder().nutrition(4).saturationMod(0.6F).build()), ModJobs.CHEF_ID.getPath(), 1);
-        ModItems.cooked_rice = new ItemBowlFood((new Item.Properties()).food(new FoodProperties.Builder().nutrition(4).saturationMod(0.6F).build()), ModJobs.CHEF_ID.getPath(), 1);
-        ModItems.tofu = new ItemFood((new Item.Properties()).food(new FoodProperties.Builder().nutrition(4).saturationMod(0.6F).build()), ModJobs.CHEF_ID.getPath(), 1);
-        ModItems.flatbread = new ItemFood((new Item.Properties()).food(new FoodProperties.Builder().nutrition(4).saturationMod(0.6F).build()), ModJobs.BAKER_ID.getPath(), 1);
+        ModItems.cheddar_cheese = new ItemFood((new Item.Properties()).food(new FoodProperties.Builder().nutrition(4).saturationMod(0.6F).build()), 1);
+        ModItems.feta_cheese = new ItemFood((new Item.Properties()).food(new FoodProperties.Builder().nutrition(4).saturationMod(0.6F).build()), 1);
+        ModItems.cooked_rice = new ItemBowlFood((new Item.Properties()).food(new FoodProperties.Builder().nutrition(4).saturationMod(0.6F).build()), 1);
+        ModItems.tofu = new ItemFood((new Item.Properties()).food(new FoodProperties.Builder().nutrition(4).saturationMod(0.6F).build()), 1);
+        ModItems.flatbread = new ItemFood((new Item.Properties()).food(new FoodProperties.Builder().nutrition(4).saturationMod(0.6F).build()), 1);
 
         // Tier 2 Food Items
-        ModItems.manchet_bread = new ItemFood((new Item.Properties()).food(new FoodProperties.Builder().nutrition(6).saturationMod(1.0F).build()), ModJobs.BAKER_ID.getPath(), 2);
-        ModItems.lembas_scone = new ItemFood((new Item.Properties()).food(new FoodProperties.Builder().nutrition(6).saturationMod(1.0F).build()), ModJobs.BAKER_ID.getPath(), 2);
-        ModItems.muffin = new ItemFood((new Item.Properties()).food(new FoodProperties.Builder().nutrition(6).saturationMod(1.0F).build()), ModJobs.BAKER_ID.getPath(), 2);
-        ModItems.pottage = new ItemBowlFood((new Item.Properties()).food(new FoodProperties.Builder().nutrition(6).saturationMod(1.0F).build()), ModJobs.CHEF_ID.getPath(), 2);
-        ModItems.pasta_plain = new ItemBowlFood((new Item.Properties()).food(new FoodProperties.Builder().nutrition(6).saturationMod(1.0F).build()), ModJobs.CHEF_ID.getPath(), 2);
+        ModItems.manchet_bread = new ItemFood((new Item.Properties()).food(new FoodProperties.Builder().nutrition(6).saturationMod(1.0F).build()), 2);
+        ModItems.lembas_scone = new ItemFood((new Item.Properties()).food(new FoodProperties.Builder().nutrition(6).saturationMod(1.0F).build()), 2);
+        ModItems.muffin = new ItemFood((new Item.Properties()).food(new FoodProperties.Builder().nutrition(6).saturationMod(1.0F).build()), 2);
+        ModItems.pottage = new ItemBowlFood((new Item.Properties()).food(new FoodProperties.Builder().nutrition(6).saturationMod(1.0F).build()), 2);
+        ModItems.pasta_plain = new ItemBowlFood((new Item.Properties()).food(new FoodProperties.Builder().nutrition(6).saturationMod(1.0F).build()), 2);
 
         // Tier 3 Food items
-        ModItems.hand_pie = new ItemFood((new Item.Properties()).food(new FoodProperties.Builder().nutrition(8).saturationMod(1.2F).build()), ModJobs.CHEF_ID.getPath(), 3);
+        ModItems.hand_pie = new ItemFood((new Item.Properties()).food(new FoodProperties.Builder().nutrition(8).saturationMod(1.2F).build()), 3);
 
         // Cold Biomes
         // Tier 2
-        ModItems.cabochis = new ItemBowlFood((new Item.Properties()).food(new FoodProperties.Builder().nutrition(6).saturationMod(1.0F).build()), ModJobs.CHEF_ID.getPath(), 2);
+        ModItems.cabochis = new ItemBowlFood((new Item.Properties()).food(new FoodProperties.Builder().nutrition(6).saturationMod(1.0F).build()), 2);
         // Tier 3
-        ModItems.lamb_stew = new ItemBowlFood((new Item.Properties()).food(new FoodProperties.Builder().nutrition(8).saturationMod(1.2F).build()), ModJobs.CHEF_ID.getPath(), 3);
+        ModItems.lamb_stew = new ItemBowlFood((new Item.Properties()).food(new FoodProperties.Builder().nutrition(8).saturationMod(1.2F).build()), 3);
 
         // Hot Humid Biomes
         // Tier 2
-        ModItems.rice_ball = new ItemFood((new Item.Properties()).food(new FoodProperties.Builder().nutrition(6).saturationMod(1.0F).build()), ModJobs.CHEF_ID.getPath(), 2);
+        ModItems.rice_ball = new ItemFood((new Item.Properties()).food(new FoodProperties.Builder().nutrition(6).saturationMod(1.0F).build()), 2);
         // Tier 3
-        ModItems.sushi_roll = new ItemFood((new Item.Properties()).food(new FoodProperties.Builder().nutrition(8).saturationMod(1.2F).build()), ModJobs.CHEF_ID.getPath(), 3);
+        ModItems.sushi_roll = new ItemFood((new Item.Properties()).food(new FoodProperties.Builder().nutrition(8).saturationMod(1.2F).build()), 3);
 
         // Temperate Biomes
         // Tier 2
-        ModItems.pasta_tomato = new ItemBowlFood((new Item.Properties()).food(new FoodProperties.Builder().nutrition(6).saturationMod(1.0F).build()), ModJobs.CHEF_ID.getPath(), 2);
+        ModItems.pasta_tomato = new ItemBowlFood((new Item.Properties()).food(new FoodProperties.Builder().nutrition(6).saturationMod(1.0F).build()), 2);
         // Tier 3
-        ModItems.eggplant_dolma = new ItemFood((new Item.Properties()).food(new FoodProperties.Builder().nutrition(8).saturationMod(1.2F).build()), ModJobs.CHEF_ID.getPath(), 3);
-        ModItems.stuffed_pita = new ItemFood((new Item.Properties()).food(new FoodProperties.Builder().nutrition(8).saturationMod(1.2F).build()), ModJobs.CHEF_ID.getPath(), 3);
+        ModItems.eggplant_dolma = new ItemFood((new Item.Properties()).food(new FoodProperties.Builder().nutrition(8).saturationMod(1.2F).build()), 3);
+        ModItems.stuffed_pita = new ItemFood((new Item.Properties()).food(new FoodProperties.Builder().nutrition(8).saturationMod(1.2F).build()), 3);
 
         // Hot Dry Biomes
         // Tier 2
-        ModItems.pepper_hummus = new ItemFood((new Item.Properties()).food(new FoodProperties.Builder().nutrition(6).saturationMod(1.0F).build()), ModJobs.CHEF_ID.getPath(), 2);
+        ModItems.pepper_hummus = new ItemFood((new Item.Properties()).food(new FoodProperties.Builder().nutrition(6).saturationMod(1.0F).build()), 2);
         // Tier 3
-        ModItems.pita_hummus = new ItemFood((new Item.Properties()).food(new FoodProperties.Builder().nutrition(8).saturationMod(1.2F).build()), ModJobs.CHEF_ID.getPath(), 3);
+        ModItems.pita_hummus = new ItemFood((new Item.Properties()).food(new FoodProperties.Builder().nutrition(8).saturationMod(1.2F).build()), 3);
 
         // Require trading
         // Tier 2
-        ModItems.congee = new ItemBowlFood((new Item.Properties()).food(new FoodProperties.Builder().nutrition(6).saturationMod(1.0F).build()), ModJobs.CHEF_ID.getPath(), 2);
+        ModItems.congee = new ItemBowlFood((new Item.Properties()).food(new FoodProperties.Builder().nutrition(6).saturationMod(1.0F).build()), 2);
         // Tier 3
-        ModItems.stew_trencher = new ItemFood((new Item.Properties()).food(new FoodProperties.Builder().nutrition(8).saturationMod(1.2F).build()), ModJobs.CHEF_ID.getPath(), 3);
-        ModItems.stuffed_pepper = new ItemFood((new Item.Properties()).food(new FoodProperties.Builder().nutrition(8).saturationMod(1.2F).build()), ModJobs.CHEF_ID.getPath(), 3);
+        ModItems.stew_trencher = new ItemFood((new Item.Properties()).food(new FoodProperties.Builder().nutrition(8).saturationMod(1.2F).build()), 3);
+        ModItems.stuffed_pepper = new ItemFood((new Item.Properties()).food(new FoodProperties.Builder().nutrition(8).saturationMod(1.2F).build()), 3);
 
         // Just dough
         ModItems.muffin_dough = new Item((new Item.Properties()));

--- a/src/main/java/com/minecolonies/core/generation/defaults/workers/DefaultBakerCraftingProvider.java
+++ b/src/main/java/com/minecolonies/core/generation/defaults/workers/DefaultBakerCraftingProvider.java
@@ -182,7 +182,7 @@ public class DefaultBakerCraftingProvider extends CustomRecipeProvider
                         new ItemStorage(new ItemStack(Items.HONEY_BOTTLE))))
                 .result(new ItemStack(ModItems.lembas_scone))
                 .lootTable(DefaultRecipeLootProvider.LOOT_TABLE_GLASS_BOTTLE)
-                .minBuildingLevel(1)
+                .showTooltip(true)
                 .build(consumer);
 
         CustomRecipeBuilder.create(BAKER, MODULE_CRAFTING, "manchet_dough")
@@ -191,7 +191,7 @@ public class DefaultBakerCraftingProvider extends CustomRecipeProvider
                         new ItemStorage(new ItemStack(ModBlocks.blockDurum)),
                         new ItemStorage(new ItemStack(ModItems.butter))))
                 .result(new ItemStack(ModItems.manchet_dough, 2))
-                .minBuildingLevel(1)
+                .showTooltip(true)
                 .build(consumer);
 
         CustomRecipeBuilder.create(BAKER, MODULE_CRAFTING, "muffin_dough")
@@ -202,7 +202,7 @@ public class DefaultBakerCraftingProvider extends CustomRecipeProvider
                         new ItemStorage(new ItemStack(Items.SUGAR)),
                         new ItemStorage(new ItemStack(Items.SWEET_BERRIES))))
                 .result(new ItemStack(ModItems.muffin_dough, 2))
-                .minBuildingLevel(1)
+                .showTooltip(true)
                 .build(consumer);
 
         CustomRecipeBuilder.create(BAKER, MODULE_CRAFTING, "flatbread")
@@ -212,20 +212,20 @@ public class DefaultBakerCraftingProvider extends CustomRecipeProvider
                         new ItemStorage(ModItems.large_water_bottle.getDefaultInstance())))
                 .result(new ItemStack(ModItems.flatbread, 1))
                 .lootTable(DefaultRecipeLootProvider.LOOT_TABLE_LARGE_BOTTLE)
-                .minBuildingLevel(1)
+                .showTooltip(true)
                 .build(consumer);
 
         CustomRecipeBuilder.create(BAKER, MODULE_SMELTING, "muffin")
                 .inputs(List.of(new ItemStorage(new ItemStack(ModItems.muffin_dough))))
                 .result(new ItemStack(ModItems.muffin))
-                .minBuildingLevel(1)
+                .showTooltip(true)
                 .intermediate(Blocks.FURNACE)
                 .build(consumer);
 
         CustomRecipeBuilder.create(BAKER, MODULE_SMELTING, "manchet")
                 .inputs(List.of(new ItemStorage(new ItemStack(ModItems.manchet_dough))))
                 .result(new ItemStack(ModItems.manchet_bread))
-                .minBuildingLevel(1)
+                .showTooltip(true)
                 .intermediate(Blocks.FURNACE)
                 .build(consumer);
 

--- a/src/main/java/com/minecolonies/core/generation/defaults/workers/DefaultChefCraftingProvider.java
+++ b/src/main/java/com/minecolonies/core/generation/defaults/workers/DefaultChefCraftingProvider.java
@@ -42,7 +42,7 @@ public class DefaultChefCraftingProvider extends CustomRecipeProvider
           .inputs(List.of(new ItemStorage(new ItemStack(ModItems.large_milk_bottle))))
           .result(new ItemStack(ModItems.butter))
           .secondaryOutputs(List.of(new ItemStack(ModItems.large_empty_bottle)))
-          .minBuildingLevel(1)
+          .showTooltip(true)
           .build(consumer);
 
         CustomRecipeBuilder.create(CHEF, MODULE_CRAFTING, "cabochis")
@@ -52,14 +52,14 @@ public class DefaultChefCraftingProvider extends CustomRecipeProvider
             new ItemStorage(new ItemStack(Items.BOWL)),
             new ItemStorage(new ItemStack(ModItems.manchet_bread))))
           .result(new ItemStack(ModItems.cabochis))
-          .minBuildingLevel(1)
+          .showTooltip(true)
           .build(consumer);
 
         CustomRecipeBuilder.create(CHEF, MODULE_CRAFTING, "cheddar_cheese")
           .inputs(List.of(new ItemStorage(new ItemStack(ModItems.large_milk_bottle))))
           .result(new ItemStack(ModItems.cheddar_cheese))
           .secondaryOutputs(List.of(new ItemStack(ModItems.large_empty_bottle)))
-          .minBuildingLevel(1)
+          .showTooltip(true)
           .build(consumer);
 
         CustomRecipeBuilder.create(CHEF, MODULE_CRAFTING, "congee")
@@ -69,7 +69,7 @@ public class DefaultChefCraftingProvider extends CustomRecipeProvider
             new ItemStorage(new ItemStack(Items.BOWL)),
             new ItemStorage(new ItemStack(ModBlocks.blockCabbage))))
           .result(new ItemStack(ModItems.congee))
-          .minBuildingLevel(1)
+          .showTooltip(true)
           .build(consumer);
 
         CustomRecipeBuilder.create(CHEF, MODULE_CRAFTING, "cooked_rice")
@@ -77,7 +77,7 @@ public class DefaultChefCraftingProvider extends CustomRecipeProvider
             new ItemStorage(new ItemStack(ModBlocks.blockRice)),
             new ItemStorage(new ItemStack(Items.BOWL))))
           .result(new ItemStack(ModItems.cooked_rice))
-          .minBuildingLevel(1)
+          .showTooltip(true)
           .build(consumer);
 
         CustomRecipeBuilder.create(CHEF, MODULE_CRAFTING, "eggplant_dolma")
@@ -89,14 +89,14 @@ public class DefaultChefCraftingProvider extends CustomRecipeProvider
             new ItemStorage(new ItemStack(ModBlocks.blockDurum)),
             new ItemStorage(new ItemStack(ModBlocks.blockOnion))))
           .result(new ItemStack(ModItems.eggplant_dolma))
-          .minBuildingLevel(1)
+          .showTooltip(true)
           .build(consumer);
 
         CustomRecipeBuilder.create(CHEF, MODULE_CRAFTING, "feta_cheese")
           .inputs(List.of(new ItemStorage(new ItemStack(ModItems.large_milk_bottle))))
           .result(new ItemStack(ModItems.feta_cheese))
           .secondaryOutputs(List.of(new ItemStack(ModItems.large_empty_bottle)))
-          .minBuildingLevel(1)
+          .showTooltip(true)
           .build(consumer);
 
         CustomRecipeBuilder.create(CHEF, MODULE_CRAFTING, "hand_pie")
@@ -107,7 +107,7 @@ public class DefaultChefCraftingProvider extends CustomRecipeProvider
             new ItemStorage(new ItemStack(ModBlocks.blockOnion)),
             new ItemStorage(new ItemStack(Items.MUTTON))))
           .result(new ItemStack(ModItems.hand_pie))
-          .minBuildingLevel(1)
+          .showTooltip(true)
           .build(consumer);
 
         CustomRecipeBuilder.create(CHEF, MODULE_CRAFTING, "lamb_stew")
@@ -122,7 +122,7 @@ public class DefaultChefCraftingProvider extends CustomRecipeProvider
             new ItemStorage(new ItemStack(ModBlocks.blockCabbage)),
             new ItemStorage(new ItemStack(Items.MUTTON))))
           .result(new ItemStack(ModItems.lamb_stew))
-          .minBuildingLevel(1)
+          .showTooltip(true)
           .build(consumer);
 
         CustomRecipeBuilder.create(CHEF, MODULE_CRAFTING, "pasta_plain")
@@ -132,7 +132,7 @@ public class DefaultChefCraftingProvider extends CustomRecipeProvider
             new ItemStorage(new ItemStack(Items.BOWL)),
             new ItemStorage(new ItemStack(ModBlocks.blockGarlic))))
           .result(new ItemStack(ModItems.pasta_plain))
-          .minBuildingLevel(1)
+          .showTooltip(true)
           .build(consumer);
 
         CustomRecipeBuilder.create(CHEF, MODULE_CRAFTING, "pasta_tomato")
@@ -144,7 +144,7 @@ public class DefaultChefCraftingProvider extends CustomRecipeProvider
             new ItemStorage(new ItemStack(Items.BOWL)),
             new ItemStorage(new ItemStack(ModBlocks.blockGarlic))))
           .result(new ItemStack(ModItems.pasta_tomato))
-          .minBuildingLevel(1)
+          .showTooltip(true)
           .build(consumer);
 
         CustomRecipeBuilder.create(CHEF, MODULE_CRAFTING, "pita_hummus")
@@ -156,7 +156,7 @@ public class DefaultChefCraftingProvider extends CustomRecipeProvider
             new ItemStorage(new ItemStack(ModBlocks.blockOnion)),
             new ItemStorage(new ItemStack(ModBlocks.blockGarlic))))
           .result(new ItemStack(ModItems.pita_hummus))
-          .minBuildingLevel(1)
+          .showTooltip(true)
           .build(consumer);
 
         CustomRecipeBuilder.create(CHEF, MODULE_CRAFTING, "pottage")
@@ -168,14 +168,14 @@ public class DefaultChefCraftingProvider extends CustomRecipeProvider
             new ItemStorage(new ItemStack(Items.CARROT)),
             new ItemStorage(new ItemStack(ModBlocks.blockGarlic))))
           .result(new ItemStack(ModItems.pottage))
-          .minBuildingLevel(1)
+          .showTooltip(true)
           .build(consumer);
 
         CustomRecipeBuilder.create(CHEF, MODULE_CRAFTING, "raw_noodle")
           .inputs(List.of(
             new ItemStorage(new ItemStack(ModBlocks.blockDurum))))
           .result(new ItemStack(ModItems.raw_noodle))
-          .minBuildingLevel(1)
+          .showTooltip(true)
           .build(consumer);
 
         CustomRecipeBuilder.create(CHEF, MODULE_CRAFTING, "rice_ball")
@@ -184,7 +184,7 @@ public class DefaultChefCraftingProvider extends CustomRecipeProvider
             new ItemStorage(new ItemStack(Items.DRIED_KELP)),
             new ItemStorage(new ItemStack(ModItems.cooked_rice))))
           .result(new ItemStack(ModItems.rice_ball, 2))
-          .minBuildingLevel(1)
+          .showTooltip(true)
           .build(consumer);
 
         CustomRecipeBuilder.create(CHEF, MODULE_CRAFTING, "stew_trencher")
@@ -194,7 +194,7 @@ public class DefaultChefCraftingProvider extends CustomRecipeProvider
             new ItemStorage(new ItemStack(ModBlocks.blockCabbage)),
             new ItemStorage(new ItemStack(ModBlocks.blockOnion))))
           .result(new ItemStack(ModItems.stew_trencher))
-          .minBuildingLevel(1)
+          .showTooltip(true)
           .build(consumer);
 
         CustomRecipeBuilder.create(CHEF, MODULE_CRAFTING, "stuffed_pepper")
@@ -206,7 +206,7 @@ public class DefaultChefCraftingProvider extends CustomRecipeProvider
             new ItemStorage(new ItemStack(ModBlocks.blockGarlic)),
             new ItemStorage(new ItemStack(ModBlocks.blockEggplant))))
           .result(new ItemStack(ModItems.stuffed_pepper))
-          .minBuildingLevel(1)
+          .showTooltip(true)
           .build(consumer);
 
         CustomRecipeBuilder.create(CHEF, MODULE_CRAFTING, "stuffed_pita")
@@ -217,7 +217,7 @@ public class DefaultChefCraftingProvider extends CustomRecipeProvider
             new ItemStorage(new ItemStack(ModBlocks.blockEggplant)),
             new ItemStorage(new ItemStack(ModBlocks.blockGarlic))))
           .result(new ItemStack(ModItems.stuffed_pita))
-          .minBuildingLevel(1)
+          .showTooltip(true)
           .build(consumer);
 
         CustomRecipeBuilder.create(CHEF, MODULE_CRAFTING, "sushi_roll")
@@ -228,14 +228,14 @@ public class DefaultChefCraftingProvider extends CustomRecipeProvider
             new ItemStorage(new ItemStack(Items.DRIED_KELP)),
             new ItemStorage(new ItemStack(ModBlocks.blockOnion))))
           .result(new ItemStack(ModItems.sushi_roll, 2))
-          .minBuildingLevel(1)
+          .showTooltip(true)
           .build(consumer);
 
         CustomRecipeBuilder.create(CHEF, MODULE_CRAFTING, "tofu")
           .inputs(List.of(
             new ItemStorage(new ItemStack(ModBlocks.blockSoyBean)), new ItemStorage(new ItemStack(ModBlocks.blockSoyBean))))
           .result(new ItemStack(ModItems.tofu))
-          .minBuildingLevel(1)
+          .showTooltip(true)
           .build(consumer);
 
         CustomRecipeBuilder.create(CHEF, MODULE_CRAFTING, "pepper_hummus")
@@ -246,7 +246,7 @@ public class DefaultChefCraftingProvider extends CustomRecipeProvider
             new ItemStorage(new ItemStack(ModBlocks.blockChickpea)),
             new ItemStorage(new ItemStack(ModBlocks.blockChickpea))))
           .result(new ItemStack(ModItems.pepper_hummus, 2))
-          .minBuildingLevel(1)
+          .showTooltip(true)
           .build(consumer);
 
         CustomRecipeBuilder.create(CHEF, MODULE_CRAFTING, "soy_milk")
@@ -256,7 +256,7 @@ public class DefaultChefCraftingProvider extends CustomRecipeProvider
             new ItemStorage(new ItemStack(ModBlocks.blockSoyBean)),
             new ItemStorage(new ItemStack(ModBlocks.blockSoyBean))))
           .result(new ItemStack(ModItems.large_soy_milk_bottle))
-          .minBuildingLevel(1)
+          .showTooltip(true)
           .build(consumer);
     }
 }

--- a/src/main/java/com/minecolonies/core/items/ItemBowlFood.java
+++ b/src/main/java/com/minecolonies/core/items/ItemBowlFood.java
@@ -18,11 +18,6 @@ import java.util.List;
 public class ItemBowlFood extends BowlFoodItem implements IMinecoloniesFoodItem
 {
     /**
-     * The job producing this.
-     */
-    private final String producer;
-
-    /**
      * The food tier.
      */
     private final int tier;
@@ -31,20 +26,17 @@ public class ItemBowlFood extends BowlFoodItem implements IMinecoloniesFoodItem
      * Creates a new food item.
      *
      * @param builder the item properties to use.
-     * @param producer the key for the worker that produces it.
      * @param tier the nutrition tier.
      */
-    public ItemBowlFood(@NotNull final Properties builder, final String producer, final int tier)
+    public ItemBowlFood(@NotNull final Properties builder, final int tier)
     {
         super(builder);
-        this.producer = producer;
         this.tier = tier;
     }
 
     @Override
     public void appendHoverText(@NotNull final ItemStack stack, @Nullable final Level worldIn, @NotNull final List<Component> tooltip, @NotNull final TooltipFlag flagIn)
     {
-        tooltip.add(Component.translatable(TranslationConstants.FOOD_TOOLTIP + this.producer));
         tooltip.add(Component.translatable(TranslationConstants.TIER_TOOLTIP + this.tier));
     }
 

--- a/src/main/java/com/minecolonies/core/items/ItemFood.java
+++ b/src/main/java/com/minecolonies/core/items/ItemFood.java
@@ -18,11 +18,6 @@ import java.util.List;
 public class ItemFood extends Item implements IMinecoloniesFoodItem
 {
     /**
-     * The job producing this.
-     */
-    private final String producer;
-
-    /**
      * The food tier.
      */
     private final int tier;
@@ -31,20 +26,17 @@ public class ItemFood extends Item implements IMinecoloniesFoodItem
      * Creates a new food item.
      *
      * @param builder the item properties to use.
-     * @param producer the key for the worker that produces it.
      * @param tier the nutrition tier.
      */
-    public ItemFood(@NotNull final Properties builder, final String producer, final int tier)
+    public ItemFood(@NotNull final Properties builder, final int tier)
     {
         super(builder);
-        this.producer = producer;
         this.tier = tier;
     }
 
     @Override
     public void appendHoverText(@NotNull final ItemStack stack, @Nullable final Level worldIn, @NotNull final List<Component> tooltip, @NotNull final TooltipFlag flagIn)
     {
-        tooltip.add(Component.translatable(TranslationConstants.FOOD_TOOLTIP + this.producer));
         tooltip.add(Component.translatable(TranslationConstants.TIER_TOOLTIP + this.tier));
     }
 


### PR DESCRIPTION
Closes #10177

# Changes proposed in this pull request:
- Fix "pepper hummus" food item missing from game.
- Re-order Food creative tab into more logical groups.
- Reuse existing recipe-based tooltip system instead of hard-coding custom tooltips.
- Remove redundant minimum level 1 building restrictions (since level 0 can't craft anyway).

[x] Yes I tested this before submitting it.
[ ] I also did a multiplayer test.

Review please (should port)
