### PR TITLE
Improve non-tool catalyst handling

### DIFF
--- a/src/main/java/com/minecolonies/api/crafting/RecipeStorage.java
+++ b/src/main/java/com/minecolonies/api/crafting/RecipeStorage.java
@@ -207,7 +207,7 @@ public class RecipeStorage implements IRecipeStorage
 
             for (ItemStack result : this.secondaryOutputs)
             {
-                if (ItemStackUtils.compareItemStacksIgnoreStackSize(inputItem.getItemStack(), result, false, true) && result.isDamageableItem())
+                if (ItemStackUtils.compareItemStacksIgnoreStackSize(inputItem.getItemStack(), result, false, true))
                 {
                     inputItem = new ItemStorage(inputItem.getItemStack(), inputItem.getAmount(), true, inputItem.shouldIgnoreNBTValue);
                     this.tools.add(result);
@@ -525,25 +525,31 @@ public class RecipeStorage implements IRecipeStorage
 
             for (final IItemHandler handler : handlers)
             {
+                boolean isTool = ItemStackUtils.compareItemStackListIgnoreStackSize(tools, stack, false, !storage.ignoreNBT());
                 int slotOfStack =
-                  InventoryUtils.findFirstSlotInItemHandlerNotEmptyWith(handler, itemStack -> !ItemStackUtils.isEmpty(itemStack) && ItemStackUtils.compareItemStacksIgnoreStackSize(itemStack, stack, false, !storage.ignoreNBT()));
+                  InventoryUtils.findFirstSlotInItemHandlerNotEmptyWith(handler, itemStack ->
+                          ItemStackUtils.compareItemStacksIgnoreStackSize(itemStack, stack, false, !storage.ignoreNBT()) &&
+                                  (!isTool || !stack.isDamageableItem() || ItemStackUtils.getDurability(itemStack) > 0));
 
                 while (slotOfStack != -1 && amountNeeded > 0)
                 {
-                    if(citizen != null && ItemStackUtils.compareItemStackListIgnoreStackSize(tools, stack, false, !storage.ignoreNBT()) && ItemStackUtils.getDurability(handler.getStackInSlot(slotOfStack)) > 0 )
+                    if(citizen != null && isTool)
                     {
-                        ItemStack toDamage = handler.extractItem(slotOfStack,1, false);
-                        if (!ItemStackUtils.isEmpty(toDamage))
+                        if (stack.isDamageableItem())
                         {
-                            // The 4 parameter inner call from forge is for adding a callback to alter the damage caused,
-                            // but unlike its description does not actually damage the item(despite the same function name). So used to just calculate the damage.
-                            toDamage.hurtAndBreak(toDamage.getItem().damageItem(stack, 1, citizen, item -> item.broadcastBreakEvent(InteractionHand.MAIN_HAND)), citizen, item -> item.broadcastBreakEvent(InteractionHand.MAIN_HAND));
+                            ItemStack toDamage = handler.extractItem(slotOfStack, 1, false);
+                            if (!ItemStackUtils.isEmpty(toDamage))
+                            {
+                                // The 4 parameter inner call from forge is for adding a callback to alter the damage caused,
+                                // but unlike its description does not actually damage the item(despite the same function name). So used to just calculate the damage.
+                                toDamage.hurtAndBreak(toDamage.getItem().damageItem(stack, 1, citizen, item -> item.broadcastBreakEvent(InteractionHand.MAIN_HAND)), citizen, item -> item.broadcastBreakEvent(InteractionHand.MAIN_HAND));
+                            }
+                            if (!ItemStackUtils.isEmpty(toDamage))
+                            {
+                                handler.insertItem(slotOfStack, toDamage, false);
+                            }
                         }
-                        if (!ItemStackUtils.isEmpty(toDamage))
-                        {
-                            handler.insertItem(slotOfStack, toDamage, false);
-                        }
-                        amountNeeded -= stack.getCount();
+                        --amountNeeded;
                     }
                     else
                     {

--- a/src/main/java/com/minecolonies/core/colony/buildings/modules/AbstractCraftingBuildingModule.java
+++ b/src/main/java/com/minecolonies/core/colony/buildings/modules/AbstractCraftingBuildingModule.java
@@ -612,7 +612,13 @@ public abstract class AbstractCraftingBuildingModule extends AbstractBuildingMod
                   newRecipe,
                   1,
                   recipe.getPrimaryOutput(),
-                  Blocks.AIR);
+                  recipe.getIntermediate(),
+                  null,     // improved recipes have no source (expected by checkForWorkerSpecificRecipes)
+                  recipe.getRecipeType().getId(),
+                  recipe.getAlternateOutputs(),
+                  recipe.getSecondaryOutputs(),
+                  recipe.getLootTable(),
+                  recipe.getRequiredTool());
 
                 final IToken<?> token = IColonyManager.getInstance().getRecipeManager().checkOrAddRecipe(storage);
                 if (isRecipeCompatibleWithCraftingModule(token))

--- a/src/main/java/com/minecolonies/core/colony/requestsystem/resolvers/core/AbstractCraftingProductionResolver.java
+++ b/src/main/java/com/minecolonies/core/colony/requestsystem/resolvers/core/AbstractCraftingProductionResolver.java
@@ -15,7 +15,6 @@ import com.minecolonies.api.colony.requestsystem.token.IToken;
 import com.minecolonies.api.crafting.IRecipeStorage;
 import com.minecolonies.api.crafting.ItemStorage;
 import com.minecolonies.api.util.CraftingUtils;
-import com.minecolonies.api.util.InventoryUtils;
 import com.minecolonies.api.util.ItemStackUtils;
 import com.minecolonies.core.colony.buildings.AbstractBuilding;
 import com.minecolonies.core.colony.requestsystem.requesters.IBuildingBasedRequester;
@@ -173,11 +172,8 @@ public abstract class AbstractCraftingProductionResolver<C extends AbstractCraft
                 }
                 else if(!storage.getCraftingTools().isEmpty() && ItemStackUtils.compareItemStackListIgnoreStackSize(storage.getCraftingTools(), craftingHelperStack, false, true))
                 {
-                    if(InventoryUtils.getItemCountInProvider(building, item -> ItemStackUtils.compareItemStacksIgnoreStackSize(item, craftingHelperStack, false, true)) <= ingredient.getAmount())
-                    {
-                        int requiredForDurability = craftingHelperStack.isDamageableItem() ? (int) Math.ceil((double) count / ingredient.getRemainingDurablityValue()) : 1;
-                        materialRequests.add(createNewRequestForStack(manager, craftingHelperStack, requiredForDurability , requiredForDurability, false));
-                    }
+                    int requiredForDurability = craftingHelperStack.isDamageableItem() ? (int) Math.ceil((double) count / ingredient.getRemainingDurablityValue()) : ingredient.getAmount();
+                    materialRequests.add(createNewRequestForStack(manager, craftingHelperStack, requiredForDurability, requiredForDurability, false));
                 }
                 else if (!ItemStackUtils.isEmpty(container) && ItemStackUtils.compareItemStacksIgnoreStackSize(container, craftingHelperStack, false, true))
                 {

--- a/src/main/java/com/minecolonies/core/colony/requestsystem/resolvers/core/AbstractCraftingProductionResolver.java
+++ b/src/main/java/com/minecolonies/core/colony/requestsystem/resolvers/core/AbstractCraftingProductionResolver.java
@@ -175,7 +175,7 @@ public abstract class AbstractCraftingProductionResolver<C extends AbstractCraft
                 {
                     if(InventoryUtils.getItemCountInProvider(building, item -> ItemStackUtils.compareItemStacksIgnoreStackSize(item, craftingHelperStack, false, true)) <= ingredient.getAmount())
                     {
-                        int requiredForDurability = (int) Math.ceil((double) count / ingredient.getRemainingDurablityValue());
+                        int requiredForDurability = craftingHelperStack.isDamageableItem() ? (int) Math.ceil((double) count / ingredient.getRemainingDurablityValue()) : 1;
                         materialRequests.add(createNewRequestForStack(manager, craftingHelperStack, requiredForDurability , requiredForDurability, false));
                     }
                 }


### PR DESCRIPTION
Closes #10037
Closes [discord issue](https://discord.com/channels/472875599422291968/1301209472265490443)
Closes [discord issue](https://discord.com/channels/472875599422291968/1300874600602800219)

# Changes proposed in this pull request
- When improving recipes, don't forget other important recipe details such as secondary outputs.
- Now supports catalyst "tool" items (that appear as both input and output) that aren't damageable.
    - For example, this should recognise that it only needs 1 template when crafting multiple netherite tools/armour.

## Testing
- [x] Yes I tested this before submitting it.
- [ ] I also did a multiplayer test.

Review please (should port)

Side note: would anyone object strongly if I removed all uses of `getNewInstance` for recipes?  (Separate to this PR.)  It just seems to lead to these sorts of issues because it's too tolerant of missing parameters.