### PR TITLE
Bunch of fixes

### DIFF
--- a/src/main/java/com/minecolonies/api/colony/buildings/IBuilding.java
+++ b/src/main/java/com/minecolonies/api/colony/buildings/IBuilding.java
@@ -33,9 +33,9 @@ import org.jetbrains.annotations.Nullable;
 import java.util.*;
 import java.util.function.Predicate;
 
-import static com.minecolonies.api.util.constant.Suppression.GENERIC_WILDCARD;
 import static com.minecolonies.api.util.constant.EquipmentLevelConstants.BASIC_TOOL_LEVEL;
 import static com.minecolonies.api.util.constant.EquipmentLevelConstants.TOOL_LEVEL_MAXIMUM;
+import static com.minecolonies.api.util.constant.Suppression.GENERIC_WILDCARD;
 
 public interface IBuilding extends IBuildingContainer, IModuleContainer<IBuildingModule>, IRequestResolverProvider, IRequester, ISchematicProvider
 {
@@ -502,7 +502,10 @@ public interface IBuilding extends IBuildingContainer, IModuleContainer<IBuildin
      * @param stack the stack to test.
      * @return true if so.
      */
-    boolean canEat(final ItemStack stack);
+    default boolean canEat(final ItemStack stack)
+    {
+        return true;
+    }
 
     /**
      * Get the standing position for a building.

--- a/src/main/java/com/minecolonies/api/compatibility/CompatibilityManager.java
+++ b/src/main/java/com/minecolonies/api/compatibility/CompatibilityManager.java
@@ -785,7 +785,7 @@ public class CompatibilityManager implements ICompatibilityManager
         if (ISFOOD.test(stack) || ISCOOKABLE.test(stack))
         {
             food.add(new ItemStorage(stack));
-            if (CAN_EAT.test(stack))
+            if (FoodUtils.EDIBLE.test(stack))
             {
                 edibles.add(new ItemStorage(stack));
             }

--- a/src/main/java/com/minecolonies/api/util/ItemStackUtils.java
+++ b/src/main/java/com/minecolonies/api/util/ItemStackUtils.java
@@ -50,7 +50,7 @@ import java.util.stream.Collectors;
 
 import static com.minecolonies.api.items.ModTags.fungi;
 import static com.minecolonies.api.util.constant.Constants.*;
-import static com.minecolonies.api.util.constant.HappinessConstants.*;
+import static com.minecolonies.api.util.constant.HappinessConstants.HADGREATFOOD;
 
 /**
  * Utility methods for the inventories.
@@ -119,11 +119,6 @@ public final class ItemStackUtils
      * Predicate describing things which work in the furnace.
      */
     public static Predicate<ItemStack> IS_SMELTABLE;
-
-    /**
-     * Predicate describing food which can be eaten (is not raw).
-     */
-    public static Predicate<ItemStack> CAN_EAT;
 
     /**
      * Predicate describing cookables.

--- a/src/main/java/com/minecolonies/apiimp/initializer/InteractionValidatorInitializer.java
+++ b/src/main/java/com/minecolonies/apiimp/initializer/InteractionValidatorInitializer.java
@@ -9,6 +9,7 @@ import com.minecolonies.api.crafting.ItemStorage;
 import com.minecolonies.api.entity.citizen.citizenhandlers.ICitizenFoodHandler;
 import com.minecolonies.api.entity.citizen.happiness.ITimeBasedHappinessModifier;
 import com.minecolonies.api.items.ModTags;
+import com.minecolonies.api.util.FoodUtils;
 import com.minecolonies.api.util.InventoryUtils;
 import com.minecolonies.api.util.ItemStackUtils;
 import com.minecolonies.core.colony.buildings.AbstractBuilding;
@@ -55,7 +56,9 @@ public class InteractionValidatorInitializer
           citizen -> citizen.getWorkBuilding() != null && citizen.getWorkBuilding().hasModule(BuildingModules.FURNACE) && citizen.getWorkBuilding().getModule(BuildingModules.FURNACE).getFurnaces().isEmpty());
         InteractionValidatorRegistry.registerStandardPredicate(Component.translatable(RAW_FOOD),
           citizen -> InventoryUtils.findFirstSlotInItemHandlerNotEmptyWith(citizen.getInventory(), ISCOOKABLE) != -1
-                       && InventoryUtils.findFirstSlotInItemHandlerNotEmptyWith(citizen.getInventory(), stack -> CAN_EAT.test(stack) && (citizen.getWorkBuilding() == null || citizen.getWorkBuilding().canEat(stack))) == -1);
+              &&
+              InventoryUtils.findFirstSlotInItemHandlerNotEmptyWith(citizen.getInventory(), stack -> FoodUtils.canEat(stack, citizen.getHomeBuilding(), citizen.getWorkBuilding()))
+                  == -1);
         InteractionValidatorRegistry.registerStandardPredicate(Component.translatable(BETTER_FOOD),
           citizen -> citizen.getSaturation() == 0 && !citizen.isChild() && citizen.needsBetterFood());
         InteractionValidatorRegistry.registerStandardPredicate(Component.translatable(BETTER_FOOD_CHILDREN),

--- a/src/main/java/com/minecolonies/core/colony/CitizenData.java
+++ b/src/main/java/com/minecolonies/core/colony/CitizenData.java
@@ -61,7 +61,6 @@ import java.util.*;
 
 import static com.minecolonies.api.entity.citizen.AbstractEntityCitizen.*;
 import static com.minecolonies.api.research.util.ResearchConstants.*;
-import static com.minecolonies.api.util.ItemStackUtils.CAN_EAT;
 import static com.minecolonies.api.util.constant.BuildingConstants.TAG_ACTIVE;
 import static com.minecolonies.api.util.constant.CitizenConstants.*;
 import static com.minecolonies.api.util.constant.ColonyConstants.UPDATE_SUBSCRIBERS_INTERVAL;
@@ -1794,9 +1793,9 @@ public class CitizenData implements ICitizenData
         else
         {
             int slotBadFood = InventoryUtils.findFirstSlotInItemHandlerNotEmptyWith(inventory,
-              stack -> CAN_EAT.test(stack) && !this.getHomeBuilding().canEat(stack));
+                stack -> FoodUtils.canEat(stack, getHomeBuilding(), getWorkBuilding()));
             int slotGoodFood = InventoryUtils.findFirstSlotInItemHandlerNotEmptyWith(inventory,
-              stack -> CAN_EAT.test(stack) && this.getHomeBuilding().canEat(stack));
+                stack -> FoodUtils.canEat(stack, getHomeBuilding(), getWorkBuilding()));
             return slotBadFood != -1 && slotGoodFood == -1;
         }
     }

--- a/src/main/java/com/minecolonies/core/colony/ColonyView.java
+++ b/src/main/java/com/minecolonies/core/colony/ColonyView.java
@@ -324,13 +324,23 @@ public final class ColonyView implements IColonyView
 
         if (colony.getRequestManager() != null && (colony.getRequestManager().isDirty() || hasNewSubscribers))
         {
-            final int preSize = buf.writerIndex();
-            buf.writeBoolean(true);
-            colony.getRequestManager().serialize(StandardFactoryController.getInstance(), buf);
-            final int postSize = buf.writerIndex();
-            if ((postSize - preSize) >= ColonyView.REQUEST_MANAGER_MAX_SIZE)
+            final int preIndex = buf.writerIndex();
+            try
             {
-                Log.getLogger().warn("Colony " + colony.getID() + " has a very big memory imprint, this could be a memory leak, please contact the mod author!");
+                buf.writeBoolean(true);
+                colony.getRequestManager().serialize(StandardFactoryController.getInstance(), buf);
+                final int postSize = buf.writerIndex();
+                if ((postSize - preIndex) >= ColonyView.REQUEST_MANAGER_MAX_SIZE)
+                {
+                    Log.getLogger().warn("Colony " + colony.getID() + " has a very big memory imprint, this could be a memory leak, please contact the mod author!");
+                }
+            }
+            catch (Exception e)
+            {
+                buf.writerIndex(preIndex);
+                Log.getLogger().warn("Error during request manager serialization for:" + colony.getID(), e);
+                colony.getRequestManager().reset();
+                buf.writeBoolean(false);
             }
         }
         else

--- a/src/main/java/com/minecolonies/core/colony/buildings/AbstractBuilding.java
+++ b/src/main/java/com/minecolonies/core/colony/buildings/AbstractBuilding.java
@@ -1187,7 +1187,7 @@ public abstract class AbstractBuilding extends AbstractBuildingContainer
 
         if (keepFood())
         {
-            toKeep.put(stack -> ItemStackUtils.CAN_EAT.test(stack) && canEat(stack), new Tuple<>(getBuildingLevel() * 2, true));
+            toKeep.put(stack -> FoodUtils.canEat(stack, null, this), new Tuple<>(getBuildingLevel() * 2, true));
         }
         for (final IHasRequiredItemsModule module : getModulesByType(IHasRequiredItemsModule.class))
         {
@@ -1196,12 +1196,6 @@ public abstract class AbstractBuilding extends AbstractBuildingContainer
 
         getModulesByType(IAltersRequiredItems.class).forEach(module -> module.alterItemsToBeKept((stack, qty, inv) -> toKeep.put(stack, new Tuple<>(qty, inv))));
         return toKeep;
-    }
-
-    @Override
-    public boolean canEat(final ItemStack stack)
-    {
-        return FoodUtils.canEat(stack, this.getBuildingLevel());
     }
 
     @Override

--- a/src/main/java/com/minecolonies/core/colony/buildings/workerbuildings/BuildingKitchen.java
+++ b/src/main/java/com/minecolonies/core/colony/buildings/workerbuildings/BuildingKitchen.java
@@ -4,7 +4,7 @@ import com.minecolonies.api.colony.IColony;
 import com.minecolonies.api.colony.jobs.registry.JobEntry;
 import com.minecolonies.api.crafting.IGenericRecipe;
 import com.minecolonies.api.util.CraftingUtils;
-import com.minecolonies.api.util.ItemStackUtils;
+import com.minecolonies.api.util.FoodUtils;
 import com.minecolonies.api.util.OptionalPredicate;
 import com.minecolonies.core.colony.buildings.AbstractBuilding;
 import com.minecolonies.core.colony.buildings.modules.AbstractCraftingBuildingModule;
@@ -13,7 +13,7 @@ import net.minecraft.core.BlockPos;
 import net.minecraft.world.item.ItemStack;
 import org.jetbrains.annotations.NotNull;
 
-import java.util.*;
+import java.util.Optional;
 
 import static com.minecolonies.api.util.constant.Suppression.OVERRIDE_EQUALS;
 import static com.minecolonies.api.util.constant.TagConstants.CRAFTING_COOK;
@@ -88,8 +88,8 @@ public class BuildingKitchen extends AbstractBuilding
             if (isRecipeAllowed.isPresent()) return isRecipeAllowed.get();
 
             final ItemStack output = recipe.getPrimaryOutput();
-            return ItemStackUtils.CAN_EAT.test(output)
-                    || ItemStackUtils.CAN_EAT.test(FurnaceRecipes.getInstance()
+            return FoodUtils.EDIBLE.test(output)
+                || FoodUtils.EDIBLE.test(FurnaceRecipes.getInstance()
                     .getSmeltingResult(output));
         }
     }
@@ -118,7 +118,7 @@ public class BuildingKitchen extends AbstractBuilding
         public boolean isRecipeCompatible(@NotNull final IGenericRecipe recipe)
         {
             if (!super.isRecipeCompatible(recipe)) return false;
-            return CraftingUtils.isRecipeCompatibleBasedOnTags(recipe, CRAFTING_COOK).orElse(ItemStackUtils.CAN_EAT.test(recipe.getPrimaryOutput()));
+            return CraftingUtils.isRecipeCompatibleBasedOnTags(recipe, CRAFTING_COOK).orElse(FoodUtils.EDIBLE.test(recipe.getPrimaryOutput()));
         }
     }
 }

--- a/src/main/java/com/minecolonies/core/colony/jobs/JobFisherman.java
+++ b/src/main/java/com/minecolonies/core/colony/jobs/JobFisherman.java
@@ -1,18 +1,17 @@
 package com.minecolonies.core.colony.jobs;
 
-import net.minecraft.resources.ResourceLocation;
 import com.minecolonies.api.client.render.modeltype.ModModelTypes;
 import com.minecolonies.api.colony.ICitizenData;
 import com.minecolonies.api.entity.citizen.AbstractEntityCitizen;
 import com.minecolonies.api.util.BlockPosUtil;
 import com.minecolonies.api.util.Tuple;
 import com.minecolonies.core.entity.ai.workers.production.agriculture.EntityAIWorkFisherman;
+import net.minecraft.core.BlockPos;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.nbt.ListTag;
 import net.minecraft.nbt.Tag;
+import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.damagesource.DamageSource;
-import net.minecraft.core.BlockPos;
-
 import org.jetbrains.annotations.NotNull;
 
 import java.util.ArrayList;
@@ -102,7 +101,7 @@ public class JobFisherman extends AbstractJob<EntityAIWorkFisherman, JobFisherma
             final ListTag listOfPonds = compound.getList(TAG_PONDS, Tag.TAG_COMPOUND);
             for (int i = 0; i < listOfPonds.size(); i++)
             {
-                ponds.add(new Tuple<>(BlockPosUtil.read(listOfPonds.getCompound(i), TAG_WATER_POND), BlockPosUtil.read(listOfPonds.getCompound(i), TAG_PARENT_POND)));
+                //  ponds.add(new Tuple<>(BlockPosUtil.read(listOfPonds.getCompound(i), TAG_WATER_POND), BlockPosUtil.read(listOfPonds.getCompound(i), TAG_PARENT_POND)));
             }
         }
     }

--- a/src/main/java/com/minecolonies/core/colony/jobs/JobFisherman.java
+++ b/src/main/java/com/minecolonies/core/colony/jobs/JobFisherman.java
@@ -101,7 +101,7 @@ public class JobFisherman extends AbstractJob<EntityAIWorkFisherman, JobFisherma
             final ListTag listOfPonds = compound.getList(TAG_PONDS, Tag.TAG_COMPOUND);
             for (int i = 0; i < listOfPonds.size(); i++)
             {
-                //  ponds.add(new Tuple<>(BlockPosUtil.read(listOfPonds.getCompound(i), TAG_WATER_POND), BlockPosUtil.read(listOfPonds.getCompound(i), TAG_PARENT_POND)));
+                ponds.add(new Tuple<>(BlockPosUtil.read(listOfPonds.getCompound(i), TAG_WATER_POND), BlockPosUtil.read(listOfPonds.getCompound(i), TAG_PARENT_POND)));
             }
         }
     }

--- a/src/main/java/com/minecolonies/core/entity/ai/minimal/EntityAIEatTask.java
+++ b/src/main/java/com/minecolonies/core/entity/ai/minimal/EntityAIEatTask.java
@@ -17,19 +17,19 @@ import com.minecolonies.core.colony.buildings.workerbuildings.BuildingCook;
 import com.minecolonies.core.colony.interactionhandling.StandardInteraction;
 import com.minecolonies.core.colony.jobs.AbstractJobGuard;
 import com.minecolonies.core.colony.jobs.JobCook;
-import com.minecolonies.core.entity.other.SittingEntity;
 import com.minecolonies.core.entity.citizen.EntityCitizen;
+import com.minecolonies.core.entity.other.SittingEntity;
 import com.minecolonies.core.network.messages.client.ItemParticleEffectMessage;
 import net.minecraft.core.BlockPos;
 import net.minecraft.network.chat.Component;
 import net.minecraft.sounds.SoundEvents;
 import net.minecraft.world.InteractionHand;
-import net.minecraft.world.item.*;
+import net.minecraft.world.item.Item;
+import net.minecraft.world.item.ItemStack;
 
 import java.util.LinkedHashSet;
 import java.util.Set;
 
-import static com.minecolonies.api.util.ItemStackUtils.CAN_EAT;
 import static com.minecolonies.api.util.ItemStackUtils.ISCOOKABLE;
 import static com.minecolonies.api.util.constant.CitizenConstants.FULL_SATURATION;
 import static com.minecolonies.api.util.constant.Constants.SECONDS_A_MINUTE;
@@ -172,18 +172,6 @@ public class EntityAIEatTask implements IStateAI
     }
 
     /**
-     * Check if a citizen can eat something.
-     *
-     * @param citizenData the citizen to check.
-     * @param stack       the stack to check.
-     * @return true if so.
-     */
-    private boolean canEat(final ICitizenData citizenData, final ItemStack stack)
-    {
-        return citizenData.getHomeBuilding() == null || citizenData.getHomeBuilding().canEat(stack);
-    }
-
-    /**
      * Actual action of eating.
      *
      * @return the next state to go to, if successful idle.
@@ -197,7 +185,7 @@ public class EntityAIEatTask implements IStateAI
 
         final ICitizenData citizenData = citizen.getCitizenData();
         final ItemStack foodStack = citizenData.getInventory().getStackInSlot(foodSlot);
-        if (!CAN_EAT.test(foodStack) || !canEat(citizenData, foodStack))
+        if (!FoodUtils.canEat(foodStack, citizenData.getHomeBuilding(), citizenData.getWorkBuilding()))
         {
             return CHECK_FOR_FOOD;
         }
@@ -273,8 +261,9 @@ public class EntityAIEatTask implements IStateAI
             final ItemStorage storageToGet = FoodUtils.checkForFoodInBuilding(citizen.getCitizenData(), cookBuilding.getModule(RESTAURANT_MENU).getMenu(), cookBuilding);
             if (storageToGet != null)
             {
-                int homeBuildingLevel = citizen.getCitizenData().getHomeBuilding() == null ? 0 : citizen.getCitizenData().getHomeBuilding().getBuildingLevel();
-                int qty = (int) (Math.max(1.0, (FULL_SATURATION - citizen.getCitizenData().getSaturation()) / FoodUtils.getFoodValue(storageToGet.getItemStack(), citizen)) * homeBuildingLevel/2.0);
+                int homeBuildingLevel = citizen.getCitizenData().getHomeBuilding() == null ? 1 : citizen.getCitizenData().getHomeBuilding().getBuildingLevel();
+                int qty = (int) (Math.max(1.0,
+                    (FULL_SATURATION - citizen.getCitizenData().getSaturation()) / FoodUtils.getFoodValue(storageToGet.getItemStack(), citizen) * homeBuildingLevel / 2.0));
                 InventoryUtils.transferItemStackIntoNextBestSlotInItemHandler(cookBuilding, storageToGet, qty, citizen.getInventoryCitizen());
                 return EAT;
             }
@@ -501,7 +490,7 @@ public class EntityAIEatTask implements IStateAI
         {
             citizenData.triggerInteraction(new StandardInteraction(Component.translatable(RAW_FOOD), ChatPriority.PENDING));
         }
-        else if (InventoryUtils.hasItemInItemHandler(citizen.getInventoryCitizen(), stack -> CAN_EAT.test(stack) && !canEat(citizenData, stack)))
+        else if (InventoryUtils.hasItemInItemHandler(citizen.getInventoryCitizen(), stack -> FoodUtils.canEat(stack, citizenData.getHomeBuilding(), citizenData.getWorkBuilding())))
         {
             if (citizenData.isChild())
             {

--- a/src/main/java/com/minecolonies/core/entity/ai/workers/service/EntityAIWorkCook.java
+++ b/src/main/java/com/minecolonies/core/entity/ai/workers/service/EntityAIWorkCook.java
@@ -30,7 +30,9 @@ import net.minecraftforge.items.IItemHandler;
 import net.minecraftforge.items.wrapper.InvWrapper;
 import org.jetbrains.annotations.NotNull;
 
-import java.util.*;
+import java.util.ArrayDeque;
+import java.util.List;
+import java.util.Queue;
 import java.util.function.Predicate;
 
 import static com.minecolonies.api.entity.ai.statemachine.states.AIWorkerState.*;
@@ -136,7 +138,7 @@ public class EntityAIWorkCook extends AbstractEntityAIUsesFurnace<JobCook, Build
         }
         final int buildingLimit = Math.max(1, building.getBuildingLevel() * building.getBuildingLevel()) * SLOT_PER_LINE;
         return InventoryUtils.getCountFromBuildingWithLimit(building,
-          ItemStackUtils.CAN_EAT.and(stack -> FoodUtils.canEat(stack, building.getBuildingLevel() - 1)),
+            FoodUtils.EDIBLE.and(stack -> FoodUtils.canEatLevel(stack, building.getBuildingLevel() - 1)),
           stack -> stack.getMaxStackSize() * 6) > buildingLimit;
     }
 

--- a/src/main/java/com/minecolonies/core/entity/pathfinding/PathfindingUtils.java
+++ b/src/main/java/com/minecolonies/core/entity/pathfinding/PathfindingUtils.java
@@ -373,49 +373,100 @@ public class PathfindingUtils
         int stepY = (endY > startY) ? 1 : -1;
         int stepZ = (endZ > startZ) ? 1 : -1;
 
-        double tMaxX = (dx == 0) ? Double.POSITIVE_INFINITY : ((stepX > 0 ? 1.0 : 0.0) / dx);
-        double tMaxY = (dy == 0) ? Double.POSITIVE_INFINITY : ((stepY > 0 ? 1.0 : 0.0) / dy);
-        double tMaxZ = (dz == 0) ? Double.POSITIVE_INFINITY : ((stepZ > 0 ? 1.0 : 0.0) / dz);
+        double stepCostX = 1.0 / dx;
+        double stepCostY = 1.0 / dy;
+        double stepCostZ = 1.0 / dz;
 
-        double tDeltaX = (dx == 0) ? Double.POSITIVE_INFINITY : 1.0 / dx;
-        double tDeltaY = (dy == 0) ? Double.POSITIVE_INFINITY : 1.0 / dy;
-        double tDeltaZ = (dz == 0) ? Double.POSITIVE_INFINITY : 1.0 / dz;
+        // Init with step cost, to determine first step
+        double stepCostSumX = (dx == 0) ? Double.POSITIVE_INFINITY : 0.5 / dx;
+        double stepCostSumY = (dy == 0) ? Double.POSITIVE_INFINITY : 0.5 / dy;
+        double stepCostSumZ = (dz == 0) ? Double.POSITIVE_INFINITY : 0.5 / dz;
 
-        while (x != endX || y != endY || z != endZ)
+        for (int i = 0; i < (dx + dy + dz) && (x != endX || y != endY || z != endZ); i++)
         {
             if (ShapeUtil.hasCollision(blockLookup, x, y, z, blockLookup.getBlockState(x, y, z)))
             {
                 return true;
             }
 
-            if (tMaxX < tMaxY)
+            // Explore multiple possibilities if two options have the same cost, e.g. on quadratic distance to make sure all blocks around get checked:
+            if (doubleEquals(stepCostSumX, stepCostSumY))
             {
-                if (tMaxX < tMaxZ)
+                if (ShapeUtil.hasCollision(blockLookup, x + stepX, y, z, blockLookup.getBlockState(x + stepX, y, z)))
+                {
+                    return true;
+                }
+
+                if (ShapeUtil.hasCollision(blockLookup, x + stepX, y + stepY, z, blockLookup.getBlockState(x + stepX, y + stepY, z)))
+                {
+                    return true;
+                }
+            }
+
+            if (doubleEquals(stepCostSumX, stepCostSumZ))
+            {
+                if (ShapeUtil.hasCollision(blockLookup, x + stepX, y, z, blockLookup.getBlockState(x + stepX, y, z)))
+                {
+                    return true;
+                }
+
+                if (ShapeUtil.hasCollision(blockLookup, x + stepX, y, z + stepZ, blockLookup.getBlockState(x + stepX, y, z + stepZ)))
+                {
+                    return true;
+                }
+            }
+
+            if (doubleEquals(stepCostSumY, stepCostSumZ))
+            {
+                if (ShapeUtil.hasCollision(blockLookup, x, y + stepY, z, blockLookup.getBlockState(x, y + stepY, z)))
+                {
+                    return true;
+                }
+
+                if (ShapeUtil.hasCollision(blockLookup, x, y + stepY, z + stepZ, blockLookup.getBlockState(x, y + stepY, z + stepZ)))
+                {
+                    return true;
+                }
+            }
+
+            if (stepCostSumX < stepCostSumY)
+            {
+                if (stepCostSumX < stepCostSumZ)
                 {
                     x += stepX;
-                    tMaxX += tDeltaX;
+                    stepCostSumX += stepCostX;
                 }
                 else
                 {
                     z += stepZ;
-                    tMaxZ += tDeltaZ;
+                    stepCostSumZ += stepCostZ;
                 }
             }
             else
             {
-                if (tMaxY < tMaxZ)
+                if (stepCostSumY < stepCostSumZ)
                 {
                     y += stepY;
-                    tMaxY += tDeltaY;
+                    stepCostSumY += stepCostY;
                 }
                 else
                 {
                     z += stepZ;
-                    tMaxZ += tDeltaZ;
+                    stepCostSumZ += stepCostZ;
                 }
             }
         }
 
         return ShapeUtil.hasCollision(blockLookup, endX, endY, endZ, blockLookup.getBlockState(endX, endY, endZ));
+    }
+
+    private static boolean doubleEquals(final double a, final double b)
+    {
+        if (Double.isFinite(a) || Double.isFinite(b) || Double.isNaN(a) || Double.isNaN(b))
+        {
+            return false;
+        }
+
+        return Math.abs(a - b) < 0.000005;
     }
 }

--- a/src/main/java/com/minecolonies/core/entity/pathfinding/navigation/MinecoloniesAdvancedPathNavigate.java
+++ b/src/main/java/com/minecolonies/core/entity/pathfinding/navigation/MinecoloniesAdvancedPathNavigate.java
@@ -664,14 +664,13 @@ public class MinecoloniesAdvancedPathNavigate extends AbstractAdvancedPathNaviga
             return;
         }
 
-        moveTo(pathResult.getPath(), getSpeedFactor());
         if (pathResult != null)
         {
             pathResult.setStatus(IN_PROGRESS_FOLLOWING);
         }
 
         // Calculate an overtime-heuristic adjustment for pathfinding to use which fits the terrain
-        if (pathResult.getPathLength() > 2 && pathResult.costPerDist != 1)
+        if (pathResult.hasPath() && pathResult.getPathLength() > 2 && pathResult.costPerDist != 1)
         {
             final double factor = 1 + pathResult.getPathLength() / 30.0;
             heuristicAvg -= heuristicAvg / (50 / factor);
@@ -685,6 +684,8 @@ public class MinecoloniesAdvancedPathNavigate extends AbstractAdvancedPathNaviga
                 pauseTicks = 50;
             }
         }
+
+        moveTo(pathResult.getPath(), getSpeedFactor());
     }
 
     private boolean handleLadders(int oldIndex)

--- a/src/main/java/com/minecolonies/core/entity/pathfinding/pathjobs/AbstractPathJob.java
+++ b/src/main/java/com/minecolonies/core/entity/pathfinding/pathjobs/AbstractPathJob.java
@@ -1798,7 +1798,8 @@ public abstract class AbstractPathJob implements Callable<Path>, IPathJob
     @Override
     public String toString()
     {
-        return getClass().getSimpleName() + " start:" + start + " entity:" + entity + " maxNodes:" + maxNodes + " totalNodesVisited:" + totalNodesVisited + " reaches:"
+        return getClass().getSimpleName() + " start:" + start + " entity:" + entity + " maxNodes:" + maxNodes + " totalNodesVisited:" + totalNodesVisited + " h-rebalances:" + (
+            visitedLevel - 1) + " reaches:"
             + reachesDestination;
     }
 }

--- a/src/main/java/com/minecolonies/core/util/FurnaceRecipes.java
+++ b/src/main/java/com/minecolonies/core/util/FurnaceRecipes.java
@@ -5,6 +5,7 @@ import com.minecolonies.api.colony.requestsystem.StandardFactoryController;
 import com.minecolonies.api.compatibility.IFurnaceRecipes;
 import com.minecolonies.api.crafting.ItemStorage;
 import com.minecolonies.api.crafting.RecipeStorage;
+import com.minecolonies.api.util.FoodUtils;
 import com.minecolonies.api.util.ItemStackUtils;
 import com.minecolonies.api.util.constant.TypeConstants;
 import net.minecraft.core.NonNullList;
@@ -18,8 +19,6 @@ import org.jetbrains.annotations.Nullable;
 
 import java.util.HashMap;
 import java.util.Map;
-import java.util.Optional;
-import java.util.function.Predicate;
 
 public class FurnaceRecipes implements IFurnaceRecipes
 {
@@ -79,7 +78,7 @@ public class FurnaceRecipes implements IFurnaceRecipes
     {
         ItemStackUtils.IS_SMELTABLE = itemStack -> !ItemStackUtils.isEmpty(instance.getSmeltingResult(itemStack));
         ItemStackUtils.ISCOOKABLE = itemStack -> ItemStackUtils.ISFOOD.test(instance.getSmeltingResult(itemStack));
-        ItemStackUtils.CAN_EAT =
+        FoodUtils.EDIBLE =
                 itemStack -> ItemStackUtils.ISFOOD.test(itemStack) && !ItemStackUtils.ISCOOKABLE.test(itemStack);
     }
 


### PR DESCRIPTION
Closes #10441
Closes #10440
Closes #10424

# Changes proposed in this pull request
- All food checks are now in Food utils
- Fix citizens getting stuck in eating state with invalid foods
- Fix citizens without homebuilding, or level 1 trying to take zero stacks of food
- CAN_EAT now is called EDIBLE as can_eat implies citizen can eat this item, which is not necessarily the case. Use FoodUtils.canEat() to check that
- RS serilization errors no longer prevent a player from joining the world, instead it logs & resets
- Fix fisher pathfinding sometimes getting caught in an infinite loop
- Fix navigator NPE when no path was found

## Testing
- [x ] Yes I tested this before submitting it.
- [ ] I also did a multiplayer test.

Review please