### PR TITLE
Stats for Florist and Composter

### DIFF
--- a/src/main/java/com/minecolonies/api/util/constant/StatisticsConstants.java
+++ b/src/main/java/com/minecolonies/api/util/constant/StatisticsConstants.java
@@ -43,5 +43,13 @@ public final class StatisticsConstants
     // Hospital
     public static final String DISEASES_TREATED = "diseases_treated";
     public static final String NUM_DISEASES_TREATED = "num_diseases_treated";
+
+    // Florist
+    public static final String FLOWERS_PICKED = "flowers_picked";
+
+    // Composter
+    public static final String ITEMS_COMPOSTED = "items_composted";
+    public static final String PRODUCT_COLLECTED = "product_collected";
+
 }
 

--- a/src/main/java/com/minecolonies/apiimp/initializer/ModBuildingsInitializer.java
+++ b/src/main/java/com/minecolonies/apiimp/initializer/ModBuildingsInitializer.java
@@ -130,6 +130,7 @@ public final class ModBuildingsInitializer
           .addBuildingModuleProducer(COMPOSTER_WORK)
           .addBuildingModuleProducer(COMPOSTER_SETTINGS)
           .addBuildingModuleProducer(ITEMLIST_COMPOSTABLE)
+          .addBuildingModuleProducer(STATS_MODULE)
           .createBuildingEntry());
 
         ModBuildings.cook = DEFERRED_REGISTER.register(ModBuildings.COOK_ID, () -> new BuildingEntry.Builder()
@@ -387,6 +388,7 @@ public final class ModBuildingsInitializer
           .addBuildingModuleProducer(FLORIST_WORK)
           .addBuildingModuleProducer(FLORIST_ITEMS)
           .addBuildingModuleProducer(MIN_STOCK)
+          .addBuildingModuleProducer(STATS_MODULE)
           .createBuildingEntry());
 
         ModBuildings.enchanter = DEFERRED_REGISTER.register(ModBuildings.ENCHANTER_ID, () -> new BuildingEntry.Builder()

--- a/src/main/resources/assets/minecolonies/lang/manual_en_us.json
+++ b/src/main/resources/assets/minecolonies/lang/manual_en_us.json
@@ -2534,6 +2534,9 @@
   "com.minecolonies.coremod.gui.townhall.stats.num_diseases_treated": "Treated Diseases: %d",
   "com.minecolonies.coremod.gui.townhall.stats.diseases_treated": "Treated %d %s",
   "com.minecolonies.coremod.gui.townhall.stats.items_cooked": "Cooked %d %s",
+  "com.minecolonies.coremod.gui.townhall.stats.flowers_picked": "Picked %d %s",
+  "com.minecolonies.coremod.gui.townhall.stats.items_composted": "Composted %d %s",
+  "com.minecolonies.coremod.gui.townhall.stats.product_collected": "Collected %d %s",
 
   "com.minecolonies.coremod.gui.interval.yesterday": "Since Yesterday",
   "com.minecolonies.coremod.gui.interval.lastweek": "Last Week",


### PR DESCRIPTION
Closes None

# Changes proposed in this pull request
- Stats modules added to both buildings.
- Composter measures what things were turned into compost and what items were harvested from the composting.
- Florist measures what flowers were picked.

## Testing
- [X] Yes I tested this before submitting it.
- [ ] I also did a multiplayer test.

If Archery stats go in before this one, StatsUtil.trackStat calls will need to be renamed to StatsUtil.trackStatByName to match the refactoring in that branch.

Review please