### PR TITLE
Level 0 Builders = No Decorating

### DIFF
--- a/src/main/java/com/minecolonies/core/client/gui/WindowBuildDecoration.java
+++ b/src/main/java/com/minecolonies/core/client/gui/WindowBuildDecoration.java
@@ -180,7 +180,8 @@ public class WindowBuildDecoration extends AbstractWindowSkeleton
         builders.add(new Tuple<>(Component.translatable(ModJobs.builder.get().getTranslationKey()).getString() + ":", BlockPos.ZERO));
         builders.addAll(colony.getBuildings().stream()
                           .filter(build -> build instanceof AbstractBuildingBuilderView && !((AbstractBuildingBuilderView) build).getWorkerName().isEmpty()
-                                             && build.getBuildingType() != ModBuildings.miner.get())
+                                             && build.getBuildingType() != ModBuildings.miner.get()
+                                             && build.getBuildingLevel() > 0)
                           .map(build -> new Tuple<>(((AbstractBuildingBuilderView) build).getWorkerName(), build.getPosition()))
                           .sorted(Comparator.comparing(item -> item.getB().distSqr(structurePos)))
                           .collect(Collectors.toList()));

--- a/src/main/java/com/minecolonies/core/colony/workorders/WorkOrderDecoration.java
+++ b/src/main/java/com/minecolonies/core/colony/workorders/WorkOrderDecoration.java
@@ -79,7 +79,7 @@ public class WorkOrderDecoration extends AbstractWorkOrder
     @SuppressWarnings(UNUSED_METHOD_PARAMETERS_SHOULD_BE_REMOVED)
     public boolean canBuild(@NotNull final ICitizenData citizen)
     {
-        return citizen.getJob() instanceof JobBuilder;
+        return citizen.getJob() instanceof JobBuilder && citizen.getJob().getWorkBuilding().getBuildingLevel() > 0;
     }
 
     @Override


### PR DESCRIPTION
Closes #10937 

# Changes proposed in this pull request
- Prevent level 0 builders from auto-assigning themselves decoration, or from being assigned to the decoration from the build confirmation drop-down.
-

## Testing
- [X] Yes I tested this before submitting it.
- [No] I also did a multiplayer test.

Review please