### PR TITLE
Fix utility predicates not being instantiated on start

### DIFF
--- a/src/main/java/com/minecolonies/api/util/FoodUtils.java
+++ b/src/main/java/com/minecolonies/api/util/FoodUtils.java
@@ -30,7 +30,7 @@ public class FoodUtils
     /**
      * Predicate describing food which can be eaten (is not raw).
      */
-    public static Predicate<ItemStack> EDIBLE;
+    public static final Predicate<ItemStack> EDIBLE = itemStack -> ItemStackUtils.ISFOOD.test(itemStack) && !ItemStackUtils.ISCOOKABLE.test(itemStack);
 
     /**
      * @param stack

--- a/src/main/java/com/minecolonies/api/util/ItemStackUtils.java
+++ b/src/main/java/com/minecolonies/api/util/ItemStackUtils.java
@@ -17,6 +17,7 @@ import com.minecolonies.api.items.ModItems;
 import com.minecolonies.api.items.ModTags;
 import com.minecolonies.core.items.ItemBowlFood;
 import com.minecolonies.core.util.AdvancementUtils;
+import com.minecolonies.core.util.FurnaceRecipes;
 import com.mojang.brigadier.exceptions.CommandSyntaxException;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.nbt.ListTag;
@@ -115,12 +116,12 @@ public final class ItemStackUtils
     /**
      * Predicate describing things which work in the furnace.
      */
-    public static Predicate<ItemStack> IS_SMELTABLE;
+    public static Predicate<ItemStack> IS_SMELTABLE = itemStack -> !ItemStackUtils.isEmpty(FurnaceRecipes.getInstance().getSmeltingResult(itemStack));
 
     /**
      * Predicate describing cookables.
      */
-    public static Predicate<ItemStack> ISCOOKABLE;
+    public static Predicate<ItemStack> ISCOOKABLE = itemStack -> ItemStackUtils.ISFOOD.test(FurnaceRecipes.getInstance().getSmeltingResult(itemStack));
 
     /**
      * Predicate to check for compost items.

--- a/src/main/java/com/minecolonies/core/network/messages/client/UpdateClientWithCompatibilityMessage.java
+++ b/src/main/java/com/minecolonies/core/network/messages/client/UpdateClientWithCompatibilityMessage.java
@@ -3,7 +3,6 @@ package com.minecolonies.core.network.messages.client;
 import com.minecolonies.api.IMinecoloniesAPI;
 import com.minecolonies.api.network.IMessage;
 import com.minecolonies.api.util.Log;
-import com.minecolonies.core.util.FurnaceRecipes;
 import io.netty.buffer.Unpooled;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.multiplayer.ClientLevel;
@@ -65,7 +64,6 @@ public class UpdateClientWithCompatibilityMessage implements IMessage
     public void onExecute(final NetworkEvent.Context ctxIn, final boolean isLogicalServer)
     {
         final ClientLevel world = Minecraft.getInstance().level;
-        FurnaceRecipes.getInstance().loadUtilityPredicates();
         try
         {
             IMinecoloniesAPI.getInstance().getColonyManager().getCompatibilityManager().deserialize(this.buffer, world);

--- a/src/main/java/com/minecolonies/core/util/FurnaceRecipes.java
+++ b/src/main/java/com/minecolonies/core/util/FurnaceRecipes.java
@@ -5,8 +5,6 @@ import com.minecolonies.api.colony.requestsystem.StandardFactoryController;
 import com.minecolonies.api.compatibility.IFurnaceRecipes;
 import com.minecolonies.api.crafting.ItemStorage;
 import com.minecolonies.api.crafting.RecipeStorage;
-import com.minecolonies.api.util.FoodUtils;
-import com.minecolonies.api.util.ItemStackUtils;
 import com.minecolonies.api.util.constant.TypeConstants;
 import net.minecraft.core.NonNullList;
 import net.minecraft.world.item.ItemStack;
@@ -23,15 +21,15 @@ import java.util.Map;
 public class FurnaceRecipes implements IFurnaceRecipes
 {
     /**
+     * Instance of the furnace recipes.
+     */
+    private static FurnaceRecipes instance;
+
+    /**
      * Furnace recipes.
      */
     private Map<ItemStorage, RecipeStorage> recipes = new HashMap<>();
     private Map<ItemStorage, RecipeStorage> reverseRecipes = new HashMap<>();
-
-    /**
-     * Instance of the furnace recipes.
-     */
-    public static FurnaceRecipes instance;
 
     /**
      * Load all the recipes in the recipe storage.
@@ -42,7 +40,6 @@ public class FurnaceRecipes implements IFurnaceRecipes
     {
         recipes.clear();
         reverseRecipes.clear();
-        loadUtilityPredicates();
         recipeManager.byType(RecipeType.SMELTING).values().forEach(recipe -> {
             final NonNullList<Ingredient> list = recipe.getIngredients();
             if (list.size() == 1)
@@ -69,17 +66,6 @@ public class FurnaceRecipes implements IFurnaceRecipes
                 }
             }
         });
-    }
-
-    /**
-     * Load all the utility predicates.
-     */
-    public void loadUtilityPredicates()
-    {
-        ItemStackUtils.IS_SMELTABLE = itemStack -> !ItemStackUtils.isEmpty(instance.getSmeltingResult(itemStack));
-        ItemStackUtils.ISCOOKABLE = itemStack -> ItemStackUtils.ISFOOD.test(instance.getSmeltingResult(itemStack));
-        FoodUtils.EDIBLE =
-                itemStack -> ItemStackUtils.ISFOOD.test(itemStack) && !ItemStackUtils.ISCOOKABLE.test(itemStack);
     }
 
     @Override


### PR DESCRIPTION
Closes #10592 

# Changes proposed in this pull request
- Instantiate the predicates directly, not requiring a separate method to call.

This works safely, even on a dedicated server. The recipes get populated before NBT load is invoked, so the menu doesn't get wiped either.

## Testing
- [X] Yes I tested this before submitting it.
- [X] I also did a multiplayer test.

Review please