### PR TITLE
Sound fixes for block placing/breaking

### DIFF
--- a/src/main/java/com/minecolonies/core/entity/ai/workers/production/EntityAIWorkLumberjack.java
+++ b/src/main/java/com/minecolonies/core/entity/ai/workers/production/EntityAIWorkLumberjack.java
@@ -844,9 +844,9 @@ public class EntityAIWorkLumberjack extends AbstractEntityAICrafting<JobLumberja
                 world.playSound(null,
                   this.worker.blockPosition(),
                   soundType.getPlaceSound(),
-                  SoundSource.BLOCKS,
-                  soundType.getVolume(),
-                  soundType.getPitch());
+                  SoundSource.BLOCKS, 
+                  (soundType.getVolume() + 1.0F) * 0.5F,
+                  soundType.getPitch() * 0.8F);
             }
 
             worker.swing(worker.getUsedItemHand());

--- a/src/main/java/com/minecolonies/core/entity/ai/workers/util/BuildingStructureHandler.java
+++ b/src/main/java/com/minecolonies/core/entity/ai/workers/util/BuildingStructureHandler.java
@@ -220,12 +220,14 @@ public class BuildingStructureHandler<J extends AbstractJobStructure<?, J>, B ex
             }
             
             BlockState blockStateForSound;
-            if (state.getBlock() == com.ldtteam.structurize.blocks.ModBlocks.blockSolidSubstitution.get()) {
+            if (state.getBlock() == com.ldtteam.structurize.blocks.ModBlocks.blockSolidSubstitution.get()) 
+            {
                 // If the builder is placing a substitution block, use the sound of the substituted block
                 // fancyPlacement() could be checked here, but is always true for this Handler.
                 blockStateForSound = structureAI.getSolidSubstitution(pos);
             }
-            else {
+            else 
+            {
                 // If the block is not a substitution block, use the sound of the block itself
                 blockStateForSound = state;
             }

--- a/src/main/java/com/minecolonies/core/entity/ai/workers/util/BuildingStructureHandler.java
+++ b/src/main/java/com/minecolonies/core/entity/ai/workers/util/BuildingStructureHandler.java
@@ -218,8 +218,18 @@ public class BuildingStructureHandler<J extends AbstractJobStructure<?, J>, B ex
                   .getStatisticsManager()
                   .increment(BLOCKS_PLACED, structureAI.getWorker().getCitizenColonyHandler().getColony().getDay());
             }
-
-            structureAI.getWorker().queueSound(state.getSoundType().getPlaceSound(), worldPos, 10, 0);
+            
+            BlockState blockStateForSound;
+            if (state.getBlock() == com.ldtteam.structurize.blocks.ModBlocks.blockSolidSubstitution.get()) {
+                // If the builder is placing a substitution block, use the sound of the substituted block
+                // fancyPlacement() could be checked here, but is always true for this Handler.
+                blockStateForSound = structureAI.getSolidSubstitution(pos);
+            }
+            else {
+                // If the block is not a substitution block, use the sound of the block itself
+                blockStateForSound = state;
+            }
+            structureAI.getWorker().queueSound(blockStateForSound.getSoundType().getPlaceSound(), worldPos, 10, 0, (blockStateForSound.getSoundType().getVolume() + 1.0F) * 0.5F, blockStateForSound.getSoundType().getPitch() * 0.8F);
         }
 
         if (state.getBlock() == ModBlocks.blockWayPoint)

--- a/src/main/java/com/minecolonies/core/entity/citizen/citizenhandlers/CitizenItemHandler.java
+++ b/src/main/java/com/minecolonies/core/entity/citizen/citizenhandlers/CitizenItemHandler.java
@@ -197,8 +197,8 @@ public class CitizenItemHandler implements ICitizenItemHandler
               blockPos,
               block.getSoundType(blockState, CompatibilityUtils.getWorldFromCitizen(citizen), blockPos, citizen).getBreakSound(),
               SoundSource.BLOCKS,
-              block.getSoundType(blockState, CompatibilityUtils.getWorldFromCitizen(citizen), blockPos, citizen).getVolume(),
-              block.getSoundType(blockState, CompatibilityUtils.getWorldFromCitizen(citizen), blockPos, citizen).getPitch());
+              (block.getSoundType(blockState, CompatibilityUtils.getWorldFromCitizen(citizen), blockPos, citizen).getVolume() + 1.0F) * 0.5F,
+              block.getSoundType(blockState, CompatibilityUtils.getWorldFromCitizen(citizen), blockPos, citizen).getPitch() * 0.8F);
             WorldUtil.removeBlock(CompatibilityUtils.getWorldFromCitizen(citizen), blockPos, false);
 
             damageItemInHand(citizen.getUsedItemHand(), 1);
@@ -217,10 +217,10 @@ public class CitizenItemHandler implements ICitizenItemHandler
             }
             CompatibilityUtils.getWorldFromCitizen(citizen).playSound(null,
               blockPos,
-              block.getSoundType(blockState, CompatibilityUtils.getWorldFromCitizen(citizen), blockPos, citizen).getBreakSound(),
+              block.getSoundType(blockState, CompatibilityUtils.getWorldFromCitizen(citizen), blockPos, citizen).getHitSound(),
               SoundSource.BLOCKS,
-              block.getSoundType(blockState, CompatibilityUtils.getWorldFromCitizen(citizen), blockPos, citizen).getVolume(),
-              block.getSoundType(blockState, CompatibilityUtils.getWorldFromCitizen(citizen), blockPos, citizen).getPitch());
+              (block.getSoundType(blockState, CompatibilityUtils.getWorldFromCitizen(citizen), blockPos, citizen).getVolume() + 1.0F) * 0.125F,
+              block.getSoundType(blockState, CompatibilityUtils.getWorldFromCitizen(citizen), blockPos, citizen).getPitch() * 0.5F);
         }
     }
 


### PR DESCRIPTION
This pull request makes slight adjustments to the sound effects created when citizens place or break blocks, to sound more in-line with the sound effects used in Vanilla.

# Changes proposed in this pull request
- When placing, hitting, or breaking a block, the same pitch and volume calculations are used as in Vanilla functions. 
   - In practice: block sounds are lowered in pitch to match Vanilla sounds.
- When a builder places a solid substitution block, use the sound effect of the block that is substituted instead of the sound of the solid substitution block itself. 
   - In practice: builders placing dirt blocks to fill an area now makes dirt placing sounds instead of wood placing sounds.
- When hitting a block but not yet breaking it, use the block's hit sound instead of the break sound. 
   - In practice: a builder digging up e.g. grass blocks now makes a lot less noise.

## Testing
- [x] Yes I tested this before submitting it.
- [x] I also did a multiplayer test.

Review please