### PR TITLE
Fix deserialization error after removing a mod that adds a job

### DIFF
--- a/src/main/java/com/minecolonies/core/colony/jobs/registry/JobDataManager.java
+++ b/src/main/java/com/minecolonies/core/colony/jobs/registry/JobDataManager.java
@@ -17,6 +17,8 @@ import net.minecraft.resources.ResourceLocation;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
+import java.util.Optional;
+
 public final class JobDataManager implements IJobDataManager
 {
     @Nullable
@@ -26,7 +28,7 @@ public final class JobDataManager implements IJobDataManager
     {
         final ResourceLocation jobType =
           compound.contains(NbtTagConstants.TAG_JOB_TYPE) ? new ResourceLocation(compound.getString(NbtTagConstants.TAG_JOB_TYPE)) : ModJobs.PLACEHOLDER_ID;
-        final IJob<?> job = IJobRegistry.getInstance().getValue(jobType).produceJob(citizen);
+        final IJob<?> job = Optional.ofNullable(IJobRegistry.getInstance().getValue(jobType)).map(r -> r.produceJob(citizen)).orElse(null);
 
         if (job != null)
         {


### PR DESCRIPTION
Closes [discord report](https://discord.com/channels/139070364159311872/1125094832143077456/1288720378092322839)

# Changes proposed in this pull request
- Fix citizen deserialization error after removing a job (by removing an addon mod).

## Testing
- [ ] Yes I tested this before submitting it.
- [ ] I also did a multiplayer test.

Review please (should port)