### PR TITLE
Add command to adjust citizen saturation

### DIFF
--- a/src/main/java/com/minecolonies/api/configuration/ServerConfiguration.java
+++ b/src/main/java/com/minecolonies/api/configuration/ServerConfiguration.java
@@ -54,6 +54,7 @@ public class ServerConfiguration extends AbstractConfiguration
     public final ForgeConfigSpec.BooleanValue canPlayerUseHomeTPCommand;
     public final ForgeConfigSpec.BooleanValue canPlayerUseShowColonyInfoCommand;
     public final ForgeConfigSpec.BooleanValue canPlayerUseKillCitizensCommand;
+    public final ForgeConfigSpec.BooleanValue canPlayerUseModifyCitizensCommand;
     public final ForgeConfigSpec.BooleanValue canPlayerUseAddOfficerCommand;
     public final ForgeConfigSpec.BooleanValue canPlayerUseDeleteColonyCommand;
     public final ForgeConfigSpec.BooleanValue canPlayerUseResetCommand;
@@ -154,6 +155,7 @@ public class ServerConfiguration extends AbstractConfiguration
         canPlayerUseHomeTPCommand = defineBoolean(builder, "canplayerusehometpcommand", false);
         canPlayerUseShowColonyInfoCommand = defineBoolean(builder, "canplayeruseshowcolonyinfocommand", true);
         canPlayerUseKillCitizensCommand = defineBoolean(builder, "canplayerusekillcitizenscommand", false);
+        canPlayerUseModifyCitizensCommand = defineBoolean(builder, "canplayerusemodifycitizenscommand", false);
         canPlayerUseAddOfficerCommand = defineBoolean(builder, "canplayeruseaddofficercommand", true);
         canPlayerUseDeleteColonyCommand = defineBoolean(builder, "canplayerusedeletecolonycommand", false);
         canPlayerUseResetCommand = defineBoolean(builder, "canplayeruseresetcommand", false);

--- a/src/main/java/com/minecolonies/api/util/constant/translation/CommandTranslationConstants.java
+++ b/src/main/java/com/minecolonies/api/util/constant/translation/CommandTranslationConstants.java
@@ -8,6 +8,8 @@ import org.jetbrains.annotations.NonNls;
 public class CommandTranslationConstants
 {
     @NonNls
+    public static final String COMMAND_REQUIRES_CREATIVE                     = "com.minecolonies.command.notcreative";
+    @NonNls
     public static final String COMMAND_REQUIRES_OP                           = "com.minecolonies.command.notop";
     @NonNls
     public static final String COMMAND_DISABLED_IN_CONFIG                    = "com.minecolonies.command.notenabledinconfig";
@@ -55,6 +57,8 @@ public class CommandTranslationConstants
     public static final String COMMAND_CITIZEN_LIST_PREVIOUS                 = "com.minecolonies.command.citizenlist.prev";
     @NonNls
     public static final String COMMAND_CITIZEN_LIST_NEXT                     = "com.minecolonies.command.citizenlist.next";
+    @NonNls
+    public static final String COMMAND_CITIZEN_MODIFY_SUCCESS                = "com.minecolonies.command.citizenmodify.success";
     @NonNls
     public static final String COMMAND_CITIZEN_RELOAD_SUCCESS                = "com.minecolonies.command.citizenreload.success";
     @NonNls

--- a/src/main/java/com/minecolonies/core/commands/EntryPoint.java
+++ b/src/main/java/com/minecolonies/core/commands/EntryPoint.java
@@ -70,6 +70,7 @@ public class EntryPoint
             .addNode(new CommandCitizenInfo().build())
             .addNode(new CommandCitizenKill().build())
             .addNode(new CommandCitizenList().build())
+            .addNode(new CommandCitizenModify().build())
             .addNode(new CommandCitizenReload().build())
             .addNode(new CommandCitizenSpawnNew().build())
             .addNode(new CommandCitizenTeleport().build())

--- a/src/main/java/com/minecolonies/core/commands/citizencommands/CommandCitizenModify.java
+++ b/src/main/java/com/minecolonies/core/commands/citizencommands/CommandCitizenModify.java
@@ -1,0 +1,144 @@
+package com.minecolonies.core.commands.citizencommands;
+
+import com.minecolonies.api.colony.ICitizenData;
+import com.minecolonies.api.colony.IColony;
+import com.minecolonies.api.colony.IColonyManager;
+import com.minecolonies.api.util.Log;
+import com.minecolonies.api.util.constant.translation.CommandTranslationConstants;
+import com.minecolonies.core.MineColonies;
+import com.minecolonies.core.commands.commandTypes.IMCColonyOfficerCommand;
+import com.minecolonies.core.commands.commandTypes.IMCCommand;
+import com.mojang.brigadier.arguments.DoubleArgumentType;
+import com.mojang.brigadier.arguments.IntegerArgumentType;
+import com.mojang.brigadier.builder.LiteralArgumentBuilder;
+import com.mojang.brigadier.context.CommandContext;
+import net.minecraft.commands.CommandSourceStack;
+import net.minecraft.commands.SharedSuggestionProvider;
+import net.minecraft.network.chat.Component;
+import net.minecraft.server.MinecraftServer;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.List;
+import java.util.function.Consumer;
+import java.util.function.Function;
+import java.util.function.ToIntFunction;
+
+import static com.minecolonies.api.colony.ICitizenData.MAX_SATURATION;
+import static com.minecolonies.core.commands.CommandArgumentNames.CITIZENID_ARG;
+import static com.minecolonies.core.commands.CommandArgumentNames.COLONYID_ARG;
+
+/**
+ * Allows modifying citizen data for test purposes.
+ */
+public class CommandCitizenModify implements IMCColonyOfficerCommand
+{
+    private static final String VALUE_ARG = "value";
+
+    @Override
+    public int onExecute(@NotNull final CommandContext<CommandSourceStack> context)
+    {
+        return 0;
+    }
+
+    @NotNull
+    @Override
+    public String getName()
+    {
+        return "modify";
+    }
+
+    @NotNull
+    @Override
+    public LiteralArgumentBuilder<CommandSourceStack> build()
+    {
+        return IMCCommand.newLiteral(getName())
+                .then(IMCCommand.newArgument(COLONYID_ARG, IntegerArgumentType.integer(1))
+                        .then(IMCCommand.newArgument(CITIZENID_ARG, IntegerArgumentType.integer(1))
+                                .then(IMCCommand.newLiteral("saturation")
+                                        .then(IMCCommand.newLiteral("=")
+                                                .then(IMCCommand.newArgument(VALUE_ARG, DoubleArgumentType.doubleArg(0, MAX_SATURATION))
+                                                        .suggests((ctx, builder) -> SharedSuggestionProvider.suggest(List.of("0.0", String.valueOf(MAX_SATURATION)), builder))
+                                                        .executes(ctx -> adjust(ctx, citizen -> citizen.setSaturation(DoubleArgumentType.getDouble(ctx, VALUE_ARG)),
+                                                                citizen -> String.valueOf(citizen.getSaturation())))))
+                                        .then(IMCCommand.newLiteral("+")
+                                                .then(IMCCommand.newArgument(VALUE_ARG, DoubleArgumentType.doubleArg(0, MAX_SATURATION))
+                                                        .suggests((ctx, builder) -> SharedSuggestionProvider.suggest(List.of("1.0"), builder))
+                                                        .executes(ctx -> adjust(ctx, citizen -> citizen.increaseSaturation(DoubleArgumentType.getDouble(ctx, VALUE_ARG)),
+                                                                citizen -> String.valueOf(citizen.getSaturation())))))
+                                        .then(IMCCommand.newLiteral("-")
+                                                .then(IMCCommand.newArgument(VALUE_ARG, DoubleArgumentType.doubleArg(0, MAX_SATURATION))
+                                                        .suggests((ctx, builder) -> SharedSuggestionProvider.suggest(List.of("1.0"), builder))
+                                                        .executes(ctx -> adjust(ctx, citizen -> citizen.decreaseSaturation(DoubleArgumentType.getDouble(ctx, VALUE_ARG)),
+                                                                citizen -> String.valueOf(citizen.getSaturation())))))
+                                )));
+    }
+
+    private int adjust(@NotNull final CommandContext<CommandSourceStack> context,
+                       @NotNull final Consumer<ICitizenData> action,
+                       @NotNull final Function<ICitizenData, String> valueProvider)
+    {
+        return execute(context, citizen ->
+        {
+            action.accept(citizen);
+
+            final String type = context.getNodes().get(5).getNode().getName();
+            final String value = valueProvider.apply(citizen);
+            context.getSource().sendSuccess(() -> Component.translatable(CommandTranslationConstants.COMMAND_CITIZEN_MODIFY_SUCCESS, type, citizen.getName(), value), true);
+            return 0;
+        });
+    }
+
+    private int execute(@NotNull final CommandContext<CommandSourceStack> context,
+                        @NotNull final ToIntFunction<ICitizenData> action)
+    {
+        try
+        {
+            if (!checkPreCondition(context))
+            {
+                return 0;
+            }
+
+            if (!context.getSource().hasPermission(OP_PERM_LEVEL) && !MineColonies.getConfig().getServer().canPlayerUseModifyCitizensCommand.get())
+            {
+                context.getSource().sendSuccess(() -> Component.translatable(CommandTranslationConstants.COMMAND_DISABLED_IN_CONFIG), true);
+                return 0;
+            }
+
+            if (context.getSource().source instanceof MinecraftServer)
+            {
+                // server console allowed
+            }
+            else if (context.getSource().isPlayer() && context.getSource().getPlayer().isCreative())
+            {
+                // creative mode allowed (if passed above checks)
+            }
+            else
+            {
+                context.getSource().sendSuccess(() -> Component.translatable(CommandTranslationConstants.COMMAND_REQUIRES_CREATIVE), true);
+                return 0;
+            }
+
+            final int colonyID = IntegerArgumentType.getInteger(context, COLONYID_ARG);
+            final IColony colony = IColonyManager.getInstance().getColonyByDimension(colonyID, context.getSource().getLevel().dimension());
+            if (colony == null)
+            {
+                context.getSource().sendSuccess(() -> Component.translatable(CommandTranslationConstants.COMMAND_COLONY_ID_NOT_FOUND, colonyID), true);
+                return 0;
+            }
+
+            final ICitizenData citizenData = colony.getCitizenManager().getCivilian(IntegerArgumentType.getInteger(context, CITIZENID_ARG));
+            if (citizenData == null)
+            {
+                context.getSource().sendSuccess(() -> Component.translatable(CommandTranslationConstants.COMMAND_CITIZEN_NOT_FOUND), true);
+                return 0;
+            }
+
+            return action.applyAsInt(citizenData);
+        }
+        catch (Throwable e)
+        {
+            Log.getLogger().warn("Error during running command:", e);
+            return 0;
+        }
+    }
+}

--- a/src/main/resources/assets/minecolonies/lang/manual_en_us.json
+++ b/src/main/resources/assets/minecolonies/lang/manual_en_us.json
@@ -153,6 +153,8 @@
   "minecolonies.config.canplayeruseshowcolonyinfocommand.comment": "Should players be allowed to use the /mc colony info command?",
   "minecolonies.config.canplayerusekillcitizenscommand": "Can Players Use the Kill Citizens Command",
   "minecolonies.config.canplayerusekillcitizenscommand.comment": "Should players be allowed to use the /mc citizens kill command?",
+  "minecolonies.config.canplayerusemodifycitizenscommand": "Can Players Use the Modify Citizens Command",
+  "minecolonies.config.canplayerusemodifycitizenscommand.comment": "Should players be allowed to use the /mc citizens modify command?",
   "minecolonies.config.canplayeruseaddofficercommand": "Can Players Use the Add Officer Command",
   "minecolonies.config.canplayeruseaddofficercommand.comment": "Should players be allowed to use the /mc colony addOfficer command?",
   "minecolonies.config.canplayerusedeletecolonycommand": "Can Players Use the Delete Colony Command",
@@ -384,6 +386,7 @@
 
   "com.minecolonies.command.help.wiki": "Check out the wiki to learn more: ",
   "com.minecolonies.command.help.discord": "Join the community at  ",
+  "com.minecolonies.command.notcreative": "Must be in Creative Mode to use this command.",
   "com.minecolonies.command.notop": "Must be OP to use this command.",
   "com.minecolonies.command.whereami.nocolony": "No close colony.",
   "com.minecolonies.command.whereami.colonyclose": "You're not inside any colony. The closest colony is approx %.2f blocks away.",
@@ -446,6 +449,7 @@
   "com.minecolonies.command.citizenlist.pagestyle": "§2 | ",
   "com.minecolonies.command.citizenlist.prev": " <- prev",
   "com.minecolonies.command.citizenlist.next": "next -> ",
+  "com.minecolonies.command.citizenmodify.success": "The %s of %s is now %s.",
   "com.minecolonies.command.citizenreload.success": "Updated entity for citizen ID %s.",
   "com.minecolonies.command.citizenspawn.success": "Spawned new citizen (%s).",
 


### PR DESCRIPTION
Closes [discord idea](https://discord.com/channels/449079260070674443/548426496956432403/1365558052584947825)

# Changes proposed in this pull request
- Adds a command `/mc citizens modify <colony> <citizen> saturation <+/-/=> <value>` which does what it says on the tin.
    - This is intended to allow more easily testing food system behaviours.
    - To limit abuse, the command can only be run on the server console, or by a player in creative mode that's also colony officer *and* either singleplayer/server-op/explicitly enabled in config.  In particular, it does _not_ run in a command block.
    - The command is structured such that it would be simple to add other modifiable attributes in the future if we want.
    - One slightly unintended quirk (but it's not really worth fixing) is that the `-` operation (and only that) is affected by the `foodmodifier` configuration -- by default that's 1.0 so it will behave as expected.

## Testing
- [x] Yes I tested this before submitting it.
- [x] I also did a multiplayer test.

Review please (should port)