### PR TITLE
Adjust strategy for refreshing hut inventory handlers for better compatibility with AE2 and other mods (fixes #10670)

### DIFF
--- a/src/main/java/com/minecolonies/core/colony/buildings/AbstractBuildingContainer.java
+++ b/src/main/java/com/minecolonies/core/colony/buildings/AbstractBuildingContainer.java
@@ -46,6 +46,11 @@ public abstract class AbstractBuildingContainer extends AbstractSchematicProvide
     protected final Set<BlockPos> containerList = new HashSet<>();
 
     /**
+     * Whether the container list has changed since the last capability rebuild.
+     */
+    private boolean containerListChanged = false;
+
+    /**
      * List of items the worker should keep. With the quantity and if he should keep it in the inventory as well.
      */
     protected final Map<Predicate<ItemStack>, Tuple<Integer, Boolean>> keepX = new HashMap<>();
@@ -71,6 +76,16 @@ public abstract class AbstractBuildingContainer extends AbstractSchematicProvide
         super(pos, colony);
     }
 
+    public boolean pollContainerListChanged()
+    {
+        if (containerListChanged)
+        {
+            containerListChanged = false;
+            return true;
+        }
+        return false;
+    }
+
     @Override
     public void deserializeNBT(@NotNull final HolderLookup.Provider provider, final CompoundTag compound)
     {
@@ -79,6 +94,7 @@ public abstract class AbstractBuildingContainer extends AbstractSchematicProvide
         final ListTag containerTagList = compound.getList(TAG_CONTAINERS, Tag.TAG_INT_ARRAY);
         for (int i = 0; i < containerTagList.size(); ++i)
         {
+            this.containerListChanged = true;
             containerList.add(NBTUtils.readBlockPos(containerTagList.get(i)));
         }
         if (compound.contains(TAG_PRIO))
@@ -126,12 +142,14 @@ public abstract class AbstractBuildingContainer extends AbstractSchematicProvide
     @Override
     public void addContainerPosition(@NotNull final BlockPos pos)
     {
+        this.containerListChanged = true;
         containerList.add(pos);
     }
 
     @Override
     public void removeContainerPosition(final BlockPos pos)
     {
+        this.containerListChanged = true;
         containerList.remove(pos);
     }
 

--- a/src/main/java/com/minecolonies/core/colony/buildings/AbstractBuildingContainer.java
+++ b/src/main/java/com/minecolonies/core/colony/buildings/AbstractBuildingContainer.java
@@ -76,6 +76,11 @@ public abstract class AbstractBuildingContainer extends AbstractSchematicProvide
         super(pos, colony);
     }
 
+    /**
+     * Returns whether the container list has changed since the last invocation of this method.
+     *
+     * @return whether the container list has changed
+     */
     public boolean pollContainerListChanged()
     {
         if (containerListChanged)

--- a/src/main/java/com/minecolonies/core/tileentities/TileEntityColonyBuilding.java
+++ b/src/main/java/com/minecolonies/core/tileentities/TileEntityColonyBuilding.java
@@ -465,7 +465,8 @@ public class TileEntityColonyBuilding extends AbstractTileEntityColonyBuilding i
         for (BlockPos pos : this.pendingExternalInvRemovals.keySet())
         {
             this.pendingExternalInvRemovals.computeInt(pos, (key, curr) -> {
-                if (WorldUtil.isBlockLoaded(getLevel(), key) && getLevel().getBlockEntity(key) instanceof AbstractTileEntityRack) {
+                if (WorldUtil.isBlockLoaded(getLevel(), key) && getLevel().getBlockEntity(key) instanceof AbstractTileEntityRack)
+                {
                     recreateInv[0] = true;
                     return null;
                 }

--- a/src/main/java/com/minecolonies/core/tileentities/TileEntityColonyBuilding.java
+++ b/src/main/java/com/minecolonies/core/tileentities/TileEntityColonyBuilding.java
@@ -597,7 +597,8 @@ public class TileEntityColonyBuilding extends AbstractTileEntityColonyBuilding i
      *
      * @return the combined inventory handler
      */
-    private CombinedItemHandler getOrCreateCombinedInv() {
+    private CombinedItemHandler getOrCreateCombinedInv()
+    {
         if (combinedInv != null)
         {
             return combinedInv;

--- a/src/main/java/com/minecolonies/core/tileentities/TileEntityColonyBuilding.java
+++ b/src/main/java/com/minecolonies/core/tileentities/TileEntityColonyBuilding.java
@@ -465,7 +465,7 @@ public class TileEntityColonyBuilding extends AbstractTileEntityColonyBuilding i
         for (BlockPos pos : this.pendingExternalInvRemovals.keySet())
         {
             this.pendingExternalInvRemovals.computeInt(pos, (key, curr) -> {
-                if (WorldUtil.isBlockLoaded(getLevel(), key) && getLevel().getBlockEntity(key) instanceof TileEntityRack) {
+                if (WorldUtil.isBlockLoaded(getLevel(), key) && getLevel().getBlockEntity(key) instanceof AbstractTileEntityRack) {
                     recreateInv[0] = true;
                     return null;
                 }


### PR DESCRIPTION
Closes #10670

# Changes proposed in this pull request
Instead of invalidating the item handler capability every tick, we only invalidate it when the external inventories have changed. This fixes issues with mods that attempt to operate with a capability over multiple ticks. For example, the AE2 storage bus requires 2 ticks for some operations, and will restart the operation on tick 1 if the capability is different on tick 2, leading to breakage when we recreate the capability every tick. There's room for improvement here on the AE2 side, but in general, I don't think we need to invalidate the capability every tick and this resolves the issue.

## Testing
- [X] Yes I tested this before submitting it.
- [X] I also did a multiplayer test.

Review please