### PR TITLE
Fix highlights not clearing due to incorrect keys

### DIFF
--- a/src/main/java/com/minecolonies/core/client/gui/WindowHutAllInventory.java
+++ b/src/main/java/com/minecolonies/core/client/gui/WindowHutAllInventory.java
@@ -135,7 +135,7 @@ public class WindowHutAllInventory extends AbstractWindowSkeleton
                     // mixing equation: alpha | red part | green part 
                     final int color = 0x80000000 | (Mth.clamp((int) (0xff * (2.0f - count / 32.0f)), 0, 255) << 16)
                         | (Mth.clamp((int) (0xff * count / 32.0f), 0, 255) << 8);
-                    HighlightManager.addHighlight("inventoryHighlight" + blockPos,
+                    HighlightManager.addHighlight("inventoryHighlight", blockPos.toString(),
                       new TimedBoxRenderData(blockPos)
                         .setDuration(Duration.ofSeconds(60))
                         .addText("" + count)

--- a/src/main/java/com/minecolonies/core/client/gui/WindowSupplies.java
+++ b/src/main/java/com/minecolonies/core/client/gui/WindowSupplies.java
@@ -187,7 +187,7 @@ public class WindowSupplies extends AbstractBlueprintManipulationWindow
             int i = 0;
             for (final PlacementError error : placementErrorList)
             {
-                HighlightManager.addHighlight(RENDER_BOX_CATEGORY + i++, new TimedBoxRenderData(error.getPos())
+                HighlightManager.addHighlight(RENDER_BOX_CATEGORY, String.valueOf(i++), new TimedBoxRenderData(error.getPos())
                   .addText(Component.translatable(PARTIAL_WARNING_SUPPLY_BUILDING_ERROR + error.getType().toString().toLowerCase()).getString())
                   .setColor(0x80FF0000)
                   .setDuration(Duration.ofSeconds(60)));

--- a/src/main/java/com/minecolonies/core/client/gui/map/WindowColonyMap.java
+++ b/src/main/java/com/minecolonies/core/client/gui/map/WindowColonyMap.java
@@ -461,7 +461,7 @@ public class WindowColonyMap extends AbstractWindowSkeleton
                 citizenImage.setSize(4, 4);
                 citizenImage.setID("citizen: " + data.getId());
                 registerButton(citizenImage.getID(), button -> {
-                    HighlightManager.addHighlight("mapsearchtracking", new CitizenRenderData(citizen.getCivilianID(), HIGHLIGHT_QUEST_LOG_TRACKER_DURATION));
+                    HighlightManager.addHighlight("mapsearchtracking", "", new CitizenRenderData(citizen.getCivilianID(), HIGHLIGHT_QUEST_LOG_TRACKER_DURATION));
                     SoundUtils.playSuccessSound(mc.player, mc.player.blockPosition());
                 });
 

--- a/src/main/java/com/minecolonies/core/client/gui/questlog/WindowQuestLogAvailableQuestModule.java
+++ b/src/main/java/com/minecolonies/core/client/gui/questlog/WindowQuestLogAvailableQuestModule.java
@@ -41,7 +41,7 @@ public class WindowQuestLogAvailableQuestModule implements WindowQuestLogQuestMo
     @Override
     public void trackQuest(final IQuestInstance quest)
     {
-        HighlightManager.addHighlight(HIGHLIGHT_QUEST_LOG_TRACKER_KEY, new CitizenRenderData(quest.getQuestGiverId(), HIGHLIGHT_QUEST_LOG_TRACKER_DURATION));
+        HighlightManager.addHighlight(HIGHLIGHT_QUEST_LOG_TRACKER_KEY, "", new CitizenRenderData(quest.getQuestGiverId(), HIGHLIGHT_QUEST_LOG_TRACKER_DURATION));
     }
 
     /**

--- a/src/main/java/com/minecolonies/core/client/gui/questlog/WindowQuestLogInProgressQuestQuestModule.java
+++ b/src/main/java/com/minecolonies/core/client/gui/questlog/WindowQuestLogInProgressQuestQuestModule.java
@@ -56,7 +56,7 @@ public class WindowQuestLogInProgressQuestQuestModule implements WindowQuestLogQ
     @Override
     public void trackQuest(final IQuestInstance quest)
     {
-        HighlightManager.addHighlight(HIGHLIGHT_QUEST_LOG_TRACKER_KEY, new CitizenRenderData(quest.getQuestTarget(), HIGHLIGHT_QUEST_LOG_TRACKER_DURATION));
+        HighlightManager.addHighlight(HIGHLIGHT_QUEST_LOG_TRACKER_KEY, "", new CitizenRenderData(quest.getQuestTarget(), HIGHLIGHT_QUEST_LOG_TRACKER_DURATION));
     }
 
     /**


### PR DESCRIPTION
# Changes proposed in this pull request
- Fixes incorrect behaviour of timed block highlights due to inappropriate use of unique keys.
    - In particular, this fixes the red error highlights from supply camp/ship placement errors so that they correctly disappear immediately when you either make another placement attempt or click the red X button.
    - (Untested) This will also fix the previous warehouse search indicators remaining when performing another search.

## Testing
- [x] Yes I tested this before submitting it.
- [ ] I also did a multiplayer test.

Review please (should port)