### PR TITLE
Skill and raid adjustments

### DIFF
--- a/src/main/java/com/minecolonies/api/entity/citizen/citizenhandlers/ICitizenSkillHandler.java
+++ b/src/main/java/com/minecolonies/api/entity/citizen/citizenhandlers/ICitizenSkillHandler.java
@@ -3,8 +3,8 @@ package com.minecolonies.api.entity.citizen.citizenhandlers;
 import com.minecolonies.api.colony.ICitizenData;
 import com.minecolonies.api.colony.IColony;
 import com.minecolonies.api.entity.citizen.Skill;
+import com.minecolonies.core.entity.citizen.citizenhandlers.CitizenSkillHandler;
 import net.minecraft.nbt.CompoundTag;
-import net.minecraft.util.Tuple;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -110,5 +110,5 @@ public interface ICitizenSkillHandler
      *
      * @return the skills.
      */
-    Map<Skill, Tuple<Integer, Double>> getSkills();
+    Map<Skill, CitizenSkillHandler.SkillData> getSkills();
 }

--- a/src/main/java/com/minecolonies/api/research/ILocalResearchTree.java
+++ b/src/main/java/com/minecolonies/api/research/ILocalResearchTree.java
@@ -93,6 +93,13 @@ public interface ILocalResearchTree
     void readFromNBT(final CompoundTag compound, final IResearchEffectManager effects);
 
     /**
+     * Get the list of all finished researches
+     *
+     * @return a copy of the completed list.
+     */
+    List<ResourceLocation> getCompletedList();
+
+    /**
      * Check if a given research is complete.
      * @param location the unique id.
      * @return true if so.

--- a/src/main/java/com/minecolonies/core/client/gui/WindowHireWorker.java
+++ b/src/main/java/com/minecolonies/core/client/gui/WindowHireWorker.java
@@ -20,6 +20,7 @@ import com.minecolonies.core.colony.CitizenDataView;
 import com.minecolonies.core.colony.buildings.moduleviews.PupilBuildingModuleView;
 import com.minecolonies.core.colony.buildings.moduleviews.WorkerBuildingModuleView;
 import com.minecolonies.core.colony.buildings.views.AbstractBuildingView;
+import com.minecolonies.core.entity.citizen.citizenhandlers.CitizenSkillHandler;
 import com.minecolonies.core.network.messages.server.colony.citizen.PauseCitizenMessage;
 import com.minecolonies.core.network.messages.server.colony.citizen.RestartCitizenMessage;
 import com.minecolonies.core.util.BuildingUtils;
@@ -29,7 +30,6 @@ import net.minecraft.network.chat.Component;
 import net.minecraft.network.chat.MutableComponent;
 import net.minecraft.network.chat.Style;
 import net.minecraft.resources.ResourceLocation;
-import net.minecraft.util.Tuple;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.*;
@@ -445,13 +445,13 @@ public class WindowHireWorker extends AbstractWindowSkeleton
                 final Skill primary = selectedModule instanceof WorkerBuildingModuleView ? ((WorkerBuildingModuleView) selectedModule).getPrimarySkill() : null;
                 final Skill secondary = selectedModule instanceof WorkerBuildingModuleView ? ((WorkerBuildingModuleView) selectedModule).getSecondarySkill() : null;
 
-                final List<Map.Entry<Skill, Tuple<Integer, Double>>> skills = new ArrayList<>(citizen.getCitizenSkillHandler().getSkills().entrySet());
+                final List<Map.Entry<Skill, CitizenSkillHandler.SkillData>> skills = new ArrayList<>(citizen.getCitizenSkillHandler().getSkills().entrySet());
                 skills.sort(Comparator.comparingInt(s -> (s.getKey() == primary ? 1 : (s.getKey() == secondary ? 2 : 3))));
 
-                for (final Map.Entry<Skill, Tuple<Integer, Double>> entry : skills)
+                for (final Map.Entry<Skill, CitizenSkillHandler.SkillData> entry : skills)
                 {
                     final String skillName = entry.getKey().name().toLowerCase(Locale.US);
-                    final int skillLevel = entry.getValue().getA();
+                    final int skillLevel = entry.getValue().getLevel();
                     final Style skillStyle = createColor(primary, secondary, entry.getKey());
 
                     textBuilder.append(Component.translatable("com.minecolonies.coremod.gui.citizen.skills." + skillName).setStyle(skillStyle));

--- a/src/main/java/com/minecolonies/core/client/gui/citizen/CitizenWindowUtils.java
+++ b/src/main/java/com/minecolonies/core/client/gui/citizen/CitizenWindowUtils.java
@@ -16,9 +16,10 @@ import com.minecolonies.api.util.constant.Constants;
 import com.minecolonies.core.client.gui.AbstractWindowSkeleton;
 import com.minecolonies.core.colony.buildings.moduleviews.WorkerBuildingModuleView;
 import com.minecolonies.core.colony.buildings.views.AbstractBuildingView;
+import com.minecolonies.core.entity.citizen.citizenhandlers.CitizenSkillHandler;
 import net.minecraft.client.Minecraft;
+import net.minecraft.network.chat.Component;
 import net.minecraft.resources.ResourceLocation;
-import net.minecraft.util.Tuple;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.ArrayList;
@@ -32,8 +33,6 @@ import static com.minecolonies.core.client.gui.modules.WindowBuilderResModule.BL
 import static com.minecolonies.core.entity.citizen.citizenhandlers.CitizenExperienceHandler.PRIMARY_DEPENDENCY_SHARE;
 import static com.minecolonies.core.entity.citizen.citizenhandlers.CitizenExperienceHandler.SECONDARY_DEPENDENCY_SHARE;
 import static net.minecraft.client.gui.Gui.GUI_ICONS_LOCATION;
-
-import net.minecraft.network.chat.Component;
 
 /**
  * BOWindow for the citizen.
@@ -387,10 +386,10 @@ public class CitizenWindowUtils
     public static void createSkillContent(final ICitizenDataView citizen, final AbstractWindowSkeleton window)
     {
         final boolean isCreative = Minecraft.getInstance().player.isCreative();
-        for (final Map.Entry<Skill, Tuple<Integer, Double>> entry : citizen.getCitizenSkillHandler().getSkills().entrySet())
+        for (final Map.Entry<Skill, CitizenSkillHandler.SkillData> entry : citizen.getCitizenSkillHandler().getSkills().entrySet())
         {
             final String id = entry.getKey().name().toLowerCase(Locale.US);
-            window.findPaneOfTypeByID(id, Text.class).setText(Component.literal(Integer.toString(entry.getValue().getA())));
+            window.findPaneOfTypeByID(id, Text.class).setText(Component.literal(Integer.toString(entry.getValue().getLevel())));
 
             final Pane buttons = window.findPaneByID(id + "_bts");
             if (buttons != null)

--- a/src/main/java/com/minecolonies/core/client/gui/townhall/WindowCitizenPage.java
+++ b/src/main/java/com/minecolonies/core/client/gui/townhall/WindowCitizenPage.java
@@ -9,12 +9,12 @@ import com.minecolonies.api.colony.ICitizenDataView;
 import com.minecolonies.api.entity.citizen.Skill;
 import com.minecolonies.core.Network;
 import com.minecolonies.core.colony.buildings.workerbuildings.BuildingTownHall;
+import com.minecolonies.core.entity.citizen.citizenhandlers.CitizenSkillHandler;
 import com.minecolonies.core.network.messages.server.colony.citizen.RecallSingleCitizenMessage;
 import net.minecraft.ChatFormatting;
 import net.minecraft.client.Minecraft;
 import net.minecraft.network.chat.Component;
 import net.minecraft.resources.ResourceLocation;
-import net.minecraft.util.Tuple;
 import net.minecraft.world.entity.Entity;
 import net.minecraft.world.entity.Pose;
 import org.jetbrains.annotations.NotNull;
@@ -23,7 +23,7 @@ import java.math.RoundingMode;
 import java.text.DecimalFormat;
 import java.util.*;
 
-import static com.minecolonies.api.util.constant.TranslationConstants.*;
+import static com.minecolonies.api.util.constant.TranslationConstants.PARTIAL_HAPPINESS_MODIFIER_NAME;
 import static com.minecolonies.api.util.constant.WindowConstants.*;
 
 /**
@@ -188,10 +188,10 @@ public class WindowCitizenPage extends AbstractWindowTownHall
                 button.setText(Component.literal(citizen.getName()));
 
                 final AbstractTextBuilder.TextBuilder textBuilder = PaneBuilders.textBuilder();
-                for (final Map.Entry<Skill, Tuple<Integer, Double>> entry : citizen.getCitizenSkillHandler().getSkills().entrySet())
+                for (final Map.Entry<Skill, CitizenSkillHandler.SkillData> entry : citizen.getCitizenSkillHandler().getSkills().entrySet())
                 {
                     final String skillName = entry.getKey().name().toLowerCase(Locale.US);
-                    final int skillLevel = entry.getValue().getA();
+                    final int skillLevel = entry.getValue().getLevel();
 
                     textBuilder.append(Component.translatable("com.minecolonies.coremod.gui.citizen.skills." + skillName));
                     textBuilder.append(Component.literal(": " + skillLevel + " "));

--- a/src/main/java/com/minecolonies/core/colony/managers/CitizenManager.java
+++ b/src/main/java/com/minecolonies/core/colony/managers/CitizenManager.java
@@ -529,7 +529,7 @@ public class CitizenManager implements ICitizenManager
     @Override
     public int getCurrentCitizenCount()
     {
-        return citizens.size() + colony.getGraveManager().getGraves().size();
+        return citizens.size();
     }
 
     @Override

--- a/src/main/java/com/minecolonies/core/commands/citizencommands/CommandCitizenInfo.java
+++ b/src/main/java/com/minecolonies/core/commands/citizencommands/CommandCitizenInfo.java
@@ -89,12 +89,13 @@ public class CommandCitizenInfo implements IMCColonyOfficerCommand
         context.getSource().sendSuccess(() -> Component.translatable(CommandTranslationConstants.COMMAND_CITIZEN_INFO_HEALTH, entityCitizen.getHealth(), entityCitizen.getMaxHealth()), true);
 
         Object[] skills =
-          new Object[] {citizenData.getCitizenSkillHandler().getSkills().get(Skill.Athletics).getA(), citizenData.getCitizenSkillHandler().getSkills().get(Skill.Dexterity).getA(),
-            citizenData.getCitizenSkillHandler().getSkills().get(Skill.Strength).getA(), citizenData.getCitizenSkillHandler().getSkills().get(Skill.Agility).getA(),
-            citizenData.getCitizenSkillHandler().getSkills().get(Skill.Stamina).getA(), citizenData.getCitizenSkillHandler().getSkills().get(Skill.Mana).getA(),
-            citizenData.getCitizenSkillHandler().getSkills().get(Skill.Adaptability).getA(), citizenData.getCitizenSkillHandler().getSkills().get(Skill.Focus).getA(),
-            citizenData.getCitizenSkillHandler().getSkills().get(Skill.Creativity).getA(), citizenData.getCitizenSkillHandler().getSkills().get(Skill.Knowledge).getA(),
-            citizenData.getCitizenSkillHandler().getSkills().get(Skill.Intelligence).getA()};
+          new Object[] {citizenData.getCitizenSkillHandler().getSkills().get(Skill.Athletics).getLevel(),
+            citizenData.getCitizenSkillHandler().getSkills().get(Skill.Dexterity).getLevel(),
+            citizenData.getCitizenSkillHandler().getSkills().get(Skill.Strength).getLevel(), citizenData.getCitizenSkillHandler().getSkills().get(Skill.Agility).getLevel(),
+            citizenData.getCitizenSkillHandler().getSkills().get(Skill.Stamina).getLevel(), citizenData.getCitizenSkillHandler().getSkills().get(Skill.Mana).getLevel(),
+            citizenData.getCitizenSkillHandler().getSkills().get(Skill.Adaptability).getLevel(), citizenData.getCitizenSkillHandler().getSkills().get(Skill.Focus).getLevel(),
+            citizenData.getCitizenSkillHandler().getSkills().get(Skill.Creativity).getLevel(), citizenData.getCitizenSkillHandler().getSkills().get(Skill.Knowledge).getLevel(),
+            citizenData.getCitizenSkillHandler().getSkills().get(Skill.Intelligence).getLevel()};
         context.getSource().sendSuccess(() -> Component.translatable(CommandTranslationConstants.COMMAND_CITIZEN_INFO_SKILLS, skills), true);
 
         if (entityCitizen.getCitizenJobHandler().getColonyJob() == null)

--- a/src/main/java/com/minecolonies/core/commands/colonycommands/CommandListColonies.java
+++ b/src/main/java/com/minecolonies/core/commands/colonycommands/CommandListColonies.java
@@ -104,9 +104,10 @@ public class CommandListColonies implements IMCCommand
               String.format(COMMAND_COLONY_INFO, colony.getID())))), true);
             final BlockPos center = colony.getCenter();
 
-            final MutableComponent teleport = Component.literal(COORDINATES_TEXT + String.format(COORDINATES_XYZ, center.getX(), center.getY(), center.getZ()));
-            teleport.setStyle(Style.EMPTY.withBold(true).withColor(ChatFormatting.GOLD).withClickEvent(
-              new ClickEvent(ClickEvent.Action.RUN_COMMAND, TELEPORT_COMMAND + colony.getID())));
+            final MutableComponent teleport = Component.literal("Citizens:" + colony.getCitizenManager().getCurrentCitizenCount() + " ")
+                                                .append(Component.literal(COORDINATES_TEXT + String.format(COORDINATES_XYZ, center.getX(), center.getY(), center.getZ()))
+                                                          .setStyle(Style.EMPTY.withBold(true).withColor(ChatFormatting.GOLD).withClickEvent(
+                                                            new ClickEvent(ClickEvent.Action.RUN_COMMAND, TELEPORT_COMMAND + colony.getID()))));
 
             context.getSource().sendSuccess(() -> teleport, true);
         }

--- a/src/main/java/com/minecolonies/core/research/LocalResearchTree.java
+++ b/src/main/java/com/minecolonies/core/research/LocalResearchTree.java
@@ -415,11 +415,7 @@ public class LocalResearchTree implements ILocalResearchTree
           });
     }
 
-    /**
-     * Get the list of all finished researches
-     *
-     * @return a copy of the completed list.
-     */
+    @Override
     public List<ResourceLocation> getCompletedList()
     {
         return new ArrayList<>(isComplete);


### PR DESCRIPTION
# Changes proposed in this pull request
- Change citizen skill handler from tuple to data class
- Fix raids not happening as often as intended when it could not find a spawn position
- Extended raids level calc by more sophisticated colony progress trackers
- Allowed raiders to scale in health instead of amount, when they hit an entity spawn limit.

## Testing
- [x ] Yes I tested this before submitting it.
- [ ] I also did a multiplayer test.

Review please