### PR TITLE
Compat for waystones and productive bees

### DIFF
--- a/src/datagen/generated/minecolonies/data/minecolonies/tags/blocks/protectionexception.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/tags/blocks/protectionexception.json
@@ -1,15 +1,7 @@
 {
   "values": [
     {
-      "id": "waystones:waystone",
-      "required": false
-    },
-    {
-      "id": "waystones:sandy_waystone",
-      "required": false
-    },
-    {
-      "id": "waystones:mossy_waystone",
+      "id": "#waystones:waystones",
       "required": false
     }
   ]

--- a/src/datagen/generated/minecolonies/data/minecolonies/tags/blocks/tree.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/tags/blocks/tree.json
@@ -2,6 +2,10 @@
   "values": [
     "#minecraft:logs",
     "#minecolonies:mangrove_tree",
-    "minecraft:mushroom_stem"
+    "minecraft:mushroom_stem",
+    {
+      "id": "#productivebees:nests/wood_nests",
+      "required": false
+    }
   ]
 }

--- a/src/main/java/com/minecolonies/core/generation/defaults/DefaultBlockTagsProvider.java
+++ b/src/main/java/com/minecolonies/core/generation/defaults/DefaultBlockTagsProvider.java
@@ -186,12 +186,11 @@ public class DefaultBlockTagsProvider extends BlockTagsProvider
         tag(ModTags.tree)
                 .addTag(BlockTags.LOGS)
                 .addTag(ModTags.mangroveTree)
-                .add(Blocks.MUSHROOM_STEM);
+                .add(Blocks.MUSHROOM_STEM)
+                .addOptionalTag(new ResourceLocation("productivebees", "nests/wood_nests"));
 
         tag(ModTags.colonyProtectionException)
-                .addOptional(new ResourceLocation("waystones:waystone"))
-                .addOptional(new ResourceLocation("waystones:sandy_waystone"))
-                .addOptional(new ResourceLocation("waystones:mossy_waystone"));
+                .addOptionalTag(new ResourceLocation("waystones", "waystones"));
 
         tag(ModTags.indestructible).add(Blocks.BEDROCK);
         tag(ModTags.oreChanceBlocks)


### PR DESCRIPTION
Closes #9358 
Closes [discord issue](https://discord.com/channels/472875599422291968/1307436829569712189/1307444857341612136)

# Changes proposed in this pull request
- Compat for Productive Bees: treat [wood nests](https://github.com/JDKDigital/productive-bees/blob/dev-1.20.0/src/main/resources/data/productivebees/tags/blocks/nests/wood_nests.json) as tree blocks so that the forester will cut them (and not be confused by them).
- Improved compat for Waystones: treat new kinds of [waystones](https://github.com/TwelveIterationMods/Waystones/blob/1.20.1/shared/src/main/generated/data/waystones/tags/blocks/waystones.json) as free blocks too.  (It's the same set in 1.20 but there's more in 1.21.)

## Testing
- [ ] Yes I tested this before submitting it.
- [ ] I also did a multiplayer test.

Review please (could port)