### PR TITLE
Reduce pathfinding cost for in block shapes

### DIFF
--- a/src/main/java/com/minecolonies/core/entity/pathfinding/PathingOptions.java
+++ b/src/main/java/com/minecolonies/core/entity/pathfinding/PathingOptions.java
@@ -55,7 +55,7 @@ public class PathingOptions
     /**
      * Cost to traverse trap doors
      */
-    public double traverseToggleAbleCost = 3D;
+    public double traverseToggleAbleCost = 2D;
 
     /**
      * Cost to climb a non ladder.
@@ -65,7 +65,7 @@ public class PathingOptions
     /**
      * Cost for walking within shapes(e.g. panels)
      */
-    public double walkInShapesCost = 2D;
+    public double walkInShapesCost = 1D;
 
     /**
      * Cost to dive (head underwater).

--- a/src/main/java/com/minecolonies/core/items/ItemAssistantHammer.java
+++ b/src/main/java/com/minecolonies/core/items/ItemAssistantHammer.java
@@ -264,21 +264,25 @@ public class ItemAssistantHammer extends AbstractItemMinecolonies
 
                         areBlocksToBuildNearby = true;
                         boolean hasItems = true;
-                        for (final ItemStack required : requiredItem)
-                        {
-                            boolean found = false;
-                            for (final ItemStack stack : player.getInventory().items)
-                            {
-                                if (ItemStackUtils.compareItemStacksIgnoreStackSize(required, stack))
-                                {
-                                    found = true;
-                                    break;
-                                }
-                            }
 
-                            if (!found)
+                        if (!player.isCreative())
+                        {
+                            for (final ItemStack required : requiredItem)
                             {
-                                hasItems = false;
+                                boolean found = false;
+                                for (final ItemStack stack : player.getInventory().items)
+                                {
+                                    if (ItemStackUtils.compareItemStacksIgnoreStackSize(required, stack))
+                                    {
+                                        found = true;
+                                        break;
+                                    }
+                                }
+
+                                if (!found)
+                                {
+                                    hasItems = false;
+                                }
                             }
                         }
 


### PR DESCRIPTION
Closes #
Closes #

# Changes proposed in this pull request
- Pathfinding costs got reworked resulting in an indirect increase of cost for walking inside block shapes and toggleables, thus reducing them a bit here
- Reduce pathfinding cost for in block shapes
- Reduce pathfinding cost for toggleables
-Assistant hammers no longer require items in creative

## Testing
- [ ] Yes I tested this before submitting it.
- [ ] I also did a multiplayer test.

Review please