### PR TITLE
Pathing fixes

### DIFF
--- a/src/main/java/com/minecolonies/api/entity/other/AbstractFastMinecoloniesEntity.java
+++ b/src/main/java/com/minecolonies/api/entity/other/AbstractFastMinecoloniesEntity.java
@@ -57,6 +57,11 @@ public abstract class AbstractFastMinecoloniesEntity extends PathfinderMob imple
     private long lastHorizontalCollision = 0;
 
     /**
+     * Last knockback time
+     */
+    protected long lastKnockBack = 0;
+
+    /**
      * Create a new instance.
      *
      * @param type    from type.
@@ -334,5 +339,15 @@ public abstract class AbstractFastMinecoloniesEntity extends PathfinderMob imple
     public boolean isShiftKeyDown()
     {
         return (this.entityData.get(DATA_SHARED_FLAGS_ID)).byteValue() == ENABLE.byteValue();
+    }
+
+    @Override
+    public void knockback(double power, double xRatio, double zRatio)
+    {
+        if (level.getGameTime() - lastKnockBack > 20 * 3)
+        {
+            lastKnockBack = level.getGameTime();
+            super.knockback(power, xRatio, zRatio);
+        }
     }
 }

--- a/src/main/java/com/minecolonies/core/colony/managers/CitizenManager.java
+++ b/src/main/java/com/minecolonies/core/colony/managers/CitizenManager.java
@@ -301,10 +301,15 @@ public class CitizenManager implements ICitizenManager
 
         if (world instanceof ServerLevel serverLevel)
         {
-            final Entity existing = serverLevel.getEntity(citizenData.getUUID());
+            Entity existing = serverLevel.getEntity(citizenData.getUUID());
             if (existing != null)
             {
                 existing.discard();
+                existing = serverLevel.getEntity(citizenData.getUUID());
+                if (existing != null)
+                {
+                    serverLevel.entityManager.stopTracking(existing);
+                }
             }
         }
 

--- a/src/main/java/com/minecolonies/core/entity/citizen/EntityCitizen.java
+++ b/src/main/java/com/minecolonies/core/entity/citizen/EntityCitizen.java
@@ -723,6 +723,7 @@ public class EntityCitizen extends AbstractEntityCitizen implements IThreatTable
             if (colonyView != null)
             {
                 this.citizenDataView = colonyView.getCitizen(citizenId);
+                // TODO: Why is this here on clientside?
                 this.getNavigation().getPathingOptions().setCanUseRails(canPathOnRails());
                 this.getNavigation().getPathingOptions().setCanClimbAdvanced(canClimbVines());
             }

--- a/src/main/java/com/minecolonies/core/entity/mobs/aitasks/RaiderWalkAI.java
+++ b/src/main/java/com/minecolonies/core/entity/mobs/aitasks/RaiderWalkAI.java
@@ -10,12 +10,12 @@ import com.minecolonies.api.entity.ai.statemachine.tickratestatemachine.ITickRat
 import com.minecolonies.api.entity.ai.statemachine.tickratestatemachine.TickingTransition;
 import com.minecolonies.api.entity.mobs.AbstractEntityRaiderMob;
 import com.minecolonies.api.entity.pathfinding.IPathJob;
-import com.minecolonies.core.entity.pathfinding.pathresults.PathResult;
 import com.minecolonies.api.util.BlockPosUtil;
 import com.minecolonies.api.util.Log;
 import com.minecolonies.core.colony.buildings.AbstractBuilding;
 import com.minecolonies.core.colony.events.raid.HordeRaidEvent;
 import com.minecolonies.core.colony.events.raid.pirateEvent.ShipBasedRaiderUtils;
+import com.minecolonies.core.entity.pathfinding.pathresults.PathResult;
 import net.minecraft.core.BlockPos;
 
 import java.util.List;
@@ -156,7 +156,10 @@ public class RaiderWalkAI implements IStateAI
                   && !building.getCorners().getA().equals(building.getCorners().getB()))
             {
                 randomPathResult = raider.getNavigation().moveToRandomPos(10, 0.9, building.getCorners());
-                randomPathResult.getJob().getPathingOptions().withCanEnterDoors(true).withToggleCost(0).withNonLadderClimbableCost(0);
+                if (randomPathResult != null)
+                {
+                    randomPathResult.getJob().getPathingOptions().withCanEnterDoors(true).withToggleCost(0).withNonLadderClimbableCost(0);
+                }
             }
             else
             {

--- a/src/main/java/com/minecolonies/core/entity/pathfinding/navigation/MinecoloniesAdvancedPathNavigate.java
+++ b/src/main/java/com/minecolonies/core/entity/pathfinding/navigation/MinecoloniesAdvancedPathNavigate.java
@@ -25,8 +25,7 @@ import net.minecraft.world.entity.ai.attributes.Attributes;
 import net.minecraft.world.level.BlockGetter;
 import net.minecraft.world.level.ChunkPos;
 import net.minecraft.world.level.Level;
-import net.minecraft.world.level.block.BaseRailBlock;
-import net.minecraft.world.level.block.LadderBlock;
+import net.minecraft.world.level.block.*;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.block.state.properties.RailShape;
 import net.minecraft.world.level.pathfinder.Node;
@@ -383,7 +382,9 @@ public class MinecoloniesAdvancedPathNavigate extends AbstractAdvancedPathNaviga
                             vector3d2.z);
                     }
                 }
-
+            }
+            if (wantedPosition != null)
+            {
                 mob.getMoveControl().setWantedPosition(wantedPosition.x, wantedPosition.y, wantedPosition.z, speedModifier);
             }
         }
@@ -412,6 +413,11 @@ public class MinecoloniesAdvancedPathNavigate extends AbstractAdvancedPathNaviga
 
         if (!state.isAir())
         {
+            if (state.getBlock() instanceof FenceGateBlock || state.getBlock() instanceof DoorBlock || state.getBlock() instanceof TrapDoorBlock)
+            {
+                return orgY;
+            }
+
             final VoxelShape voxelshape = state.getCollisionShape(world, pos);
             if (!ShapeUtil.isEmpty(voxelshape))
             {

--- a/src/main/java/com/minecolonies/core/entity/pathfinding/pathjobs/AbstractPathJob.java
+++ b/src/main/java/com/minecolonies/core/entity/pathfinding/pathjobs/AbstractPathJob.java
@@ -1218,7 +1218,7 @@ public abstract class AbstractPathJob implements Callable<Path>, IPathJob
         if (!block.isAir())
         {
             final VoxelShape shape = block.getCollisionShape(world, tempWorldPos.set(x, y, z));
-            if (ShapeUtil.max(shape, Direction.Axis.Y) < 0.5 && PathfindingUtils.isDangerous(cachedBlockLookup.getBlockState(x, y - 1, z)))
+            if (!pathingOptions.canPassDanger() && ShapeUtil.max(shape, Direction.Axis.Y) < 0.5 && PathfindingUtils.isDangerous(cachedBlockLookup.getBlockState(x, y - 1, z)))
             {
                 return false;
             }
@@ -1282,7 +1282,7 @@ public abstract class AbstractPathJob implements Callable<Path>, IPathJob
                              || !block.getBlock().properties.hasCollision;
                 }
             }
-            else if (PathfindingUtils.isDangerous(block))
+            else if (!pathingOptions.canPassDanger() && PathfindingUtils.isDangerous(block))
             {
                 return false;
             }

--- a/src/main/java/com/minecolonies/core/event/EventHandler.java
+++ b/src/main/java/com/minecolonies/core/event/EventHandler.java
@@ -136,7 +136,8 @@ public class EventHandler
         {
             if (MineColonies.getConfig().getServer().mobAttackCitizens.get() && event.getEntity() instanceof Mob && event.getEntity() instanceof Enemy && !(event.getEntity()
               .getType()
-              .is(ModTags.mobAttackBlacklist)))
+                .is(ModTags.mobAttackBlacklist))
+                && !(event.getEntity() instanceof AbstractFastMinecoloniesEntity))
             {
                 ((Mob) event.getEntity()).targetSelector.addGoal(6,
                   new NearestAttackableTargetGoal<>((Mob) event.getEntity(), EntityCitizen.class, true, citizen -> !citizen.isInvisible()));

--- a/src/main/resources/META-INF/accesstransformer.cfg
+++ b/src/main/resources/META-INF/accesstransformer.cfg
@@ -131,4 +131,5 @@ public net.minecraft.client.renderer.entity.layers.HumanoidArmorLayer f_266073_ 
 public net.minecraft.world.entity.LivingEntity m_21333_()V # updateSwimAmount
 
 public-f net.minecraft.world.entity.Entity m_142467_(Lnet/minecraft/world/entity/Entity$RemovalReason;)V # setRemoved
-
+public net.minecraft.world.level.entity.PersistentEntitySectionManager m_157580_(Lnet/minecraft/world/level/entity/EntityAccess;)V # stopTracking
+public net.minecraft.server.level.ServerLevel f_143244_ # entityManager


### PR DESCRIPTION
# Changes proposed in this pull request
- Fix berry bush pathfinding
- Fix citizen not fully pathing to the end of the path
- Fix raiders getting a vanilla target goal, while they already have a custom targeting AI
- Add knockback cooldown, so entities during combat do not get knocked around all the time
- Fix jumping on doors
- Add recovery for stuck entities

## Testing
- [ x] Yes I tested this before submitting it.
- [ ] I also did a multiplayer test.

Review please