### PR TITLE
Fix time based happiness working as expected

### DIFF
--- a/src/main/java/com/minecolonies/api/entity/citizen/citizenhandlers/ICitizenHappinessHandler.java
+++ b/src/main/java/com/minecolonies/api/entity/citizen/citizenhandlers/ICitizenHappinessHandler.java
@@ -53,15 +53,17 @@ public interface ICitizenHappinessHandler
      * Read the handler from NBT.
      *
      * @param compound the compound to read it from.
+     * @param persist  whether we're reading from persisted data or from networking.
      */
-    void read(CompoundTag compound);
+    void read(CompoundTag compound, final boolean persist);
 
     /**
      * Write the handler to NBT.
      *
      * @param compound the compound to write it to.
+     * @param persist  whether we're reading from persisted data or from networking.
      */
-    void write(CompoundTag compound);
+    void write(CompoundTag compound, final boolean persist);
 
     /**
      * Get a list of all modifiers.

--- a/src/main/java/com/minecolonies/api/entity/citizen/happiness/AbstractHappinessModifier.java
+++ b/src/main/java/com/minecolonies/api/entity/citizen/happiness/AbstractHappinessModifier.java
@@ -60,7 +60,7 @@ public abstract class AbstractHappinessModifier implements IHappinessModifier
     }
 
     @Override
-    public void read(final CompoundTag compoundNBT)
+    public void read(final CompoundTag compoundNBT, final boolean persist)
     {
         this.id = compoundNBT.getString(TAG_ID);
         this.weight = compoundNBT.getDouble(TAG_WEIGHT);
@@ -77,7 +77,7 @@ public abstract class AbstractHappinessModifier implements IHappinessModifier
     }
 
     @Override
-    public void write(final CompoundTag compoundNBT)
+    public void write(final CompoundTag compoundNBT, final boolean persist)
     {
         compoundNBT.putString(TAG_ID, this.id);
         compoundNBT.putDouble(TAG_WEIGHT, this.weight);

--- a/src/main/java/com/minecolonies/api/entity/citizen/happiness/ExpirationBasedHappinessModifier.java
+++ b/src/main/java/com/minecolonies/api/entity/citizen/happiness/ExpirationBasedHappinessModifier.java
@@ -15,17 +15,12 @@ public final class ExpirationBasedHappinessModifier extends AbstractHappinessMod
     /**
      * The number of passed days.
      */
-    private int days = 0;
+    private int days;
 
     /**
      * Period of time this modifier applies.
      */
     private int period;
-
-    /**
-     * If this should give a penalty if not active.
-     */
-    private boolean inverted;
 
     /**
      * Create an instance of the happiness modifier.
@@ -38,22 +33,8 @@ public final class ExpirationBasedHappinessModifier extends AbstractHappinessMod
     public ExpirationBasedHappinessModifier(final String id, final double weight, final IHappinessSupplierWrapper supplier, final int period)
     {
         super(id, weight, supplier);
+        this.days = period;
         this.period = period;
-    }
-
-    /**
-     * Create an instance of the happiness modifier.
-     *
-     * @param id       its string id.
-     * @param weight   its weight.
-     * @param period   the period.
-     * @param supplier the supplier to get the factor.
-     * @param inverted if inverted.
-     */
-    public ExpirationBasedHappinessModifier(final String id, final double weight, final IHappinessSupplierWrapper supplier, final int period, final boolean inverted)
-    {
-        this(id, weight, supplier, period);
-        this.inverted = inverted;
     }
 
     /**
@@ -67,22 +48,11 @@ public final class ExpirationBasedHappinessModifier extends AbstractHappinessMod
     @Override
     public double getFactor(final ICitizenData data)
     {
-        if (inverted)
+        if (days > 0 && days <= period)
         {
-            if (days <= period)
-            {
-                return 1.0;
-            }
             return super.getFactor(data);
         }
-        else
-        {
-            if (days < period)
-            {
-                return super.getFactor(data);
-            }
-            return 1.0;
-        }
+        return 1.0;
     }
 
     @Override
@@ -107,21 +77,19 @@ public final class ExpirationBasedHappinessModifier extends AbstractHappinessMod
     }
 
     @Override
-    public void read(final CompoundTag compoundNBT)
+    public void read(final CompoundTag compoundNBT, final boolean persist)
     {
-        super.read(compoundNBT);
+        super.read(compoundNBT, persist);
         this.days = compoundNBT.getInt(TAG_DAY);
-        this.inverted = compoundNBT.getBoolean(TAG_INVERTED);
         this.period = compoundNBT.getInt(TAG_PERIOD);
     }
 
     @Override
-    public void write(final CompoundTag compoundNBT)
+    public void write(final CompoundTag compoundNBT, final boolean persist)
     {
-        super.write(compoundNBT);
+        super.write(compoundNBT, persist);
         compoundNBT.putString(NbtTagConstants.TAG_MODIFIER_TYPE, HappinessRegistry.EXPIRATION_MODIFIER.toString());
         compoundNBT.putInt(TAG_DAY, days);
-        compoundNBT.putBoolean(TAG_INVERTED, inverted);
         compoundNBT.putInt(TAG_PERIOD, period);
     }
 }

--- a/src/main/java/com/minecolonies/api/entity/citizen/happiness/HappinessRegistry.java
+++ b/src/main/java/com/minecolonies/api/entity/citizen/happiness/HappinessRegistry.java
@@ -66,9 +66,10 @@ public class HappinessRegistry
      * Static getter to load a happiness modifier from a compound.
      *
      * @param compound the compound to load it from.
+     * @param persist  whether we're reading from persisted data or from networking.
      * @return the modifier instance.
      */
-    public static IHappinessModifier loadFrom(@NotNull final CompoundTag compound)
+    public static IHappinessModifier loadFrom(@NotNull final CompoundTag compound, final boolean persist)
     {
         final ResourceLocation modifierType = compound.contains(NbtTagConstants.TAG_MODIFIER_TYPE)
                                                 ? new ResourceLocation(compound.getString(NbtTagConstants.TAG_MODIFIER_TYPE))
@@ -79,7 +80,7 @@ public class HappinessRegistry
         {
             try
             {
-                modifier.read(compound);
+                modifier.read(compound, persist);
             }
             catch (final RuntimeException ex)
             {

--- a/src/main/java/com/minecolonies/api/entity/citizen/happiness/IHappinessModifier.java
+++ b/src/main/java/com/minecolonies/api/entity/citizen/happiness/IHappinessModifier.java
@@ -34,13 +34,15 @@ public interface IHappinessModifier
      * Read the modifier from nbt.
      *
      * @param compoundNBT the compound to read it from.
+     * @param persist     whether we're reading from persisted data or from networking.
      */
-    void read(final CompoundTag compoundNBT);
+    void read(final CompoundTag compoundNBT, final boolean persist);
 
     /**
      * Write it to NBT.
      *
      * @param compoundNBT the compound to write it to.
+     * @param persist     whether we're reading from persisted data or from networking.
      */
-    void write(final CompoundTag compoundNBT);
+    void write(final CompoundTag compoundNBT, final boolean persist);
 }

--- a/src/main/java/com/minecolonies/api/entity/citizen/happiness/StaticHappinessModifier.java
+++ b/src/main/java/com/minecolonies/api/entity/citizen/happiness/StaticHappinessModifier.java
@@ -29,9 +29,9 @@ public final class StaticHappinessModifier extends AbstractHappinessModifier
     }
 
     @Override
-    public void write(final CompoundTag compoundNBT)
+    public void write(final CompoundTag compoundNBT, final boolean persist)
     {
-        super.write(compoundNBT);
+        super.write(compoundNBT, persist);
         compoundNBT.putString(NbtTagConstants.TAG_MODIFIER_TYPE, HappinessRegistry.STATIC_MODIFIER.toString());
     }
 }

--- a/src/main/java/com/minecolonies/api/util/constant/NbtTagConstants.java
+++ b/src/main/java/com/minecolonies/api/util/constant/NbtTagConstants.java
@@ -60,7 +60,6 @@ public final class NbtTagConstants
     public static final String TAG_OFFHAND_HELD_ITEM_SLOT = "OffhandHeldItemSlot";
     public static final String TAG_STATUS                 = "status";
     public static final String TAG_DAY                    = "day";
-    public static final String TAG_INVERTED               = "inverted";
     public static final String TAG_PERIOD                 = "period";
     public static final String TAG_IS_BUILT               = "isBuilt";
     public static final String TAG_CUSTOM_NAME            = "customName";

--- a/src/main/java/com/minecolonies/apiimp/initializer/ModHappinessFactorTypeInitializer.java
+++ b/src/main/java/com/minecolonies/apiimp/initializer/ModHappinessFactorTypeInitializer.java
@@ -45,7 +45,7 @@ public final class ModHappinessFactorTypeInitializer
         HappinessRegistry.healthFunction = DEFERRED_REGISTER_HAPPINESS_FUNCTION.register(HEALTH_FUNCTION.getPath(), () -> new HappinessFunctionEntry(data -> data.getEntity().isPresent() ? (data.getEntity().get().getCitizenDiseaseHandler().isSick() ? 0.5 : 1.0) : 1.0));
         HappinessRegistry.idleatjobFunction = DEFERRED_REGISTER_HAPPINESS_FUNCTION.register(IDLEATJOB_FUNCTION.getPath(), () -> new HappinessFunctionEntry(data -> data.isIdleAtJob() ? 0.5 : 1.0));
 
-        HappinessRegistry.sleptTonightFunction = DEFERRED_REGISTER_HAPPINESS_FUNCTION.register(SLEPTTONIGHT_FUNCTION.getPath(), () -> new HappinessFunctionEntry(data -> data.getJob() instanceof AbstractJobGuard ? 1 : 0.0));
-        HappinessRegistry.foodFunction = DEFERRED_REGISTER_HAPPINESS_FUNCTION.register(FOOD_FUNCTION.getPath(), () -> new HappinessFunctionEntry(data -> (data.getHomeBuilding() == null || data.getHomeBuilding().getBuildingLevel() <= 2) ? 0.0 : data.getHomeBuilding().getBuildingLevel() - 2.0));
+        HappinessRegistry.sleptTonightFunction = DEFERRED_REGISTER_HAPPINESS_FUNCTION.register(SLEPTTONIGHT_FUNCTION.getPath(), () -> new HappinessFunctionEntry(data -> data.getJob() instanceof AbstractJobGuard ? 1 : 0.5));
+        HappinessRegistry.foodFunction = DEFERRED_REGISTER_HAPPINESS_FUNCTION.register(FOOD_FUNCTION.getPath(), () -> new HappinessFunctionEntry(data -> (data.getHomeBuilding() == null || data.getHomeBuilding().getBuildingLevel() <= 2) ? 1 : 0.5));
     }
 }

--- a/src/main/java/com/minecolonies/core/colony/CitizenData.java
+++ b/src/main/java/com/minecolonies/core/colony/CitizenData.java
@@ -997,7 +997,7 @@ public class CitizenData implements ICitizenData
         }
 
         final CompoundTag happinessCompound = new CompoundTag();
-        citizenHappinessHandler.write(happinessCompound);
+        citizenHappinessHandler.write(happinessCompound, false);
         buf.writeNbt(happinessCompound);
 
         buf.writeInt(status != null ? status.getId() : -1);
@@ -1234,7 +1234,7 @@ public class CitizenData implements ICitizenData
             nbtTagCompound.put("job", jobCompound);
         }
 
-        citizenHappinessHandler.write(nbtTagCompound);
+        citizenHappinessHandler.write(nbtTagCompound, true);
         citizenMournHandler.write(nbtTagCompound);
 
         inventory.write(nbtTagCompound);
@@ -1399,7 +1399,7 @@ public class CitizenData implements ICitizenData
             }
         }
 
-        this.citizenHappinessHandler.read(nbtTagCompound);
+        this.citizenHappinessHandler.read(nbtTagCompound, true);
         this.citizenMournHandler.read(nbtTagCompound);
 
         if (nbtTagCompound.contains(TAG_LEVEL_MAP) && !nbtTagCompound.contains(TAG_NEW_SKILLS))

--- a/src/main/java/com/minecolonies/core/colony/CitizenDataView.java
+++ b/src/main/java/com/minecolonies/core/colony/CitizenDataView.java
@@ -362,7 +362,7 @@ public class CitizenDataView implements ICitizenDataView
         sortedInteractions = new ArrayList<>(citizenChatOptions.values());
         sortedInteractions.sort(Comparator.comparingInt(e -> -e.getPriority().getPriority()));
 
-        citizenHappinessHandler.read(buf.readNbt());
+        citizenHappinessHandler.read(buf.readNbt(), false);
 
         int statusindex = buf.readInt();
         statusIcon = statusindex >= 0 ? VisibleCitizenStatus.getForId(statusindex) : null;

--- a/src/main/java/com/minecolonies/core/entity/citizen/citizenhandlers/CitizenHappinessHandler.java
+++ b/src/main/java/com/minecolonies/core/entity/citizen/citizenhandlers/CitizenHappinessHandler.java
@@ -75,8 +75,8 @@ public class CitizenHappinessHandler implements ICitizenHappinessHandler
           new DynamicHappinessSupplier(IDLEATJOB_FUNCTION),
           new Tuple<>(IDLE_AT_JOB_COMPLAINS_DAYS, 0.5), new Tuple<>(IDLE_AT_JOB_DEMANDS_DAYS, 0.1)));
 
-        addModifier(new ExpirationBasedHappinessModifier(SLEPTTONIGHT, 1.5, new DynamicHappinessSupplier(SLEPTTONIGHT_FUNCTION), 3, true));
-        addModifier(new ExpirationBasedHappinessModifier(HADDECENTFOOD, 3.0, new DynamicHappinessSupplier(FOOD_FUNCTION), 7, true));
+        addModifier(new TimeBasedHappinessModifier(SLEPTTONIGHT, 1.5, new DynamicHappinessSupplier(SLEPTTONIGHT_FUNCTION), (modifier, d) -> true, new Tuple<>(0, 2d), new Tuple<>(2, 1.6d), new Tuple<>(3, 1d)));
+        addModifier(new TimeBasedHappinessModifier(HADDECENTFOOD, 3.0, new DynamicHappinessSupplier(FOOD_FUNCTION), (modifier, d) -> true, new Tuple<>(0, 2d), new Tuple<>(4, 1.6d), new Tuple<>(7, 1d)));
     }
 
     /**
@@ -156,7 +156,7 @@ public class CitizenHappinessHandler implements ICitizenHappinessHandler
     }
 
     @Override
-    public void read(final CompoundTag compound)
+    public void read(final CompoundTag compound, final boolean persist)
     {
         // Only deserialize for new version. Old can keep the above defaults just fine.
         if (compound.contains(TAG_NEW_HAPPINESS))
@@ -168,11 +168,11 @@ public class CitizenHappinessHandler implements ICitizenHappinessHandler
                 final String id = compoundTag.getString(TAG_ID);
                 if (happinessFactors.containsKey(id))
                 {
-                    happinessFactors.get(id).read(compoundTag);
+                    happinessFactors.get(id).read(compoundTag, persist);
                 }
                 else if (VALID_HAPPINESS_MODIFIERS.contains(id))
                 {
-                    final IHappinessModifier modifier = HappinessRegistry.loadFrom(compoundTag);
+                    final IHappinessModifier modifier = HappinessRegistry.loadFrom(compoundTag, persist);
                     if (modifier != null)
                     {
                         happinessFactors.put(modifier.getId(), modifier);
@@ -183,13 +183,13 @@ public class CitizenHappinessHandler implements ICitizenHappinessHandler
     }
 
     @Override
-    public void write(final CompoundTag compound)
+    public void write(final CompoundTag compound, final boolean persist)
     {
         final ListTag listTag = new ListTag();
         for (final IHappinessModifier happinessModifier : happinessFactors.values())
         {
             final CompoundTag compoundNbt = new CompoundTag();
-            happinessModifier.write(compoundNbt);
+            happinessModifier.write(compoundNbt, persist);
             listTag.add(compoundNbt);
         }
 


### PR DESCRIPTION
Closes basically every report of happiness not working.
Closes #10182

# Changes proposed in this pull request:
- Expiration based happiness got rid of it's inverted logic
- Time based happiness can now be used as an inverted day counter for this purpose
- Sleep and food modifiers converted into time based to mitigate issues these modifiers were having
- Migration should happen automatically, because currently stored NBT data used to be for expiration, but holds the same day values that time based has. So the old NBT data will be loaded on top of the new time based instance.


[X] Yes I tested this before submitting it.
[ ] I also did a multiplayer test.

Review please
