### PR TITLE
Fix JEI with later-loading compat

### DIFF
--- a/src/main/java/com/minecolonies/api/compatibility/CompatibilityManager.java
+++ b/src/main/java/com/minecolonies/api/compatibility/CompatibilityManager.java
@@ -3,6 +3,7 @@ package com.minecolonies.api.compatibility;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
+import com.minecolonies.api.IMinecoloniesAPI;
 import com.minecolonies.api.MinecoloniesAPIProxy;
 import com.minecolonies.api.colony.requestsystem.StandardFactoryController;
 import com.minecolonies.api.compatibility.dynamictrees.DynamicTreeCompat;
@@ -12,6 +13,7 @@ import com.minecolonies.api.compatibility.tinkers.TinkersToolHelper;
 import com.minecolonies.api.crafting.CompostRecipe;
 import com.minecolonies.api.crafting.ItemStorage;
 import com.minecolonies.api.crafting.registry.ModRecipeSerializer;
+import com.minecolonies.api.eventbus.events.CompatibilityManagerLoadedEvent;
 import com.minecolonies.api.items.ModTags;
 import com.minecolonies.api.util.*;
 import com.minecolonies.api.util.constant.NbtTagConstants;
@@ -179,6 +181,8 @@ public class CompatibilityManager implements ICompatibilityManager
 
         discoverCompostRecipes(recipeManager);
         discoverMobs();
+
+        IMinecoloniesAPI.getInstance().getEventBus().post(new CompatibilityManagerLoadedEvent(false));
     }
 
     @Override
@@ -253,6 +257,8 @@ public class CompatibilityManager implements ICompatibilityManager
 
         // the below are loaded from config files, which have been synched already by this point
         discoverModCompat();
+
+        IMinecoloniesAPI.getInstance().getEventBus().post(new CompatibilityManagerLoadedEvent(true));
     }
 
     private static void serializeItemStorageList(

--- a/src/main/java/com/minecolonies/api/eventbus/events/CompatibilityManagerLoadedEvent.java
+++ b/src/main/java/com/minecolonies/api/eventbus/events/CompatibilityManagerLoadedEvent.java
@@ -1,0 +1,16 @@
+package com.minecolonies.api.eventbus.events;
+
+public class CompatibilityManagerLoadedEvent extends AbstractModEvent
+{
+    private final boolean isClientSide;
+
+    public CompatibilityManagerLoadedEvent(final boolean isClientSide)
+    {
+        this.isClientSide = isClientSide;
+    }
+
+    public boolean isClientSide()
+    {
+        return this.isClientSide;
+    }
+}

--- a/src/main/java/com/minecolonies/core/compatibility/jei/FloristRecipeCategory.java
+++ b/src/main/java/com/minecolonies/core/compatibility/jei/FloristRecipeCategory.java
@@ -62,6 +62,7 @@ public class FloristRecipeCategory extends JobBasedRecipeCategory<FloristRecipeC
                 .setBackground(this.slot, -1, -1)
                 .addItemStack(new ItemStack(ModItems.compost));
 
+        if (recipe.flowers().isEmpty()) return;
         final int initialColumns = LOOT_SLOTS_W / this.slot.getWidth();
         final int rows = (recipe.flowers().size() + initialColumns - 1) / initialColumns;
         final int columns = (recipe.flowers().size() + rows - 1) / rows;

--- a/src/main/java/com/minecolonies/core/compatibility/jei/JEIPlugin.java
+++ b/src/main/java/com/minecolonies/core/compatibility/jei/JEIPlugin.java
@@ -9,6 +9,7 @@ import com.minecolonies.api.colony.jobs.ModJobs;
 import com.minecolonies.api.colony.jobs.registry.JobEntry;
 import com.minecolonies.api.crafting.IGenericRecipe;
 import com.minecolonies.api.crafting.registry.CraftingType;
+import com.minecolonies.api.eventbus.events.CompatibilityManagerLoadedEvent;
 import com.minecolonies.api.util.Log;
 import com.minecolonies.api.util.constant.Constants;
 import com.minecolonies.api.util.constant.TranslationConstants;
@@ -22,6 +23,7 @@ import mezz.jei.api.helpers.IJeiHelpers;
 import mezz.jei.api.helpers.IModIdHelper;
 import mezz.jei.api.recipe.RecipeType;
 import mezz.jei.api.registration.*;
+import mezz.jei.api.runtime.IJeiRuntime;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.multiplayer.ClientLevel;
 import net.minecraft.network.chat.Component;
@@ -29,6 +31,7 @@ import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.entity.animal.Animal;
 import net.minecraft.world.level.Level;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 import java.util.*;
 import java.util.function.BiConsumer;
@@ -36,6 +39,8 @@ import java.util.function.BiConsumer;
 @mezz.jei.api.JeiPlugin
 public class JEIPlugin implements IModPlugin
 {
+    @Nullable IJeiRuntime jei;
+
     @NotNull
     @Override
     public ResourceLocation getPluginUid()
@@ -128,9 +133,7 @@ public class JEIPlugin implements IModPlugin
 
         registration.addRecipes(ModRecipeTypes.TOOLS, ToolRecipeCategory.findRecipes(Minecraft.getInstance().level));
         registration.addRecipes(ModRecipeTypes.CROPS, CropRecipeCategory.findRecipes());
-        registration.addRecipes(ModRecipeTypes.COMPOSTING, CompostRecipeCategory.findRecipes());
         registration.addRecipes(ModRecipeTypes.FISHING, FishermanRecipeCategory.findRecipes());
-        registration.addRecipes(ModRecipeTypes.FLOWERS, FloristRecipeCategory.findRecipes());
 
         final ClientLevel level = Objects.requireNonNull(Minecraft.getInstance().level);
         final Map<CraftingType, List<IGenericRecipe>> vanilla = RecipeAnalyzer.buildVanillaRecipesMap(level.getRecipeManager(), level);
@@ -139,6 +142,16 @@ public class JEIPlugin implements IModPlugin
         for (final JobBasedRecipeCategory<?> category : this.categories)
         {
             addJobBasedRecipes(vanilla, animals, category, registration::addRecipes, level);
+        }
+    }
+
+    private void onCompatibilityManagerLoaded(@NotNull final CompatibilityManagerLoadedEvent event)
+    {
+        if (event.isClientSide() && this.jei != null)
+        {
+            // defer some recipes until after the compatibility manager is populated, because they use it
+            this.jei.getRecipeManager().addRecipes(ModRecipeTypes.COMPOSTING, CompostRecipeCategory.findRecipes());
+            this.jei.getRecipeManager().addRecipes(ModRecipeTypes.FLOWERS, FloristRecipeCategory.findRecipes());
         }
     }
 
@@ -186,5 +199,18 @@ public class JEIPlugin implements IModPlugin
         new CraftingGuiHandler(this.categories).register(registration);
         new FurnaceCraftingGuiHandler(this.categories).register(registration);
         new BrewingCraftingGuiHandler(this.categories).register(registration);
+    }
+
+    @Override
+    public void onRuntimeAvailable(@NotNull final IJeiRuntime jeiRuntime)
+    {
+        this.jei = jeiRuntime;
+        IMinecoloniesAPI.getInstance().getEventBus().subscribe(CompatibilityManagerLoadedEvent.class, this::onCompatibilityManagerLoaded);
+    }
+
+    @Override
+    public void onRuntimeUnavailable()
+    {
+        this.jei = null;
     }
 }

--- a/src/main/java/com/minecolonies/core/compatibility/jei/JEIPlugin.java
+++ b/src/main/java/com/minecolonies/core/compatibility/jei/JEIPlugin.java
@@ -40,6 +40,7 @@ import java.util.function.BiConsumer;
 public class JEIPlugin implements IModPlugin
 {
     @Nullable IJeiRuntime jei;
+    boolean compatLoaded;
 
     @NotNull
     @Override
@@ -128,6 +129,8 @@ public class JEIPlugin implements IModPlugin
     @Override
     public void registerRecipes(@NotNull final IRecipeRegistration registration)
     {
+        IMinecoloniesAPI.getInstance().getEventBus().subscribe(CompatibilityManagerLoadedEvent.class, this::onCompatibilityManagerLoaded);
+
         registration.addIngredientInfo(ModBlocks.blockHutComposter,
                 Component.translatableEscape(TranslationConstants.PARTIAL_JEI_INFO + ModJobs.COMPOSTER_ID.getPath()));
 
@@ -147,11 +150,16 @@ public class JEIPlugin implements IModPlugin
 
     private void onCompatibilityManagerLoaded(@NotNull final CompatibilityManagerLoadedEvent event)
     {
-        if (event.isClientSide() && this.jei != null)
+        if (event.isClientSide())
         {
-            // defer some recipes until after the compatibility manager is populated, because they use it
-            this.jei.getRecipeManager().addRecipes(ModRecipeTypes.COMPOSTING, CompostRecipeCategory.findRecipes());
-            this.jei.getRecipeManager().addRecipes(ModRecipeTypes.FLOWERS, FloristRecipeCategory.findRecipes());
+            this.compatLoaded = true;
+
+            if (this.jei != null)
+            {
+                // defer some recipes until after the compatibility manager is populated, because they use it
+                this.jei.getRecipeManager().addRecipes(ModRecipeTypes.COMPOSTING, CompostRecipeCategory.findRecipes());
+                this.jei.getRecipeManager().addRecipes(ModRecipeTypes.FLOWERS, FloristRecipeCategory.findRecipes());
+            }
         }
     }
 
@@ -205,7 +213,11 @@ public class JEIPlugin implements IModPlugin
     public void onRuntimeAvailable(@NotNull final IJeiRuntime jeiRuntime)
     {
         this.jei = jeiRuntime;
-        IMinecoloniesAPI.getInstance().getEventBus().subscribe(CompatibilityManagerLoadedEvent.class, this::onCompatibilityManagerLoaded);
+
+        if (this.compatLoaded)
+        {
+            onCompatibilityManagerLoaded(new CompatibilityManagerLoadedEvent(true));
+        }
     }
 
     @Override

--- a/src/main/java/com/minecolonies/core/event/DataPackSyncEventHandler.java
+++ b/src/main/java/com/minecolonies/core/event/DataPackSyncEventHandler.java
@@ -103,7 +103,12 @@ public class DataPackSyncEventHandler
                 final UpdateClientWithCompatibilityMessage compatMsg = new UpdateClientWithCompatibilityMessage(server.registryAccess());
                 for (final ServerPlayer player : event.getPlayerList().getPlayers())
                 {
-                    if (player.getGameProfile() != owner)   // don't need to send them in SP, or LAN owner
+                    if (player.getGameProfile() == owner)
+                    {
+                        // SP 'server' doesn't need most of the packets, but does need compatmgr since we keep separate instances
+                        compatMsg.sendToPlayer(player);
+                    }
+                    else
                     {
                         sendPackets(player, compatMsg);
                     }


### PR DESCRIPTION
Closes #10834

# Changes proposed in this pull request
- Fixes JEI recipe errors as a result of later CompatibilityManager (#10791)
- Fixes client-side CompatibilityManager not populating properly on /reload

## Testing
- [x] Yes I tested this before submitting it.
- [ ] I also did a multiplayer test.

Review please (do not port)