### PR TITLE
Only upload resources for 1.21

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -93,6 +93,6 @@ usesSonarQube=true
 
 usesCrowdInTranslationManagement=true
 crowdInDownloadDirectory=src/main/resources/assets/minecolonies/lang
-usesCrowdInUploadWithFilteredBranchesSpec=(version|release)\/.+
+usesCrowdInUploadWithFilteredBranchesSpec=(version|release)\/1\.21
 
 additionalModsInDataGen=structurize;domum_ornamentum


### PR DESCRIPTION
Closes #10528

# Changes proposed in this pull request
- Only upload language resources to crowdin in 1.21

## Testing
- [ ] Yes I tested this before submitting it.
- [ ] I also did a multiplayer test.

Review please (would need to be ported to any branch we're likely to trigger a build on)

This is completely untested, but seems plausible as per [discussion](https://discord.com/channels/449079260070674443/449792808371355665/1312100861974941888).