### PR TITLE
Fix colony banners not always rendering correctly

### DIFF
--- a/src/main/java/com/minecolonies/api/blocks/decorative/AbstractColonyFlagBanner.java
+++ b/src/main/java/com/minecolonies/api/blocks/decorative/AbstractColonyFlagBanner.java
@@ -53,21 +53,27 @@ public abstract class AbstractColonyFlagBanner<B extends AbstractColonyFlagBanne
     @Override
     public void setPlacedBy(final Level worldIn, final @NotNull BlockPos pos, @NotNull BlockState state, @Nullable LivingEntity placer, @NotNull ItemStack stack)
     {
-        if (worldIn.isClientSide) return;
+        if (worldIn.isClientSide)
+        {
+            return;
+        }
 
         BlockEntity te = worldIn.getBlockEntity(pos);
-        if (te instanceof TileEntityColonyFlag && ((TileEntityColonyFlag) te).colonyId == -1 )
+        if (te instanceof TileEntityColonyFlag flagTileEntity)
         {
             IColony colony = IColonyManager.getInstance().getIColony(worldIn, pos);
 
             // Allow the player to place their own beyond the colony
             if (colony == null && placer instanceof Player)
+            {
                 colony = IColonyManager.getInstance().getIColonyByOwner(worldIn, (Player) placer);
+            }
 
             if (colony != null)
-                ((TileEntityColonyFlag) te).colonyId = colony.getID();
+            {
+                flagTileEntity.colonyId = colony.getID();
+            }
         }
-
     }
 
     @NotNull


### PR DESCRIPTION
Reported to me by Kezmodius on another server.

# Changes proposed in this pull request
- When a colony banner is scanned in inside of a colony it already gets assigned a colony ID in the tile entity, causing them to, upon placement, no longer update their actual colony ID. Causing them to render the wrong or a nonexistent banner. Removed this condition so banners will always re-check the colony they are in upon placement.
- Updated code to current day code style

Example scan found in fairytale:
![2024-09-17 12_20_13-NBTExplorer](https://github.com/user-attachments/assets/82ba5703-242e-40b0-b58f-6b6067e8371a)

## Testing
- [X] Yes I tested this before submitting it.
- [ ] I also did a multiplayer test.

Review please