### PR TITLE
Fix deco controller rotation & display

### DIFF
--- a/src/main/java/com/minecolonies/core/client/gui/WindowDecorationController.java
+++ b/src/main/java/com/minecolonies/core/client/gui/WindowDecorationController.java
@@ -59,7 +59,8 @@ public class WindowDecorationController extends AbstractWindowSkeleton
         registerButton(BUTTON_REPAIR, this::repairClicked);
         registerButton(BUTTON_CANCEL, this::cancelClicked);
 
-        findPaneOfTypeByID(LABEL_NAME, Text.class).setText(Component.literal(controller.getBlueprintPath()));
+        findPaneOfTypeByID(LABEL_NAME, Text.class).setText(Component.literal(controller.getBlueprintPath()
+                .replace(".blueprint", "").replace("\\", "/").replace("/", "\n")));
 
         final IColonyView view = IColonyManager.getInstance().getClosestColonyView(world, controller.getBlockPos());
 

--- a/src/main/java/com/minecolonies/core/tileentities/TileEntityDecorationController.java
+++ b/src/main/java/com/minecolonies/core/tileentities/TileEntityDecorationController.java
@@ -3,11 +3,12 @@ package com.minecolonies.core.tileentities;
 import com.ldtteam.structurize.api.util.IRotatableBlockEntity;
 import com.ldtteam.structurize.blockentities.interfaces.IBlueprintDataProviderBE;
 import com.ldtteam.structurize.storage.StructurePacks;
-import com.ldtteam.structurize.util.RotationMirror;
 import com.minecolonies.api.compatibility.newstruct.BlueprintMapping;
 import com.minecolonies.api.tileentities.MinecoloniesTileEntities;
+import com.minecolonies.api.util.BlockPosUtil;
 import com.minecolonies.api.util.Utils;
 import com.minecolonies.api.util.WorldUtil;
+import com.minecolonies.core.util.BuildingUtils;
 import net.minecraft.core.BlockPos;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.network.Connection;
@@ -17,6 +18,7 @@ import net.minecraft.world.level.block.Mirror;
 import net.minecraft.world.level.block.Rotation;
 import net.minecraft.world.level.block.entity.BlockEntity;
 import net.minecraft.world.level.block.state.BlockState;
+import org.apache.commons.lang3.StringUtils;
 import org.jetbrains.annotations.NotNull;
 
 import javax.annotation.Nullable;
@@ -54,7 +56,8 @@ public class TileEntityDecorationController extends BlockEntity implements IBlue
     /**
      * The used rotation/mirror.
      */
-    private RotationMirror rotMir = RotationMirror.NONE;
+    private int cachedRotation = -1;
+    private boolean isMirrored = false;
 
     /**
      * Map of block positions relative to TE pos and string tags
@@ -210,18 +213,27 @@ public class TileEntityDecorationController extends BlockEntity implements IBlue
     }
 
     @Override
-    public void load(final CompoundTag compound)
+    public void load(@NotNull final CompoundTag compound)
     {
         super.load(compound);
         IBlueprintDataProviderBE.super.readSchematicDataFromNBT(compound);
-        this.rotMir = RotationMirror.of(Rotation.values()[compound.getInt(TAG_ROTATION)],
-                compound.getBoolean(TAG_MIRROR) ? Mirror.FRONT_BACK : Mirror.NONE);
-        if(compound.contains(TAG_PATH))
+        this.cachedRotation = -1;
+        this.isMirrored = compound.getBoolean(TAG_MIRROR);
+
+        // inexplicably IBlueprintDataProviderBE does not load the pack/path even though it saved them
+        this.packName = compound.getCompound(TAG_BLUEPRINTDATA).getString(TAG_PACK);
+        this.schematicPath = compound.getCompound(TAG_BLUEPRINTDATA).getString(TAG_PATH);
+
+        // the rest of this is backwards compat code that can be removed at some point (maybe even now)
+        if(compound.contains(TAG_PATH) && StringUtils.isEmpty(this.schematicPath))
         {
             this.schematicPath = compound.getString(TAG_PATH);
         }
-
-        if(compound.contains(TAG_NAME))
+        if(compound.contains(TAG_PACK) && StringUtils.isEmpty(this.packName))
+        {
+            this.packName = compound.getString(TAG_PACK);
+        }
+        if(compound.contains(TAG_NAME) && StringUtils.isEmpty(this.schematicName))
         {
             this.schematicName = compound.getString(TAG_NAME);
             if (this.schematicPath == null || this.schematicPath.isEmpty())
@@ -231,7 +243,7 @@ public class TileEntityDecorationController extends BlockEntity implements IBlue
                 this.schematicName = "";
             }
         }
-        this.packName = compound.getString(TAG_PACK);
+        // end of backwards compat code
 
         if (!this.schematicPath.endsWith(".blueprint"))
         {
@@ -240,15 +252,11 @@ public class TileEntityDecorationController extends BlockEntity implements IBlue
     }
 
     @Override
-    public void saveAdditional(final CompoundTag compound)
+    public void saveAdditional(@NotNull final CompoundTag compound)
     {
         super.saveAdditional(compound);
         writeSchematicDataToNBT(compound);
-        compound.putInt(TAG_ROTATION, this.rotMir.rotation().ordinal());
-        compound.putBoolean(TAG_MIRROR, this.rotMir.isMirrored());
-        compound.putString(TAG_NAME, schematicName == null ? "" : schematicName);
-        compound.putString(TAG_PATH, schematicPath == null ? "" : schematicPath);
-        compound.putString(TAG_PACK, (packName == null || packName.isEmpty()) ? "" : packName);
+        compound.putBoolean(TAG_MIRROR, this.isMirrored);
     }
 
     @Nullable
@@ -299,13 +307,13 @@ public class TileEntityDecorationController extends BlockEntity implements IBlue
     @Override
     public void rotate(final Rotation rotationIn)
     {
-        this.rotMir = this.rotMir.rotate(rotationIn);
+        this.cachedRotation = -1;
     }
 
     @Override
     public void mirror(final Mirror mirror)
     {
-        this.rotMir = this.rotMir.mirrorate(mirror);
+        this.isMirrored = mirror != Mirror.NONE;
     }
 
     /**
@@ -314,7 +322,11 @@ public class TileEntityDecorationController extends BlockEntity implements IBlue
      */
     public Rotation getRotation()
     {
-        return this.rotMir.rotation();
+        if (this.cachedRotation == -1)
+        {
+            this.cachedRotation = BuildingUtils.getRotationFromBlueprint(getLevel(), getBlockPos());
+        }
+        return BlockPosUtil.getRotationFromRotations(this.cachedRotation);
     }
 
     /**
@@ -323,6 +335,6 @@ public class TileEntityDecorationController extends BlockEntity implements IBlue
      */
     public boolean getMirror()
     {
-        return this.rotMir.isMirrored();
+        return this.isMirrored;
     }
 }

--- a/src/main/resources/assets/minecolonies/gui/windowdecorationcontroller.xml
+++ b/src/main/resources/assets/minecolonies/gui/windowdecorationcontroller.xml
@@ -2,15 +2,15 @@
 
     <image source="minecolonies:textures/gui/citizen/colonist_paper.png" size="100% 100%"/>
 
-    <label id="name" size="150 11" pos="15 10" textcolor="black" textalign="TOP_MIDDLE"/>
+    <label id="name" size="150 60" pos="15 10" color="black" textalign="TOP_MIDDLE"/>
 
     <buttonimage id="cancel" size="14 15" pos="400 0"
-                 source="minecolonies:textures/gui/button_x.png" textcolor="black"/>
+                 source="minecolonies:textures/gui/button_x.png" color="black"/>
 
-    <buttonimage id="repair" size="86 17" pos="50 50"
+    <buttonimage id="repair" size="86 17" pos="50 70"
                  source="minecolonies:textures/gui/builderhut/builder_button_medium.png"
-                 label="$(com.minecolonies.coremod.gui.workerhuts.repair)" textcolor="black"/>
-    <buttonimage id="build" size="86 17" pos="50 70"
+                 label="$(com.minecolonies.coremod.gui.workerhuts.repair)" color="black"/>
+    <buttonimage id="build" size="86 17" pos="50 90"
                  source="minecolonies:textures/gui/builderhut/builder_button_medium.png"
-                 label="$(com.minecolonies.coremod.gui.workerhuts.upgrade)" textcolor="black"/>
+                 label="$(com.minecolonies.coremod.gui.workerhuts.upgrade)" color="black"/>
 </window>


### PR DESCRIPTION
Closes [discord request](https://discord.com/channels/472875599422291968/938589424441233458/1339880577175916554)

# Changes proposed in this pull request
- Make decoration controllers use the same "refer to blueprint" method as huts to determine relative rotation (fixes rotation bugs if not scanned at 0 rotation).
- Removes some redundant NBT values from decoration controllers.
- Adjusts deco controller UI to make blueprint path more readable.

## Testing
- [x] Yes I tested this before submitting it.
- [ ] I also did a multiplayer test.

Review please (probably port)

One alternative to this would be to just set the stored rotation to 0 on scan, but that's actually harder to arrange since there isn't a good hook in Structurize that isn't called at other times.  And this avoids having to re-scan existing blueprints.