### PR TITLE
Adjust WorldUtil.isChunkLoaded and ChunkCache for compatibility with Moonrise chunk system

### DIFF
--- a/src/main/java/com/minecolonies/api/util/WorldUtil.java
+++ b/src/main/java/com/minecolonies/api/util/WorldUtil.java
@@ -68,7 +68,7 @@ public class WorldUtil
             final ChunkHolder holder = ((ServerChunkCache) world.getChunkSource()).chunkMap.getVisibleChunkIfPresent(ChunkPos.asLong(x, z));
             if (holder != null)
             {
-                return holder.getChunkIfPresent(ChunkStatus.FULL) != null;
+                return holder.getFullStatus().isOrAfter(FullChunkStatus.FULL) && holder.getChunkIfPresent(ChunkStatus.FULL) != null;
             }
 
             return false;

--- a/src/main/java/com/minecolonies/api/util/WorldUtil.java
+++ b/src/main/java/com/minecolonies/api/util/WorldUtil.java
@@ -7,6 +7,7 @@ import net.minecraft.core.registries.Registries;
 import net.minecraft.resources.ResourceKey;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.server.level.ChunkHolder;
+import net.minecraft.server.level.FullChunkStatus;
 import net.minecraft.server.level.ServerChunkCache;
 import net.minecraft.server.level.ServerLevel;
 import net.minecraft.util.Tuple;
@@ -67,7 +68,7 @@ public class WorldUtil
             final ChunkHolder holder = ((ServerChunkCache) world.getChunkSource()).chunkMap.getVisibleChunkIfPresent(ChunkPos.asLong(x, z));
             if (holder != null)
             {
-                return holder.getFullChunkFuture().getNow(ChunkHolder.UNLOADED_LEVEL_CHUNK).isSuccess();
+                return holder.getFullStatus().isOrAfter(FullChunkStatus.FULL);
             }
 
             return false;

--- a/src/main/java/com/minecolonies/api/util/WorldUtil.java
+++ b/src/main/java/com/minecolonies/api/util/WorldUtil.java
@@ -68,7 +68,7 @@ public class WorldUtil
             final ChunkHolder holder = ((ServerChunkCache) world.getChunkSource()).chunkMap.getVisibleChunkIfPresent(ChunkPos.asLong(x, z));
             if (holder != null)
             {
-                return holder.getFullStatus().isOrAfter(FullChunkStatus.FULL);
+                return holder.getChunkIfPresent(ChunkStatus.FULL) != null;
             }
 
             return false;

--- a/src/main/java/com/minecolonies/core/entity/pathfinding/world/ChunkCache.java
+++ b/src/main/java/com/minecolonies/core/entity/pathfinding/world/ChunkCache.java
@@ -78,7 +78,7 @@ public class ChunkCache implements LevelReader
                     final ChunkHolder holder = serverChunkCache.chunkMap.getVisibleChunkIfPresent(ChunkPos.asLong(k, l));
                     if (holder != null)
                     {
-                        this.chunkArray[k - this.chunkX][l - this.chunkZ] = holder.getFullChunkFuture().getNow(ChunkHolder.UNLOADED_LEVEL_CHUNK).orElse(null);
+                        this.chunkArray[k - this.chunkX][l - this.chunkZ] = (LevelChunk) holder.getChunkIfPresent(ChunkStatus.FULL);
                     }
                 }
             }


### PR DESCRIPTION
Fixes #10417
Fixes #10418
Fixes https://github.com/Tuinity/Moonrise/issues/69

# Changes proposed in this pull request
Adjusts chunk loaded check and chunk cache for compatibility with the Moonrise chunk system.
The new calls have equivalent functionality and will work with the Vanilla chunk system and Moonrise's.
I tested founding a colony in a fresh world as well as founding a second colony (abandoning the first one) with and without Moonrise.

## Testing
- [X] Yes I tested this before submitting it.
- [ ] I also did a multiplayer test.

Review please