### PR TITLE
Remove reset config and just make available to managers

### DIFF
--- a/src/main/java/com/minecolonies/api/configuration/ServerConfiguration.java
+++ b/src/main/java/com/minecolonies/api/configuration/ServerConfiguration.java
@@ -57,7 +57,6 @@ public class ServerConfiguration extends AbstractConfiguration
     public final ForgeConfigSpec.BooleanValue canPlayerUseKillCitizensCommand;
     public final ForgeConfigSpec.BooleanValue canPlayerUseAddOfficerCommand;
     public final ForgeConfigSpec.BooleanValue canPlayerUseDeleteColonyCommand;
-    public final ForgeConfigSpec.BooleanValue canPlayerUseResetCommand;
 
     /*  --------------------------------------------------------------------------- *
      *  ------------------- ######## Claim settings ######## ------------------- *
@@ -163,7 +162,6 @@ public class ServerConfiguration extends AbstractConfiguration
         canPlayerUseKillCitizensCommand = defineBoolean(builder, "canplayerusekillcitizenscommand", false);
         canPlayerUseAddOfficerCommand = defineBoolean(builder, "canplayeruseaddofficercommand", true);
         canPlayerUseDeleteColonyCommand = defineBoolean(builder, "canplayerusedeletecolonycommand", false);
-        canPlayerUseResetCommand = defineBoolean(builder, "canplayeruseresetcommand", false);
 
         swapToCategory(builder, "claims");
 

--- a/src/main/java/com/minecolonies/api/util/constant/translation/CommandTranslationConstants.java
+++ b/src/main/java/com/minecolonies/api/util/constant/translation/CommandTranslationConstants.java
@@ -10,6 +10,8 @@ public class CommandTranslationConstants
     @NonNls
     public static final String COMMAND_REQUIRES_OP                           = "com.minecolonies.command.notop";
     @NonNls
+    public static final String COMMAND_REQUIRES_OFFICER                      = "com.minecolonies.command.notofficer";
+    @NonNls
     public static final String COMMAND_DISABLED_IN_CONFIG                    = "com.minecolonies.command.notenabledinconfig";
     @NonNls
     public static final String COMMAND_COLONY_ID_NOT_FOUND                   = "com.minecolonies.command.colonyidnotfound";

--- a/src/main/java/com/minecolonies/core/commands/colonycommands/requestsystem/CommandRSReset.java
+++ b/src/main/java/com/minecolonies/core/commands/colonycommands/requestsystem/CommandRSReset.java
@@ -1,9 +1,10 @@
 package com.minecolonies.core.commands.colonycommands.requestsystem;
 
+import com.google.common.base.Stopwatch;
 import com.minecolonies.api.colony.IColony;
 import com.minecolonies.api.colony.IColonyManager;
 import com.minecolonies.api.util.constant.translation.CommandTranslationConstants;
-import com.minecolonies.core.MineColonies;
+import com.minecolonies.core.commands.commandTypes.IMCColonyOfficerCommand;
 import com.minecolonies.core.commands.commandTypes.IMCCommand;
 import com.mojang.brigadier.arguments.IntegerArgumentType;
 import com.mojang.brigadier.builder.LiteralArgumentBuilder;
@@ -13,7 +14,7 @@ import net.minecraft.network.chat.Component;
 
 import static com.minecolonies.core.commands.CommandArgumentNames.COLONYID_ARG;
 
-public class CommandRSReset implements IMCCommand
+public class CommandRSReset implements IMCColonyOfficerCommand
 {
     /**
      * What happens when the command is executed after preConditions are successful.
@@ -32,14 +33,10 @@ public class CommandRSReset implements IMCCommand
             return 0;
         }
 
-        if (!context.getSource().hasPermission(OP_PERM_LEVEL) && !MineColonies.getConfig().getServer().canPlayerUseResetCommand.get())
-        {
-            context.getSource().sendSuccess(() -> Component.translatable(CommandTranslationConstants.COMMAND_DISABLED_IN_CONFIG), true);
-            return 0;
-        }
-
+        final Stopwatch watch = Stopwatch.createStarted();
         colony.getRequestManager().reset();
-        context.getSource().sendSuccess(() -> Component.translatable(CommandTranslationConstants.COMMAND_REQUEST_SYSTEM_RESET_SUCCESS, colony.getName()), true);
+        watch.stop();
+        context.getSource().sendSuccess(() -> Component.translatable(CommandTranslationConstants.COMMAND_REQUEST_SYSTEM_RESET_SUCCESS, colony.getName(), watch.toString()), true);
 
         return 1;
     }

--- a/src/main/java/com/minecolonies/core/commands/colonycommands/requestsystem/CommandRSResetAll.java
+++ b/src/main/java/com/minecolonies/core/commands/colonycommands/requestsystem/CommandRSResetAll.java
@@ -1,5 +1,6 @@
 package com.minecolonies.core.commands.colonycommands.requestsystem;
 
+import com.google.common.base.Stopwatch;
 import com.minecolonies.api.colony.IColony;
 import com.minecolonies.api.colony.IColonyManager;
 import com.minecolonies.core.commands.commandTypes.IMCOPCommand;
@@ -19,11 +20,13 @@ public class CommandRSResetAll implements IMCOPCommand
     @Override
     public int onExecute(final CommandContext<CommandSourceStack> context)
     {
+        final Stopwatch watch = Stopwatch.createStarted();
         for (final IColony colony : IColonyManager.getInstance().getAllColonies())
         {
             colony.getRequestManager().reset();
         }
-        context.getSource().sendSuccess(() -> Component.translatable(COMMAND_REQUEST_SYSTEM_RESET_ALL_SUCCESS), true);
+        watch.stop();
+        context.getSource().sendSuccess(() -> Component.translatable(COMMAND_REQUEST_SYSTEM_RESET_ALL_SUCCESS, watch.toString()), true);
 
         return 1;
     }

--- a/src/main/resources/assets/minecolonies/lang/manual_en_us.json
+++ b/src/main/resources/assets/minecolonies/lang/manual_en_us.json
@@ -259,8 +259,6 @@
   "minecolonies.config.delaybetweenretries.comment": "The amount of ticks between retries of the request system for retryable requests. Lower increases server load.",
   "minecolonies.config.creativeresolve": "Creatively Resolve Requests",
   "minecolonies.config.creativeresolve.comment": "Should the request system creatively resolve (if possible) when the player is required to resolve a request? This is a debugging tool and can take a very long time to resolve a request.",
-  "minecolonies.config.canplayeruseresetcommand": "Can Players Use the Request System Reset Command",
-  "minecolonies.config.canplayeruseresetcommand.comment": "Should players be allowed to use the /mc colony requestsystem-reset command?",
 
   "minecolonies.config.default.boolean": "[Default: %b]",
   "minecolonies.config.default.int": "[Default: %d, min: %d, max: %d]",
@@ -385,6 +383,7 @@
   "com.minecolonies.command.help.wiki": "Check out the wiki to learn more: ",
   "com.minecolonies.command.help.discord": "Join the community at  ",
   "com.minecolonies.command.notop": "Must be OP to use this command.",
+  "com.minecolonies.command.notofficer": "You do not have permission to use this command.",
   "com.minecolonies.command.whereami.nocolony": "No close colony.",
   "com.minecolonies.command.whereami.colonyclose": "You're not inside any colony. The closest colony is approx %.2f blocks away.",
   "com.minecolonies.command.whereami.incolony": "You're inside colony %s with ID %s. The colony center is approx %.2f blocks away.",
@@ -421,8 +420,8 @@
   "com.minecolonies.command.loadbackup.success": "Successfully loaded backup.",
   "com.minecolonies.command.export.success": "Exported colony to zip: %s",
   "com.minecolonies.command.deleteable.success": "Changed deletable flag of colony ID %s. It is now set to %s.",
-  "com.minecolonies.command.rsreset.success": "The request system for colony %s has been restarted in 1.618 seconds.",
-  "com.minecolonies.command.rsresetall.success": "The request systems for all colonies have been restarted in 1.618 seconds.",
+  "com.minecolonies.command.rsreset.success": "The request system for colony %s has been restarted in %s.",
+  "com.minecolonies.command.rsresetall.success": "The request systems for all colonies have been restarted in %s.",
 
   "com.minecolonies.command.citizeninfo.desc": "§2ID: §f %d §2 Name: §f %s",
   "com.minecolonies.command.citizeninfo.skills": "§2Athletics: §f%s §2Dexterity: §f%s §2Strength: §f%s\n§2Agility: §f%s §2Stamina: §f%s §2Mana: §f%s\n§2Adaptability: §f%s §2Focus: §f%s §2Creativity: §f%s\n§2Knowledge: §f%s §2Intelligence: §f%s",


### PR DESCRIPTION
Closes [discord request](https://discord.com/channels/472875599422291968/473575384445878273/1302053820800700437)

# Changes proposed in this pull request
- Fixes the requestsystem reset commands blatantly lying about how much time they take.
- Allows all colony managers to run the colony-specific reset command, since that's usually one of the first troubleshooting steps anyway when things are misbehaving.
- Removes the `canplayeruseresetcommand` config setting, as it's no longer needed.
- Displays an explicit error message for any manager-only command run by a non-manager instead of silence.

## Testing
- [x] Yes I tested this before submitting it.
- [x] I also did a multiplayer test.

Review please (should port)

I considered adding an explicit TH permission setting for it, but I couldn't think of any particular reason why colony owners might want to restrict who could run it (there's a lot more dangerous things that managers can currently do anyway).