### PR TITLE
Builder unstuck

### DIFF
--- a/src/main/java/com/minecolonies/core/colony/buildings/AbstractBuilding.java
+++ b/src/main/java/com/minecolonies/core/colony/buildings/AbstractBuilding.java
@@ -1579,9 +1579,10 @@ public abstract class AbstractBuilding extends AbstractBuildingContainer
     }
 
     @Override
-    public Collection<IRequest<?>> getCompletedRequests(@NotNull final ICitizenData data)
+    public Collection<IRequest<?>> getCompletedRequests(@Nullable final ICitizenData data)
     {
-        final Collection<IToken<?>> tokens = getCompletedRequestsByCitizen().get(data.getId());
+        final int citizenId = data == null ? -1 : data.getId();
+        final Collection<IToken<?>> tokens = getCompletedRequestsByCitizen().get(citizenId);
         if (tokens == null || tokens.isEmpty())
         {
             return ImmutableList.of();
@@ -1598,10 +1599,10 @@ public abstract class AbstractBuilding extends AbstractBuildingContainer
             }
             else
             {
-                getCompletedRequestsByCitizen().get(data.getId()).remove(token);
-                if (getCompletedRequestsByCitizen().get(data.getId()).isEmpty())
+                getCompletedRequestsByCitizen().get(citizenId).remove(token);
+                if (getCompletedRequestsByCitizen().get(citizenId).isEmpty())
                 {
-                    getCompletedRequestsByCitizen().remove(data.getId());
+                    getCompletedRequestsByCitizen().remove(citizenId);
                 }
             }
         }
@@ -1652,9 +1653,10 @@ public abstract class AbstractBuilding extends AbstractBuildingContainer
     }
 
     @Override
-    public void cancelAllRequestsOfCitizen(@NotNull final ICitizenData data)
+    public void cancelAllRequestsOfCitizen(@Nullable final ICitizenData data)
     {
-        getOpenRequests(data.getId()).forEach(request ->
+        final int citizenId = data == null ? -1 : data.getId();
+        getOpenRequests(citizenId).forEach(request ->
         {
             colony.getRequestManager().updateRequestState(request.getId(), RequestState.CANCELLED);
 
@@ -1672,9 +1674,9 @@ public abstract class AbstractBuilding extends AbstractBuildingContainer
 
         getCompletedRequests(data).forEach(request -> colony.getRequestManager().updateRequestState(request.getId(), RequestState.RECEIVED));
 
-        getOpenRequestsByCitizen().remove(data.getId());
+        getOpenRequestsByCitizen().remove(citizenId);
 
-        getCompletedRequestsByCitizen().remove(data.getId());
+        getCompletedRequestsByCitizen().remove(citizenId);
 
         markDirty();
     }

--- a/src/main/java/com/minecolonies/core/colony/buildings/modules/BuildingResourcesModule.java
+++ b/src/main/java/com/minecolonies/core/colony/buildings/modules/BuildingResourcesModule.java
@@ -175,8 +175,9 @@ public class BuildingResourcesModule extends AbstractBuildingModule implements I
     @Nullable
     public BuilderBucket getRequiredResources()
     {
-        return (buckets.isEmpty() || ((AbstractBuildingStructureBuilder) building).getProgress() == null
-                  || ((AbstractBuildingStructureBuilder) building).getProgress().getB() == BuildingStructureHandler.Stage.CLEAR) ? null : buckets.getFirst();
+        return (buckets.isEmpty()
+            || ((AbstractBuildingStructureBuilder) building).getProgress() == null
+            || ((AbstractBuildingStructureBuilder) building).getProgress().getB() == BuildingStructureHandler.Stage.CLEAR) ? null : buckets.getFirst();
     }
 
     /**

--- a/src/main/java/com/minecolonies/core/colony/buildings/modules/BuildingResourcesModule.java
+++ b/src/main/java/com/minecolonies/core/colony/buildings/modules/BuildingResourcesModule.java
@@ -368,7 +368,7 @@ public class BuildingResourcesModule extends AbstractBuildingModule implements I
                 }
             }
 
-            worker.createRequestAsync(new Stack(itemStack.getItemStack(), requestCount * ((AbstractBuildingStructureBuilder) building).getResourceBatchMultiplier(), 1));
+            building.createRequest(new Stack(itemStack.getItemStack(), requestCount * ((AbstractBuildingStructureBuilder) building).getResourceBatchMultiplier(), 1), true);
         }
     }
 

--- a/src/main/java/com/minecolonies/core/entity/ai/workers/AbstractEntityAIStructure.java
+++ b/src/main/java/com/minecolonies/core/entity/ai/workers/AbstractEntityAIStructure.java
@@ -126,6 +126,11 @@ public abstract class AbstractEntityAIStructure<J extends AbstractJobStructure<?
     protected BlockPos workFrom;
 
     /**
+     * Previous Position where the Builders constructed from.
+     */
+    protected BlockPos prevBlockPosition;
+
+    /**
      * Block to mine.
      */
     protected BlockPos blockToMine;

--- a/src/main/java/com/minecolonies/core/entity/ai/workers/AbstractEntityAIStructure.java
+++ b/src/main/java/com/minecolonies/core/entity/ai/workers/AbstractEntityAIStructure.java
@@ -373,7 +373,8 @@ public abstract class AbstractEntityAIStructure<J extends AbstractJobStructure<?
 
         final StructurePhasePlacementResult result;
         final StructurePlacer placer = structurePlacer.getA();
-        switch (structurePlacer.getB().getStage())
+        final BuildingStructureHandler.Stage currentStage = structurePlacer.getB().getStage();
+        switch (currentStage)
         {
             case BUILD_SOLID:
                 //structure
@@ -435,10 +436,6 @@ public abstract class AbstractEntityAIStructure<J extends AbstractJobStructure<?
             default:
                 result =
                   placer.executeStructureStep(world, null, progress, StructurePlacer.Operation.BLOCK_REMOVAL, () -> placer.getIterator().decrement(this::skipClearing), false);
-                if (result.getBlockResult().getResult() == BlockPlacementResult.Result.FINISHED)
-                {
-                    building.checkOrRequestBucket(building.getRequiredResources(), worker.getCitizenData());
-                }
                 break;
         }
 
@@ -447,6 +444,7 @@ public abstract class AbstractEntityAIStructure<J extends AbstractJobStructure<?
             Log.getLogger().error("Failed placement at: " + result.getBlockResult().getWorldPos().toShortString());
         }
 
+        final boolean firstIteration = building.getProgress() == null;
         if (result.getBlockResult().getResult() == BlockPlacementResult.Result.FINISHED)
         {
             building.nextStage();
@@ -457,6 +455,10 @@ public abstract class AbstractEntityAIStructure<J extends AbstractJobStructure<?
                 return COMPLETE_BUILD;
             }
             this.storeProgressPos(NULL_POS, structurePlacer.getB().getStage());
+            if (currentStage == CLEAR)
+            {
+                building.checkOrRequestBucket(building.getRequiredResources(), worker.getCitizenData());
+            }
         }
         else if (result.getBlockResult().getResult() == BlockPlacementResult.Result.LIMIT_REACHED)
         {
@@ -477,6 +479,10 @@ public abstract class AbstractEntityAIStructure<J extends AbstractJobStructure<?
             this.storeProgressPos(result.getIteratorPos(), structurePlacer.getB().getStage());
         }
 
+        if (firstIteration)
+        {
+            building.checkOrRequestBucket(building.getRequiredResources(), worker.getCitizenData());
+        }
 
         if (result.getBlockResult().getResult() == BlockPlacementResult.Result.MISSING_ITEMS)
         {

--- a/src/main/java/com/minecolonies/core/entity/ai/workers/AbstractEntityAIStructureWithWorkOrder.java
+++ b/src/main/java/com/minecolonies/core/entity/ai/workers/AbstractEntityAIStructureWithWorkOrder.java
@@ -487,6 +487,7 @@ public abstract class AbstractEntityAIStructureWithWorkOrder<J extends AbstractJ
             job.setWorkOrder(null);
             resetCurrentStructure();
             building.cancelAllRequestsOfCitizen(worker.getCitizenData());
+            building.cancelAllRequestsOfCitizen(null);
             building.setProgressPos(null, BuildingStructureHandler.Stage.CLEAR);
             return true;
         }

--- a/src/main/java/com/minecolonies/core/entity/ai/workers/builder/EntityAIStructureBuilder.java
+++ b/src/main/java/com/minecolonies/core/entity/ai/workers/builder/EntityAIStructureBuilder.java
@@ -227,21 +227,36 @@ public class EntityAIStructureBuilder extends AbstractEntityAIStructureWithWorkO
                 gotoPath = null;
             }
 
+            if (prevBlockPosition != null)
+            {
+                return BlockPosUtil.dist(prevBlockPosition, currentBlock) <= 10;
+            }
             return false;
         }
 
         if (!walkToSafePos(workFrom))
         {
+            // Something might have changed, new wall and we can't reach the position anymore. Reset workfrom if stuck.
+            if (worker.getNavigation() instanceof MinecoloniesAdvancedPathNavigate pathNavigate && pathNavigate.getStuckHandler().getStuckLevel() > 0)
+            {
+                workFrom = null;
+            }
             return false;
         }
 
         if (BlockPosUtil.getDistance2D(worker.blockPosition(), currentBlock) > 5)
         {
-            double distToBuilding = BlockPosUtil.dist(workFrom, job.getWorkOrder().getLocation());
+            if (BlockPosUtil.dist(workFrom, job.getWorkOrder().getLocation()) < 100)
+            {
+                prevBlockPosition = currentBlock;
+                workFrom = null;
+                return true;
+            }
             workFrom = null;
-            return distToBuilding < 100;
+            return false;
         }
 
+        prevBlockPosition = currentBlock;
         return true;
     }
 


### PR DESCRIPTION
Closes #10669
Closes #10802

# Changes proposed in this pull request
- Builder now always properly requests all the buckets even in the edge cases. (Should speed up builder)
- Builder can now recover from positions becoming unavailable mid build (before the builder would insist until teleporting there)
- Builder now continues placing in a bit of a range around the last position while pathing to the next position.

## Testing
- [x] Yes I tested this before submitting it.
- [ ] I also did a multiplayer test.

Review please