### PR TITLE
Update JEI and optimize load time

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -32,8 +32,9 @@ structurize_version=1.0.751-1.21.1-snapshot
 domumOrnamentumVersion=1.0.203-1.21.1-snapshot
 multiPistonVersion=1.2.50-1.21.1-snapshot
 
+# jei versions: https://github.com/mezz/JustEnoughItems#1211
 jei_mcversion=1.21.1
-jei_version=19.8.4.116
+jei_version=19.19.6.235
 jmapApiVersion=2.0.0-1.21-SNAPSHOT
 jmapVersion=1.21-6.0.0-beta.19
 tinkersConstructVersion=0

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -36,7 +36,6 @@ dependencies {
 
     // optional compat mods (not included in test environment by default)
 
-    compileOnly "mezz.jei:jei-${project.jei_mcversion}-common-api:${project.jei_version}"
     compileOnly "mezz.jei:jei-${project.jei_mcversion}-neoforge-api:${project.jei_version}"
     runtimeOnly "mezz.jei:jei-${project.jei_mcversion}-neoforge:${project.jei_version}"
 

--- a/src/main/java/com/minecolonies/api/crafting/GenericRecipe.java
+++ b/src/main/java/com/minecolonies/api/crafting/GenericRecipe.java
@@ -344,18 +344,22 @@ public class GenericRecipe implements IGenericRecipe
     private static class IngredientStacks implements Comparable<IngredientStacks>
     {
         private final List<ItemStack> stacks;
-        private final Set<Item> items;
+        private final List<Item> items;
 
         public IngredientStacks(final List<ItemStack> ingredient)
         {
-            this.stacks = ingredient.stream()
-                    .filter(stack -> !stack.isEmpty())
-                    .map(ItemStack::copy)
-                    .collect(Collectors.toList());
-
-            this.items = this.stacks.stream()
-                    .map(ItemStack::getItem)
-                    .collect(Collectors.toSet());
+            this.stacks = new ArrayList<>(ingredient.size());
+            this.items = new ArrayList<>(ingredient.size());
+            for (ItemStack stack : ingredient)
+            {
+                if (!stack.isEmpty())
+                {
+                    ItemStack copy = stack.copy();
+                    this.stacks.add(copy);
+                    Item item = copy.getItem();
+                    this.items.add(item);
+                }
+            }
         }
 
         @NotNull

--- a/src/main/java/com/minecolonies/core/colony/crafting/GenericRecipeUtils.java
+++ b/src/main/java/com/minecolonies/core/colony/crafting/GenericRecipeUtils.java
@@ -19,6 +19,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 import java.util.Set;
+import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
 import static com.minecolonies.api.util.constant.BuildingConstants.CONST_DEFAULT_MAX_BUILDING_LEVEL;
@@ -89,9 +90,7 @@ public final class GenericRecipeUtils
 
         for (final List<ItemStack> slot : recipe.getInputs())
         {
-            final List<ItemStack> newSlot = slot.stream()
-                    .filter(stack -> predicate.test(stack).orElse(fallbackAccept))
-                    .collect(Collectors.toList());
+            final List<ItemStack> newSlot = filterList(slot, predicate, fallbackAccept);
 
             if (newSlot.isEmpty() && !slot.isEmpty())
             {
@@ -120,6 +119,21 @@ public final class GenericRecipeUtils
                 recipe.getRequiredTool(),
                 recipe.getRestrictions(),
                 recipe.getLevelSort());
+    }
+
+    private static <T> List<T> filterList(@NotNull final List<T> input,
+                                          @NotNull final OptionalPredicate<T> predicate,
+                                          final boolean fallbackAccept)
+    {
+        final List<T> newList = new ArrayList<>();
+        for (T stack : input)
+        {
+            if (predicate.test(stack).orElse(fallbackAccept))
+            {
+                newList.add(stack);
+            }
+        }
+        return newList;
     }
 
     private static boolean isDomumRecipe(@NotNull final IGenericRecipe recipe)

--- a/src/main/java/com/minecolonies/core/compatibility/jei/CompostRecipeCategory.java
+++ b/src/main/java/com/minecolonies/core/compatibility/jei/CompostRecipeCategory.java
@@ -5,20 +5,15 @@ import com.minecolonies.api.blocks.ModBlocks;
 import com.minecolonies.api.blocks.types.BarrelType;
 import com.minecolonies.api.colony.IColonyManager;
 import com.minecolonies.api.crafting.CompostRecipe;
-import mezz.jei.api.constants.VanillaTypes;
 import mezz.jei.api.gui.ITickTimer;
 import mezz.jei.api.gui.builder.IRecipeLayoutBuilder;
-import mezz.jei.api.gui.drawable.IDrawable;
 import mezz.jei.api.gui.ingredient.IRecipeSlotsView;
 import mezz.jei.api.helpers.IGuiHelper;
 import mezz.jei.api.recipe.IFocusGroup;
-import mezz.jei.api.recipe.RecipeIngredientRole;
-import mezz.jei.api.recipe.RecipeType;
-import mezz.jei.api.recipe.category.IRecipeCategory;
+import mezz.jei.api.recipe.category.AbstractRecipeCategory;
 import net.minecraft.client.gui.GuiGraphics;
 import net.minecraft.core.Direction;
 import net.minecraft.network.chat.Component;
-import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.level.block.state.BlockState;
 import org.jetbrains.annotations.NotNull;
 
@@ -28,22 +23,19 @@ import java.util.stream.Collectors;
 /**
  * JEI compost recipe category renderer
  */
-@SuppressWarnings("MethodParameterOfConcreteClass")
-public class CompostRecipeCategory implements IRecipeCategory<CompostRecipe>
+public class CompostRecipeCategory extends AbstractRecipeCategory<CompostRecipe>
 {
-    private final String title;
-    private final IDrawable background;
-    private final IDrawable icon;
-    private final IDrawable slot;
     private final ITickTimer timer;
 
     public CompostRecipeCategory(@NotNull final IGuiHelper guiHelper)
     {
-        this.title = Component.translatableEscape(ModBlocks.blockBarrel.getDescriptionId()).getString();
-
-        this.background = guiHelper.createBlankDrawable(80, 50);
-        this.icon = guiHelper.createDrawableIngredient(VanillaTypes.ITEM_STACK, new ItemStack(ModBlocks.blockBarrel));
-        this.slot = guiHelper.getSlotDrawable();
+        super(
+            ModRecipeTypes.COMPOSTING,
+            Component.translatableEscape(ModBlocks.blockBarrel.getDescriptionId()),
+            guiHelper.createDrawableItemLike(ModBlocks.blockBarrel),
+            80,
+            50
+        );
         this.timer = guiHelper.createTickTimer(60, BarrelType.values().length - 2, false);
     }
 
@@ -55,45 +47,17 @@ public class CompostRecipeCategory implements IRecipeCategory<CompostRecipe>
                 .collect(Collectors.toList());
     }
 
-    @NotNull
-    @Override
-    public RecipeType<CompostRecipe> getRecipeType()
-    {
-        return ModRecipeTypes.COMPOSTING;
-    }
-
-    @NotNull
-    @Override
-    public IDrawable getBackground()
-    {
-        return this.background;
-    }
-
-    @NotNull
-    @Override
-    public IDrawable getIcon()
-    {
-        return this.icon;
-    }
-
-    @NotNull
-    @Override
-    public Component getTitle()
-    {
-        return Component.literal(this.title);
-    }
-
     @Override
     public void setRecipe(@NotNull final IRecipeLayoutBuilder builder,
                           @NotNull final CompostRecipe recipe,
                           @NotNull final IFocusGroup focuses)
     {
-        builder.addSlot(RecipeIngredientRole.INPUT, 0, 0)
-                .setBackground(this.slot, -1, -1)
+        builder.addInputSlot(0, 0)
+                .setStandardSlotBackground()
                 .addIngredients(recipe.getIngredients().get(0));
 
-        builder.addSlot(RecipeIngredientRole.OUTPUT, 62, 0)
-                .setBackground(this.slot, -1, -1)
+        builder.addOutputSlot(62, 0)
+                .setStandardSlotBackground()
                 .addItemStack(recipe.getResultItem(null));
     }
 

--- a/src/main/java/com/minecolonies/core/compatibility/jei/FishermanRecipeCategory.java
+++ b/src/main/java/com/minecolonies/core/compatibility/jei/FishermanRecipeCategory.java
@@ -9,7 +9,6 @@ import com.minecolonies.core.colony.crafting.LootTableAnalyzer;
 import mezz.jei.api.gui.builder.IRecipeLayoutBuilder;
 import mezz.jei.api.helpers.IGuiHelper;
 import mezz.jei.api.recipe.IFocusGroup;
-import mezz.jei.api.recipe.RecipeIngredientRole;
 import net.minecraft.network.chat.Component;
 import net.minecraft.resources.ResourceKey;
 import net.minecraft.world.item.ItemStack;
@@ -68,10 +67,10 @@ public class FishermanRecipeCategory extends JobBasedRecipeCategory<FishermanRec
 
             for (final LootTableAnalyzer.LootDrop drop : recipe.getDrops())
             {
-                builder.addSlot(RecipeIngredientRole.OUTPUT, x, y)
+                builder.addOutputSlot(x, y)
                         .setBackground(this.chanceSlot, -1, -1)
                         .addItemStacks(drop.getItemStacks())
-                        .addTooltipCallback(new LootTableTooltipCallback(drop, recipe.getId()));
+                        .addRichTooltipCallback(new LootTableTooltipCallback(drop, recipe.getId()));
                 if (++c >= columns)
                 {
                     c = 0;

--- a/src/main/java/com/minecolonies/core/compatibility/jei/GenericRecipeCategory.java
+++ b/src/main/java/com/minecolonies/core/compatibility/jei/GenericRecipeCategory.java
@@ -15,12 +15,12 @@ import com.mojang.blaze3d.platform.Lighting;
 import mezz.jei.api.gui.ITickTimer;
 import mezz.jei.api.gui.builder.IRecipeLayoutBuilder;
 import mezz.jei.api.gui.builder.IRecipeSlotBuilder;
+import mezz.jei.api.gui.builder.ITooltipBuilder;
 import mezz.jei.api.gui.drawable.IDrawableStatic;
 import mezz.jei.api.gui.ingredient.IRecipeSlotsView;
 import mezz.jei.api.helpers.IGuiHelper;
 import mezz.jei.api.helpers.IModIdHelper;
 import mezz.jei.api.recipe.IFocusGroup;
-import mezz.jei.api.recipe.RecipeIngredientRole;
 import mezz.jei.api.recipe.RecipeType;
 import net.minecraft.client.gui.GuiGraphics;
 import net.minecraft.client.renderer.Rect2i;
@@ -128,19 +128,19 @@ public class GenericRecipeCategory extends JobBasedRecipeCategory<IGenericRecipe
 
         int x = outputSlotX;
         int y = outputSlotY;
-        IRecipeSlotBuilder slot = builder.addSlot(RecipeIngredientRole.OUTPUT, x, y)
-                .setBackground(this.slot, -1, -1)
+        IRecipeSlotBuilder slot = builder.addOutputSlot(x, y)
+                .setStandardSlotBackground()
                 .addItemStacks(recipe.getAllMultiOutputs());
         if (id != null)
         {
-            slot.addTooltipCallback(new RecipeIdTooltipCallback(id, this.modIdHelper));
+            slot.addRichTooltipCallback(new RecipeIdTooltipCallback(id, this.modIdHelper));
         }
         x += this.slot.getWidth();
 
         for (final ItemStack extra : recipe.getAdditionalOutputs())
         {
-            builder.addSlot(RecipeIngredientRole.OUTPUT, x, y)
-                    .setBackground(this.slot, -1, -1)
+            builder.addOutputSlot(x, y)
+                    .setStandardSlotBackground()
                     .addItemStack(extra);
             x += this.slot.getWidth();
         }
@@ -150,10 +150,10 @@ public class GenericRecipeCategory extends JobBasedRecipeCategory<IGenericRecipe
             final List<LootTableAnalyzer.LootDrop> drops = getLootDrops(recipe.getLootTable());
             for (final LootTableAnalyzer.LootDrop drop : drops)
             {
-                builder.addSlot(RecipeIngredientRole.OUTPUT, x, y)
+                builder.addOutputSlot(x, y)
                         .setBackground(this.chanceSlot, -1, -1)
                         .addItemStacks(drop.getItemStacks())
-                        .addTooltipCallback(new LootTableTooltipCallback(drop, recipe.getLootTable()));
+                        .addRichTooltipCallback(new LootTableTooltipCallback(drop, recipe.getLootTable()));
                 x += this.chanceSlot.getWidth();
             }
         }
@@ -170,7 +170,7 @@ public class GenericRecipeCategory extends JobBasedRecipeCategory<IGenericRecipe
             int c = 0;
             for (final List<ItemStack> input : inputs)
             {
-                builder.addSlot(RecipeIngredientRole.INPUT, x, y)
+                builder.addInputSlot(x, y)
                         .addItemStacks(input);
                 if (++c >= inputColumns)
                 {
@@ -204,7 +204,7 @@ public class GenericRecipeCategory extends JobBasedRecipeCategory<IGenericRecipe
         {
             for (final List<ItemStack> input : inputs)
             {
-                builder.addSlot(RecipeIngredientRole.INPUT, x, y)
+                builder.addInputSlot(x, y)
                         .addItemStacks(input);
                 x += this.slot.getWidth() + 2;
             }
@@ -233,16 +233,16 @@ public class GenericRecipeCategory extends JobBasedRecipeCategory<IGenericRecipe
 
             for (final LootTableAnalyzer.LootDrop drop : drops)
             {
-                final IRecipeSlotBuilder slot = builder.addSlot(RecipeIngredientRole.OUTPUT, x, y)
+                final IRecipeSlotBuilder slot = builder.addOutputSlot(x, y)
                         .setBackground(this.chanceSlot, -1, -1)
                         .addItemStacks(drop.getItemStacks());
                 if (showLootTooltip)
                 {
-                    slot.addTooltipCallback(new LootTableTooltipCallback(drop, recipe.getLootTable()));
+                    slot.addRichTooltipCallback(new LootTableTooltipCallback(drop, recipe.getLootTable()));
                 }
                 if (id != null)
                 {
-                    slot.addTooltipCallback(new RecipeIdTooltipCallback(id, this.modIdHelper));
+                    slot.addRichTooltipCallback(new RecipeIdTooltipCallback(id, this.modIdHelper));
                 }
                 if (++c >= columns)
                 {
@@ -295,21 +295,18 @@ public class GenericRecipeCategory extends JobBasedRecipeCategory<IGenericRecipe
     }
 
     @Override
-    public @NotNull List<Component> getTooltipStrings(@NotNull final IGenericRecipe recipe,
-                                                      @NotNull final IRecipeSlotsView recipeSlotsView,
-                                                      final double mouseX, final double mouseY)
+    public void getTooltip(@NotNull final ITooltipBuilder tooltip,
+                           @NotNull final IGenericRecipe recipe,
+                           @NotNull final IRecipeSlotsView recipeSlotsView,
+                           final double mouseX, final double mouseY)
     {
-        final List<Component> tooltips = super.getTooltipStrings(recipe, recipeSlotsView, mouseX, mouseY);
-
         if (recipe.getIntermediate() != Blocks.AIR)
         {
             if (new Rect2i(CITIZEN_X + CITIZEN_W + 4, CITIZEN_Y - 2, 24, 24).contains((int) mouseX, (int) mouseY))
             {
-                tooltips.add(Component.translatableEscape(TranslationConstants.PARTIAL_JEI_INFO + "intermediate.tip", recipe.getIntermediate().getName()));
+                tooltip.add(Component.translatableEscape(TranslationConstants.PARTIAL_JEI_INFO + "intermediate.tip", recipe.getIntermediate().getName()));
             }
         }
-
-        return tooltips;
     }
 
     private static boolean isLootBasedRecipe(@NotNull final IGenericRecipe recipe)

--- a/src/main/java/com/minecolonies/core/compatibility/jei/JEIPlugin.java
+++ b/src/main/java/com/minecolonies/core/compatibility/jei/JEIPlugin.java
@@ -17,7 +17,6 @@ import com.minecolonies.core.colony.crafting.RecipeAnalyzer;
 import com.minecolonies.core.compatibility.jei.transfer.*;
 import mezz.jei.api.IModPlugin;
 import mezz.jei.api.constants.RecipeTypes;
-import mezz.jei.api.constants.VanillaTypes;
 import mezz.jei.api.helpers.IGuiHelper;
 import mezz.jei.api.helpers.IJeiHelpers;
 import mezz.jei.api.helpers.IModIdHelper;
@@ -28,7 +27,6 @@ import net.minecraft.client.multiplayer.ClientLevel;
 import net.minecraft.network.chat.Component;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.entity.animal.Animal;
-import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.level.Level;
 import org.jetbrains.annotations.NotNull;
 
@@ -54,16 +52,18 @@ public class JEIPlugin implements IModPlugin
         final IGuiHelper guiHelper = jeiHelpers.getGuiHelper();
         final IModIdHelper modIdHelper = jeiHelpers.getModIdHelper();
 
-        registration.addRecipeCategories(new ToolRecipeCategory(guiHelper));
-        registration.addRecipeCategories(new CompostRecipeCategory(guiHelper));
-        registration.addRecipeCategories(new FishermanRecipeCategory(guiHelper));
+        registration.addRecipeCategories(
+            new ToolRecipeCategory(guiHelper),
+            new CompostRecipeCategory(guiHelper),
+            new FishermanRecipeCategory(guiHelper)
+        );
 
         categories.clear();
         for (final BuildingEntry building : IMinecoloniesAPI.getInstance().getBuildingRegistry())
         {
             final Map<JobEntry, GenericRecipeCategory> craftingCategories = new HashMap<>();
 
-            for (final BuildingEntry.ModuleProducer producer : building.getModuleProducers())
+            for (final BuildingEntry.ModuleProducer<?, ?> producer : building.getModuleProducers())
             {
                 if (!producer.hasServerModule())
                 {
@@ -121,7 +121,7 @@ public class JEIPlugin implements IModPlugin
     @Override
     public void registerRecipes(@NotNull final IRecipeRegistration registration)
     {
-        registration.addIngredientInfo(new ItemStack(ModBlocks.blockHutComposter.asItem()), VanillaTypes.ITEM_STACK,
+        registration.addIngredientInfo(ModBlocks.blockHutComposter,
                 Component.translatableEscape(TranslationConstants.PARTIAL_JEI_INFO + ModJobs.COMPOSTER_ID.getPath()));
 
         registration.addRecipes(ModRecipeTypes.TOOLS, ToolRecipeCategory.findRecipes(Minecraft.getInstance().level));
@@ -157,9 +157,9 @@ public class JEIPlugin implements IModPlugin
     @Override
     public void registerRecipeCatalysts(@NotNull final IRecipeCatalystRegistration registration)
     {
-        registration.addRecipeCatalyst(new ItemStack(ModBlocks.blockBarrel), ModRecipeTypes.COMPOSTING);
-        registration.addRecipeCatalyst(new ItemStack(ModBlocks.blockHutComposter), ModRecipeTypes.COMPOSTING);
-        registration.addRecipeCatalyst(new ItemStack(ModBlocks.blockHutFisherman), ModRecipeTypes.FISHING);
+        registration.addRecipeCatalyst(ModBlocks.blockBarrel, ModRecipeTypes.COMPOSTING);
+        registration.addRecipeCatalyst(ModBlocks.blockHutComposter, ModRecipeTypes.COMPOSTING);
+        registration.addRecipeCatalyst(ModBlocks.blockHutFisherman, ModRecipeTypes.FISHING);
 
         for (final JobBasedRecipeCategory<?> category : this.categories)
         {


### PR DESCRIPTION
I was carefully profiling JEI in some large packs and noticed that Minecolonies takes more time than any other plugin.
Looking into the code, this is mostly because of tag predicates for recipes (which is almost unavoidable) but I also found some other low-hanging fruit that I could optimize here.

In the spirit of [Modtoberfest](https://modtoberfest.com/), I thought it would be nice to contribute directly!

# Changes proposed in this pull request
- Optimize load time 
	- ~~merge and improve logic for tool checks~~
	- remove Streams from a small number of extremely hot areas
	- Cache the expensive check that gets all tools of a certain type for recipes
	- Improve `IngredientStacks#equals` speed and correctness by using a `List<Item>` instead of `Set<Item>`
- Modernize JEI plugin by using new features for laying out text and reducing redundant code.

## Testing
- [X] Yes I tested this before submitting it.
- [ ] I also did a multiplayer test. (I did not because these are client-only changes)

## Comparison:
before: `Registering recipes: minecolonies:minecolonies took 2.793 seconds`
after: `Registering recipes: minecolonies:minecolonies took 1.725 seconds`

Review please