### PR TITLE
Additional raid delay after deaths

### DIFF
--- a/src/main/java/com/minecolonies/core/colony/events/raid/RaidManager.java
+++ b/src/main/java/com/minecolonies/core/colony/events/raid/RaidManager.java
@@ -104,6 +104,7 @@ public class RaidManager implements IRaiderManager
      * Difficulty nbt tag
      */
     private static final String TAG_RAID_DIFFICULTY = "difficulty";
+    private static final String TAG_RAID_DELAY = "delay";
     private static final String TAG_LOST_CITIZENS   = "lostCitizens";
 
     /**
@@ -212,6 +213,11 @@ public class RaidManager implements IRaiderManager
     private long passingThroughRaidTime = 0;
 
     /**
+     * Delays the next raid by additional days
+     */
+    private int extraDaysToNextRaid = 0;
+
+    /**
      * Creates the RaidManager for a colony.
      *
      * @param colony the colony.
@@ -245,6 +251,7 @@ public class RaidManager implements IRaiderManager
         this.raidTonight = willRaid;
         this.nextForcedType = raidType;
         this.allowShips = allowShips;
+        extraDaysToNextRaid = 0;
     }
 
     @Override
@@ -737,6 +744,7 @@ public class RaidManager implements IRaiderManager
                     if (lostPct > LOST_CITIZEN_DIFF_REDUCE_PCT)
                     {
                         raidDifficulty = Math.max(MIN_RAID_DIFFICULTY, raidDifficulty - (int) (lostPct / LOST_CITIZEN_DIFF_REDUCE_PCT));
+                        extraDaysToNextRaid = Mth.ceil(MineColonies.getConfig().getServer().averageNumberOfNightsBetweenRaids.get() * 0.4);
                     }
                     else if (lostPct < LOST_CITIZEN_DIFF_INCREASE_PCT)
                     {
@@ -851,7 +859,7 @@ public class RaidManager implements IRaiderManager
      */
     private boolean raidThisNight(final Level world, final IColony colony)
     {
-        if (nightsSinceLastRaid < MineColonies.getConfig().getServer().minimumNumberOfNightsBetweenRaids.get())
+        if (nightsSinceLastRaid < MineColonies.getConfig().getServer().minimumNumberOfNightsBetweenRaids.get() + extraDaysToNextRaid)
         {
             return false;
         }
@@ -967,6 +975,7 @@ public class RaidManager implements IRaiderManager
         compound.putBoolean(TAG_RAIDABLE, canHaveRaiderEvents());
         compound.putInt(TAG_NIGHTS_SINCE_LAST_RAID, getNightsSinceLastRaid());
         compound.putInt(TAG_RAID_DIFFICULTY, raidDifficulty);
+        compound.putInt(TAG_RAID_DELAY, extraDaysToNextRaid);
 
         ListTag nbtList = new ListTag();
         for (final RaidHistory history : raidHistories)
@@ -991,6 +1000,11 @@ public class RaidManager implements IRaiderManager
         if (compound.contains(TAG_NIGHTS_SINCE_LAST_RAID))
         {
             setNightsSinceLastRaid(compound.getInt(TAG_NIGHTS_SINCE_LAST_RAID));
+        }
+
+        if (compound.contains(TAG_RAID_DELAY))
+        {
+            extraDaysToNextRaid = compound.getInt(TAG_RAID_DELAY);
         }
 
         raidDifficulty = Mth.clamp(compound.getInt(TAG_RAID_DIFFICULTY), MIN_RAID_DIFFICULTY, MAX_RAID_DIFFICULTY);
@@ -1041,6 +1055,7 @@ public class RaidManager implements IRaiderManager
         if (((double) raidHistories.get(0).lostCitizens / colony.getCitizenManager().getMaxCitizens()) > 0.5)
         {
             MessageUtils.format(RAID_END_MERCY, colony.getName()).sendTo(colony).forManagers();
+            extraDaysToNextRaid = MineColonies.getConfig().getServer().averageNumberOfNightsBetweenRaids.get() * 2;
         }
         else
         {

--- a/src/main/java/com/minecolonies/core/colony/events/raid/RaidManager.java
+++ b/src/main/java/com/minecolonies/core/colony/events/raid/RaidManager.java
@@ -251,7 +251,6 @@ public class RaidManager implements IRaiderManager
         this.raidTonight = willRaid;
         this.nextForcedType = raidType;
         this.allowShips = allowShips;
-        extraDaysToNextRaid = 0;
     }
 
     @Override
@@ -766,6 +765,7 @@ public class RaidManager implements IRaiderManager
             RaidSpawnResult result = raiderEvent(nextForcedType, overrideConfig, allowShips);
             if (result == RaidSpawnResult.SUCCESS || result == RaidSpawnResult.TOO_SMALL)
             {
+                extraDaysToNextRaid = 0;
                 raidTonight = false;
                 nextForcedType = INITIAL_NEXT_RAID_TYPE;
             }


### PR DESCRIPTION
Closes #
Closes #

# Changes proposed in this pull request
- Increase delay to next raid, depending on previous success

## Testing
- [ ] Yes I tested this before submitting it.
- [ ] I also did a multiplayer test.

Review please