### PR TITLE
Bugfix: restore removed import in DefaultRecipeProvider

### DIFF
--- a/src/main/java/com/minecolonies/core/generation/defaults/DefaultRecipeProvider.java
+++ b/src/main/java/com/minecolonies/core/generation/defaults/DefaultRecipeProvider.java
@@ -1,6 +1,7 @@
 package com.minecolonies.core.generation.defaults;
 
 import com.minecolonies.api.blocks.ModBlocks;
+import com.minecolonies.api.crafting.ZeroWasteRecipe;
 import com.minecolonies.api.items.ModItems;
 import com.minecolonies.api.items.ModTags;
 import com.minecolonies.api.util.constant.TagConstants;


### PR DESCRIPTION
# Changes proposed in this pull request
- Re-add import for ZeroWasteRecipe in DefaultRecipeProvider, fixing build failures caused by the import line accidentally being removed by #10836 

## Testing
- [x] Yes I tested this before submitting it.
- [ ] I also did a multiplayer test.

Review please