### PR TITLE
feat: add minimum stock to the postbox

### DIFF
--- a/src/main/java/com/minecolonies/apiimp/initializer/ModBuildingsInitializer.java
+++ b/src/main/java/com/minecolonies/apiimp/initializer/ModBuildingsInitializer.java
@@ -376,6 +376,7 @@ public final class ModBuildingsInitializer
           .setBuildingProducer(PostBox::new)
           .setBuildingViewProducer(() -> PostBox.View::new)
           .setRegistryName(new ResourceLocation(Constants.MOD_ID, ModBuildings.POSTBOX_ID))
+          .addBuildingModuleProducer(MIN_STOCK)
           .createBuildingEntry());
 
         ModBuildings.florist = DEFERRED_REGISTER.register(ModBuildings.FLORIST_ID, () -> new BuildingEntry.Builder()

--- a/src/main/java/com/minecolonies/core/client/gui/AbstractModuleWindow.java
+++ b/src/main/java/com/minecolonies/core/client/gui/AbstractModuleWindow.java
@@ -6,6 +6,7 @@ import com.minecolonies.api.colony.buildings.modules.IBuildingModuleView;
 import com.minecolonies.api.colony.buildings.modules.IModuleWindow;
 import com.minecolonies.api.colony.buildings.views.IBuildingView;
 import com.minecolonies.core.colony.buildings.views.AbstractBuildingView;
+import net.minecraft.client.Minecraft;
 import net.minecraft.client.resources.sounds.SimpleSoundInstance;
 import net.minecraft.network.chat.Component;
 import net.minecraft.resources.ResourceLocation;
@@ -32,12 +33,19 @@ public abstract class AbstractModuleWindow extends AbstractWindowSkeleton implem
      * @param building   {@link AbstractBuildingView}.
      * @param res        the resource String.
      */
+
     public AbstractModuleWindow(final IBuildingView building, final String res)
     {
         super(res);
         this.buildingView = building;
+        placeWindowModuleViews(this, building, -20, this.mc);
+
+    }
+    // need mc as its own arg because it's protected in Pane
+    static void placeWindowModuleViews(AbstractWindowSkeleton window, final IBuildingView building, int xOffset, Minecraft mc) {
         final Random random = new Random(building.getID().hashCode());
         int offset = 0;
+        final int iconXOffset = xOffset+5;
 
         boolean anyVisible = false;
 
@@ -50,26 +58,26 @@ public abstract class AbstractModuleWindow extends AbstractWindowSkeleton implem
             }
         }
 
-            //todo We have to move this to 0 as soon as we're finished with modularization and remove the switch views in favor of a sidenav xml.
-        if (building.getAllModuleViews().size() > 0 && anyVisible)
+        //todo We have to move this to 0 as soon as we're finished with modularization and remove the switch views in favor of a sidenav xml.
+        if (!building.getAllModuleViews().isEmpty() && anyVisible)
         {
             final ButtonImage image = new ButtonImage();
             image.setImage(new ResourceLocation("minecolonies:textures/gui/modules/tab_side" + (random.nextInt(3) + 1) + ".png"), false);
-            image.setPosition(-20, 10 + offset);
+            image.setPosition(xOffset, 10 + offset);
             image.setSize(32, 26);
             image.setHandler(button -> building.getWindow().open());
 
             final ButtonImage iconImage = new ButtonImage();
             iconImage.setImage(new ResourceLocation("minecolonies:textures/gui/modules/main.png"), false);
             iconImage.setID("main");
-            iconImage.setPosition(-15, 13 + offset);
+            iconImage.setPosition(iconXOffset, 13 + offset);
             iconImage.setSize(20, 20);
             iconImage.setHandler(button -> building.getWindow().open());
 
             offset += image.getHeight() + 2;
 
-            this.addChild(image);
-            this.addChild(iconImage);
+            window.addChild(image);
+            window.addChild(iconImage);
 
             PaneBuilders.tooltipBuilder().hoverPane(iconImage).build().setText(Component.translatable(LABEL_MAIN_TAB_NAME));
         }
@@ -80,7 +88,7 @@ public abstract class AbstractModuleWindow extends AbstractWindowSkeleton implem
 
             final ButtonImage image = new ButtonImage();
             image.setImage(new ResourceLocation("minecolonies:textures/gui/modules/tab_side" + (random.nextInt(3) + 1) + ".png"), false);
-            image.setPosition(-20, 10 + offset);
+            image.setPosition(xOffset, 10 + offset);
             image.setSize(32, 26);
             image.setHandler(button -> {
                 mc.getSoundManager().play(SimpleSoundInstance.forUI(SoundEvents.BOOK_PAGE_TURN, 1.0F));
@@ -92,7 +100,7 @@ public abstract class AbstractModuleWindow extends AbstractWindowSkeleton implem
             iconImage.setImage(new ResourceLocation("minecolonies:textures/gui/modules/" + icon + ".png"), false);
             iconImage.setSize(20, 20);
             iconImage.setID(icon);
-            iconImage.setPosition(-15, 13 + offset);
+            iconImage.setPosition(iconXOffset, 13 + offset);
             iconImage.setHandler(button -> {
                 mc.getSoundManager().play(SimpleSoundInstance.forUI(SoundEvents.BOOK_PAGE_TURN, 1.0F));
                 view.getWindow().open();
@@ -100,8 +108,8 @@ public abstract class AbstractModuleWindow extends AbstractWindowSkeleton implem
 
             offset += image.getHeight() + 2;
 
-            this.addChild(image);
-            this.addChild(iconImage);
+            window.addChild(image);
+            window.addChild(iconImage);
 
             PaneBuilders.tooltipBuilder().hoverPane(iconImage).build().setText(Component.translatable(view.getDesc().toLowerCase(Locale.US)));
         }

--- a/src/main/java/com/minecolonies/core/client/gui/WindowPostBox.java
+++ b/src/main/java/com/minecolonies/core/client/gui/WindowPostBox.java
@@ -1,18 +1,20 @@
 package com.minecolonies.core.client.gui;
 
 import com.ldtteam.blockui.Pane;
-import com.ldtteam.blockui.controls.Button;
-import com.ldtteam.blockui.controls.ItemIcon;
-import com.ldtteam.blockui.controls.Text;
-import com.ldtteam.blockui.controls.TextField;
+import com.ldtteam.blockui.PaneBuilders;
+import com.ldtteam.blockui.controls.*;
 import com.ldtteam.blockui.views.ScrollingList;
+import com.minecolonies.api.colony.buildings.modules.IBuildingModuleView;
 import com.minecolonies.api.util.ItemStackUtils;
 import com.minecolonies.api.util.constant.Constants;
 import com.minecolonies.core.Network;
 import com.minecolonies.core.colony.buildings.views.AbstractBuildingView;
 import com.minecolonies.core.network.messages.server.colony.OpenInventoryMessage;
 import com.minecolonies.core.network.messages.server.colony.building.postbox.PostBoxRequestMessage;
+import net.minecraft.client.resources.sounds.SimpleSoundInstance;
 import net.minecraft.network.chat.Component;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.sounds.SoundEvents;
 import net.minecraft.world.item.EnchantedBookItem;
 import net.minecraft.client.Minecraft;
 import net.minecraft.world.item.ItemStack;
@@ -24,6 +26,7 @@ import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
 import static com.minecolonies.api.util.constant.WindowConstants.*;
+import static com.minecolonies.api.util.constant.translation.GuiTranslationConstants.LABEL_MAIN_TAB_NAME;
 
 /**
  * BOWindow for the replace block GUI.
@@ -97,6 +100,75 @@ public class WindowPostBox extends AbstractWindowRequestTree
                 this.tick = 10;
             }
         });
+
+        int offset = 0;
+        final Random random = new Random(buildingView.getID().hashCode());
+        boolean anyVisible = false;
+
+        for (IBuildingModuleView view : buildingView.getAllModuleViews())
+        {
+            if (view.isPageVisible())
+            {
+                anyVisible = true;
+                break;
+            }
+        }
+
+
+        if (buildingView.getAllModuleViews().size() > 0 && anyVisible)
+        {
+            final ButtonImage image = new ButtonImage();
+            image.setImage(new ResourceLocation("minecolonies:textures/gui/modules/tab_side" + (random.nextInt(3) + 1) + ".png"), false);
+            image.setPosition(-5, 10 + offset);
+            image.setSize(32, 26);
+            image.setHandler(button -> buildingView.getWindow().open());
+
+            final ButtonImage iconImage = new ButtonImage();
+            iconImage.setImage(new ResourceLocation("minecolonies:textures/gui/modules/main.png"), false);
+            iconImage.setID("main");
+            iconImage.setPosition(0, 13 + offset);
+            iconImage.setSize(20, 20);
+            iconImage.setHandler(button -> buildingView.getWindow().open());
+
+            offset += image.getHeight() + 2;
+
+            this.addChild(image);
+            this.addChild(iconImage);
+
+            PaneBuilders.tooltipBuilder().hoverPane(iconImage).build().setText(Component.translatable(LABEL_MAIN_TAB_NAME));
+        }
+
+        for (IBuildingModuleView view : buildingView.getAllModuleViews())
+        {
+            if (!view.isPageVisible()) continue;
+
+            final ButtonImage image = new ButtonImage();
+            image.setImage(new ResourceLocation("minecolonies:textures/gui/modules/tab_side" + (random.nextInt(3) + 1) + ".png"), false);
+            image.setPosition(-5, 10 + offset);
+            image.setSize(32, 26);
+            image.setHandler(button -> {
+                mc.getSoundManager().play(SimpleSoundInstance.forUI(SoundEvents.BOOK_PAGE_TURN, 1.0F));
+                view.getWindow().open();
+            });
+
+            final String icon = view.getIcon();
+            final ButtonImage iconImage = new ButtonImage();
+            iconImage.setImage(new ResourceLocation("minecolonies:textures/gui/modules/" + icon + ".png"), false);
+            iconImage.setSize(20, 20);
+            iconImage.setID(icon);
+            iconImage.setPosition(0, 13 + offset);
+            iconImage.setHandler(button -> {
+                mc.getSoundManager().play(SimpleSoundInstance.forUI(SoundEvents.BOOK_PAGE_TURN, 1.0F));
+                view.getWindow().open();
+            });
+
+            offset += image.getHeight() + 2;
+
+            this.addChild(image);
+            this.addChild(iconImage);
+
+            PaneBuilders.tooltipBuilder().hoverPane(iconImage).build().setText(Component.translatable(view.getDesc().toLowerCase(Locale.US)));
+        }
     }
 
     /**

--- a/src/main/java/com/minecolonies/core/client/gui/WindowPostBox.java
+++ b/src/main/java/com/minecolonies/core/client/gui/WindowPostBox.java
@@ -27,6 +27,7 @@ import java.util.stream.Collectors;
 
 import static com.minecolonies.api.util.constant.WindowConstants.*;
 import static com.minecolonies.api.util.constant.translation.GuiTranslationConstants.LABEL_MAIN_TAB_NAME;
+import static com.minecolonies.core.client.gui.AbstractModuleWindow.placeWindowModuleViews;
 
 /**
  * BOWindow for the replace block GUI.
@@ -100,75 +101,7 @@ public class WindowPostBox extends AbstractWindowRequestTree
                 this.tick = 10;
             }
         });
-
-        int offset = 0;
-        final Random random = new Random(buildingView.getID().hashCode());
-        boolean anyVisible = false;
-
-        for (IBuildingModuleView view : buildingView.getAllModuleViews())
-        {
-            if (view.isPageVisible())
-            {
-                anyVisible = true;
-                break;
-            }
-        }
-
-
-        if (buildingView.getAllModuleViews().size() > 0 && anyVisible)
-        {
-            final ButtonImage image = new ButtonImage();
-            image.setImage(new ResourceLocation("minecolonies:textures/gui/modules/tab_side" + (random.nextInt(3) + 1) + ".png"), false);
-            image.setPosition(-5, 10 + offset);
-            image.setSize(32, 26);
-            image.setHandler(button -> buildingView.getWindow().open());
-
-            final ButtonImage iconImage = new ButtonImage();
-            iconImage.setImage(new ResourceLocation("minecolonies:textures/gui/modules/main.png"), false);
-            iconImage.setID("main");
-            iconImage.setPosition(0, 13 + offset);
-            iconImage.setSize(20, 20);
-            iconImage.setHandler(button -> buildingView.getWindow().open());
-
-            offset += image.getHeight() + 2;
-
-            this.addChild(image);
-            this.addChild(iconImage);
-
-            PaneBuilders.tooltipBuilder().hoverPane(iconImage).build().setText(Component.translatable(LABEL_MAIN_TAB_NAME));
-        }
-
-        for (IBuildingModuleView view : buildingView.getAllModuleViews())
-        {
-            if (!view.isPageVisible()) continue;
-
-            final ButtonImage image = new ButtonImage();
-            image.setImage(new ResourceLocation("minecolonies:textures/gui/modules/tab_side" + (random.nextInt(3) + 1) + ".png"), false);
-            image.setPosition(-5, 10 + offset);
-            image.setSize(32, 26);
-            image.setHandler(button -> {
-                mc.getSoundManager().play(SimpleSoundInstance.forUI(SoundEvents.BOOK_PAGE_TURN, 1.0F));
-                view.getWindow().open();
-            });
-
-            final String icon = view.getIcon();
-            final ButtonImage iconImage = new ButtonImage();
-            iconImage.setImage(new ResourceLocation("minecolonies:textures/gui/modules/" + icon + ".png"), false);
-            iconImage.setSize(20, 20);
-            iconImage.setID(icon);
-            iconImage.setPosition(0, 13 + offset);
-            iconImage.setHandler(button -> {
-                mc.getSoundManager().play(SimpleSoundInstance.forUI(SoundEvents.BOOK_PAGE_TURN, 1.0F));
-                view.getWindow().open();
-            });
-
-            offset += image.getHeight() + 2;
-
-            this.addChild(image);
-            this.addChild(iconImage);
-
-            PaneBuilders.tooltipBuilder().hoverPane(iconImage).build().setText(Component.translatable(view.getDesc().toLowerCase(Locale.US)));
-        }
+        placeWindowModuleViews(this, buildingView, -5, this.mc);
     }
 
     /**

--- a/src/main/java/com/minecolonies/core/colony/buildings/modules/MinimumStockModule.java
+++ b/src/main/java/com/minecolonies/core/colony/buildings/modules/MinimumStockModule.java
@@ -57,8 +57,9 @@ public class MinimumStockModule extends AbstractBuildingModule implements IMinim
     private int minimumStockSize()
     {
         final double increase = 1 + building.getColony().getResearchManager().getResearchEffects().getEffectStrength(MINIMUM_STOCK);
+        final int buildingLevelOr1 = building.getMaxBuildingLevel() != 0 ? building.getBuildingLevel() : 1;
 
-        return (int) (building.getBuildingLevel() * STOCK_PER_LEVEL * increase);
+        return (int) (buildingLevelOr1 * STOCK_PER_LEVEL * increase);
     }
 
     @Override

--- a/src/main/java/com/minecolonies/core/colony/buildings/modules/MinimumStockModule.java
+++ b/src/main/java/com/minecolonies/core/colony/buildings/modules/MinimumStockModule.java
@@ -57,9 +57,9 @@ public class MinimumStockModule extends AbstractBuildingModule implements IMinim
     private int minimumStockSize()
     {
         final double increase = 1 + building.getColony().getResearchManager().getResearchEffects().getEffectStrength(MINIMUM_STOCK);
-        final int buildingLevelOr1 = building.getMaxBuildingLevel() != 0 ? building.getBuildingLevel() : 1;
+        final int buildingLevelOr5 = building.getMaxBuildingLevel() != 0 ? building.getBuildingLevel() : 5;
 
-        return (int) (buildingLevelOr1 * STOCK_PER_LEVEL * increase);
+        return (int) (buildingLevelOr5 * STOCK_PER_LEVEL * increase);
     }
 
     @Override

--- a/src/main/java/com/minecolonies/core/colony/buildings/workerbuildings/PostBox.java
+++ b/src/main/java/com/minecolonies/core/colony/buildings/workerbuildings/PostBox.java
@@ -62,6 +62,9 @@ public class PostBox extends AbstractBuilding implements IRSComponent
     }
 
     @Override
+    public int getBuildingLevel() { return 1; }
+
+    @Override
     public boolean canBeGathered()
     {
         return false;

--- a/src/main/java/com/minecolonies/core/colony/buildings/workerbuildings/PostBox.java
+++ b/src/main/java/com/minecolonies/core/colony/buildings/workerbuildings/PostBox.java
@@ -62,9 +62,6 @@ public class PostBox extends AbstractBuilding implements IRSComponent
     }
 
     @Override
-    public int getBuildingLevel() { return 1; }
-
-    @Override
     public boolean canBeGathered()
     {
         return false;


### PR DESCRIPTION
## Testing
- [x] Yes I tested this before submitting it.
- [ ] I also did a multiplayer test.

![image](https://github.com/user-attachments/assets/f43fe1d2-9786-4fa0-854e-8be408daca65)

Structural notes that might need changed:

 - As noted in discord, I copied a bunch of code, which doesn't feel great.  `WindowPostBox extends AbstractWindowRequestTree extends AbstractWindowSkeleton`, but the existing code for rendering those tabs is in `AbstractModuleWindow extends AbstractWindowSkeleton`.  I copied the code to WindowPostBox because I don't see a good way of refactoring the inheritance to make it work without multiple inheritance (which isn't in Java)

 - The Minimum Stock module gets the amount of minimum stocks based on the hut level.  I added a check to use '1' if the building `getMaxBuildingLevel() == 0`.

Review please


