### PR TITLE
Adjust assistant hammer building stage & building block registering

### DIFF
--- a/src/main/java/com/minecolonies/api/colony/workorders/IBuilderWorkOrder.java
+++ b/src/main/java/com/minecolonies/api/colony/workorders/IBuilderWorkOrder.java
@@ -106,4 +106,11 @@ public interface IBuilderWorkOrder extends IServerWorkOrder
      * @return
      */
     boolean canBuild(@NotNull ICitizenData citizen);
+
+    /**
+     * Sets the building stage of the workorder
+     *
+     * @param stageIndex
+     */
+    void setStage(int stageIndex);
 }

--- a/src/main/java/com/minecolonies/api/colony/workorders/IWorkOrder.java
+++ b/src/main/java/com/minecolonies/api/colony/workorders/IWorkOrder.java
@@ -190,4 +190,11 @@ public interface IWorkOrder
      * @return
      */
     public void setColony(IColony colony);
+
+    /**
+     * The buildings stage
+     *
+     * @return stage index
+     */
+    int getStage();
 }

--- a/src/main/java/com/minecolonies/core/colony/workorders/AbstractWorkOrder.java
+++ b/src/main/java/com/minecolonies/core/colony/workorders/AbstractWorkOrder.java
@@ -29,6 +29,7 @@ import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Consumer;
 
+import static com.minecolonies.api.util.constant.NbtTagConstants.TAG_STAGE;
 import static com.minecolonies.api.util.constant.Suppression.UNUSED_METHOD_PARAMETERS_SHOULD_BE_REMOVED;
 
 /**
@@ -139,6 +140,11 @@ public abstract class AbstractWorkOrder implements IBuilderWorkOrder
      * The amount of resources the work order its structure still requires.
      */
     private int amountOfResources;
+
+    /**
+     * The building stage this workorder is in
+     */
+    private int stage = 0;
 
     /**
      * The iterator type (building method) of this work order.
@@ -666,6 +672,11 @@ public abstract class AbstractWorkOrder implements IBuilderWorkOrder
         cleared = compound.getBoolean(TAG_IS_CLEARED);
         requested = compound.getBoolean(TAG_IS_REQUESTED);
 
+        if (compound.contains(TAG_STAGE))
+        {
+            stage = compound.getInt(TAG_STAGE);
+        }
+
         if (compound.contains(TAG_BB))
         {
             CompoundTag tag = (CompoundTag) compound.get(TAG_BB);
@@ -698,6 +709,7 @@ public abstract class AbstractWorkOrder implements IBuilderWorkOrder
         compound.putString(TAG_ITERATOR, iteratorType);
         compound.putBoolean(TAG_IS_CLEARED, cleared);
         compound.putBoolean(TAG_IS_REQUESTED, requested);
+        compound.putInt(TAG_STAGE, stage);
 
         if (box != Constants.EMPTY_AABB)
         {
@@ -733,6 +745,7 @@ public abstract class AbstractWorkOrder implements IBuilderWorkOrder
         buf.writeBoolean(isMirrored);
         buf.writeInt(currentLevel);
         buf.writeInt(targetLevel);
+        buf.writeInt(stage);
         buf.writeDouble(getBoundingBox().minX);
         buf.writeDouble(getBoundingBox().minY);
         buf.writeDouble(getBoundingBox().minZ);
@@ -831,5 +844,21 @@ public abstract class AbstractWorkOrder implements IBuilderWorkOrder
     public boolean tooFarFromAnyBuilder(final IColony colony, final int level)
     {
         return false;
+    }
+
+    @Override
+    public int getStage()
+    {
+        return stage;
+    }
+
+    @Override
+    public void setStage(final int stage)
+    {
+        if (stage != this.stage)
+        {
+            changed = true;
+            this.stage = stage;
+        }
     }
 }

--- a/src/main/java/com/minecolonies/core/colony/workorders/view/AbstractWorkOrderView.java
+++ b/src/main/java/com/minecolonies/core/colony/workorders/view/AbstractWorkOrderView.java
@@ -80,6 +80,11 @@ public abstract class AbstractWorkOrderView implements IWorkOrderView
     private int targetLevel;
 
     /**
+     * The building stage this workorder is in
+     */
+    private int stage = 0;
+
+    /**
      * Translation key.
      */
     private String translationKey;
@@ -183,6 +188,12 @@ public abstract class AbstractWorkOrderView implements IWorkOrderView
         this.colony = colony;
     }
 
+    @Override
+    public int getStage()
+    {
+        return stage;
+    }
+
     /**
      * Value getter.
      *
@@ -284,6 +295,7 @@ public abstract class AbstractWorkOrderView implements IWorkOrderView
         isMirrored = buf.readBoolean();
         currentLevel = buf.readInt();
         targetLevel = buf.readInt();
+        stage = buf.readInt();
         box = new AABB(buf.readDouble(), buf.readDouble(), buf.readDouble(), buf.readDouble(), buf.readDouble(), buf.readDouble());
     }
 

--- a/src/main/java/com/minecolonies/core/entity/ai/workers/AbstractEntityAIStructure.java
+++ b/src/main/java/com/minecolonies/core/entity/ai/workers/AbstractEntityAIStructure.java
@@ -1,6 +1,5 @@
 package com.minecolonies.core.entity.ai.workers;
 
-import com.google.common.collect.ImmutableList;
 import com.ldtteam.structurize.blocks.schematic.BlockFluidSubstitution;
 import com.ldtteam.structurize.blueprints.v1.Blueprint;
 import com.ldtteam.structurize.placement.BlockPlacementResult;
@@ -9,7 +8,6 @@ import com.ldtteam.structurize.placement.StructurePlacer;
 import com.ldtteam.structurize.placement.structure.IStructureHandler;
 import com.ldtteam.structurize.util.BlockUtils;
 import com.ldtteam.structurize.util.BlueprintPositionInfo;
-import com.ldtteam.structurize.util.PlacementSettings;
 import com.minecolonies.api.blocks.AbstractBlockHut;
 import com.minecolonies.api.blocks.ModBlocks;
 import com.minecolonies.api.colony.ICitizenData;
@@ -27,7 +25,6 @@ import com.minecolonies.api.entity.ai.workers.util.IBuilderUndestroyable;
 import com.minecolonies.api.entity.citizen.AbstractEntityCitizen;
 import com.minecolonies.api.items.ModTags;
 import com.minecolonies.api.util.*;
-import com.minecolonies.api.util.constant.TypeConstants;
 import com.minecolonies.core.colony.buildings.AbstractBuildingStructureBuilder;
 import com.minecolonies.core.colony.buildings.modules.BuildingResourcesModule;
 import com.minecolonies.core.colony.buildings.utils.BuilderBucket;
@@ -44,7 +41,6 @@ import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.level.block.AirBlock;
 import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.Blocks;
-import net.minecraft.world.level.block.Mirror;
 import net.minecraft.world.level.block.entity.BlockEntity;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.phys.AABB;
@@ -52,7 +48,10 @@ import net.minecraftforge.common.util.TriPredicate;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
-import java.util.*;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 import java.util.function.Predicate;
 
 import static com.ldtteam.structurize.placement.AbstractBlueprintIterator.NULL_POS;
@@ -706,9 +705,7 @@ public abstract class AbstractEntityAIStructure<J extends AbstractJobStructure<?
             if (removal)
             {
                 structure = new BuildingStructureHandler<>(world,
-                  position,
-                  blueprint,
-                    new PlacementSettings(workOrder.isMirrored() ? Mirror.FRONT_BACK : Mirror.NONE, BlockPosUtil.getRotationFromRotations(workOrder.getRotation())),
+                    workOrder,
                   this, new BuildingStructureHandler.Stage[] {REMOVE_WATER, REMOVE});
                 building.setTotalStages(2);
             }
@@ -716,18 +713,14 @@ public abstract class AbstractEntityAIStructure<J extends AbstractJobStructure<?
                        (entity instanceof TileEntityDecorationController && Utils.getBlueprintLevel(((TileEntityDecorationController) entity).getBlueprintPath()) != -1))
             {
                 structure = new BuildingStructureHandler<>(world,
-                  position,
-                  blueprint,
-                    new PlacementSettings(workOrder.isMirrored() ? Mirror.FRONT_BACK : Mirror.NONE, BlockPosUtil.getRotationFromRotations(workOrder.getRotation())),
+                    workOrder,
                   this, new BuildingStructureHandler.Stage[] {BUILD_SOLID, WEAK_SOLID, CLEAR_WATER, CLEAR_NON_SOLIDS, DECORATE, SPAWN});
                 building.setTotalStages(5);
             }
             else
             {
                 structure = new BuildingStructureHandler<>(world,
-                  position,
-                  blueprint,
-                    new PlacementSettings(workOrder.isMirrored() ? Mirror.FRONT_BACK : Mirror.NONE, BlockPosUtil.getRotationFromRotations(workOrder.getRotation())),
+                    workOrder,
                   this, new BuildingStructureHandler.Stage[] {CLEAR, BUILD_SOLID, WEAK_SOLID, CLEAR_WATER, CLEAR_NON_SOLIDS, DECORATE, SPAWN});
                 building.setTotalStages(6);
             }

--- a/src/main/java/com/minecolonies/core/entity/ai/workers/production/EntityAIQuarrier.java
+++ b/src/main/java/com/minecolonies/core/entity/ai/workers/production/EntityAIQuarrier.java
@@ -35,7 +35,6 @@ import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.Items;
 import net.minecraft.world.level.block.AirBlock;
 import net.minecraft.world.level.block.Block;
-import net.minecraft.world.level.block.Mirror;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.material.FluidState;
 import net.minecraftforge.common.ToolActions;
@@ -230,9 +229,7 @@ public class EntityAIQuarrier extends AbstractEntityAIStructureWithWorkOrder<Job
 
             final BuildingStructureHandler<JobQuarrier, BuildingMiner> structure;
             structure = new BuildingStructureHandler<>(world,
-              position,
-              blueprint,
-                new PlacementSettings(workOrder.isMirrored() ? Mirror.FRONT_BACK : Mirror.NONE, BlockPosUtil.getRotationFromRotations(workOrder.getRotation())),
+                workOrder,
               this, new BuildingStructureHandler.Stage[] {BUILD_SOLID, DECORATE, CLEAR});
             building.setTotalStages(3);
 

--- a/src/main/java/com/minecolonies/core/entity/pathfinding/PathingOptions.java
+++ b/src/main/java/com/minecolonies/core/entity/pathfinding/PathingOptions.java
@@ -55,7 +55,7 @@ public class PathingOptions
     /**
      * Cost to traverse trap doors
      */
-    public double traverseToggleAbleCost = 3D;
+    public double traverseToggleAbleCost = 2D;
 
     /**
      * Cost to climb a non ladder.
@@ -65,7 +65,7 @@ public class PathingOptions
     /**
      * Cost for walking within shapes(e.g. panels)
      */
-    public double walkInShapesCost = 2D;
+    public double walkInShapesCost = 1D;
 
     /**
      * Cost to dive (head underwater).

--- a/src/main/java/com/minecolonies/core/items/ItemAssistantHammer.java
+++ b/src/main/java/com/minecolonies/core/items/ItemAssistantHammer.java
@@ -264,21 +264,25 @@ public class ItemAssistantHammer extends AbstractItemMinecolonies
 
                         areBlocksToBuildNearby = true;
                         boolean hasItems = true;
-                        for (final ItemStack required : requiredItem)
-                        {
-                            boolean found = false;
-                            for (final ItemStack stack : player.getInventory().items)
-                            {
-                                if (ItemStackUtils.compareItemStacksIgnoreStackSize(required, stack))
-                                {
-                                    found = true;
-                                    break;
-                                }
-                            }
 
-                            if (!found)
+                        if (!player.isCreative())
+                        {
+                            for (final ItemStack required : requiredItem)
                             {
-                                hasItems = false;
+                                boolean found = false;
+                                for (final ItemStack stack : player.getInventory().items)
+                                {
+                                    if (ItemStackUtils.compareItemStacksIgnoreStackSize(required, stack))
+                                    {
+                                        found = true;
+                                        break;
+                                    }
+                                }
+
+                                if (!found)
+                                {
+                                    hasItems = false;
+                                }
                             }
                         }
 

--- a/src/main/resources/assets/minecolonies/lang/manual_en_us.json
+++ b/src/main/resources/assets/minecolonies/lang/manual_en_us.json
@@ -2757,7 +2757,8 @@
   "item.minecolonies.assistanthammer.happybuilder": "Thanks a lot for helping me building!",
   "item.minecolonies.assistanthammer.noitems": "No fitting items in your inventory",
   "item.minecolonies.assistanthammer.notloaded": "Structure not loaded yet, loading...",
-  "item.minecolonies.assistanthammer.onlyactive": "Your builder needs to start working on this construction site before you can assist them",
+  "item.minecolonies.assistanthammer.notcleared": "You need to wait until the builder finishes clearing the area",
+  "item.minecolonies.assistanthammer.onlyactive": "You are too far from the building site or your builder needs to start working on it yet",
   "item.minecolonies.assistanthammer.desc": "A useful tool for assisting a Minecolonies builder with their active task, allows you to place materials for them.",
 
   "com.minecolonies.core.item.food.tooltip.chef": "Ask a Chef in a Cookery to cook this for you",


### PR DESCRIPTION
Closes #
Closes #

# Changes proposed in this pull request
- Workorder now remembers and syncs the building stage
- Assistant hammers no longer allow building before the builder finished the clearing of the structure(removal of blocks, planning to add a paxel tool for allowing the player to remove blocks aswell)
- Buildings now properly register the blocks placed by the assistant hammer e.g. Furnaces and Storage racks should now function


## Testing
- [x ] Yes I tested this before submitting it.
- [ ] I also did a multiplayer test.

Review please