### PR TITLE
Guard armor/dimension change fixes

### DIFF
--- a/src/main/java/com/minecolonies/api/entity/other/AbstractFastMinecoloniesEntity.java
+++ b/src/main/java/com/minecolonies/api/entity/other/AbstractFastMinecoloniesEntity.java
@@ -369,4 +369,15 @@ public abstract class AbstractFastMinecoloniesEntity extends PathfinderMob imple
      * @return the team name.
      */
     public abstract int getTeamId();
+
+    /**
+     * Preven dimension changes
+     *
+     * @return
+     */
+    @Override
+    public boolean canChangeDimensions()
+    {
+        return false;
+    }
 }

--- a/src/main/java/com/minecolonies/core/colony/events/raid/RaidManager.java
+++ b/src/main/java/com/minecolonies/core/colony/events/raid/RaidManager.java
@@ -489,7 +489,10 @@ public class RaidManager implements IRaiderManager
 
         if (amount == 0)
         {
-            Log.getLogger().info("Trying to spawn raid on colony with no loaded buildings, aborting!");
+            Log.getLogger()
+                .info("Trying to spawn raid on colony with no loaded buildings, aborting! Colony:" + colony.getID() + " buildings:" + colony.getBuildingManager()
+                    .getBuildings()
+                    .size() + " isActive:" + colony.isActive() + " colony state:" + colony.getState());
             return null;
         }
 

--- a/src/main/java/com/minecolonies/core/colony/jobs/AbstractJob.java
+++ b/src/main/java/com/minecolonies/core/colony/jobs/AbstractJob.java
@@ -11,18 +11,18 @@ import com.minecolonies.api.colony.jobs.registry.IJobRegistry;
 import com.minecolonies.api.colony.jobs.registry.JobEntry;
 import com.minecolonies.api.colony.requestsystem.StandardFactoryController;
 import com.minecolonies.api.colony.requestsystem.request.IRequest;
-import com.minecolonies.api.colony.requestsystem.requestable.IDeliverable;
 import com.minecolonies.api.colony.requestsystem.token.IToken;
 import com.minecolonies.api.entity.ai.ITickingStateAI;
 import com.minecolonies.api.entity.ai.statemachine.states.AIWorkerState;
 import com.minecolonies.api.entity.citizen.AbstractEntityCitizen;
 import com.minecolonies.api.util.BlockPosUtil;
+import com.minecolonies.api.util.ItemStackUtils;
 import com.minecolonies.api.util.Log;
 import com.minecolonies.api.util.NBTUtils;
-import com.minecolonies.api.util.constant.TypeConstants;
 import com.minecolonies.api.util.constant.translation.RequestSystemTranslationConstants;
 import com.minecolonies.core.colony.interactionhandling.RequestBasedInteraction;
 import com.minecolonies.core.entity.ai.workers.AbstractAISkeleton;
+import com.minecolonies.core.entity.citizen.EntityCitizen;
 import net.minecraft.core.BlockPos;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.nbt.Tag;
@@ -30,6 +30,7 @@ import net.minecraft.network.FriendlyByteBuf;
 import net.minecraft.network.chat.Component;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.damagesource.DamageSource;
+import net.minecraft.world.entity.EquipmentSlot;
 import net.minecraft.world.item.ItemStack;
 import org.jetbrains.annotations.NotNull;
 
@@ -444,6 +445,25 @@ public abstract class AbstractJob<AI extends AbstractAISkeleton<J> & ITickingSta
 
         workBuilding = null;
         workModule = null;
+
+        citizen.getInventory().moveArmorToInventory(EquipmentSlot.MAINHAND);
+        citizen.getInventory().moveArmorToInventory(EquipmentSlot.OFFHAND);
+        citizen.getInventory().moveArmorToInventory(EquipmentSlot.HEAD);
+        citizen.getInventory().moveArmorToInventory(EquipmentSlot.CHEST);
+        citizen.getInventory().moveArmorToInventory(EquipmentSlot.LEGS);
+        citizen.getInventory().moveArmorToInventory(EquipmentSlot.FEET);
+
+        if (this.getCitizen().getEntity().isPresent())
+        {
+            final EntityCitizen citizenEntity = (EntityCitizen) getCitizen().getEntity().get();
+
+            citizenEntity.setItemSlot(EquipmentSlot.MAINHAND, ItemStackUtils.EMPTY);
+            citizenEntity.setItemSlot(EquipmentSlot.OFFHAND, ItemStackUtils.EMPTY);
+            citizenEntity.setItemSlot(EquipmentSlot.HEAD, ItemStackUtils.EMPTY);
+            citizenEntity.setItemSlot(EquipmentSlot.CHEST, ItemStackUtils.EMPTY);
+            citizenEntity.setItemSlot(EquipmentSlot.LEGS, ItemStackUtils.EMPTY);
+            citizenEntity.setItemSlot(EquipmentSlot.FEET, ItemStackUtils.EMPTY);
+        }
     }
 
     @Override

--- a/src/main/java/com/minecolonies/core/colony/jobs/AbstractJobGuard.java
+++ b/src/main/java/com/minecolonies/core/colony/jobs/AbstractJobGuard.java
@@ -3,14 +3,11 @@ package com.minecolonies.core.colony.jobs;
 import com.minecolonies.api.colony.ICitizenData;
 import com.minecolonies.api.colony.buildings.IBuilding;
 import com.minecolonies.api.entity.citizen.AbstractEntityCitizen;
-import com.minecolonies.api.util.ItemStackUtils;
 import com.minecolonies.core.MineColonies;
 import com.minecolonies.core.colony.buildings.AbstractBuildingGuards;
 import com.minecolonies.core.entity.ai.workers.guard.AbstractEntityAIGuard;
 import com.minecolonies.core.util.AttributeModifierUtils;
 import net.minecraft.world.damagesource.DamageSource;
-import net.minecraft.world.entity.EquipmentSlot;
-import net.minecraft.world.entity.Mob;
 import net.minecraft.world.entity.ai.attributes.AttributeModifier;
 
 import static com.minecolonies.api.entity.ai.statemachine.states.AIWorkerState.GUARD_SLEEP;
@@ -82,24 +79,6 @@ public abstract class AbstractJobGuard<J extends AbstractJobGuard<J>> extends Ab
                 new AttributeModifier(GUARD_HEALTH_MOD_CONFIG_NAME,
                     MineColonies.getConfig().getServer().guardHealthMult.get() - 1.0,
                     AttributeModifier.Operation.MULTIPLY_TOTAL));
-        }
-    }
-
-    @Override
-    public void onRemoval()
-    {
-        super.onRemoval();
-
-        if (this.getCitizen().getEntity().isPresent())
-        {
-            final Mob citizenEntity = getCitizen().getEntity().get();
-            // Unequip armor and weapons
-            citizenEntity.setItemSlot(EquipmentSlot.MAINHAND, ItemStackUtils.EMPTY);
-            citizenEntity.setItemSlot(EquipmentSlot.OFFHAND, ItemStackUtils.EMPTY);
-            citizenEntity.setItemSlot(EquipmentSlot.HEAD, ItemStackUtils.EMPTY);
-            citizenEntity.setItemSlot(EquipmentSlot.CHEST, ItemStackUtils.EMPTY);
-            citizenEntity.setItemSlot(EquipmentSlot.LEGS, ItemStackUtils.EMPTY);
-            citizenEntity.setItemSlot(EquipmentSlot.FEET, ItemStackUtils.EMPTY);
         }
     }
 }

--- a/src/main/java/com/minecolonies/core/colony/jobs/AbstractJobGuard.java
+++ b/src/main/java/com/minecolonies/core/colony/jobs/AbstractJobGuard.java
@@ -3,11 +3,14 @@ package com.minecolonies.core.colony.jobs;
 import com.minecolonies.api.colony.ICitizenData;
 import com.minecolonies.api.colony.buildings.IBuilding;
 import com.minecolonies.api.entity.citizen.AbstractEntityCitizen;
+import com.minecolonies.api.util.ItemStackUtils;
 import com.minecolonies.core.MineColonies;
 import com.minecolonies.core.colony.buildings.AbstractBuildingGuards;
 import com.minecolonies.core.entity.ai.workers.guard.AbstractEntityAIGuard;
 import com.minecolonies.core.util.AttributeModifierUtils;
 import net.minecraft.world.damagesource.DamageSource;
+import net.minecraft.world.entity.EquipmentSlot;
+import net.minecraft.world.entity.Mob;
 import net.minecraft.world.entity.ai.attributes.AttributeModifier;
 
 import static com.minecolonies.api.entity.ai.statemachine.states.AIWorkerState.GUARD_SLEEP;
@@ -74,11 +77,29 @@ public abstract class AbstractJobGuard<J extends AbstractJobGuard<J>> extends Ab
         if (workBuilding instanceof AbstractBuildingGuards)
         {
             AttributeModifierUtils.addHealthModifier(citizen,
-              new AttributeModifier(GUARD_HEALTH_MOD_BUILDING_NAME, ((AbstractBuildingGuards) workBuilding).getBonusHealth(), AttributeModifier.Operation.ADDITION));
+                new AttributeModifier(GUARD_HEALTH_MOD_BUILDING_NAME, ((AbstractBuildingGuards) workBuilding).getBonusHealth(), AttributeModifier.Operation.ADDITION));
             AttributeModifierUtils.addHealthModifier(citizen,
-              new AttributeModifier(GUARD_HEALTH_MOD_CONFIG_NAME,
-                MineColonies.getConfig().getServer().guardHealthMult.get() - 1.0,
-                AttributeModifier.Operation.MULTIPLY_TOTAL));
+                new AttributeModifier(GUARD_HEALTH_MOD_CONFIG_NAME,
+                    MineColonies.getConfig().getServer().guardHealthMult.get() - 1.0,
+                    AttributeModifier.Operation.MULTIPLY_TOTAL));
+        }
+    }
+
+    @Override
+    public void onRemoval()
+    {
+        super.onRemoval();
+
+        if (this.getCitizen().getEntity().isPresent())
+        {
+            final Mob citizenEntity = getCitizen().getEntity().get();
+            // Unequip armor and weapons
+            citizenEntity.setItemSlot(EquipmentSlot.MAINHAND, ItemStackUtils.EMPTY);
+            citizenEntity.setItemSlot(EquipmentSlot.OFFHAND, ItemStackUtils.EMPTY);
+            citizenEntity.setItemSlot(EquipmentSlot.HEAD, ItemStackUtils.EMPTY);
+            citizenEntity.setItemSlot(EquipmentSlot.CHEST, ItemStackUtils.EMPTY);
+            citizenEntity.setItemSlot(EquipmentSlot.LEGS, ItemStackUtils.EMPTY);
+            citizenEntity.setItemSlot(EquipmentSlot.FEET, ItemStackUtils.EMPTY);
         }
     }
 }


### PR DESCRIPTION
Closes #10653
Closes #

# Changes proposed in this pull request
- Prevent entity dimension changes
- Fix guards not unequipping armor after loosing their job
- Improve raidmanager logging for raids on colonies without loaded buildings

## Testing
- [x] Yes I tested this before submitting it.
- [ ] I also did a multiplayer test.

Review please