### PR TITLE
Prevent an exception during attribute calculation caused by modded items

### DIFF
--- a/src/main/java/com/minecolonies/api/util/ItemStackUtils.java
+++ b/src/main/java/com/minecolonies/api/util/ItemStackUtils.java
@@ -954,9 +954,18 @@ public final class ItemStackUtils
      */
     public static double getItemStackAttributeValue(final ItemStack itemStack, final Attribute attribute)
     {
-        final AttributeInstance instance = new AttributeInstance(attribute, (f) -> {});
-        itemStack.getAttributeModifiers(LivingEntity.getEquipmentSlotForItem(itemStack)).get(attribute).forEach(instance::addTransientModifier);
-        return instance.getValue();
+        try
+        {
+            final AttributeInstance instance = new AttributeInstance(attribute, (f) -> {
+            });
+            itemStack.getAttributeModifiers(LivingEntity.getEquipmentSlotForItem(itemStack)).get(attribute).forEach(instance::addTransientModifier);
+            return instance.getValue();
+        }
+        catch (final Exception e)
+        {
+            Log.getLogger().warn("Could not get attribute value for '{}' on item '{}'", attribute.getDescriptionId(), itemStack.getDescriptionId(), e);
+            return 0;
+        }
     }
 }
 

--- a/src/main/java/com/minecolonies/api/util/ItemStackUtils.java
+++ b/src/main/java/com/minecolonies/api/util/ItemStackUtils.java
@@ -956,8 +956,7 @@ public final class ItemStackUtils
     {
         try
         {
-            final AttributeInstance instance = new AttributeInstance(attribute, (f) -> {
-            });
+            final AttributeInstance instance = new AttributeInstance(attribute, (f) -> {});
             itemStack.getAttributeModifiers(LivingEntity.getEquipmentSlotForItem(itemStack)).get(attribute).forEach(instance::addTransientModifier);
             return instance.getValue();
         }


### PR DESCRIPTION
Closes #10726

# Changes proposed in this pull request
- Add a try catch around the method and logging in case this happens, so we can tell what items cause this issue.

## Testing
- [ ] Yes I tested this before submitting it.
- [ ] I also did a multiplayer test.

Review please