### PR TITLE
Fix builders not accepting distant jobs manually assigned

### DIFF
--- a/src/main/java/com/minecolonies/core/colony/workorders/WorkOrderBuilding.java
+++ b/src/main/java/com/minecolonies/core/colony/workorders/WorkOrderBuilding.java
@@ -157,11 +157,12 @@ public class WorkOrderBuilding extends AbstractWorkOrder
         //  - The Builder's Work AbstractBuilding is built
         //  - OR the WorkOrder is for the Builder's Work AbstractBuilding
         //  - OR the WorkOrder is for the TownHall
-        //  - OR the WorkOrder is not farther away than 100 blocks from any builder
+        //  - OR the WorkOrder is not farther away than 100 blocks from any builder and not manually assigned
 
         final IBuilding building = citizen.getWorkBuilding();
         return canBuildIgnoringDistance(building.getPosition(), building.getBuildingLevel())
-                 && citizen.getWorkBuilding().getPosition().distSqr(getLocation()) <= MAX_DISTANCE_SQ;
+                 && (citizen.getWorkBuilding().getPosition().distSqr(getLocation()) <= MAX_DISTANCE_SQ
+                 || (isClaimed() && getClaimedBy().equals(building.getPosition())));
     }
 
     /**


### PR DESCRIPTION
Closes [discord report](https://discord.com/channels/139070364159311872/1003402487417548801/1362951058162454710)
Closes #10808

# Changes proposed in this pull request
- Fixes builders not accepting jobs manually assigned to them when out of normal range.

## Testing
- [x] Yes I tested this before submitting it.
- [ ] I also did a multiplayer test.

Review please (should port with WO refactor)