### PR TITLE
Disease Durations

### DIFF
--- a/src/main/java/com/minecolonies/api/configuration/ServerConfiguration.java
+++ b/src/main/java/com/minecolonies/api/configuration/ServerConfiguration.java
@@ -30,6 +30,7 @@ public class ServerConfiguration extends AbstractConfiguration
     public final ForgeConfigSpec.IntValue     minThLevelToTeleport;
     public final ForgeConfigSpec.DoubleValue  foodModifier;
     public final ForgeConfigSpec.IntValue     diseaseModifier;
+    public final ForgeConfigSpec.IntValue     diseaseDuration;
     public final ForgeConfigSpec.BooleanValue forceLoadColony;
     public final ForgeConfigSpec.IntValue     loadtime;
     public final ForgeConfigSpec.IntValue     colonyLoadStrictness;
@@ -135,6 +136,7 @@ public class ServerConfiguration extends AbstractConfiguration
         minThLevelToTeleport = defineInteger(builder, "minthleveltoteleport", 3, 0, 5);
         foodModifier = defineDouble(builder, "foodmodifier", 1.0, 0.1, 100);
         diseaseModifier = defineInteger(builder, "diseasemodifier", 5, 1, 100);
+        diseaseDuration = defineInteger(builder, "diseaseduration", 5, 0, 100);
         forceLoadColony = defineBoolean(builder, "forceloadcolony", true);
         loadtime = defineInteger(builder, "loadtime", 10, 1, 1440);
         colonyLoadStrictness = defineInteger(builder, "colonyloadstrictness", 3, 1, 15);

--- a/src/main/java/com/minecolonies/api/util/constant/CitizenConstants.java
+++ b/src/main/java/com/minecolonies/api/util/constant/CitizenConstants.java
@@ -224,6 +224,11 @@ public final class CitizenConstants
     public static final String TAG_IMMUNITY = "immunity";
 
     /**
+     * Disease duration tag,
+     */
+    public static final String TAG_DURATION = "duration";
+
+    /**
      * Noon day time.
      */
     public static final int NOON = 6000;

--- a/src/main/java/com/minecolonies/core/entity/citizen/citizenhandlers/CitizenDiseaseHandler.java
+++ b/src/main/java/com/minecolonies/core/entity/citizen/citizenhandlers/CitizenDiseaseHandler.java
@@ -46,6 +46,11 @@ public class CitizenDiseaseHandler implements ICitizenDiseaseHandler
     private static final int IMMUNITY_TIME = 20 * 60 * 90;
 
     /**
+     * Maximum number of ticks a citizen can be sick before automatically recovering.
+     */
+    private static final int DISEASE_DURATION = 20 * 60 * 20;
+
+    /**
      * Additional immunity time through vaccines.
      */
     private static final int VACCINE_MODIFIER = 10;
@@ -65,6 +70,11 @@ public class CitizenDiseaseHandler implements ICitizenDiseaseHandler
      * Special immunity time after being cured.
      */
     private int immunityTicks = 0;
+
+    /**
+     * How long the citizen has been sick.
+     */
+    private int durationTicks = 0;
 
     /**
      * Whether the citizen sleeps at the hostpital
@@ -105,6 +115,19 @@ public class CitizenDiseaseHandler implements ICitizenDiseaseHandler
             if (citizenData.getRandom().nextInt(configModifier * DISEASE_FACTOR) < citizenModifier * 10)
             {
                 this.disease = DiseasesListener.getRandomDisease(citizenData.getEntity().map(AbstractEntityCitizen::getRandom).orElse(RandomSource.create()));
+            }
+        }
+
+        if (isSick())
+        {
+            final int configDuration = MineColonies.getConfig().getServer().diseaseDuration.get();
+            if (configDuration > 0 && durationTicks >= DISEASE_DURATION * configDuration)
+            {
+                this.cure();
+            }
+            else
+            {
+               durationTicks += tickRate;
             }
         }
 
@@ -176,6 +199,7 @@ public class CitizenDiseaseHandler implements ICitizenDiseaseHandler
             diseaseTag.putString(TAG_DISEASE_ID, disease.id().toString());
         }
         diseaseTag.putInt(TAG_IMMUNITY, immunityTicks);
+        diseaseTag.putInt(TAG_DURATION, durationTicks);
         compound.put(TAG_DISEASE, diseaseTag);
     }
 
@@ -193,6 +217,7 @@ public class CitizenDiseaseHandler implements ICitizenDiseaseHandler
             this.disease = DiseasesListener.getDisease(new ResourceLocation(diseaseTag.getString(TAG_DISEASE_ID)));
         }
         this.immunityTicks = diseaseTag.getInt(TAG_IMMUNITY);
+        this.durationTicks = diseaseTag.getInt(TAG_DURATION);
     }
 
     @Override
@@ -206,6 +231,7 @@ public class CitizenDiseaseHandler implements ICitizenDiseaseHandler
     public void cure()
     {
         this.disease = null;
+        durationTicks = 0;
         sleepsAtHospital = false;
         if (citizenData.isAsleep() && citizenData.getEntity().isPresent())
         {

--- a/src/main/resources/assets/minecolonies/lang/manual_en_us.json
+++ b/src/main/resources/assets/minecolonies/lang/manual_en_us.json
@@ -41,6 +41,8 @@
 
   "minecolonies.config.diseasemodifier": "Disease Modifier",
   "minecolonies.config.diseasemodifier.comment": "How common diseases are. 1 = Very common, 100 = extremely rare.",
+  "minecolonies.config.diseaseduration": "Disease Duration",
+  "minecolonies.config.diseaseduration.comment": "Maximum duration of a disease in days. 0 = No Limit",
   "minecolonies.config.diseases": "Diseases",
   "minecolonies.config.diseases.comment": "All diseases citizens can get. The name, how common it is, and all ingredients to cure it.",
   "minecolonies.config.configliststudyitems": "List of Study Items",


### PR DESCRIPTION
initial config and default values for disease duration

# Changes proposed in this pull request
- Sets a maximum number of days a citizen can be sick before natural recovery
- Sets the default for that to 5 days
- Makes that value configurable

## Testing
- [X] Yes I tested this before submitting it.
- [ ] I also did a multiplayer test.

First time touching anything config related. I tried to mirror how the surrounding code was set up but I might have missed things.
Since a citizen sleeping in a hospital will get better in less than one minecraft day (on average) even without a cure, I started with a default of 100 minutes (5 days). Long enough to be noticeable but close to the existing timescale things operate on.

In an ideal world this duration would be set on a disease level with a config based multiplier.