### PR TITLE
Fix guards unable to request shields

### DIFF
--- a/src/main/java/com/minecolonies/core/entity/ai/workers/guard/EntityAIKnight.java
+++ b/src/main/java/com/minecolonies/core/entity/ai/workers/guard/EntityAIKnight.java
@@ -13,6 +13,8 @@ import org.jetbrains.annotations.NotNull;
 import java.util.List;
 
 import static com.minecolonies.api.research.util.ResearchConstants.SHIELD_USAGE;
+import static com.minecolonies.api.util.constant.EquipmentLevelConstants.TOOL_LEVEL_MAXIMUM;
+import static com.minecolonies.api.util.constant.EquipmentLevelConstants.TOOL_LEVEL_WOOD_OR_GOLD;
 import static com.minecolonies.api.util.constant.GuardConstants.SHIELD_BUILDING_LEVEL_RANGE;
 import static com.minecolonies.api.util.constant.GuardConstants.SHIELD_LEVEL_RANGE;
 
@@ -31,7 +33,12 @@ public class EntityAIKnight extends AbstractEntityAIGuard<JobKnight, AbstractBui
 
         for (final List<GuardGear> list : itemsNeeded)
         {
-            list.add(new GuardGear(ModEquipmentTypes.shield.get(), EquipmentSlot.OFFHAND, 0, 0, SHIELD_LEVEL_RANGE, SHIELD_BUILDING_LEVEL_RANGE));
+            list.add(new GuardGear(ModEquipmentTypes.shield.get(),
+              EquipmentSlot.OFFHAND,
+              TOOL_LEVEL_WOOD_OR_GOLD,
+              TOOL_LEVEL_MAXIMUM,
+              SHIELD_LEVEL_RANGE,
+              SHIELD_BUILDING_LEVEL_RANGE));
         }
 
         new KnightCombatAI((EntityCitizen) worker, getStateAI(), this);


### PR DESCRIPTION
Closes [discord report](https://discord.com/channels/139070364159311872/1125094832143077456/1285593528696836140) (guards unable to request shields)

# Changes proposed in this pull request
- With the tool rework shields were returning an item level of 1 by default, and can actually be levellable based on their durability to cope with modded shields better. The knight AI however was attempting to request shields in the range of level [0, 0]. Made the effective range for shields requests between 0 and max int.

## Testing
- [X] Yes I tested this before submitting it.
- [ ] I also did a multiplayer test.

Review please