### PR TITLE
Fix banner crashing client when copying blank vanilia banner and desync in multiplayer

### DIFF
--- a/src/main/java/com/minecolonies/core/client/render/TileEntityColonyFlagRenderer.java
+++ b/src/main/java/com/minecolonies/core/client/render/TileEntityColonyFlagRenderer.java
@@ -53,7 +53,7 @@ public class TileEntityColonyFlagRenderer implements BlockEntityRenderer<TileEnt
     @Override
     public void render(TileEntityColonyFlag flagIn, float partialTicks, PoseStack transform, MultiBufferSource bufferIn, int combinedLightIn, int combinedOverlayIn)
     {
-        List<Pair<Holder<BannerPattern>, DyeColor>> list = flagIn.getPatternList();
+        List<Pair<Holder<BannerPattern>, DyeColor>> list = flagIn.getPatterns();
 
         boolean noWorld = flagIn.getLevel() == null;
         transform.pushPose();

--- a/src/main/java/com/minecolonies/core/items/ItemColonyFlagBanner.java
+++ b/src/main/java/com/minecolonies/core/items/ItemColonyFlagBanner.java
@@ -2,17 +2,22 @@ package com.minecolonies.core.items;
 
 import com.minecolonies.api.blocks.ModBlocks;
 import com.minecolonies.core.tileentities.TileEntityColonyFlag;
+import com.mojang.datafixers.util.Pair;
+
 import net.minecraft.world.level.block.AbstractBannerBlock;
 import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.entity.BannerPatterns;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.item.TooltipFlag;
 import net.minecraft.world.item.BannerItem;
+import net.minecraft.world.item.DyeColor;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.context.UseOnContext;
+import net.minecraft.core.Holder;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.nbt.ListTag;
 import net.minecraft.world.level.block.entity.BannerBlockEntity;
+import net.minecraft.world.level.block.entity.BannerPattern;
 import net.minecraft.world.level.block.entity.BlockEntity;
 import net.minecraft.world.InteractionResult;
 import net.minecraft.network.chat.Component;
@@ -46,39 +51,24 @@ public class ItemColonyFlagBanner extends BannerItem
     {
         // Duplicate the patterns of the banner that was clicked on
         BlockEntity te = context.getLevel().getBlockEntity(context.getClickedPos());
-        BlockState state = context.getLevel().getBlockState(context.getClickedPos());
-        ItemStack stack = context.getPlayer().getMainHandItem();
+        ItemStack stack = context.getItemInHand();
 
         if (te instanceof BannerBlockEntity || te instanceof TileEntityColonyFlag)
         {
-            CompoundTag source;
-            if (te instanceof BannerBlockEntity)
-            {
-                source = ((BannerBlockEntity) te).getItem()
-                           .getTag().getCompound("BlockEntityTag");
-            }
-            else
-            {
-                source = (context.getLevel().isClientSide ? ((TileEntityColonyFlag) te).getItemClient() : ((TileEntityColonyFlag) te).getItemServer())
-                           .getTag().getCompound("BlockEntityTag");
-            }
-
-            ListTag patternList = source.getList(TAG_BANNER_PATTERNS, 10);
-
-            // Set the base pattern, if there wasn't one set.
-            // This saves us attempting to alter the item itself to change the base color.
-            if (!patternList.getCompound(0).getString(TAG_SINGLE_PATTERN).equals(BannerPatterns.BASE.location().toString()))
-            {
-                CompoundTag nbt = new CompoundTag();
-                nbt.putString(TAG_SINGLE_PATTERN, BannerPatterns.BASE.location().toString());
-                nbt.putInt(TAG_PATTERN_COLOR, ((AbstractBannerBlock) state.getBlock()).getColor().getId());
-                patternList.add(0, nbt);
-            }
-
-            CompoundTag tag = stack.getOrCreateTagElement("BlockEntityTag");
-            tag.put(TAG_BANNER_PATTERNS, patternList);
-
-            return InteractionResult.SUCCESS;
+	    BannerPattern.Builder patternsBuilder = new BannerPattern.Builder();
+	    List<Pair<Holder<BannerPattern>, DyeColor>> source;
+	    
+	    if (te instanceof BannerBlockEntity)
+		source = ((BannerBlockEntity) te).getPatterns();
+	    else
+		source = ((TileEntityColonyFlag) te).getPatterns();
+	    
+	    CompoundTag bannerPattern  = new CompoundTag();
+	    source.forEach((pattern) -> patternsBuilder.addPattern(pattern.getFirst(), pattern.getSecond()));
+	    bannerPattern.put(TAG_BANNER_PATTERNS, patternsBuilder.toListTag());
+            
+	    stack.addTagElement("BlockEntityTag", bannerPattern);
+	    return InteractionResult.SUCCESS;
         }
         return super.useOn(context);
     }

--- a/src/main/java/com/minecolonies/core/items/ItemColonyFlagBanner.java
+++ b/src/main/java/com/minecolonies/core/items/ItemColonyFlagBanner.java
@@ -50,22 +50,23 @@ public class ItemColonyFlagBanner extends BannerItem
         BlockEntity te = context.getLevel().getBlockEntity(context.getClickedPos());
         ItemStack stack = context.getItemInHand();
 
-        if (te instanceof BannerBlockEntity || te instanceof TileEntityColonyFlag)
-        {
-	    BannerPattern.Builder patternsBuilder = new BannerPattern.Builder();
-	    List<Pair<Holder<BannerPattern>, DyeColor>> source;
-	    
-	    if (te instanceof BannerBlockEntity)
-		    source = ((BannerBlockEntity) te).getPatterns();
-	    else
-		    source = ((TileEntityColonyFlag) te).getPatterns();
-	    
-	    CompoundTag bannerPattern  = new CompoundTag();
-	    source.forEach((pattern) -> patternsBuilder.addPattern(pattern.getFirst(), pattern.getSecond()));
-	    bannerPattern.put(TAG_BANNER_PATTERNS, patternsBuilder.toListTag());
-            
-	    stack.addTagElement("BlockEntityTag", bannerPattern);
-	    return InteractionResult.SUCCESS;
+        if (te instanceof BannerBlockEntity || te instanceof TileEntityColonyFlag) {
+            BannerPattern.Builder patternsBuilder = new BannerPattern.Builder();
+            List<Pair<Holder<BannerPattern>, DyeColor>> source;
+
+            if (te instanceof BannerBlockEntity) {
+                source = ((BannerBlockEntity) te).getPatterns();
+            }
+            else {
+                source = ((TileEntityColonyFlag) te).getPatterns();
+            }
+
+            CompoundTag bannerPattern = new CompoundTag();
+            source.forEach((pattern) -> patternsBuilder.addPattern(pattern.getFirst(), pattern.getSecond()));
+            bannerPattern.put(TAG_BANNER_PATTERNS, patternsBuilder.toListTag());
+
+            stack.addTagElement("BlockEntityTag", bannerPattern);
+            return InteractionResult.SUCCESS;
         }
         return super.useOn(context);
     }

--- a/src/main/java/com/minecolonies/core/items/ItemColonyFlagBanner.java
+++ b/src/main/java/com/minecolonies/core/items/ItemColonyFlagBanner.java
@@ -4,10 +4,7 @@ import com.minecolonies.api.blocks.ModBlocks;
 import com.minecolonies.core.tileentities.TileEntityColonyFlag;
 import com.mojang.datafixers.util.Pair;
 
-import net.minecraft.world.level.block.AbstractBannerBlock;
 import net.minecraft.world.level.block.Block;
-import net.minecraft.world.level.block.entity.BannerPatterns;
-import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.item.TooltipFlag;
 import net.minecraft.world.item.BannerItem;
 import net.minecraft.world.item.BlockItem;
@@ -16,7 +13,6 @@ import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.context.UseOnContext;
 import net.minecraft.core.Holder;
 import net.minecraft.nbt.CompoundTag;
-import net.minecraft.nbt.ListTag;
 import net.minecraft.world.level.block.entity.BannerBlockEntity;
 import net.minecraft.world.level.block.entity.BannerPattern;
 import net.minecraft.world.level.block.entity.BlockEntity;
@@ -60,9 +56,9 @@ public class ItemColonyFlagBanner extends BannerItem
 	    List<Pair<Holder<BannerPattern>, DyeColor>> source;
 	    
 	    if (te instanceof BannerBlockEntity)
-		source = ((BannerBlockEntity) te).getPatterns();
+		    source = ((BannerBlockEntity) te).getPatterns();
 	    else
-		source = ((TileEntityColonyFlag) te).getPatterns();
+		    source = ((TileEntityColonyFlag) te).getPatterns();
 	    
 	    CompoundTag bannerPattern  = new CompoundTag();
 	    source.forEach((pattern) -> patternsBuilder.addPattern(pattern.getFirst(), pattern.getSecond()));

--- a/src/main/java/com/minecolonies/core/items/ItemColonyFlagBanner.java
+++ b/src/main/java/com/minecolonies/core/items/ItemColonyFlagBanner.java
@@ -75,7 +75,8 @@ public class ItemColonyFlagBanner extends BannerItem
     }
 
     @Override
-    public void appendHoverText(ItemStack stack, @Nullable Level worldIn, List<Component> tooltip, TooltipFlag flagIn) {
+    public void appendHoverText(ItemStack stack, @Nullable Level worldIn, List<Component> tooltip, TooltipFlag flagIn)
+    {
         CompoundTag tag = BlockItem.getBlockEntityData(stack);
         if (tag != null && tag.contains(TAG_BANNER_PATTERNS))
         {

--- a/src/main/java/com/minecolonies/core/items/ItemColonyFlagBanner.java
+++ b/src/main/java/com/minecolonies/core/items/ItemColonyFlagBanner.java
@@ -50,14 +50,17 @@ public class ItemColonyFlagBanner extends BannerItem
         BlockEntity te = context.getLevel().getBlockEntity(context.getClickedPos());
         ItemStack stack = context.getItemInHand();
 
-        if (te instanceof BannerBlockEntity || te instanceof TileEntityColonyFlag) {
+        if (te instanceof BannerBlockEntity || te instanceof TileEntityColonyFlag)
+        {
             BannerPattern.Builder patternsBuilder = new BannerPattern.Builder();
             List<Pair<Holder<BannerPattern>, DyeColor>> source;
 
-            if (te instanceof BannerBlockEntity) {
+            if (te instanceof BannerBlockEntity)
+            {
                 source = ((BannerBlockEntity) te).getPatterns();
             }
-            else {
+            else
+            {
                 source = ((TileEntityColonyFlag) te).getPatterns();
             }
 
@@ -74,9 +77,12 @@ public class ItemColonyFlagBanner extends BannerItem
     @Override
     public void appendHoverText(ItemStack stack, @Nullable Level worldIn, List<Component> tooltip, TooltipFlag flagIn) {
         CompoundTag tag = BlockItem.getBlockEntityData(stack);
-        if (tag != null && tag.contains(TAG_BANNER_PATTERNS)) {
+        if (tag != null && tag.contains(TAG_BANNER_PATTERNS))
+        {
             super.appendHoverText(stack, worldIn, tooltip, flagIn);
-        } else {
+        }
+        else
+        {
             tooltip.add(Component.translatable("com.minecolonies.coremod.item.colony_banner.tooltipempty"));
         }
     }

--- a/src/main/java/com/minecolonies/core/items/ItemColonyFlagBanner.java
+++ b/src/main/java/com/minecolonies/core/items/ItemColonyFlagBanner.java
@@ -10,6 +10,7 @@ import net.minecraft.world.level.block.entity.BannerPatterns;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.item.TooltipFlag;
 import net.minecraft.world.item.BannerItem;
+import net.minecraft.world.item.BlockItem;
 import net.minecraft.world.item.DyeColor;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.context.UseOnContext;
@@ -76,9 +77,10 @@ public class ItemColonyFlagBanner extends BannerItem
     @Override
     public void appendHoverText(ItemStack stack, @Nullable Level worldIn, List<Component> tooltip, TooltipFlag flagIn)
     {
-        super.appendHoverText(stack, worldIn, tooltip, flagIn);
-
-        // Remove the base, as they have no translations (Mojang were lazy. Or maybe saving space?)
-        if (tooltip.size() > 1) tooltip.remove(1);
+	CompoundTag tag = BlockItem.getBlockEntityData(stack);
+	if (tag != null && tag.contains(TAG_BANNER_PATTERNS))
+	    super.appendHoverText(stack, worldIn, tooltip, flagIn);
+	else
+	    tooltip.add(Component.translatable("com.mincolonies.coremod.item.colony_baner.tooltipempty"));
     }
 }

--- a/src/main/java/com/minecolonies/core/items/ItemColonyFlagBanner.java
+++ b/src/main/java/com/minecolonies/core/items/ItemColonyFlagBanner.java
@@ -72,12 +72,12 @@ public class ItemColonyFlagBanner extends BannerItem
     }
 
     @Override
-    public void appendHoverText(ItemStack stack, @Nullable Level worldIn, List<Component> tooltip, TooltipFlag flagIn)
-    {
-	CompoundTag tag = BlockItem.getBlockEntityData(stack);
-	if (tag != null && tag.contains(TAG_BANNER_PATTERNS))
-	    super.appendHoverText(stack, worldIn, tooltip, flagIn);
-	else
-	    tooltip.add(Component.translatable("com.mincolonies.coremod.item.colony_baner.tooltipempty"));
+    public void appendHoverText(ItemStack stack, @Nullable Level worldIn, List<Component> tooltip, TooltipFlag flagIn) {
+        CompoundTag tag = BlockItem.getBlockEntityData(stack);
+        if (tag != null && tag.contains(TAG_BANNER_PATTERNS)) {
+            super.appendHoverText(stack, worldIn, tooltip, flagIn);
+        } else {
+            tooltip.add(Component.translatable("com.mincolonies.coremod.item.colony_baner.tooltipempty"));
+        }
     }
 }

--- a/src/main/java/com/minecolonies/core/items/ItemColonyFlagBanner.java
+++ b/src/main/java/com/minecolonies/core/items/ItemColonyFlagBanner.java
@@ -77,7 +77,7 @@ public class ItemColonyFlagBanner extends BannerItem
         if (tag != null && tag.contains(TAG_BANNER_PATTERNS)) {
             super.appendHoverText(stack, worldIn, tooltip, flagIn);
         } else {
-            tooltip.add(Component.translatable("com.mincolonies.coremod.item.colony_baner.tooltipempty"));
+            tooltip.add(Component.translatable("com.minecolonies.coremod.item.colony_banner.tooltipempty"));
         }
     }
 }

--- a/src/main/java/com/minecolonies/core/tileentities/TileEntityColonyFlag.java
+++ b/src/main/java/com/minecolonies/core/tileentities/TileEntityColonyFlag.java
@@ -28,9 +28,6 @@ import static com.minecolonies.api.util.constant.NbtTagConstants.*;
 
 public class TileEntityColonyFlag extends BlockEntity
 {
-    /** The last known flag. Required for when the colony is not available. */
-    private ListTag flag = new ListTag();
-
     /** A list of the default banner patterns, for colonies that have not chosen a flag */
     private ListTag patterns = new ListTag();
 
@@ -44,7 +41,6 @@ public class TileEntityColonyFlag extends BlockEntity
     {
         super.saveAdditional(compound);
 
-        compound.put(TAG_FLAG_PATTERNS, this.flag);
         compound.put(TAG_BANNER_PATTERNS, this.patterns);
 
         compound.putInt(TAG_COLONY_ID, colonyId);
@@ -55,7 +51,6 @@ public class TileEntityColonyFlag extends BlockEntity
     {
         super.load(compound);
 
-        this.flag = compound.getList(TAG_FLAG_PATTERNS, 10);
         this.patterns = compound.getList(TAG_BANNER_PATTERNS, 10);
         this.colonyId = compound.getInt(TAG_COLONY_ID);
 
@@ -97,16 +92,16 @@ public class TileEntityColonyFlag extends BlockEntity
         if (level != null && level.dimension() != null)
         {
             IColonyView colony = IColonyManager.getInstance().getColonyView(this.colonyId, level.dimension());
-            if (colony != null && this.flag != colony.getColonyFlag())
+            if (colony != null && this.patterns != colony.getColonyFlag())
             {
-                this.flag = colony.getColonyFlag();
+                this.patterns = colony.getColonyFlag();
                 setChanged();
             }
         }
 
         return BannerBlockEntity.createPatterns(
                 DyeColor.WHITE,
-                this.flag.size() > 1 ? this.flag : this.patterns
+                this.patterns
         );
     }
 

--- a/src/main/java/com/minecolonies/core/tileentities/TileEntityColonyFlag.java
+++ b/src/main/java/com/minecolonies/core/tileentities/TileEntityColonyFlag.java
@@ -82,11 +82,10 @@ public class TileEntityColonyFlag extends BlockEntity
     }
 
     /**
-     * Retrieves the patterns for the renderer
+     * Retrieves the patterns, similar to {@link BannerBlockEntity#getPatterns()}
      * @return the list of pattern-color pairs
      */
-    @OnlyIn(Dist.CLIENT)
-    public List<Pair<Holder<BannerPattern>, DyeColor>> getPatternList()
+    public List<Pair<Holder<BannerPattern>, DyeColor>> getPatterns()
     {
         // Structurize will cause the second condition to be false
         if (level != null && level.dimension() != null)
@@ -113,7 +112,7 @@ public class TileEntityColonyFlag extends BlockEntity
     public ItemStack getItemClient()
     {
         ItemStack itemstack = new ItemStack(ModBlocks.blockColonyBanner);
-        List<Pair<Holder<BannerPattern>, DyeColor>> list = getPatternList();
+        List<Pair<Holder<BannerPattern>, DyeColor>> list = getPatterns();
         ListTag nbt = new ListTag();
 
         for (Pair<Holder<BannerPattern>, DyeColor> pair : list)

--- a/src/main/java/com/minecolonies/core/tileentities/TileEntityColonyFlag.java
+++ b/src/main/java/com/minecolonies/core/tileentities/TileEntityColonyFlag.java
@@ -98,10 +98,13 @@ public class TileEntityColonyFlag extends BlockEntity
             }
         }
 
-        return BannerBlockEntity.createPatterns(
-                DyeColor.WHITE,
+        List<Pair<Holder<BannerPattern>, DyeColor>> pattern = BannerBlockEntity.createPatterns(
+                DyeColor.WHITE, // <-- add a useless white base layer
                 this.patterns
         );
+	//remove the first base layer
+	pattern.remove(0);
+    	return pattern;
     }
 
     /**

--- a/src/main/java/com/minecolonies/core/tileentities/TileEntityColonyFlag.java
+++ b/src/main/java/com/minecolonies/core/tileentities/TileEntityColonyFlag.java
@@ -99,7 +99,7 @@ public class TileEntityColonyFlag extends BlockEntity
         }
 
         List<Pair<Holder<BannerPattern>, DyeColor>> pattern = BannerBlockEntity.createPatterns(
-                DyeColor.WHITE, // <-- add a useless white base layer
+                DyeColor.WHITE,
                 this.patterns
         );
 	//remove the first base layer

--- a/src/main/resources/assets/minecolonies/lang/manual_en_us.json
+++ b/src/main/resources/assets/minecolonies/lang/manual_en_us.json
@@ -1921,7 +1921,7 @@
   "com.minecolonies.coremod.gui.flag.base_layer": "Base",
   "com.minecolonies.coremod.gui.townhall.edit_flag": "Edit Colony Flag",
   "block.minecolonies.colony_banner": "Colony Flag Banner",
-  "com.mincolonies.coremod.item.colony_baner.tooltipempty": "Right click to copy pattern on the item",
+  "com.minecolonies.coremod.item.colony_banner.tooltipempty": "Right click to copy pattern on the item",
   "com.minecolonies.coremod.gui.locate": "Locate",
   "com.minecolonies.coremod.locating": "Successfully located rack with respective item(s).",
 

--- a/src/main/resources/assets/minecolonies/lang/manual_en_us.json
+++ b/src/main/resources/assets/minecolonies/lang/manual_en_us.json
@@ -1921,6 +1921,7 @@
   "com.minecolonies.coremod.gui.flag.base_layer": "Base",
   "com.minecolonies.coremod.gui.townhall.edit_flag": "Edit Colony Flag",
   "block.minecolonies.colony_banner": "Colony Flag Banner",
+  "com.mincolonies.coremod.item.colony_baner.tooltipempty": "Right click to copy pattern on the item",
   "com.minecolonies.coremod.gui.locate": "Locate",
   "com.minecolonies.coremod.locating": "Successfully located rack with respective item(s).",
 


### PR DESCRIPTION
# Changes proposed in this pull request
- Fix banner crashing client on banner that didn't have tags (aka blank patterns)
- Fix server not copying but client did, causing a desync
- add a explanation on how to copy banner's patterns

## Testing
- [X] Yes I tested this before submitting it.
- [X] I also did a multiplayer test.

Review please