### PR TITLE
Update max placement height for scarecrows

### DIFF
--- a/src/main/java/com/minecolonies/core/blocks/BlockScarecrow.java
+++ b/src/main/java/com/minecolonies/core/blocks/BlockScarecrow.java
@@ -153,7 +153,7 @@ public class BlockScarecrow extends AbstractBlockMinecoloniesDefault<BlockScarec
     {
         @NotNull final Direction dir = (context.getPlayer() == null) ? Direction.NORTH : Direction.fromYRot(context.getPlayer().getYRot() + 180);
 
-        if (context.getClickedPos().getY() < 255 && context.getLevel().getBlockState(context.getClickedPos().above()).canBeReplaced(context))
+        if (context.getClickedPos().getY() < context.getLevel().getMaxBuildHeight() && context.getLevel().getBlockState(context.getClickedPos().above()).canBeReplaced(context))
         {
             return this.defaultBlockState().setValue(FACING, dir).setValue(HALF, DoubleBlockHalf.LOWER);
         }

--- a/src/main/java/com/minecolonies/core/entity/ai/workers/util/Tree.java
+++ b/src/main/java/com/minecolonies/core/entity/ai/workers/util/Tree.java
@@ -327,7 +327,7 @@ public class Tree
     private BlockPos getFirstLeaf(final LevelAccessor world)
     {
         // Find the closest leaf above, stay below max height
-        for (int i = 1; (i + topLog.getY()) < 255 && i < 10; i++)
+        for (int i = 1; (i + topLog.getY()) < world.getMaxBuildHeight() && i < 10; i++)
         {
             final BlockState blockState = world.getBlockState(topLog.offset(0, i, 0));
             if (blockState.is(BlockTags.LEAVES) || blockState.is(ModTags.hugeMushroomBlocks))


### PR DESCRIPTION
Closes [discord report](https://discord.com/channels/472875599422291968/473575384445878273/1323952982261239840) Scarecrow cannot be placed past 255 disregarding increased world height

# Changes proposed in this pull request
- Use level max build height rather than hardcoded 255
- Fix identical issue in tree lookup for the forester

## Testing
- [ ] Yes I tested this before submitting it.
- [ ] I also did a multiplayer test.

Review please