### PR TITLE
Couple o fixes

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.10-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.13-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/src/main/java/com/minecolonies/core/colony/buildings/AbstractBuilding.java
+++ b/src/main/java/com/minecolonies/core/colony/buildings/AbstractBuilding.java
@@ -1665,18 +1665,25 @@ public abstract class AbstractBuilding extends AbstractBuildingContainer
         final int citizenId = data == null ? -1 : data.getId();
         getOpenRequests(citizenId).forEach(request ->
         {
-            colony.getRequestManager().updateRequestState(request.getId(), RequestState.CANCELLED);
-
-            if (getOpenRequestsByRequestableType().containsKey(TypeToken.of(request.getRequest().getClass())))
+            try
             {
-                getOpenRequestsByRequestableType().get(TypeToken.of(request.getRequest().getClass())).remove(request.getId());
-                if (getOpenRequestsByRequestableType().get(TypeToken.of(request.getRequest().getClass())).isEmpty())
-                {
-                    getOpenRequestsByRequestableType().remove(TypeToken.of(request.getRequest().getClass()));
-                }
-            }
+                colony.getRequestManager().updateRequestState(request.getId(), RequestState.CANCELLED);
 
-            getCitizensByRequest().remove(request.getId());
+                if (getOpenRequestsByRequestableType().containsKey(TypeToken.of(request.getRequest().getClass())))
+                {
+                    getOpenRequestsByRequestableType().get(TypeToken.of(request.getRequest().getClass())).remove(request.getId());
+                    if (getOpenRequestsByRequestableType().get(TypeToken.of(request.getRequest().getClass())).isEmpty())
+                    {
+                        getOpenRequestsByRequestableType().remove(TypeToken.of(request.getRequest().getClass()));
+                    }
+                }
+
+                getCitizensByRequest().remove(request.getId());
+            }
+            catch (Exception ex)
+            {
+                Log.getLogger().error("Tried cancelling request of citizen but errored: " + (data == null ? -1 : data.getName()), ex);
+            }
         });
 
         getCompletedRequests(data).forEach(request -> colony.getRequestManager().updateRequestState(request.getId(), RequestState.RECEIVED));

--- a/src/main/java/com/minecolonies/core/colony/buildings/workerbuildings/BuildingBaker.java
+++ b/src/main/java/com/minecolonies/core/colony/buildings/workerbuildings/BuildingBaker.java
@@ -8,7 +8,6 @@ import com.minecolonies.api.colony.jobs.registry.JobEntry;
 import com.minecolonies.api.colony.requestsystem.request.IRequest;
 import com.minecolonies.api.colony.requestsystem.requestable.IRequestable;
 import com.minecolonies.api.colony.requestsystem.requestable.crafting.AbstractCrafting;
-import com.minecolonies.api.colony.requestsystem.requestable.crafting.PublicCrafting;
 import com.minecolonies.api.colony.requestsystem.token.IToken;
 import com.minecolonies.api.crafting.IGenericRecipe;
 import com.minecolonies.api.crafting.IRecipeStorage;
@@ -18,7 +17,6 @@ import com.minecolonies.api.util.CraftingUtils;
 import com.minecolonies.api.util.OptionalPredicate;
 import com.minecolonies.core.colony.buildings.AbstractBuilding;
 import com.minecolonies.core.colony.buildings.modules.AbstractCraftingBuildingModule;
-import com.minecolonies.core.colony.buildings.modules.WorkerBuildingModule;
 import com.minecolonies.core.colony.jobs.AbstractJobCrafter;
 import net.minecraft.core.BlockPos;
 import net.minecraft.util.Tuple;
@@ -32,6 +30,7 @@ import java.util.Set;
 import java.util.function.Predicate;
 
 import static com.minecolonies.api.util.constant.TagConstants.CRAFTING_BAKER;
+import static com.minecolonies.core.colony.buildings.modules.BuildingModules.BAKER_WORK;
 
 /**
  * Building for the bakery.
@@ -96,7 +95,7 @@ public class BuildingBaker extends AbstractBuilding
             return false;
         }
 
-        final ICitizenData citizenData = getFirstModuleOccurance(WorkerBuildingModule.class).getFirstCitizen();
+        final ICitizenData citizenData = getModule(BAKER_WORK).getFirstCitizen();
         if (citizenData != null)
         {
             final IRequest<? extends IRequestable> currentTask = ((AbstractJobCrafter<?, ?>) citizenData.getJob()).getCurrentTask();

--- a/src/main/java/com/minecolonies/core/colony/buildings/workerbuildings/BuildingBaker.java
+++ b/src/main/java/com/minecolonies/core/colony/buildings/workerbuildings/BuildingBaker.java
@@ -1,9 +1,13 @@
 package com.minecolonies.core.colony.buildings.workerbuildings;
 
 import com.google.common.collect.ImmutableSet;
+import com.minecolonies.api.colony.ICitizenData;
 import com.minecolonies.api.colony.IColony;
 import com.minecolonies.api.colony.IColonyManager;
 import com.minecolonies.api.colony.jobs.registry.JobEntry;
+import com.minecolonies.api.colony.requestsystem.request.IRequest;
+import com.minecolonies.api.colony.requestsystem.requestable.IRequestable;
+import com.minecolonies.api.colony.requestsystem.requestable.crafting.PublicCrafting;
 import com.minecolonies.api.colony.requestsystem.token.IToken;
 import com.minecolonies.api.crafting.IGenericRecipe;
 import com.minecolonies.api.crafting.IRecipeStorage;
@@ -13,6 +17,8 @@ import com.minecolonies.api.util.CraftingUtils;
 import com.minecolonies.api.util.OptionalPredicate;
 import com.minecolonies.core.colony.buildings.AbstractBuilding;
 import com.minecolonies.core.colony.buildings.modules.AbstractCraftingBuildingModule;
+import com.minecolonies.core.colony.buildings.modules.WorkerBuildingModule;
+import com.minecolonies.core.colony.jobs.AbstractJobCrafter;
 import net.minecraft.core.BlockPos;
 import net.minecraft.util.Tuple;
 import net.minecraft.world.item.ItemStack;
@@ -87,6 +93,33 @@ public class BuildingBaker extends AbstractBuilding
         if (stack.getItem() == Items.WHEAT)
         {
             return false;
+        }
+
+        final ICitizenData citizenData = getFirstModuleOccurance(WorkerBuildingModule.class).getFirstCitizen();
+        if (citizenData != null)
+        {
+            final IRequest<? extends IRequestable> currentTask = ((AbstractJobCrafter<?, ?>) citizenData.getJob()).getCurrentTask();
+            if (currentTask == null)
+            {
+                return super.canEat(stack);
+            }
+            final IRequestable request = currentTask.getRequest();
+            if (request instanceof PublicCrafting craftingRequest)
+            {
+                final IRecipeStorage recipe = IColonyManager.getInstance().getRecipeManager().getRecipe(craftingRequest.getRecipeID());
+                if (recipe != null)
+                {
+                    if (recipe.getCleanedInput().contains(new ItemStorage(stack)))
+                    {
+                        return false;
+                    }
+
+                    if (ItemStack.isSameItem(recipe.getPrimaryOutput(), stack))
+                    {
+                        return false;
+                    }
+                }
+            }
         }
         return super.canEat(stack);
     }

--- a/src/main/java/com/minecolonies/core/colony/buildings/workerbuildings/BuildingBaker.java
+++ b/src/main/java/com/minecolonies/core/colony/buildings/workerbuildings/BuildingBaker.java
@@ -7,6 +7,7 @@ import com.minecolonies.api.colony.IColonyManager;
 import com.minecolonies.api.colony.jobs.registry.JobEntry;
 import com.minecolonies.api.colony.requestsystem.request.IRequest;
 import com.minecolonies.api.colony.requestsystem.requestable.IRequestable;
+import com.minecolonies.api.colony.requestsystem.requestable.crafting.AbstractCrafting;
 import com.minecolonies.api.colony.requestsystem.requestable.crafting.PublicCrafting;
 import com.minecolonies.api.colony.requestsystem.token.IToken;
 import com.minecolonies.api.crafting.IGenericRecipe;
@@ -104,7 +105,7 @@ public class BuildingBaker extends AbstractBuilding
                 return super.canEat(stack);
             }
             final IRequestable request = currentTask.getRequest();
-            if (request instanceof PublicCrafting craftingRequest)
+            if (request instanceof AbstractCrafting craftingRequest)
             {
                 final IRecipeStorage recipe = IColonyManager.getInstance().getRecipeManager().getRecipe(craftingRequest.getRecipeID());
                 if (recipe != null)

--- a/src/main/java/com/minecolonies/core/colony/buildings/workerbuildings/BuildingDeliveryman.java
+++ b/src/main/java/com/minecolonies/core/colony/buildings/workerbuildings/BuildingDeliveryman.java
@@ -14,6 +14,7 @@ import net.minecraft.world.item.ItemStack;
 import org.jetbrains.annotations.NotNull;
 
 import static com.minecolonies.api.util.constant.BuildingConstants.CONST_DEFAULT_MAX_BUILDING_LEVEL;
+import static com.minecolonies.core.colony.buildings.modules.BuildingModules.COURIER_WORK;
 
 /**
  * Class of the warehouse building.
@@ -50,7 +51,7 @@ public class BuildingDeliveryman extends AbstractBuilding implements IBuildingDe
     @Override
     public boolean canEat(final ItemStack stack)
     {
-        final ICitizenData citizenData = getFirstModuleOccurance(WorkerBuildingModule.class).getFirstCitizen();
+        final ICitizenData citizenData = getModule(COURIER_WORK).getFirstCitizen();
         if (citizenData != null)
         {
             final JobDeliveryman job = (JobDeliveryman) citizenData.getJob();

--- a/src/main/java/com/minecolonies/core/colony/buildings/workerbuildings/BuildingKitchen.java
+++ b/src/main/java/com/minecolonies/core/colony/buildings/workerbuildings/BuildingKitchen.java
@@ -68,6 +68,43 @@ public class BuildingKitchen extends AbstractBuilding
         return MAX_BUILDING_LEVEL;
     }
 
+    @Override
+    protected boolean keepFood()
+    {
+        return false;
+    }
+
+    @Override
+    public boolean canEat(final ItemStack stack)
+    {
+        final ICitizenData citizenData = getModule(CHEF_WORK).getFirstCitizen();
+        if (citizenData != null)
+        {
+            final IRequest<? extends IRequestable> currentTask = ((AbstractJobCrafter<?, ?>) citizenData.getJob()).getCurrentTask();
+            if (currentTask == null)
+            {
+                return super.canEat(stack);
+            }
+            final IRequestable request = currentTask.getRequest();
+            if (request instanceof AbstractCrafting craftingRequest)
+            {
+                final IRecipeStorage recipe = IColonyManager.getInstance().getRecipeManager().getRecipe(craftingRequest.getRecipeID());
+                if (recipe != null)
+                {
+                    if (recipe.getCleanedInput().contains(new ItemStorage(stack)))
+                    {
+                        return false;
+                    }
+
+                    if (ItemStack.isSameItem(recipe.getPrimaryOutput(), stack))
+                    {
+                        return false;
+                    }
+                }
+            }
+        }
+        return super.canEat(stack);
+    }
 
     public static class CraftingModule extends AbstractCraftingBuildingModule.Crafting
     {
@@ -130,37 +167,5 @@ public class BuildingKitchen extends AbstractBuilding
             if (!super.isRecipeCompatible(recipe)) return false;
             return CraftingUtils.isRecipeCompatibleBasedOnTags(recipe, CRAFTING_COOK).orElse(FoodUtils.EDIBLE.test(recipe.getPrimaryOutput()));
         }
-    }
-
-    @Override
-    public boolean canEat(final ItemStack stack)
-    {
-        final ICitizenData citizenData = getModule(CHEF_WORK).getFirstCitizen();
-        if (citizenData != null)
-        {
-            final IRequest<? extends IRequestable> currentTask = ((AbstractJobCrafter<?, ?>) citizenData.getJob()).getCurrentTask();
-            if (currentTask == null)
-            {
-                return super.canEat(stack);
-            }
-            final IRequestable request = currentTask.getRequest();
-            if (request instanceof AbstractCrafting craftingRequest)
-            {
-                final IRecipeStorage recipe = IColonyManager.getInstance().getRecipeManager().getRecipe(craftingRequest.getRecipeID());
-                if (recipe != null)
-                {
-                    if (recipe.getCleanedInput().contains(new ItemStorage(stack)))
-                    {
-                        return false;
-                    }
-
-                    if (ItemStack.isSameItem(recipe.getPrimaryOutput(), stack))
-                    {
-                        return false;
-                    }
-                }
-            }
-        }
-        return super.canEat(stack);
     }
 }

--- a/src/main/java/com/minecolonies/core/colony/buildings/workerbuildings/BuildingKitchen.java
+++ b/src/main/java/com/minecolonies/core/colony/buildings/workerbuildings/BuildingKitchen.java
@@ -6,6 +6,7 @@ import com.minecolonies.api.colony.IColonyManager;
 import com.minecolonies.api.colony.jobs.registry.JobEntry;
 import com.minecolonies.api.colony.requestsystem.request.IRequest;
 import com.minecolonies.api.colony.requestsystem.requestable.IRequestable;
+import com.minecolonies.api.colony.requestsystem.requestable.crafting.AbstractCrafting;
 import com.minecolonies.api.colony.requestsystem.requestable.crafting.PublicCrafting;
 import com.minecolonies.api.crafting.IGenericRecipe;
 import com.minecolonies.api.crafting.IRecipeStorage;
@@ -142,7 +143,7 @@ public class BuildingKitchen extends AbstractBuilding
                 return super.canEat(stack);
             }
             final IRequestable request = currentTask.getRequest();
-            if (request instanceof PublicCrafting craftingRequest)
+            if (request instanceof AbstractCrafting craftingRequest)
             {
                 final IRecipeStorage recipe = IColonyManager.getInstance().getRecipeManager().getRecipe(craftingRequest.getRecipeID());
                 if (recipe != null)

--- a/src/main/java/com/minecolonies/core/colony/buildings/workerbuildings/BuildingKitchen.java
+++ b/src/main/java/com/minecolonies/core/colony/buildings/workerbuildings/BuildingKitchen.java
@@ -26,6 +26,7 @@ import java.util.Optional;
 
 import static com.minecolonies.api.util.constant.Suppression.OVERRIDE_EQUALS;
 import static com.minecolonies.api.util.constant.TagConstants.CRAFTING_COOK;
+import static com.minecolonies.core.colony.buildings.modules.BuildingModules.CHEF_WORK;
 
 /**
  * Class of the kitchen building.
@@ -134,7 +135,7 @@ public class BuildingKitchen extends AbstractBuilding
     @Override
     public boolean canEat(final ItemStack stack)
     {
-        final ICitizenData citizenData = getFirstModuleOccurance(WorkerBuildingModule.class).getFirstCitizen();
+        final ICitizenData citizenData = getModule(CHEF_WORK).getFirstCitizen();
         if (citizenData != null)
         {
             final IRequest<? extends IRequestable> currentTask = ((AbstractJobCrafter<?, ?>) citizenData.getJob()).getCurrentTask();

--- a/src/main/java/com/minecolonies/core/colony/buildings/workerbuildings/BuildingKitchen.java
+++ b/src/main/java/com/minecolonies/core/colony/buildings/workerbuildings/BuildingKitchen.java
@@ -1,14 +1,22 @@
 package com.minecolonies.core.colony.buildings.workerbuildings;
 
+import com.minecolonies.api.colony.ICitizenData;
 import com.minecolonies.api.colony.IColony;
 import com.minecolonies.api.colony.IColonyManager;
 import com.minecolonies.api.colony.jobs.registry.JobEntry;
+import com.minecolonies.api.colony.requestsystem.request.IRequest;
+import com.minecolonies.api.colony.requestsystem.requestable.IRequestable;
+import com.minecolonies.api.colony.requestsystem.requestable.crafting.PublicCrafting;
 import com.minecolonies.api.crafting.IGenericRecipe;
+import com.minecolonies.api.crafting.IRecipeStorage;
+import com.minecolonies.api.crafting.ItemStorage;
 import com.minecolonies.api.util.CraftingUtils;
 import com.minecolonies.api.util.FoodUtils;
 import com.minecolonies.api.util.OptionalPredicate;
 import com.minecolonies.core.colony.buildings.AbstractBuilding;
 import com.minecolonies.core.colony.buildings.modules.AbstractCraftingBuildingModule;
+import com.minecolonies.core.colony.buildings.modules.WorkerBuildingModule;
+import com.minecolonies.core.colony.jobs.AbstractJobCrafter;
 import net.minecraft.core.BlockPos;
 import net.minecraft.world.item.ItemStack;
 import org.jetbrains.annotations.NotNull;
@@ -120,5 +128,37 @@ public class BuildingKitchen extends AbstractBuilding
             if (!super.isRecipeCompatible(recipe)) return false;
             return CraftingUtils.isRecipeCompatibleBasedOnTags(recipe, CRAFTING_COOK).orElse(FoodUtils.EDIBLE.test(recipe.getPrimaryOutput()));
         }
+    }
+
+    @Override
+    public boolean canEat(final ItemStack stack)
+    {
+        final ICitizenData citizenData = getFirstModuleOccurance(WorkerBuildingModule.class).getFirstCitizen();
+        if (citizenData != null)
+        {
+            final IRequest<? extends IRequestable> currentTask = ((AbstractJobCrafter<?, ?>) citizenData.getJob()).getCurrentTask();
+            if (currentTask == null)
+            {
+                return super.canEat(stack);
+            }
+            final IRequestable request = currentTask.getRequest();
+            if (request instanceof PublicCrafting craftingRequest)
+            {
+                final IRecipeStorage recipe = IColonyManager.getInstance().getRecipeManager().getRecipe(craftingRequest.getRecipeID());
+                if (recipe != null)
+                {
+                    if (recipe.getCleanedInput().contains(new ItemStorage(stack)))
+                    {
+                        return false;
+                    }
+
+                    if (ItemStack.isSameItem(recipe.getPrimaryOutput(), stack))
+                    {
+                        return false;
+                    }
+                }
+            }
+        }
+        return super.canEat(stack);
     }
 }

--- a/src/main/java/com/minecolonies/core/colony/requestsystem/data/StandardRequestSystemBuildingDataStore.java
+++ b/src/main/java/com/minecolonies/core/colony/requestsystem/data/StandardRequestSystemBuildingDataStore.java
@@ -83,7 +83,7 @@ public class StandardRequestSystemBuildingDataStore implements IRequestSystemBui
     @Override
     public void moveToSyncCitizen(final ICitizenData citizenData, final IRequest<?> request)
     {
-        if (citizenByOpenRequest.containsKey(request.getId()))
+        if (citizenByOpenRequest.get(request.getId()) == -1)
         {
             citizenByOpenRequest.remove(request.getId());
             citizenByOpenRequest.put(request.getId(), citizenData.getId());


### PR DESCRIPTION
Closes #10920
Closes #10921

# Changes proposed in this pull request
- Builder should only move request that are not already sync assigned to them, that was causing duplication and missing request issues.
- Chef/baker shouldn't eat the food that is currently assigned to them.
- Still issues during cancel shouldn't crash

## Testing
- [x] Yes I tested this before submitting it.
- [ ] I also did a multiplayer test.

Review please