### PR TITLE
Fix/building rotation

### DIFF
--- a/src/main/java/com/minecolonies/api/util/ColonyUtils.java
+++ b/src/main/java/com/minecolonies/api/util/ColonyUtils.java
@@ -10,6 +10,8 @@ import net.minecraft.util.Tuple;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.Mirror;
 import net.minecraft.world.level.chunk.LevelChunk;
+import net.minecraft.world.phys.AABB;
+import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.*;
@@ -101,7 +103,7 @@ public final class ColonyUtils
     }
 
     /**
-     * Calculated the corner of a building.
+     * Calculated the corner of a building.  Also rotates the blueprint accordingly.
      *
      * @param pos        the central position.
      * @param world      the world.
@@ -129,6 +131,19 @@ public final class ColonyUtils
         final BlockPos pos2 = new BlockPos(zeroPos.getX() + blueprint.getSizeX() - 1, zeroPos.getY() + blueprint.getSizeY() - 1, zeroPos.getZ() + blueprint.getSizeZ() - 1);
 
         return new Tuple<>(pos1, pos2);
+    }
+
+    /**
+     * Reports the block corners from a bounding box.
+     *
+     * @param box the bounding box.
+     * @return    the corners.
+     */
+    public static Tuple<BlockPos, BlockPos> calculateCorners(@NotNull final AABB box)
+    {
+        final BlockPos min = BlockPos.containing(box.minX, box.minY, box.minZ);
+        final BlockPos max = BlockPos.containing(box.maxX, box.maxY, box.maxZ);
+        return new Tuple<>(min, max);
     }
 
     /**

--- a/src/main/java/com/minecolonies/core/entity/ai/workers/util/ConstructionTapeHelper.java
+++ b/src/main/java/com/minecolonies/core/entity/ai/workers/util/ConstructionTapeHelper.java
@@ -19,8 +19,11 @@ import net.minecraft.world.level.block.HorizontalDirectionalBlock;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.block.state.properties.BooleanProperty;
 import net.minecraft.world.level.block.state.properties.DirectionProperty;
+import net.minecraft.world.phys.AABB;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
+
+import static com.minecolonies.api.util.constant.Constants.EMPTY_AABB;
 
 /**
  * Helper class to place and remove constructionTapes from the buildings.
@@ -43,13 +46,11 @@ public final class ConstructionTapeHelper
      */
     public static void placeConstructionTape(@NotNull final IWorkOrder workOrder, @NotNull final Level world, final IColony colony)
     {
-        workOrder.loadBlueprint(world, (blueprint -> {
-            if (blueprint != null)
-            {
-                final Tuple<BlockPos, BlockPos> corners = ColonyUtils.calculateCorners(workOrder.getLocation(), world, blueprint, workOrder.getRotation(), workOrder.isMirrored());
-                placeConstructionTape(corners, colony);
-            }
-        }));
+        final AABB box = workOrder.getBoundingBox();
+        if (box != null && box != EMPTY_AABB)
+        {
+            placeConstructionTape(ColonyUtils.calculateCorners(box), colony);
+        }
     }
 
     /**
@@ -175,13 +176,11 @@ public final class ConstructionTapeHelper
      */
     public static void removeConstructionTape(@NotNull final IWorkOrder workOrder, @NotNull final Level world)
     {
-        workOrder.loadBlueprint(world, (blueprint -> {
-            if (blueprint != null)
-            {
-                final Tuple<BlockPos, BlockPos> corners = ColonyUtils.calculateCorners(workOrder.getLocation(), world, blueprint, workOrder.getRotation(), workOrder.isMirrored());
-                removeConstructionTape(corners, world);
-            }
-        }));
+        final AABB box = workOrder.getBoundingBox();
+        if (box != null && box != EMPTY_AABB)
+        {
+            removeConstructionTape(ColonyUtils.calculateCorners(box), world);
+        }
     }
 
     /**

--- a/src/main/java/com/minecolonies/core/placementhandlers/main/SurvivalHandler.java
+++ b/src/main/java/com/minecolonies/core/placementhandlers/main/SurvivalHandler.java
@@ -2,7 +2,6 @@ package com.minecolonies.core.placementhandlers.main;
 
 import com.ldtteam.structurize.blocks.interfaces.ILeveledBlueprintAnchorBlock;
 import com.ldtteam.structurize.blueprints.v1.Blueprint;
-import com.ldtteam.structurize.placement.handlers.placement.PlacementHandlers;
 import com.ldtteam.structurize.storage.ISurvivalBlueprintHandler;
 import com.ldtteam.structurize.storage.StructurePacks;
 import com.ldtteam.structurize.util.PlacementSettings;
@@ -167,7 +166,6 @@ public class SurvivalHandler implements ISurvivalBlueprintHandler
 
                 world.destroyBlock(blockPos, true);
                 world.setBlockAndUpdate(blockPos, anchor);
-                PlacementHandlers.handleTileEntityPlacement(blueprint.getTileEntityData(blockPos, blueprint.getPrimaryBlockOffset()), world, blockPos);
                 ((AbstractBlockHut<?>) anchor.getBlock()).onBlockPlacedByBuildTool(world,
                   blockPos,
                   anchor,


### PR DESCRIPTION
Closes #10803

# Changes proposed in this pull request
- Reverts the "level 0 tags" change from #10804 since it causes weird chunk claims.
- Fixes incorrect building rotation due to duplicate rotation on cached blueprint.

## Testing
- [x] Yes I tested this before submitting it.
- [ ] I also did a multiplayer test.

Review please (should port, with WO refactor)