### PR TITLE
bunch of food related fixes

### DIFF
--- a/src/main/java/com/minecolonies/api/util/FoodUtils.java
+++ b/src/main/java/com/minecolonies/api/util/FoodUtils.java
@@ -248,6 +248,99 @@ public class FoodUtils
     }
 
     /**
+     * Get the best food for a given citizen from a given inventory and return the index where it is.
+     * @param citizenData the citizen data the food is for.
+     * @param menu the menu that has to be matched or null.
+     * @return the matching inv slot, or -1.
+     */
+    public static boolean hasBestOptionInInv(final InventoryCitizen inventoryCitizen, final ICitizenData citizenData, @Nullable final Set<ItemStorage> menu, final IBuilding building)
+    {
+        final int invSlot = getBestFoodForCitizen(inventoryCitizen, citizenData, menu);
+        // Smaller score is better.
+        int bestScore = Integer.MAX_VALUE;
+        ItemStorage bestStorage = null;
+
+        final Level world = building.getColony().getWorld();
+        final int homeBuildingLevel = citizenData.getHomeBuilding() == null ? 0 : citizenData.getHomeBuilding().getBuildingLevel();
+
+        final ICitizenFoodHandler.CitizenFoodStats foodStats = citizenData.getCitizenFoodHandler().getFoodHappinessStats();
+        final int diversityRequirement = FoodUtils.getMinFoodDiversityRequirement(citizenData.getHomeBuilding() == null ? 0 : citizenData.getHomeBuilding().getBuildingLevel());
+        final int qualityRequirement = FoodUtils.getMinFoodQualityRequirement(citizenData.getHomeBuilding() == null ? 0 : citizenData.getHomeBuilding().getBuildingLevel());
+
+        final boolean criticalDiversity = foodStats.diversity() <= diversityRequirement;
+        final boolean criticalQuality = foodStats.quality() <= qualityRequirement;
+        final ICitizenFoodHandler foodHandler = citizenData.getCitizenFoodHandler();
+
+        int bestInvScore = Integer.MAX_VALUE;
+        if (invSlot >= 0)
+        {
+            final ItemStack stack = inventoryCitizen.getStackInSlot(invSlot);
+            final boolean isMinecolfood = stack.getItem() instanceof IMinecoloniesFoodItem;
+            bestInvScore = foodHandler.checkLastEaten(stack.getItem()) * (isMinecolfood ? 2 : 1);;
+
+            // Already good enough food in inventory? Skip building check.
+            if ((bestInvScore < 0 && isMinecolfood) && (criticalDiversity || criticalQuality))
+            {
+                return true;
+            }
+        }
+
+        for (final BlockPos pos : building.getContainers())
+        {
+            if (WorldUtil.isBlockLoaded(world, pos))
+            {
+                final BlockEntity entity = world.getBlockEntity(pos);
+                if (entity instanceof TileEntityRack rackEntity)
+                {
+                    for (final ItemStorage storage : rackEntity.getAllContent().keySet())
+                    {
+                        if ((menu == null || menu.contains(storage)) && FoodUtils.canEat(storage.getItemStack(), citizenData.getHomeBuilding(), citizenData.getWorkBuilding()))
+                        {
+                            final boolean isMinecolfood = storage.getItem() instanceof IMinecoloniesFoodItem;
+                            final int localScore = foodHandler.checkLastEaten(storage.getItem());
+
+                            // If this is great food and we're at critical levels, go with it!
+                            if ((localScore < 0 && isMinecolfood) && (criticalDiversity || criticalQuality))
+                            {
+                                return false;
+                            }
+
+                            if (localScore > bestScore)
+                            {
+                                continue;
+                            }
+
+                            if (isMinecolfood && !criticalQuality && MathUtils.RANDOM.nextInt(Math.max(1, ((IMinecoloniesFoodItem) storage.getItem()).getTier() + 2 - homeBuildingLevel)) <= 0)
+                            {
+                                bestScore = localScore;
+                                bestStorage = storage;
+                                continue;
+                            }
+
+                            bestScore = localScore * (isMinecolfood ? 2 : 1);
+                            bestStorage = storage;
+
+                            // If the quality and diversity requirement would be fulfilled, already go ahead with this food. Don't need to check others.
+                            if ((localScore < 0 && isMinecolfood)
+                                || (localScore < 0 && foodStats.quality() > qualityRequirement * 2)
+                                || (isMinecolfood && foodStats.diversity() > diversityRequirement * 2))
+                            {
+                                return bestInvScore < localScore;
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        if (bestStorage == null)
+        {
+            return bestInvScore < Integer.MAX_VALUE;
+        }
+        return bestInvScore < bestScore;
+    }
+
+    /**
      * Get the min food quality requirement.
      * @param buildingLevel the building level to take into account.
      * @return the food quality requirement in number of items.

--- a/src/main/java/com/minecolonies/api/util/ItemStackUtils.java
+++ b/src/main/java/com/minecolonies/api/util/ItemStackUtils.java
@@ -874,8 +874,6 @@ public final class ItemStackUtils
             itemUseReturn = ItemStack.EMPTY;
         }
 
-        citizenData.increaseSaturation(satIncrease);
-
         if (!itemUseReturn.isEmpty())
         {
             if (citizenData.getInventory().isFull() || (player != null && !player.getInventory().add(itemUseReturn)))

--- a/src/main/java/com/minecolonies/core/colony/CitizenData.java
+++ b/src/main/java/com/minecolonies/core/colony/CitizenData.java
@@ -1631,12 +1631,12 @@ public class CitizenData implements ICitizenData
     @Override
     public void triggerInteraction(@NotNull final IInteractionResponseHandler handler)
     {
-        if (!this.citizenChatOptions.containsKey(handler.getId()))
+        if (handler.isValid(this) && !this.citizenChatOptions.containsKey(handler.getId()))
         {
             this.citizenChatOptions.put(handler.getId(), handler);
             for (final IInteractionResponseHandler childHandler : handler.genChildInteractions())
             {
-                this.citizenChatOptions.put(childHandler.getId(), (ServerCitizenInteraction) childHandler);
+                this.citizenChatOptions.put(childHandler.getId(), childHandler);
             }
             markDirty(20 * 5);
         }

--- a/src/main/java/com/minecolonies/core/entity/ai/workers/service/EntityAIWorkCook.java
+++ b/src/main/java/com/minecolonies/core/entity/ai/workers/service/EntityAIWorkCook.java
@@ -362,7 +362,7 @@ public class EntityAIWorkCook extends AbstractEntityAIUsesFurnace<JobCook, Build
                 continue;
             }
 
-            if (FoodUtils.getBestFoodForCitizen(worker.getInventoryCitizen(), citizen.getCitizenData(), module.getMenu()) >= 0)
+            if (FoodUtils.hasBestOptionInInv(worker.getInventoryCitizen(), citizen.getCitizenData(), module.getMenu(), building))
             {
                 citizenToServe.add(citizen);
             }

--- a/src/main/java/com/minecolonies/core/entity/citizen/citizenhandlers/CitizenFoodHandler.java
+++ b/src/main/java/com/minecolonies/core/entity/citizen/citizenhandlers/CitizenFoodHandler.java
@@ -73,7 +73,7 @@ public class CitizenFoodHandler implements ICitizenFoodHandler
         if (lastEatenFoods.size() >= FOOD_QUEUE_SIZE)
         {
             citizenData.triggerInteraction(new StandardInteraction(Component.translatable(NO + FOOD_DIVERSITY), ChatPriority.IMPORTANT));
-            citizenData.triggerInteraction(new StandardInteraction(Component.translatable(NO + FOOD_DIVERSITY), ChatPriority.IMPORTANT));
+            citizenData.triggerInteraction(new StandardInteraction(Component.translatable(NO + FOOD_QUALITY), ChatPriority.IMPORTANT));
             citizenData.triggerInteraction(new StandardInteraction(Component.translatable(NO + FOOD_QUALITY + URGENT), ChatPriority.BLOCKING));
             citizenData.triggerInteraction(new StandardInteraction(Component.translatable(NO + FOOD_QUALITY + URGENT), ChatPriority.BLOCKING));
         }
@@ -88,16 +88,18 @@ public class CitizenFoodHandler implements ICitizenFoodHandler
     @Override
     public int checkLastEaten(final Item item)
     {
+        int foundIndex = -1;
+
         int index = -1;
         for (final Item foodItem : lastEatenFoods)
         {
+            index++;
             if (foodItem == item)
             {
-                return index;
+                foundIndex = index;
             }
-            index++;
         }
-        return -1;
+        return foundIndex;
     }
 
     @Override

--- a/src/main/java/com/minecolonies/core/entity/citizen/citizenhandlers/CitizenFoodHandler.java
+++ b/src/main/java/com/minecolonies/core/entity/citizen/citizenhandlers/CitizenFoodHandler.java
@@ -74,7 +74,7 @@ public class CitizenFoodHandler implements ICitizenFoodHandler
         {
             citizenData.triggerInteraction(new StandardInteraction(Component.translatable(NO + FOOD_DIVERSITY), ChatPriority.IMPORTANT));
             citizenData.triggerInteraction(new StandardInteraction(Component.translatable(NO + FOOD_QUALITY), ChatPriority.IMPORTANT));
-            citizenData.triggerInteraction(new StandardInteraction(Component.translatable(NO + FOOD_QUALITY + URGENT), ChatPriority.BLOCKING));
+            citizenData.triggerInteraction(new StandardInteraction(Component.translatable(NO + FOOD_DIVERSITY + URGENT), ChatPriority.BLOCKING));
             citizenData.triggerInteraction(new StandardInteraction(Component.translatable(NO + FOOD_QUALITY + URGENT), ChatPriority.BLOCKING));
         }
     }


### PR DESCRIPTION
Closes #
Closes #

# Changes proposed in this pull request
- Verify interaction handlers before adding them (simplifies code) & reduces short lived popups.
- Correctly report the last eaten index (not just return on the first index which could be -1)
- Check if there is better food in the building we could serve to the citizen (and pick up if so)
- Remove double saturation increase for 1.21 (oopsy) this resulted in them walking around with leftover food etc

## Testing
- [x] Yes I tested this before submitting it.
- [ ] I also did a multiplayer test.

Review please