### PR TITLE
Correct implementation for the entity remove event handler

### DIFF
--- a/src/main/java/com/minecolonies/api/eventbus/events/colony/citizens/AbstractCitizenModEvent.java
+++ b/src/main/java/com/minecolonies/api/eventbus/events/colony/citizens/AbstractCitizenModEvent.java
@@ -13,14 +13,15 @@ public class AbstractCitizenModEvent extends AbstractColonyModEvent
     /**
      * The citizen related to the event.
      */
-    private final @NotNull ICitizenData citizen;
+    @NotNull
+    private final ICitizenData citizen;
 
     /**
      * Constructs a citizen-based event.
      *
      * @param citizen the citizen related to the event.
      */
-    protected AbstractCitizenModEvent(final @NotNull ICitizenData citizen)
+    protected AbstractCitizenModEvent(@NotNull final ICitizenData citizen)
     {
         super(citizen.getColony());
         this.citizen = citizen;

--- a/src/main/java/com/minecolonies/api/eventbus/events/colony/citizens/CitizenRemovedModEvent.java
+++ b/src/main/java/com/minecolonies/api/eventbus/events/colony/citizens/CitizenRemovedModEvent.java
@@ -1,29 +1,48 @@
 package com.minecolonies.api.eventbus.events.colony.citizens;
 
-import com.minecolonies.api.colony.ICitizenData;
+import com.minecolonies.api.colony.IColony;
+import com.minecolonies.api.eventbus.events.colony.AbstractColonyModEvent;
 import net.minecraft.world.entity.Entity;
 import org.jetbrains.annotations.NotNull;
 
 /**
  * Event for when a citizen was removed from the colony.
  */
-public final class CitizenRemovedModEvent extends AbstractCitizenModEvent
+public final class CitizenRemovedModEvent extends AbstractColonyModEvent
 {
+    /**
+     * The id of the citizen.
+     */
+    private final int citizenId;
+
     /**
      * The damage source that caused a citizen to die.
      */
-    private final @NotNull Entity.RemovalReason reason;
+    @NotNull
+    private final Entity.RemovalReason reason;
 
     /**
      * Citizen removed event.
      *
-     * @param citizen the citizen related to the event.
-     * @param reason  the reason the citizen was removed.
+     * @param colony    the colony related to the event.
+     * @param citizenId the id of the citizen.
+     * @param reason    the reason the citizen was removed.
      */
-    public CitizenRemovedModEvent(final @NotNull ICitizenData citizen, final @NotNull Entity.RemovalReason reason)
+    public CitizenRemovedModEvent(final @NotNull IColony colony, final int citizenId, final @NotNull Entity.RemovalReason reason)
     {
-        super(citizen);
+        super(colony);
+        this.citizenId = citizenId;
         this.reason = reason;
+    }
+
+    /**
+     * The id of the citizen.
+     *
+     * @return the id.
+     */
+    public int getCitizenId()
+    {
+        return citizenId;
     }
 
     /**

--- a/src/main/java/com/minecolonies/core/entity/citizen/EntityCitizen.java
+++ b/src/main/java/com/minecolonies/core/entity/citizen/EntityCitizen.java
@@ -1582,10 +1582,7 @@ public class EntityCitizen extends AbstractEntityCitizen implements IThreatTable
     public void remove(final @NotNull RemovalReason reason)
     {
         super.remove(reason);
-        if (reason != RemovalReason.DISCARDED && citizenData != null)
-        {
-            IMinecoloniesAPI.getInstance().getEventBus().post(new CitizenRemovedModEvent(citizenData, reason));
-        }
+        IMinecoloniesAPI.getInstance().getEventBus().post(new CitizenRemovedModEvent(citizenColonyHandler.getColony(), citizenId, reason));
     }
 
     /**


### PR DESCRIPTION
# Changes proposed in this pull request
- Redo incorrect call to event handler in #10558
- Modified the removal event to not include citizen data as this is null at the point of event creation, using citizen ID instead.

## Testing
- [X] Yes I tested this before submitting it.
- [ ] I also did a multiplayer test.

Review please