### PR TITLE
Fix building

### DIFF
--- a/src/main/java/com/minecolonies/core/colony/jobs/AbstractJobStructure.java
+++ b/src/main/java/com/minecolonies/core/colony/jobs/AbstractJobStructure.java
@@ -37,11 +37,6 @@ public abstract class AbstractJobStructure<AI extends AbstractAISkeleton<J>, J e
     private int workOrderId;
 
     /**
-     * The structure the job should build.
-     */
-    protected Blueprint blueprint;
-
-    /**
      * Initialize citizen data.
      *
      * @param entity the citizen data.
@@ -105,6 +100,7 @@ public abstract class AbstractJobStructure<AI extends AbstractAISkeleton<J>, J e
     {
         getWorkOrder().onCompleted(getCitizen().getColony(), this.getCitizen());
 
+        final Blueprint blueprint = getWorkOrder().getBlueprint();
         if (blueprint != null)
         {
             final CompoundTag[][][] tileEntityData = blueprint.getTileEntities();

--- a/src/main/java/com/minecolonies/core/placementhandlers/main/SurvivalHandler.java
+++ b/src/main/java/com/minecolonies/core/placementhandlers/main/SurvivalHandler.java
@@ -2,6 +2,7 @@ package com.minecolonies.core.placementhandlers.main;
 
 import com.ldtteam.structurize.blocks.interfaces.ILeveledBlueprintAnchorBlock;
 import com.ldtteam.structurize.blueprints.v1.Blueprint;
+import com.ldtteam.structurize.placement.handlers.placement.PlacementHandlers;
 import com.ldtteam.structurize.storage.ISurvivalBlueprintHandler;
 import com.ldtteam.structurize.storage.StructurePacks;
 import com.ldtteam.structurize.util.PlacementSettings;
@@ -39,9 +40,7 @@ import net.minecraftforge.api.distmarker.Dist;
 import net.minecraftforge.api.distmarker.OnlyIn;
 import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.common.util.BlockSnapshot;
-import net.minecraftforge.event.entity.EntityAttributeCreationEvent;
 import net.minecraftforge.event.level.BlockEvent;
-import net.minecraftforge.event.level.BlockEvent.EntityPlaceEvent;
 import net.minecraftforge.items.wrapper.InvWrapper;
 import org.jetbrains.annotations.Nullable;
 
@@ -168,6 +167,7 @@ public class SurvivalHandler implements ISurvivalBlueprintHandler
 
                 world.destroyBlock(blockPos, true);
                 world.setBlockAndUpdate(blockPos, anchor);
+                PlacementHandlers.handleTileEntityPlacement(blueprint.getTileEntityData(blockPos, blueprint.getPrimaryBlockOffset()), world, blockPos);
                 ((AbstractBlockHut<?>) anchor.getBlock()).onBlockPlacedByBuildTool(world,
                   blockPos,
                   anchor,


### PR DESCRIPTION
Closes #10800
Closes #10796
maybe some others

# Changes proposed in this pull request
- When hut block Assigned to Builder from build tool, restore TE data immediately.
    - This applies the level 1 tags to the level 0 block, which is technically new and not directly the bugfix, but fixes some other cases that behave a bit unexpectedly.
- When build/repair complete, actually apply the correct blueprint data (broken by work order refactoring).

## Testing
- [x] Yes I tested this before submitting it.
- [ ] I also did a multiplayer test.

Review please (should port)