### PR TITLE
Fix computation of the mean factor for happiness

### DIFF
--- a/src/main/java/com/minecolonies/core/entity/citizen/citizenhandlers/CitizenHappinessHandler.java
+++ b/src/main/java/com/minecolonies/core/entity/citizen/citizenhandlers/CitizenHappinessHandler.java
@@ -141,11 +141,12 @@ public class CitizenHappinessHandler implements ICitizenHappinessHandler
             double totalWeight = 0.0;
             for (final IHappinessModifier happinessModifier : happinessFactors.values())
             {
-                final double factor = happinessModifier.getFactor(citizenData);
-                if (factor == 1.0)
+                final double weight = happinessModifier.getWeight();
+                if (weight == 0.0)
                     continue;
-                total += factor * happinessModifier.getWeight();
-                totalWeight += happinessModifier.getWeight();
+                final double factor = happinessModifier.getFactor(citizenData);
+                total += factor * weight;
+                totalWeight += weight;
             }
 
             final double happinessResult = (total / totalWeight) * (1 + colony.getResearchManager().getResearchEffects().getEffectStrength(HAPPINESS));


### PR DESCRIPTION
Closes #10320 

# Changes proposed in this pull request
- Fix the computation of the mean: a 1 - factors does influence the mean
- Add a small optimizeation that bypass the factor computation (complexe getter) if the weight is 0.0 (simple getter)

## Testing
- [x] Yes I tested this before submitting it. Happiness of the very first citizen is now 4.
- [ ] I also did a multiplayer test.

Review please