### PR TITLE
Fix builders requesting items again after already having them available

### DIFF
--- a/src/main/java/com/minecolonies/core/colony/buildings/AbstractBuildingStructureBuilder.java
+++ b/src/main/java/com/minecolonies/core/colony/buildings/AbstractBuildingStructureBuilder.java
@@ -404,11 +404,10 @@ public abstract class AbstractBuildingStructureBuilder extends AbstractBuilding
      *
      * @param requiredResources the bucket to check and request.
      * @param worker            the worker.
-     * @param workerInv         if the worker inv should be checked too.
      */
-    public void checkOrRequestBucket(@Nullable final BuilderBucket requiredResources, final ICitizenData worker, final boolean workerInv)
+    public void checkOrRequestBucket(@Nullable final BuilderBucket requiredResources, final ICitizenData worker)
     {
-        getFirstModuleOccurance(BuildingResourcesModule.class).checkOrRequestBucket(requiredResources, worker, workerInv);
+        getFirstModuleOccurance(BuildingResourcesModule.class).checkOrRequestBucket(requiredResources, worker);
     }
 
     /**

--- a/src/main/java/com/minecolonies/core/colony/buildings/modules/BuildingResourcesModule.java
+++ b/src/main/java/com/minecolonies/core/colony/buildings/modules/BuildingResourcesModule.java
@@ -327,9 +327,8 @@ public class BuildingResourcesModule extends AbstractBuildingModule implements I
      *
      * @param requiredResources the bucket to check and request.
      * @param worker            the worker.
-     * @param workerInv         if the worker inv should be checked too.
      */
-    public void checkOrRequestBucket(@Nullable final BuilderBucket requiredResources, final ICitizenData worker, final boolean workerInv)
+    public void checkOrRequestBucket(@Nullable final BuilderBucket requiredResources, final ICitizenData worker)
     {
         if (requiredResources == null)
         {
@@ -353,13 +352,10 @@ public class BuildingResourcesModule extends AbstractBuildingModule implements I
                 continue;
             }
 
-            if (workerInv)
+            count += InventoryUtils.getItemCountInItemHandler(worker.getInventory(), stack -> ItemStackUtils.compareItemStacksIgnoreStackSize(stack, itemStack.getItemStack()));
+            if (count >= entry.getValue())
             {
-                count += InventoryUtils.getItemCountInItemHandler(worker.getInventory(), stack -> ItemStackUtils.compareItemStacksIgnoreStackSize(stack, itemStack.getItemStack()));
-                if (count >= entry.getValue())
-                {
-                    continue;
-                }
+                continue;
             }
 
             int requestCount = entry.getValue() - count;

--- a/src/main/java/com/minecolonies/core/entity/ai/workers/AbstractEntityAIStructure.java
+++ b/src/main/java/com/minecolonies/core/entity/ai/workers/AbstractEntityAIStructure.java
@@ -227,8 +227,8 @@ public abstract class AbstractEntityAIStructure<J extends AbstractJobStructure<?
 
         if (neededItemsList.size() <= pickUpCount || InventoryUtils.openSlotCount(worker.getInventoryCitizen()) <= MIN_OPEN_SLOTS)
         {
-            building.checkOrRequestBucket(building.getRequiredResources(), worker.getCitizenData(), true);
-            building.checkOrRequestBucket(building.getNextBucket(), worker.getCitizenData(), false);
+            building.checkOrRequestBucket(building.getRequiredResources(), worker.getCitizenData());
+            building.checkOrRequestBucket(building.getNextBucket(), worker.getCitizenData());
             pickUpCount = 0;
             return START_WORKING;
         }
@@ -448,7 +448,7 @@ public abstract class AbstractEntityAIStructure<J extends AbstractJobStructure<?
                   placer.executeStructureStep(world, null, progress, StructurePlacer.Operation.BLOCK_REMOVAL, () -> placer.getIterator().decrement(this::skipClearing), false);
                 if (result.getBlockResult().getResult() == BlockPlacementResult.Result.FINISHED)
                 {
-                    building.checkOrRequestBucket(building.getRequiredResources(), worker.getCitizenData(), true);
+                    building.checkOrRequestBucket(building.getRequiredResources(), worker.getCitizenData());
                 }
                 break;
         }


### PR DESCRIPTION
Closes #10123

Some background in the problem:
When a builder calculates the resources for the build they'll be split into several buckets of items, to allow for gradual requesting of items as time progresses.
When the builder is requesting items they'll look for the current and the next bucket, to ask ahead for some items.

The current bucket was being checked against the building and worker inventory, to see if they have everything available.
However, the next bucket was only being checked against the building inventory, not the worker.
For some reason the builders are pulling items from any bucket into their inventory at times, not to mention that players could potentially be inserting items into their inventory directly.
Because of the old logic, you would see requests disappear, but because the next bucket is only verified against the building inventory, and not the worker, these requests would show up again and again, provided the items are not inside of the building.

So the easiest fix was to allow the next bucket to verify against the worker inventory as well, rather than somehow ensure the worker doesn't pull the items into their inventory.

# Changes proposed in this pull request
- Builders will now check items in their inventory for the next bucket. Due to this change the last boolean of the method was always true, making it redundant, and thus removed.

## Testing
- [X] Yes I tested this before submitting it.
- [ ] I also did a multiplayer test.

Review please