### PR TITLE
Raidcommand changes

### DIFF
--- a/src/main/java/com/minecolonies/api/colony/managers/interfaces/IRaiderManager.java
+++ b/src/main/java/com/minecolonies/api/colony/managers/interfaces/IRaiderManager.java
@@ -104,10 +104,10 @@ public interface IRaiderManager
     /**
      * Trigger a specific type of raid on a colony.
      * @param raidType the type of raid (or empty).
-     * @param overrideConfig if it should override the config to allow raiders.
+     * @param forced if it is forced to spawn.
      * @param allowShips if ship spawns are allowed.
      */
-    RaidSpawnResult raiderEvent(String raidType, final boolean overrideConfig, final boolean allowShips);
+    RaidSpawnResult raiderEvent(String raidType, final boolean forced, final boolean allowShips);
 
     /**
      * Calculates the spawn position for raids
@@ -163,14 +163,6 @@ public interface IRaiderManager
      * @return true if possible.
      */
     boolean canRaid();
-
-    /**
-     * Whether the colony can be raided.
-     *
-     * @param overrideConfig if the config should be overriden.
-     * @return true if possible.
-     */
-    boolean canRaid(final boolean overrideConfig);
 
     /**
      * calculates the colonies raid level

--- a/src/main/java/com/minecolonies/api/entity/ai/combat/threat/ThreatTable.java
+++ b/src/main/java/com/minecolonies/api/entity/ai/combat/threat/ThreatTable.java
@@ -186,6 +186,11 @@ public class ThreatTable<T extends LivingEntity & IThreatTableEntity>
             return null;
         }
 
+        if (current instanceof IThreatTableEntity threatTableEntity && threatTableEntity.getThreatTable().threatList.isEmpty())
+        {
+            threatTableEntity.getThreatTable().addThreat(owner, 0);
+        }
+
         return current;
     }
 

--- a/src/main/java/com/minecolonies/core/colony/events/raid/RaidManager.java
+++ b/src/main/java/com/minecolonies/core/colony/events/raid/RaidManager.java
@@ -40,6 +40,7 @@ import net.minecraft.network.chat.Component;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.tags.BiomeTags;
 import net.minecraft.util.Mth;
+import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.biome.Biome;
 import net.minecraft.world.level.block.Blocks;
@@ -260,13 +261,13 @@ public class RaidManager implements IRaiderManager
     }
 
     @Override
-    public RaidSpawnResult raiderEvent(String raidType, final boolean overrideConfig, final boolean allowShips)
+    public RaidSpawnResult raiderEvent(String raidType, final boolean forced, final boolean allowShips)
     {
         if (colony.getWorld() == null || raidType == null)
         {
             return RaidSpawnResult.ERROR;
         }
-        else if (!canRaid(overrideConfig))
+        else if (!forced && !canRaid())
         {
             return RaidSpawnResult.CANNOT_RAID;
         }
@@ -417,7 +418,7 @@ public class RaidManager implements IRaiderManager
                 {
                     event = new PirateGroundRaidEvent(colony);
                 }
-                else if (raidType.isEmpty() || raidType.equals(BarbarianRaidEvent.BARBARIAN_RAID_EVENT_TYPE_ID))
+                else if (raidType.isEmpty() || raidType.equals(BarbarianRaidEvent.BARBARIAN_RAID_EVENT_TYPE_ID.getPath()))
                 {
                     event = new BarbarianRaidEvent(colony);
                 }
@@ -680,10 +681,19 @@ public class RaidManager implements IRaiderManager
     @Override
     public int calculateRaiderAmount(final int raidLevel)
     {
+        int nearbyColonyPlayers = 0;
+        for (final Player player : colony.getMessagePlayerEntities())
+        {
+            if (!player.isSpectator())
+            {
+                nearbyColonyPlayers++;
+            }
+        }
+
         return 1 + Math.min(MineColonies.getConfig().getServer().maxRaiders.get(),
           (int) ((raidLevel / SPAWN_MODIFIER)
                    * getRaidDifficultyModifier()
-                   * (1.0 + colony.getMessagePlayerEntities().size() * INCREASE_PER_PLAYER)
+                   * (1.0 + nearbyColonyPlayers * INCREASE_PER_PLAYER)
                    * ((ColonyConstants.rand.nextDouble() * 0.5d) + 0.75)));
     }
 
@@ -764,14 +774,8 @@ public class RaidManager implements IRaiderManager
     @Override
     public boolean canRaid()
     {
-        return canRaid(false);
-    }
-
-    @Override
-    public boolean canRaid(final boolean override)
-    {
         return !WorldUtil.isPeaceful(colony.getWorld())
-                 && (MineColonies.getConfig().getServer().enableColonyRaids.get() || override)
+                 && (MineColonies.getConfig().getServer().enableColonyRaids.get())
                  && colony.getRaiderManager().canHaveRaiderEvents()
                  && !colony.getPackageManager().getImportantColonyPlayers().isEmpty();
     }
@@ -857,7 +861,7 @@ public class RaidManager implements IRaiderManager
     public BlockPos getRandomBuilding()
     {
         buildingPosUsage++;
-        if (buildingPosUsage > 6 || lastBuilding == null)
+        if (buildingPosUsage > getLastRaid().raiderAmount / 3 || lastBuilding == null)
         {
             buildingPosUsage = 0;
             final Collection<IBuilding> buildingList = colony.getBuildingManager().getBuildings().values();

--- a/src/main/java/com/minecolonies/core/colony/events/raid/RaidManager.java
+++ b/src/main/java/com/minecolonies/core/colony/events/raid/RaidManager.java
@@ -861,7 +861,7 @@ public class RaidManager implements IRaiderManager
     public BlockPos getRandomBuilding()
     {
         buildingPosUsage++;
-        if (buildingPosUsage > getLastRaid().raiderAmount / 3 || lastBuilding == null)
+        if (buildingPosUsage > Math.max(6, getLastRaid().raiderAmount / 3) || lastBuilding == null)
         {
             buildingPosUsage = 0;
             final Collection<IBuilding> buildingList = colony.getBuildingManager().getBuildings().values();

--- a/src/main/java/com/minecolonies/core/colony/managers/CitizenManager.java
+++ b/src/main/java/com/minecolonies/core/colony/managers/CitizenManager.java
@@ -312,10 +312,11 @@ public class CitizenManager implements ICitizenManager
 
         entity.setUUID(citizenData.getUUID());
         entity.setPos(spawnPoint.getX() + HALF_BLOCK, spawnPoint.getY() + SLIGHTLY_UP, spawnPoint.getZ() + HALF_BLOCK);
-        world.addFreshEntity(entity);
 
         entity.setCitizenId(citizenData.getId());
         entity.getCitizenColonyHandler().setColonyId(colony.getID());
+
+        world.addFreshEntity(entity);
         if (entity.isAddedToWorld())
         {
             entity.getCitizenColonyHandler().registerWithColony(citizenData.getColony().getID(), citizenData.getId());

--- a/src/main/java/com/minecolonies/core/commands/colonycommands/CommandRaid.java
+++ b/src/main/java/com/minecolonies/core/commands/colonycommands/CommandRaid.java
@@ -76,7 +76,7 @@ public class CommandRaid implements IMCOPCommand
         }
         else if(StringArgumentType.getString(context, RAID_TIME_ARG).equals(RAID_TONIGHT))
         {
-            if (!colony.getRaiderManager().canRaid(true))
+            if (!colony.getRaiderManager().canRaid())
             {
                 context.getSource().sendSuccess(() -> Component.translatable(CommandTranslationConstants.COMMAND_RAID_NOW_FAILURE, colony.getName(), IRaiderManager.RaidSpawnResult.CANNOT_RAID), true);
                 return 1;


### PR DESCRIPTION
Closes #
Closes #

# Changes proposed in this pull request
- Make chased targets turn aware of their pursuer
- Raid command now ignores restrictions, like officer online
- Raiders now split into slightly bigger grps
- Fix barbarians raiders not able to spawn when chosen via command

## Testing
- [ x] Yes I tested this before submitting it.
- [ ] I also did a multiplayer test.

Review please