### PR TITLE
Partial port of #10656

### DIFF
--- a/src/main/java/com/minecolonies/core/client/gui/WindowDecorationController.java
+++ b/src/main/java/com/minecolonies/core/client/gui/WindowDecorationController.java
@@ -59,7 +59,8 @@ public class WindowDecorationController extends AbstractWindowSkeleton
         registerButton(BUTTON_REPAIR, this::repairClicked);
         registerButton(BUTTON_CANCEL, this::cancelClicked);
 
-        findPaneOfTypeByID(LABEL_NAME, Text.class).setText(Component.literal(controller.getBlueprintPath()));
+        findPaneOfTypeByID(LABEL_NAME, Text.class).setText(Component.literal(controller.getBlueprintPath()
+                .replace(".blueprint", "").replace("\\", "/").replace("/", "\n")));
 
         final IColonyView view = IColonyManager.getInstance().getClosestColonyView(world, controller.getBlockPos());
 

--- a/src/main/java/com/minecolonies/core/tileentities/TileEntityDecorationController.java
+++ b/src/main/java/com/minecolonies/core/tileentities/TileEntityDecorationController.java
@@ -19,6 +19,7 @@ import net.minecraft.network.protocol.game.ClientboundBlockEntityDataPacket;
 import net.minecraft.world.level.block.entity.BlockEntity;
 import net.minecraft.util.Tuple;
 import net.minecraft.core.BlockPos;
+import org.codehaus.plexus.util.StringUtils;
 import org.jetbrains.annotations.NotNull;
 
 import javax.annotation.Nullable;
@@ -225,12 +226,21 @@ public class TileEntityDecorationController extends BlockEntity implements IBlue
             // TODO: remove this later (data break introduced in 1.20.4) because of blueprint data
             this.rotationMirror = RotationMirror.of(Rotation.values()[compound.getInt(TAG_ROTATION)], compound.getBoolean(TAG_MIRROR) ? Mirror.FRONT_BACK : Mirror.NONE);
         }
-        if(compound.contains(TAG_PATH))
+
+        // inexplicably IBlueprintDataProviderBE does not load the pack/path even though it saved them
+        this.packName = compound.getCompound(TAG_BLUEPRINTDATA).getString(TAG_PACK);
+        this.schematicPath = compound.getCompound(TAG_BLUEPRINTDATA).getString(TAG_PATH);
+
+        // the rest of this is backwards compat code that can be removed at some point (maybe even now)
+        if(compound.contains(TAG_PATH) && StringUtils.isEmpty(this.schematicName))
         {
             this.schematicPath = compound.getString(TAG_PATH);
         }
-
-        if(compound.contains(TAG_NAME))
+        if(compound.contains(TAG_PACK) && StringUtils.isEmpty(this.packName))
+        {
+            this.packName = compound.getString(TAG_PACK);
+        }
+        if(compound.contains(TAG_NAME) && StringUtils.isEmpty(this.schematicName))
         {
             this.schematicName = compound.getString(TAG_NAME);
             if (this.schematicPath == null || this.schematicPath.isEmpty())
@@ -240,7 +250,7 @@ public class TileEntityDecorationController extends BlockEntity implements IBlue
                 this.schematicName = "";
             }
         }
-        this.packName = compound.getString(TAG_PACK);
+        // end of backwards compat code
 
         if (!this.schematicPath.endsWith(".blueprint"))
         {
@@ -254,9 +264,6 @@ public class TileEntityDecorationController extends BlockEntity implements IBlue
         super.saveAdditional(compound, provider);
         writeSchematicDataToNBT(compound);
         compound.putByte(TAG_ROTATION_MIRROR, (byte) this.rotationMirror.ordinal());
-        compound.putString(TAG_NAME, schematicName == null ? "" : schematicName);
-        compound.putString(TAG_PATH, schematicPath == null ? "" : schematicPath);
-        compound.putString(TAG_PACK, (packName == null || packName.isEmpty()) ? "" : packName);
     }
 
     @Nullable

--- a/src/main/resources/assets/minecolonies/gui/windowdecorationcontroller.xml
+++ b/src/main/resources/assets/minecolonies/gui/windowdecorationcontroller.xml
@@ -2,15 +2,15 @@
 
     <image source="minecolonies:textures/gui/citizen/colonist_paper.png" size="100% 100%"/>
 
-    <text id="name" size="150 11" pos="15 10" color="black" textalign="TOP_MIDDLE"/>
+    <text id="name" size="150 60" pos="15 10" color="black" textalign="TOP_MIDDLE"/>
 
     <button id="cancel" size="14 15" pos="400 0"
                  source="minecolonies:textures/gui/button_x.png" color="black"/>
 
-    <button id="repair" size="86 17" pos="50 50"
+    <button id="repair" size="86 17" pos="50 70"
                  source="minecolonies:textures/gui/builderhut/builder_button_medium.png"
                  label="$(com.minecolonies.coremod.gui.workerhuts.repair)" color="black"/>
-    <button id="build" size="86 17" pos="50 70"
+    <button id="build" size="86 17" pos="50 90"
                  source="minecolonies:textures/gui/builderhut/builder_button_medium.png"
                  label="$(com.minecolonies.coremod.gui.workerhuts.upgrade)" color="black"/>
 </window>


### PR DESCRIPTION
# Changes proposed in this pull request
- Partial port of #10656
    - Does not adjust rotation behaviour; 1.21 already used a different implementation that does not appear to be susceptible to the issues in 1.20.
    - Removes some redundant NBT values from decoration controllers.
    - Adjusts deco controller UI to make blueprint path more readable.

## Testing
- [x] Yes I tested this before submitting it.
- [ ] I also did a multiplayer test.

Review please (do not port)