### PR TITLE
Skip request update for nonexisting request

### DIFF
--- a/src/main/java/com/minecolonies/core/colony/requestsystem/management/handlers/RequestHandler.java
+++ b/src/main/java/com/minecolonies/core/colony/requestsystem/management/handlers/RequestHandler.java
@@ -596,7 +596,7 @@ public class RequestHandler implements IRequestHandler
     {
         if (!manager.getRequestIdentitiesDataStore().getIdentities().containsKey(token))
         {
-            throw new IllegalArgumentException("The given token is not registered as a request to this manager");
+            throw new IllegalArgumentException("The given token:" + token + " is not registered as a request to this manager");
         }
 
         return getRequestOrNull(token);

--- a/src/main/java/com/minecolonies/core/colony/requestsystem/management/manager/StandardRequestManager.java
+++ b/src/main/java/com/minecolonies/core/colony/requestsystem/management/manager/StandardRequestManager.java
@@ -25,9 +25,9 @@ import com.minecolonies.core.colony.requestsystem.management.IStandardRequestMan
 import com.minecolonies.core.colony.requestsystem.management.handlers.*;
 import com.minecolonies.core.colony.requestsystem.management.manager.wrapped.WrappedStaticStateRequestManager;
 import net.minecraft.core.HolderLookup;
-import net.minecraft.world.item.ItemStack;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.network.RegistryFriendlyByteBuf;
+import net.minecraft.world.item.ItemStack;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.jetbrains.annotations.NotNull;
@@ -293,7 +293,11 @@ public class StandardRequestManager implements IStandardRequestManager
     @Override
     public void updateRequestState(@NotNull final IToken<?> token, @NotNull final RequestState state)
     {
-        final IRequest<?> request = getRequestHandler().getRequest(token);
+        final IRequest<?> request = getRequestHandler().getRequestOrNull(token);
+        if (request == null)
+        {
+            return;
+        }
 
         log("Updating request state from:" + token + ". With original state: " + request.getState() + " to : " + state);
 


### PR DESCRIPTION
Closes #
Closes #

# Changes proposed in this pull request
- Skips updating request state of a not existing request
- Print the missing token in its exception

## Testing
- [ ] Yes I tested this before submitting it.
- [ ] I also did a multiplayer test.

Review please