### PR TITLE
Fix kitchen resolving food requests that are not taught

### DIFF
--- a/src/main/java/com/minecolonies/core/colony/buildings/workerbuildings/BuildingKitchen.java
+++ b/src/main/java/com/minecolonies/core/colony/buildings/workerbuildings/BuildingKitchen.java
@@ -1,28 +1,20 @@
 package com.minecolonies.core.colony.buildings.workerbuildings;
 
-import com.minecolonies.api.colony.ICitizenData;
 import com.minecolonies.api.colony.IColony;
 import com.minecolonies.api.colony.jobs.registry.JobEntry;
-import com.minecolonies.api.crafting.GenericRecipe;
 import com.minecolonies.api.crafting.IGenericRecipe;
-import com.minecolonies.api.crafting.IRecipeStorage;
 import com.minecolonies.api.util.CraftingUtils;
 import com.minecolonies.api.util.ItemStackUtils;
 import com.minecolonies.api.util.OptionalPredicate;
 import com.minecolonies.core.colony.buildings.AbstractBuilding;
 import com.minecolonies.core.colony.buildings.modules.AbstractCraftingBuildingModule;
-import com.minecolonies.core.colony.buildings.modules.CraftingWorkerBuildingModule;
 import com.minecolonies.core.util.FurnaceRecipes;
 import net.minecraft.core.BlockPos;
 import net.minecraft.world.item.ItemStack;
-import net.minecraftforge.items.IItemHandler;
 import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
 
 import java.util.*;
-import java.util.function.Predicate;
 
-import static com.minecolonies.api.util.ItemStackUtils.ISFOOD;
 import static com.minecolonies.api.util.constant.Suppression.OVERRIDE_EQUALS;
 import static com.minecolonies.api.util.constant.TagConstants.CRAFTING_COOK;
 
@@ -127,61 +119,6 @@ public class BuildingKitchen extends AbstractBuilding
         {
             if (!super.isRecipeCompatible(recipe)) return false;
             return CraftingUtils.isRecipeCompatibleBasedOnTags(recipe, CRAFTING_COOK).orElse(ItemStackUtils.CAN_EAT.test(recipe.getPrimaryOutput()));
-        }
-
-        @Override
-        @Nullable
-        public IRecipeStorage getFirstRecipe(final Predicate<ItemStack> stackPredicate)
-        {
-            if (building.getModuleMatching(CraftingWorkerBuildingModule.class, m -> m.getJobEntry() == jobEntry).getAssignedCitizen().isEmpty())
-            {
-                return null;
-            }
-
-            //First, do the normal check against taught recipes, and return those if found
-            IRecipeStorage storage = super.getFirstRecipe(stackPredicate);
-            if (storage != null)
-            {
-                return storage;
-            }
-
-
-            //If we didn't have a stored recipe, see if there is a smelting recipe that is also a food output, and use it.
-            storage = FurnaceRecipes.getInstance().getFirstSmeltingRecipeByResult(stackPredicate);
-            if (storage != null && storage.getRecipeSource() != null && ISFOOD.test(storage.getPrimaryOutput()) && isRecipeCompatible(GenericRecipe.of(storage)))
-            {
-                return storage;
-            }
-
-            return null;
-        }
-
-        @Override
-        public IRecipeStorage getFirstFulfillableRecipe(final Predicate<ItemStack> stackPredicate, final int count, final boolean considerReservation)
-        {
-            //Try to fulfill normally
-            IRecipeStorage storage = super.getFirstFulfillableRecipe(stackPredicate, count, considerReservation);
-
-            //Couldn't fulfill normally, let's try to fulfill with a temporary smelting recipe.
-            if (storage == null)
-            {
-                storage = FurnaceRecipes.getInstance().getFirstSmeltingRecipeByResult(stackPredicate);
-                if (storage != null)
-                {
-                    final Set<IItemHandler> handlers = new HashSet<>();
-                    for (final ICitizenData workerEntity :  building.getModuleMatching(CraftingWorkerBuildingModule.class, m -> m.getJobEntry() == jobEntry).getAssignedCitizen())
-                    {
-                        handlers.add(workerEntity.getInventory());
-                    }
-
-                    if (!storage.canFullFillRecipe(count, Collections.emptyMap(), new ArrayList<>(handlers), building))
-                    {
-                        return null;
-                    }
-                }
-            }
-
-            return storage;
         }
     }
 }


### PR DESCRIPTION
Closes [discord report](https://discord.com/channels/139070364159311872/1125094832143077456/1289823558507298836) Cookery resolving smelting requests instead of the baker

# Changes proposed in this pull request
- Cookery was incorrectly overriding the recipe resolving logic, causing them to pick up any food related request, ignoring to only use taught recipes. Removed this logic to make it function as expected.

## Testing
- [X] Yes I tested this before submitting it.
- [ ] I also did a multiplayer test.

Review please