### PR TITLE
Take the napalm away from knights

### DIFF
--- a/src/main/java/com/minecolonies/core/entity/ai/workers/guard/KnightCombatAI.java
+++ b/src/main/java/com/minecolonies/core/entity/ai/workers/guard/KnightCombatAI.java
@@ -167,7 +167,7 @@ public class KnightCombatAI extends AttackMoveAI<EntityCitizen>
         final int fireLevel = EnchantmentHelper.getItemEnchantmentLevel(Enchantments.FIRE_ASPECT, user.getItemInHand(InteractionHand.MAIN_HAND));
         if (fireLevel > 0)
         {
-            target.setSecondsOnFire(fireLevel * 80);
+            target.setSecondsOnFire(fireLevel * 4);
         }
 
         if (user.level.getGameTime() - lastAoeUseTime > KNOCKBACK_COOLDOWN)

--- a/src/main/java/com/minecolonies/core/entity/ai/workers/guard/RangerCombatAI.java
+++ b/src/main/java/com/minecolonies/core/entity/ai/workers/guard/RangerCombatAI.java
@@ -179,7 +179,7 @@ public class RangerCombatAI extends AttackMoveAI<EntityCitizen>
 
             if (EnchantmentHelper.getItemEnchantmentLevel(Enchantments.FLAMING_ARROWS, bow) > 0)
             {
-                arrow.setSecondsOnFire(100);
+                arrow.setSecondsOnFire(5);
             }
             final int k = EnchantmentHelper.getItemEnchantmentLevel(Enchantments.PUNCH_ARROWS, bow);
             if (k > 0)

--- a/src/main/java/com/minecolonies/core/entity/mobs/aitasks/RaiderRangedAI.java
+++ b/src/main/java/com/minecolonies/core/entity/mobs/aitasks/RaiderRangedAI.java
@@ -108,7 +108,7 @@ public class RaiderRangedAI<T extends AbstractEntityMinecoloniesMonster & IThrea
         if (flightCounter > 5 && arrowEntity instanceof CustomArrowEntity)
         {
             ((CustomArrowEntity) arrowEntity).setPlayerArmorPierce();
-            arrowEntity.setSecondsOnFire(200);
+            arrowEntity.setSecondsOnFire(10);
             arrowEntity.setBaseDamage(10);
         }
 

--- a/src/main/java/com/minecolonies/core/items/ItemPharaoScepter.java
+++ b/src/main/java/com/minecolonies/core/items/ItemPharaoScepter.java
@@ -94,7 +94,7 @@ public class ItemPharaoScepter extends BowItem
 
                     if (EnchantmentHelper.getItemEnchantmentLevel(Enchantments.FLAMING_ARROWS, stack) > 0)
                     {
-                        abstractarrowentity.setSecondsOnFire(100);
+                        abstractarrowentity.setSecondsOnFire(5);
                     }
 
                     stack.hurtAndBreak(1, playerentity, new Consumer<Player>() {


### PR DESCRIPTION
Closes [discord report](https://discord.com/channels/139070364159311872/1003402487417548801/1381531204330983424)

# Changes proposed in this pull request
- Nerf the knights when using Fire Aspect back to normal values.
- Also confiscate the napalm arrows from the rangers and raiders.

## Testing
- [ ] Yes I tested this before submitting it.
- [ ] I also did a multiplayer test.

Review please (should port)