### PR TITLE
Improve armor distribution, make use of attribute modifiers

### DIFF
--- a/src/main/java/com/minecolonies/api/equipment/ModEquipmentTypes.java
+++ b/src/main/java/com/minecolonies/api/equipment/ModEquipmentTypes.java
@@ -125,25 +125,25 @@ public class ModEquipmentTypes
         helmet = register("helmet",
           builder -> builder.setDisplayName(Component.translatable(ToolTranslationConstants.TOOL_TYPE_HELMET))
                        .setIsEquipment((itemStack, equipmentType) -> itemStack.getItem() instanceof ArmorItem armor && EquipmentSlot.HEAD.equals(armor.getEquipmentSlot()))
-                       .setEquipmentLevel((itemStack, equipmentType) -> ModEquipmentTypes.armorLevel(itemStack))
+                       .setEquipmentLevel((itemStack, equipmentType) -> ItemStackUtils.getArmorLevel(itemStack))
                   .build());
 
         leggings = register("leggings",
           builder -> builder.setDisplayName(Component.translatable(ToolTranslationConstants.TOOL_TYPE_LEGGINGS))
                        .setIsEquipment((itemStack, equipmentType) -> itemStack.getItem() instanceof ArmorItem armor && EquipmentSlot.LEGS.equals(armor.getEquipmentSlot()))
-                       .setEquipmentLevel((itemStack, equipmentType) -> ModEquipmentTypes.armorLevel(itemStack))
+                       .setEquipmentLevel((itemStack, equipmentType) -> ItemStackUtils.getArmorLevel(itemStack))
                   .build());
 
         chestplate = register("chestplate",
           builder -> builder.setDisplayName(Component.translatable(ToolTranslationConstants.TOOL_TYPE_CHEST_PLATE))
                        .setIsEquipment((itemStack, equipmentType) -> itemStack.getItem() instanceof ArmorItem armor && EquipmentSlot.CHEST.equals(armor.getEquipmentSlot()))
-                       .setEquipmentLevel((itemStack, equipmentType) -> ModEquipmentTypes.armorLevel(itemStack))
+                       .setEquipmentLevel((itemStack, equipmentType) -> ItemStackUtils.getArmorLevel(itemStack))
                   .build());
 
         boots = register("boots",
           builder -> builder.setDisplayName(Component.translatable(ToolTranslationConstants.TOOL_TYPE_BOOTS))
                        .setIsEquipment((itemStack, equipmentType) -> itemStack.getItem() instanceof ArmorItem armor && EquipmentSlot.FEET.equals(armor.getEquipmentSlot()))
-                       .setEquipmentLevel((itemStack, equipmentType) -> ModEquipmentTypes.armorLevel(itemStack))
+                       .setEquipmentLevel((itemStack, equipmentType) ->ItemStackUtils.getArmorLevel(itemStack))
                   .build());
 
         flint_and_steel = register("flintandsteel",
@@ -194,21 +194,6 @@ public class ModEquipmentTypes
         else if (itemStack.getItem() instanceof final TieredItem tieredItem)  // most tools
         {
             return tieredItem.getTier().getLevel();
-        }
-        return -1;
-    }
-
-    /**
-     * Get the armor level.
-     *
-     * @param itemStack The item stack to check
-     * @return The armor level
-     */
-    public static int armorLevel(ItemStack itemStack)
-    {
-        if (itemStack.getItem() instanceof final ArmorItem armorItem)
-        {
-            return ItemStackUtils.getArmorLevel(armorItem.getMaterial());
         }
         return -1;
     }


### PR DESCRIPTION
# Changes proposed in this pull request
- No longer use ArmorMaterial to calculate the armor level, not all armors provide a full set, giving wrong indications of armor level
- Vanilla armor is forced into levels 1-5
- Non-vanilla armor it's armor level is deteremined, then compared against leather - chainmail - iron - diamond in that exact order for the same armor items, giving an indication of where the armor should fit in the list
- Armor and toughness are calculated from an itemstack directly, taking attribute modifiers into account, hopefully to resolve #10586

## Testing
- [X] Yes I tested this before submitting it.
- [ ] I also did a multiplayer test.

Review please