### PR TITLE
Don't forget crafting tools when improving recipes

### DIFF
--- a/src/main/java/com/minecolonies/api/crafting/GenericRecipe.java
+++ b/src/main/java/com/minecolonies/api/crafting/GenericRecipe.java
@@ -300,7 +300,7 @@ public class GenericRecipe implements IGenericRecipe
         return builder()
                 .withRecipeId(storage.getRecipeSource())
                 .withOutputs(storage.getPrimaryOutput(), storage.getAlternateOutputs())
-                .withAdditionalOutputs(storage.getSecondaryOutputs())
+                .withAdditionalOutputs(storage.getCraftingToolsAndSecondaryOutputs())
                 .withInputs(inputs)
                 .withGridSize(storage.getGridSize())
                 .withIntermediate(storage.getIntermediate())

--- a/src/main/java/com/minecolonies/api/crafting/RecipeStorage.java
+++ b/src/main/java/com/minecolonies/api/crafting/RecipeStorage.java
@@ -161,7 +161,7 @@ public class RecipeStorage implements IRecipeStorage
             this.input = recipe.getInput();
             this.primaryOutput = recipe.getPrimaryOutput();
             this.alternateOutputs = recipe.getAlternateOutputs();
-            this.secondaryOutputs = recipe.getSecondaryOutputs();
+            this.secondaryOutputs = recipe.getCraftingToolsAndSecondaryOutputs();
             this.intermediate = recipe.getIntermediate();
             this.gridSize = recipe.getGridSize();
             this.token = null;


### PR DESCRIPTION
Closes #10940

# Changes proposed in this pull request
- Don't forget about crafting tools when improving recipes.

## Testing
- [ ] Yes I tested this before submitting it.
- [ ] I also did a multiplayer test.

Review please (should port)

Note that this won't fix already-improved recipes that have already forgotten them.  The recipes will need to be deleted, re-added, and then improved again.