### PR TITLE
Don't eat the bowls!

### DIFF
--- a/src/datagen/generated/minecolonies/data/minecolonies/crafterrecipes/chef/borscht.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/crafterrecipes/chef/borscht.json
@@ -19,6 +19,9 @@
     },
     {
       "id": "minecraft:beetroot"
+    },
+    {
+      "id": "minecraft:bowl"
     }
   ],
   "intermediate": "minecraft:air",

--- a/src/datagen/generated/minecolonies/data/minecolonies/crafterrecipes/chef/lamb_stew.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/crafterrecipes/chef/lamb_stew.json
@@ -28,6 +28,9 @@
     },
     {
       "id": "minecraft:mutton"
+    },
+    {
+      "id": "minecraft:bowl"
     }
   ],
   "intermediate": "minecraft:air",

--- a/src/datagen/generated/minecolonies/data/minecolonies/crafterrecipes/chef/ramen.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/crafterrecipes/chef/ramen.json
@@ -13,6 +13,9 @@
     },
     {
       "id": "minecolonies:soysauce"
+    },
+    {
+      "id": "minecraft:bowl"
     }
   ],
   "intermediate": "minecraft:air",

--- a/src/datagen/generated/minecolonies/data/minecolonies/recipe/kimchi.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/recipe/kimchi.json
@@ -16,6 +16,9 @@
     },
     {
       "item": "minecraft:carrot"
+    },
+    {
+      "item": "minecraft:bowl"
     }
   ],
   "result": {

--- a/src/main/java/com/minecolonies/apiimp/initializer/ModItemsInitializer.java
+++ b/src/main/java/com/minecolonies/apiimp/initializer/ModItemsInitializer.java
@@ -159,12 +159,12 @@ public final class ModItemsInitializer
         ModItems.tofu = new ItemFood((new Item.Properties()).food(new FoodProperties.Builder().nutrition(4).saturationModifier(0.6F).build()), 1);
         ModItems.flatbread = new ItemFood((new Item.Properties()).food(new FoodProperties.Builder().nutrition(4).saturationModifier(0.6F).build()), 1);
         ModItems.cheese_ravioli = new ItemFood((new Item.Properties()).food(new FoodProperties.Builder().nutrition(4).saturationModifier(0.6F).build()), 1);
-        ModItems.chicken_broth = new ItemFood((new Item.Properties()).food(new FoodProperties.Builder().nutrition(4).saturationModifier(0.6F).build()), 1);
+        ModItems.chicken_broth = new ItemFood((new Item.Properties()).food(new FoodProperties.Builder().usingConvertsTo(Items.BOWL).nutrition(4).saturationModifier(0.6F).build()), 1);
         ModItems.meat_ravioli = new ItemFood((new Item.Properties()).food(new FoodProperties.Builder().nutrition(4).saturationModifier(0.6F).build()), 1);
         ModItems.mint_jelly = new ItemFood((new Item.Properties()).food(new FoodProperties.Builder().nutrition(4).saturationModifier(0.6F).build()), 1);
         ModItems.mint_tea = new ItemFood((new Item.Properties()).food(new FoodProperties.Builder().nutrition(4).saturationModifier(0.6F).build()), 1);
-        ModItems.polenta = new ItemFood((new Item.Properties()).food(new FoodProperties.Builder().nutrition(4).saturationModifier(0.6F).build()), 1);
-        ModItems.potato_soup = new ItemFood((new Item.Properties()).food(new FoodProperties.Builder().nutrition(4).saturationModifier(0.6F).build()), 1);
+        ModItems.polenta = new ItemFood((new Item.Properties()).food(new FoodProperties.Builder().usingConvertsTo(Items.BOWL).nutrition(4).saturationModifier(0.6F).build()), 1);
+        ModItems.potato_soup = new ItemFood((new Item.Properties()).food(new FoodProperties.Builder().usingConvertsTo(Items.BOWL).nutrition(4).saturationModifier(0.6F).build()), 1);
         ModItems.veggie_ravioli = new ItemFood((new Item.Properties()).food(new FoodProperties.Builder().nutrition(4).saturationModifier(0.6F).build()), 1);
         ModItems.yogurt = new ItemFood((new Item.Properties()).food(new FoodProperties.Builder().nutrition(4).saturationModifier(0.6F).build()), 1);
 
@@ -180,8 +180,8 @@ public final class ModItemsInitializer
         ModItems.eggdrop_soup = new ItemFood((new Item.Properties()).food(new FoodProperties.Builder().nutrition(6).saturationModifier(1.0F).build()), 2);
         ModItems.fish_n_chips = new ItemFood((new Item.Properties()).food(new FoodProperties.Builder().nutrition(6).saturationModifier(1.0F).build()), 2);
         ModItems.pierogi = new ItemFood((new Item.Properties()).food(new FoodProperties.Builder().nutrition(6).saturationModifier(1.0F).build()), 2);
-        ModItems.veggie_soup = new ItemFood((new Item.Properties()).food(new FoodProperties.Builder().nutrition(6).saturationModifier(1.0F).build()), 2);
-        ModItems.yogurt_with_berries = new ItemFood((new Item.Properties()).food(new FoodProperties.Builder().nutrition(6).saturationModifier(1.0F).build()), 2);
+        ModItems.veggie_soup = new ItemFood((new Item.Properties()).food(new FoodProperties.Builder().usingConvertsTo(Items.BOWL).nutrition(6).saturationModifier(1.0F).build()), 2);
+        ModItems.yogurt_with_berries = new ItemFood((new Item.Properties()).food(new FoodProperties.Builder().usingConvertsTo(Items.BOWL).nutrition(6).saturationModifier(1.0F).build()), 2);
 
         // Tier 3 Food items
         ModItems.hand_pie = new ItemFood((new Item.Properties()).food(new FoodProperties.Builder().nutrition(8).saturationModifier(1.2F).build()), 3);
@@ -192,7 +192,7 @@ public final class ModItemsInitializer
 
         // Cold Biomes
         // Tier 1
-        ModItems.squash_soup = new ItemFood((new Item.Properties()).food(new FoodProperties.Builder().nutrition(4).saturationModifier(0.6F).build()), 1);
+        ModItems.squash_soup = new ItemFood((new Item.Properties()).food(new FoodProperties.Builder().usingConvertsTo(Items.BOWL).nutrition(4).saturationModifier(0.6F).build()), 1);
         // Tier 2
         ModItems.cabochis = new ItemFood((new Item.Properties()).food(new FoodProperties.Builder().usingConvertsTo(Items.BOWL).nutrition(6).saturationModifier(1.0F).build()), 2);
         ModItems.veggie_quiche = new ItemFood((new Item.Properties()).food(new FoodProperties.Builder().nutrition(6).saturationModifier(1.0F).build()), 2);
@@ -202,7 +202,7 @@ public final class ModItemsInitializer
 
         // Hot Humid Biomes
         // Tier 1
-        ModItems.pea_soup = new ItemFood((new Item.Properties()).food(new FoodProperties.Builder().nutrition(4).saturationModifier(0.6F).build()), 1);
+        ModItems.pea_soup = new ItemFood((new Item.Properties()).food(new FoodProperties.Builder().usingConvertsTo(Items.BOWL).nutrition(4).saturationModifier(0.6F).build()), 1);
         // Tier 2
         ModItems.rice_ball = new ItemFood((new Item.Properties()).food(new FoodProperties.Builder().nutrition(6).saturationModifier(1.0F).build()), 2);
         ModItems.mutton_dinner = new ItemFood((new Item.Properties()).food(new FoodProperties.Builder().nutrition(6).saturationModifier(1.0F).build()), 3);
@@ -212,7 +212,7 @@ public final class ModItemsInitializer
 
         // Temperate Biomes
         // Tier 1
-        ModItems.corn_chowder = new ItemFood((new Item.Properties()).food(new FoodProperties.Builder().nutrition(4).saturationModifier(0.6F).build()), 1);
+        ModItems.corn_chowder = new ItemFood((new Item.Properties()).food(new FoodProperties.Builder().usingConvertsTo(Items.BOWL).nutrition(4).saturationModifier(0.6F).build()), 1);
         ModItems.tortillas = new ItemFood((new Item.Properties()).food(new FoodProperties.Builder().nutrition(4).saturationModifier(0.6F).build()), 1);
         // Tier 2
         ModItems.pasta_tomato = new ItemFood((new Item.Properties()).food(new FoodProperties.Builder().usingConvertsTo(Items.BOWL).nutrition(6).saturationModifier(1.0F).build()), 2);

--- a/src/main/java/com/minecolonies/apiimp/initializer/ModItemsInitializer.java
+++ b/src/main/java/com/minecolonies/apiimp/initializer/ModItemsInitializer.java
@@ -177,7 +177,7 @@ public final class ModItemsInitializer
         ModItems.apple_pie = new ItemFood((new Item.Properties()).food(new FoodProperties.Builder().nutrition(6).saturationModifier(1.0F).build()), 2);
         ModItems.plain_cheesecake = new ItemFood((new Item.Properties()).food(new FoodProperties.Builder().nutrition(6).saturationModifier(1.0F).build()), 2);
         ModItems.baked_salmon = new ItemFood((new Item.Properties()).food(new FoodProperties.Builder().nutrition(6).saturationModifier(1.0F).build()), 2);
-        ModItems.eggdrop_soup = new ItemFood((new Item.Properties()).food(new FoodProperties.Builder().nutrition(6).saturationModifier(1.0F).build()), 2);
+        ModItems.eggdrop_soup = new ItemFood((new Item.Properties()).food(new FoodProperties.Builder().nutrition(6).usingConvertsTo(Items.BOWL).saturationModifier(1.0F).build()), 2);
         ModItems.fish_n_chips = new ItemFood((new Item.Properties()).food(new FoodProperties.Builder().nutrition(6).saturationModifier(1.0F).build()), 2);
         ModItems.pierogi = new ItemFood((new Item.Properties()).food(new FoodProperties.Builder().nutrition(6).saturationModifier(1.0F).build()), 2);
         ModItems.veggie_soup = new ItemFood((new Item.Properties()).food(new FoodProperties.Builder().usingConvertsTo(Items.BOWL).nutrition(6).saturationModifier(1.0F).build()), 2);
@@ -186,7 +186,7 @@ public final class ModItemsInitializer
         // Tier 3 Food items
         ModItems.hand_pie = new ItemFood((new Item.Properties()).food(new FoodProperties.Builder().nutrition(8).saturationModifier(1.2F).build()), 3);
         ModItems.mintchoco_cheesecake = new ItemFood((new Item.Properties()).food(new FoodProperties.Builder().nutrition(8).saturationModifier(1.2F).build()), 3);
-        ModItems.borscht = new ItemFood((new Item.Properties()).food(new FoodProperties.Builder().nutrition(8).saturationModifier(1.2F).build()), 3);
+        ModItems.borscht = new ItemFood((new Item.Properties()).food(new FoodProperties.Builder().usingConvertsTo(Items.BOWL).nutrition(8).saturationModifier(1.2F).build()), 3);
         ModItems.schnitzel = new ItemFood((new Item.Properties()).food(new FoodProperties.Builder().nutrition(8).saturationModifier(1.2F).build()), 3);
         ModItems.steak_dinner = new ItemFood((new Item.Properties()).food(new FoodProperties.Builder().nutrition(8).saturationModifier(1.2F).build()), 3);
 
@@ -208,7 +208,7 @@ public final class ModItemsInitializer
         ModItems.mutton_dinner = new ItemFood((new Item.Properties()).food(new FoodProperties.Builder().nutrition(6).saturationModifier(1.0F).build()), 3);
         // Tier 3
         ModItems.sushi_roll = new ItemFood((new Item.Properties()).food(new FoodProperties.Builder().nutrition(8).saturationModifier(1.2F).build()), 3);
-        ModItems.ramen = new ItemFood((new Item.Properties()).food(new FoodProperties.Builder().nutrition(8).saturationModifier(1.2F).build()), 3);
+        ModItems.ramen = new ItemFood((new Item.Properties()).food(new FoodProperties.Builder().usingConvertsTo(Items.BOWL).nutrition(8).saturationModifier(1.2F).build()), 3);
 
         // Temperate Biomes
         // Tier 1
@@ -230,12 +230,12 @@ public final class ModItemsInitializer
         ModItems.kebab = new ItemFood((new Item.Properties()).food(new FoodProperties.Builder().nutrition(6).saturationModifier(1.0F).build()), 1);
         // Tier 3
         ModItems.pita_hummus = new ItemFood((new Item.Properties()).food(new FoodProperties.Builder().nutrition(8).saturationModifier(1.2F).build()), 3);
-        ModItems.spicy_eggplant = new ItemFood((new Item.Properties()).food(new FoodProperties.Builder().nutrition(8).saturationModifier(1.2F).build()), 3);
+        ModItems.spicy_eggplant = new ItemFood((new Item.Properties()).food(new FoodProperties.Builder().usingConvertsTo(Items.BOWL).nutrition(8).saturationModifier(1.2F).build()), 3);
 
         // Require trading
         // Tier 2
         ModItems.congee = new ItemFood((new Item.Properties()).food(new FoodProperties.Builder().usingConvertsTo(Items.BOWL).nutrition(6).saturationModifier(1.0F).build()), 2);
-        ModItems.kimchi = new ItemFood((new Item.Properties()).food(new FoodProperties.Builder().nutrition(6).saturationModifier(1.0F).build()), 2);
+        ModItems.kimchi = new ItemFood((new Item.Properties()).food(new FoodProperties.Builder().usingConvertsTo(Items.BOWL).nutrition(6).saturationModifier(1.0F).build()), 2);
         // Tier 3
         ModItems.stew_trencher = new ItemFood((new Item.Properties()).food(new FoodProperties.Builder().nutrition(8).saturationModifier(1.2F).build()), 3);
         ModItems.stuffed_pepper = new ItemFood((new Item.Properties()).food(new FoodProperties.Builder().nutrition(8).saturationModifier(1.2F).build()), 3);

--- a/src/main/java/com/minecolonies/core/entity/citizen/EntityCitizen.java
+++ b/src/main/java/com/minecolonies/core/entity/citizen/EntityCitizen.java
@@ -63,10 +63,8 @@ import com.minecolonies.core.network.messages.client.colony.PlaySoundForCitizenM
 import com.minecolonies.core.network.messages.server.colony.OpenInventoryMessage;
 import com.minecolonies.core.util.TeleportHelper;
 import net.minecraft.core.BlockPos;
-import net.minecraft.core.Direction;
 import net.minecraft.core.particles.ParticleTypes;
 import net.minecraft.core.registries.BuiltInRegistries;
-import net.minecraft.core.registries.Registries;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.network.chat.Component;
 import net.minecraft.network.syncher.EntityDataAccessor;
@@ -86,9 +84,6 @@ import net.minecraft.world.effect.MobEffectInstance;
 import net.minecraft.world.effect.MobEffects;
 import net.minecraft.world.entity.*;
 import net.minecraft.world.entity.ai.attributes.Attributes;
-import net.minecraft.world.entity.ai.goal.Goal;
-import net.minecraft.world.entity.ai.goal.GoalSelector;
-import net.minecraft.world.entity.ai.goal.InteractGoal;
 import net.minecraft.world.entity.item.ItemEntity;
 import net.minecraft.world.entity.player.Inventory;
 import net.minecraft.world.entity.player.Player;
@@ -99,15 +94,10 @@ import net.minecraft.world.item.Items;
 import net.minecraft.world.item.ShieldItem;
 import net.minecraft.world.level.ChunkPos;
 import net.minecraft.world.level.Level;
-import net.minecraft.world.phys.AABB;
-import net.minecraft.world.phys.Vec3;
-import net.minecraft.world.scores.PlayerTeam;
-import net.minecraft.world.scores.Team;
 import net.neoforged.neoforge.common.CommonHooks;
 import net.neoforged.neoforge.common.NeoForge;
 import net.neoforged.neoforge.event.entity.living.LivingShieldBlockEvent;
 import net.neoforged.neoforge.items.IItemHandler;
-import net.neoforged.neoforge.network.PacketDistributor;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -583,7 +573,7 @@ public class EntityCitizen extends AbstractEntityCitizen implements IThreatTable
 
                 playSound(SoundEvents.GENERIC_EAT, 1.5f, (float) SoundUtils.getRandomPitch(getRandom()));
                 new ItemParticleEffectMessage(usedStack.copy(), getX(), getY(), getZ(), getXRot(), getYRot(), getEyeHeight()).sendToTrackingEntity(this);
-                ItemStackUtils.consumeFood(usedStack, this, player.getInventory());
+                ItemStackUtils.consumeFood(usedStack, this, player);
             }
         }
         else
@@ -618,7 +608,7 @@ public class EntityCitizen extends AbstractEntityCitizen implements IThreatTable
             {
                 citizenData.getCitizenFoodHandler().addLastEaten(usedStack.getItem());
             }
-            ItemStackUtils.consumeFood(usedStack, this, player.getInventory());
+            ItemStackUtils.consumeFood(usedStack, this, player);
         }
 
         interactionCooldown = 100;

--- a/src/main/java/com/minecolonies/core/entity/visitor/VisitorCitizen.java
+++ b/src/main/java/com/minecolonies/core/entity/visitor/VisitorCitizen.java
@@ -514,7 +514,7 @@ public class VisitorCitizen extends AbstractEntityCitizen
             {
                 playSound(SoundEvents.GENERIC_EAT, 1.5f, (float) SoundUtils.getRandomPitch(getRandom()));
                 new ItemParticleEffectMessage(usedStack.copy(), getX(), getY(), getZ(), getXRot(), getYRot(), getEyeHeight()).sendToTrackingEntity(this);
-                ItemStackUtils.consumeFood(usedStack, this, player.getInventory());
+                ItemStackUtils.consumeFood(usedStack, this, player);
                 MessageUtils.forCitizen(this, MESSAGE_INTERACTION_VISITOR_FOOD).sendTo(player);
             }
             return InteractionResult.CONSUME;

--- a/src/main/java/com/minecolonies/core/generation/defaults/DefaultRecipeProvider.java
+++ b/src/main/java/com/minecolonies/core/generation/defaults/DefaultRecipeProvider.java
@@ -960,6 +960,7 @@ public class DefaultRecipeProvider extends RecipeProvider
           .requires(ModBlocks.blockNetherPepper)
           .requires(ModBlocks.blockOnion)
           .requires(Items.CARROT)
+          .requires(Items.BOWL)
           .unlockedBy("has_nether_pepper", has(ModBlocks.blockNetherPepper))
           .save(consumer, new ResourceLocation(MOD_ID, "kimchi"));
 

--- a/src/main/java/com/minecolonies/core/generation/defaults/workers/DefaultChefCraftingProvider.java
+++ b/src/main/java/com/minecolonies/core/generation/defaults/workers/DefaultChefCraftingProvider.java
@@ -135,7 +135,8 @@ public class DefaultChefCraftingProvider extends CustomRecipeProvider
             new ItemStorage(new ItemStack(Items.POTATO)),
             new ItemStorage(new ItemStack(Items.BROWN_MUSHROOM)),
             new ItemStorage(new ItemStack(ModBlocks.blockCabbage)),
-            new ItemStorage(new ItemStack(Items.MUTTON))))
+            new ItemStorage(new ItemStack(Items.MUTTON)),
+            new ItemStorage(new ItemStack(Items.BOWL))))
           .result(new ItemStack(ModItems.lamb_stew))
           .showTooltip(true)
           .minBuildingLevel(4)
@@ -148,7 +149,8 @@ public class DefaultChefCraftingProvider extends CustomRecipeProvider
             new ItemStorage(new ItemStack(ModItems.chicken_broth)),
             new ItemStorage(new ItemStack(Items.POTATO)),
             new ItemStorage(new ItemStack(Items.BEETROOT)),
-            new ItemStorage(new ItemStack(Items.BEETROOT))
+            new ItemStorage(new ItemStack(Items.BEETROOT)),
+            new ItemStorage(new ItemStack(Items.BOWL))
           ))
           .result(new ItemStack(ModItems.borscht, 2))
           .showTooltip(true)
@@ -173,7 +175,8 @@ public class DefaultChefCraftingProvider extends CustomRecipeProvider
             new ItemStorage(new ItemStack(ModBlocks.blockGarlic)),
             new ItemStorage(new ItemStack(ModBlocks.blockOnion)),
             new ItemStorage(new ItemStack(ModItems.raw_noodle)),
-            new ItemStorage(new ItemStack(ModItems.soysauce))
+            new ItemStorage(new ItemStack(ModItems.soysauce)),
+            new ItemStorage(new ItemStack(Items.BOWL))
           ))
           .result(new ItemStack(ModItems.ramen, 1))
           .showTooltip(true)


### PR DESCRIPTION
# Changes proposed in this pull request
- Port #10322
- Fix several food items that use bowls in their recipes not returning them when eaten.

## Testing
- [x] Yes I tested this before submitting it.
- [ ] I also did a multiplayer test.

Review please (do not port)

Haven't checked if the affected foods need to be converted to ItemBowlFood in 1.20.. that part might need not-quite-backporting.