### PR TITLE
Fix jmap integration

### DIFF
--- a/src/main/java/com/minecolonies/core/compatibility/journeymap/EventListener.java
+++ b/src/main/java/com/minecolonies/core/compatibility/journeymap/EventListener.java
@@ -54,7 +54,6 @@ public class EventListener
         }
     }
 
-    @SubscribeEvent
     public void onColonyViewUpdated(@NotNull final ColonyViewUpdatedModEvent event)
     {
         final IColonyView colony = event.getColony();


### PR DESCRIPTION
Closes [discord report](https://discord.com/channels/139070364159311872/1003402487417548801/1321768200186236979) Journeymap no longer seems to be working

# Changes proposed in this pull request
- Removed a SubscribeEvent annotation, this caused Neoforge to assume the method was a Neoforge event handler, throwing an exception because the parameter wasn't an Event class. This was a silent exception caused during the Jmap plugin load, causing the plugin not to start.

## Testing
- [X] Yes I tested this before submitting it.
- [ ] I also did a multiplayer test.

Review please