### PR TITLE
Use teleport permission for alliance

### DIFF
--- a/src/main/resources/assets/minecolonies/gui/townhall/layoutalliance.xml
+++ b/src/main/resources/assets/minecolonies/gui/townhall/layoutalliance.xml
@@ -7,7 +7,7 @@
         <box size="100% 25" linewidth="1">
             <label id="name" size="100 12" pos="5 0" color="black"/>
             <label id="dist" size="40 13" pos="112 12" color="black"/>
-            <button id="tp" size="100 12" pos="5 12" label="$(com.minecolonies.coremod.permission.teleport_to_colony)"/>
+            <button id="tp" size="100 12" pos="5 12" label="$(com.minecolonies.coremod.permission.teleport_to_colony)" textscale="0.8"/>
         </box>
     </list>
 


### PR DESCRIPTION
Closes [discord request](https://discord.com/channels/472875599422291968/473575384445878273/1307643419354464286)

# Changes proposed in this pull request
- Colonies are now considered as "allies" if the owners mutually have "teleport to colony" permission in the other colony.
    - By default, Friend and higher have this permission enabled, so now Friend is sufficient to enable teleportation; Manager is no longer required.
    - This permission didn't otherwise do anything at all in current versions.
    - Teleportation still requires the originating colony to be at least level 3 and the person doing the teleportation requires permission to access hut blocks (usually also Friend and above, but beware: it's possible to be unable to return if the destination colony is less than level 3 or you don't have permission).
    - Abandoned colonies still disable teleportation, even if you're officer/manager.
- Rescales teleport button text so that it's actually readable.

## Testing
- [x] Yes I tested this before submitting it.
- [x] I also did a multiplayer test.

Review please (could port)