### PR TITLE
Quick hotfix to prevent stackoverflow from happening

### DIFF
--- a/src/main/java/com/minecolonies/api/entity/other/AbstractFastMinecoloniesEntity.java
+++ b/src/main/java/com/minecolonies/api/entity/other/AbstractFastMinecoloniesEntity.java
@@ -384,8 +384,11 @@ public abstract class AbstractFastMinecoloniesEntity extends PathfinderMob imple
     public void remove(@NotNull final RemovalReason reason)
     {
         super.remove(reason);
-        // TODO: This causes a stackoverflow, how do we properly clean up team assignments?
-        //removeFromTeam();
+        final PlayerTeam playersTeam = level.getScoreboard().getPlayersTeam(getScoreboardName());
+        if (playersTeam != null)
+        {
+            level.getScoreboard().removePlayerFromTeam(getScoreboardName(), playersTeam);
+        }
     }
 
     /**

--- a/src/main/java/com/minecolonies/api/entity/other/AbstractFastMinecoloniesEntity.java
+++ b/src/main/java/com/minecolonies/api/entity/other/AbstractFastMinecoloniesEntity.java
@@ -384,7 +384,8 @@ public abstract class AbstractFastMinecoloniesEntity extends PathfinderMob imple
     public void remove(@NotNull final RemovalReason reason)
     {
         super.remove(reason);
-        removeFromTeam();
+        // TODO: This causes a stackoverflow, how do we properly clean up team assignments?
+        //removeFromTeam();
     }
 
     /**


### PR DESCRIPTION
Closes [discord report](https://discord.com/channels/139070364159311872/1125094832143077456/1302925098558423134) Crash upon entering area of the colony
Closes #10399 

# Changes proposed in this pull request
- Due to a recent change in registerWithColony, the team behaviour code wasn't rechecked and now causes a stackoverflow in the code. As a quick patch just disable the method whilst we look more in depth for a better solution.

## Testing
- [X] Yes I tested this before submitting it.
- [ ] I also did a multiplayer test.

Review please