### PR TITLE
separate postbox/stash from blockhut

### DIFF
--- a/src/main/java/com/minecolonies/api/blocks/AbstractBaseBlockHut.java
+++ b/src/main/java/com/minecolonies/api/blocks/AbstractBaseBlockHut.java
@@ -1,0 +1,348 @@
+package com.minecolonies.api.blocks;
+
+import com.minecolonies.api.MinecoloniesAPIProxy;
+import com.minecolonies.api.blocks.interfaces.ITickableBlockMinecolonies;
+import com.minecolonies.api.colony.IColony;
+import com.minecolonies.api.colony.IColonyManager;
+import com.minecolonies.api.colony.buildings.IBuilding;
+import com.minecolonies.api.colony.buildings.registry.BuildingEntry;
+import com.minecolonies.api.colony.buildings.views.IBuildingView;
+import com.minecolonies.api.colony.permissions.Action;
+import com.minecolonies.api.entity.ai.workers.util.IBuilderUndestroyable;
+import com.minecolonies.api.items.ItemBlockHut;
+import com.minecolonies.api.tileentities.MinecoloniesTileEntities;
+import com.minecolonies.core.tileentities.TileEntityColonyBuilding;
+import com.minecolonies.api.util.*;
+import com.minecolonies.api.util.constant.Constants;
+import net.minecraft.core.BlockPos;
+import net.minecraft.core.Direction;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.world.InteractionHand;
+import net.minecraft.world.InteractionResult;
+import net.minecraft.world.entity.LivingEntity;
+import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.item.Item;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.context.BlockPlaceContext;
+import net.minecraft.world.level.BlockGetter;
+import net.minecraft.world.level.Level;
+import net.minecraft.world.level.block.*;
+import net.minecraft.world.level.block.entity.BlockEntity;
+import net.minecraft.world.level.block.state.BlockState;
+import net.minecraft.world.level.block.state.StateDefinition;
+import net.minecraft.world.level.block.state.properties.DirectionProperty;
+import net.minecraft.world.level.chunk.LevelChunk;
+import net.minecraft.world.level.material.MapColor;
+import net.minecraft.world.phys.BlockHitResult;
+import net.minecraft.world.phys.shapes.CollisionContext;
+import net.minecraft.world.phys.shapes.Shapes;
+import net.minecraft.world.phys.shapes.VoxelShape;
+import net.minecraftforge.registries.IForgeRegistry;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.Collection;
+
+import static com.minecolonies.api.util.constant.BuildingConstants.DEACTIVATED;
+import static com.minecolonies.api.util.constant.TranslationConstants.*;
+
+/**
+ * Abstract class for all minecolonies blocks.
+ * <p>
+ * The method {@link AbstractBaseBlockHut#getName()} is abstract.
+ * <p>
+ * All AbstractBlockHut[something] should extend this class.
+ */
+@SuppressWarnings("PMD.ExcessiveImports")
+public abstract class AbstractBaseBlockHut<B extends AbstractBaseBlockHut<B>> extends AbstractBlockMinecolonies<B> implements IBuilderUndestroyable, ITickableBlockMinecolonies
+
+{
+    /**
+     * Hardness factor of the pvp mode.
+     */
+    private static final int HARDNESS_PVP_FACTOR = 4;
+
+    /**
+     * The direction the block is facing.
+     */
+    public static final DirectionProperty FACING = HorizontalDirectionalBlock.FACING;
+
+    /**
+     * The default hardness.
+     */
+    public static final float HARDNESS = 10F;
+
+    /**
+     * The default resistance (against explosions).
+     */
+    public static final float RESISTANCE = Float.POSITIVE_INFINITY;
+
+    /**
+     * Smaller shape.
+     */
+    private static final VoxelShape SHAPE = Shapes.box(0.1, 0.1, 0.1, 0.9, 0.9, 0.9);
+
+    /**
+     * The hut's lower-case building-registry-compatible name.
+     */
+    private final String name;
+
+    /**
+     * The timepoint of the last chat warning message
+     */
+    private long lastBreakTickWarn = 0;
+
+    /**
+     * Constructor for a hut block.
+     * <p>
+     * Registers the block, sets the creative tab, as well as the resistance and the hardness.
+     */
+    public AbstractBaseBlockHut()
+    {
+        super(Properties.of().mapColor(MapColor.WOOD).sound(SoundType.WOOD).strength(HARDNESS, RESISTANCE).noOcclusion());
+        this.registerDefaultState(this.defaultBlockState().setValue(FACING, Direction.NORTH));
+        this.name = getHutName();
+    }
+
+    @Override
+    public float getDestroyProgress(final BlockState state, @NotNull final Player player, @NotNull final BlockGetter world, @NotNull final BlockPos pos)
+    {
+        final IBuilding building = IColonyManager.getInstance().getBuilding(player.level(), pos);
+        if (building != null && !building.getChildren().isEmpty() && (player.level().getGameTime() - lastBreakTickWarn) < 100)
+        {
+            lastBreakTickWarn = player.level().getGameTime();
+            MessageUtils.format(HUT_BREAK_WARNING_CHILD_BUILDINGS).sendTo(player);
+        }
+
+        return (MinecoloniesAPIProxy.getInstance().getConfig().getServer().pvp_mode.get() ? 1 / (HARDNESS * HARDNESS_PVP_FACTOR) : 1 / HARDNESS) / 30;
+    }
+
+    /**
+     * Constructor for a hut block.
+     * <p>
+     * Registers the block, sets the creative tab, as well as the resistance and the hardness.
+     *
+     * @param properties custom properties.
+     */
+    public AbstractBaseBlockHut(final Properties properties)
+    {
+        super(properties.noOcclusion());
+        this.registerDefaultState(this.defaultBlockState().setValue(FACING, Direction.NORTH));
+        this.name = getHutName();
+    }
+
+    /**
+     * Method to return the name of the block.
+     *
+     * @return Name of the block.
+     */
+    public abstract String getHutName();
+
+    @Nullable
+    @Override
+    public BlockEntity newBlockEntity(@NotNull final BlockPos blockPos, @NotNull final BlockState blockState)
+    {
+        final TileEntityColonyBuilding building = (TileEntityColonyBuilding) MinecoloniesTileEntities.BUILDING.get().create(blockPos, blockState);
+        building.registryName = this.getBuildingEntry().getRegistryName();
+        return building;
+    }
+
+    /**
+     * Method to get the building registry entry.
+     *
+     * @return The building entry.
+     */
+    public abstract BuildingEntry getBuildingEntry();
+
+    @NotNull
+    @Override
+    public VoxelShape getShape(final BlockState state, final BlockGetter worldIn, final BlockPos pos, final CollisionContext context)
+    {
+        return SHAPE;
+    }
+
+    @NotNull
+    @Override
+    public InteractionResult use(
+      final BlockState state,
+      final Level worldIn,
+      final BlockPos pos,
+      final Player player,
+      final InteractionHand hand,
+      final BlockHitResult ray)
+    {
+       /*
+        If the world is client, open the gui of the building
+         */
+        if (worldIn.isClientSide)
+        {
+            if (hand == InteractionHand.OFF_HAND)
+            {
+                return InteractionResult.FAIL;
+            }
+
+            @Nullable final IBuildingView building = IColonyManager.getInstance().getBuildingView(worldIn.dimension(), pos);
+            final LevelChunk chunk = worldIn.getChunkAt(pos);
+            final BlockEntity entity = worldIn.getBlockEntity(pos);
+            if (entity instanceof final TileEntityColonyBuilding te && te.getPositionedTags().containsKey(BlockPos.ZERO) && te.getPositionedTags().get(BlockPos.ZERO).contains(DEACTIVATED))
+            {
+                if (building == null && ColonyUtils.getOwningColony(chunk) == 0)
+                {
+                    MessageUtils.format(MISSING_COLONY).sendTo(player);
+                    return InteractionResult.FAIL;
+                }
+
+                if (building == null && ColonyUtils.getAllClaimingBuildings(chunk).values().stream().flatMap(Collection::stream).noneMatch(p -> p.equals(pos)))
+                {
+                    IColonyManager.getInstance().openReactivationWindow(pos);
+                    return InteractionResult.SUCCESS;
+                }
+            }
+
+            if (building == null)
+            {
+                MessageUtils.format(HUT_BLOCK_MISSING_BUILDING).sendTo(player);
+                return InteractionResult.FAIL;
+            }
+
+            if (building.getColony() == null)
+            {
+                MessageUtils.format(HUT_BLOCK_MISSING_COLONY).sendTo(player);
+                return InteractionResult.FAIL;
+            }
+
+            if (!building.getColony().getPermissions().hasPermission(player, Action.ACCESS_HUTS))
+            {
+                MessageUtils.format(PERMISSION_DENIED).sendTo(player);
+                return InteractionResult.FAIL;
+            }
+
+            building.openGui(player.isShiftKeyDown());
+        }
+        return InteractionResult.SUCCESS;
+    }
+
+    @Nullable
+    @Override
+    public BlockState getStateForPlacement(final BlockPlaceContext context)
+    {
+        @NotNull final Direction facing = (context.getPlayer() == null) ? Direction.NORTH : Direction.fromYRot(context.getPlayer().getYRot());
+        return this.defaultBlockState().setValue(FACING, facing);
+    }
+
+    @NotNull
+    @Override
+    public BlockState rotate(final BlockState state, final Rotation rot)
+    {
+        return state.setValue(FACING, rot.rotate(state.getValue(FACING)));
+    }
+
+    @Override
+    public void setPlacedBy(@NotNull final Level worldIn, @NotNull final BlockPos pos, final BlockState state, final LivingEntity placer, final ItemStack stack)
+    {
+        super.setPlacedBy(worldIn, pos, state, placer, stack);
+
+        /*
+        Only work on server side
+        */
+        if (worldIn.isClientSide)
+        {
+            return;
+        }
+
+        final BlockEntity tileEntity = worldIn.getBlockEntity(pos);
+        if (tileEntity instanceof TileEntityColonyBuilding)
+        {
+            @NotNull final TileEntityColonyBuilding hut = (TileEntityColonyBuilding) tileEntity;
+            if (hut.getBuildingName() != getBuildingEntry().getRegistryName())
+            {
+                hut.registryName = getBuildingEntry().getRegistryName();
+            }
+            @Nullable final IColony colony = IColonyManager.getInstance().getColonyByPosFromWorld(worldIn, hut.getPosition());
+
+            if (colony != null)
+            {
+                colony.getBuildingManager().addNewBuilding(hut, worldIn);
+            }
+        }
+    }
+
+    @Override
+    protected void createBlockStateDefinition(StateDefinition.Builder<Block, BlockState> builder)
+    {
+        builder.add(FACING);
+    }
+
+    /**
+     * Get the registry name frm the blck hut.
+     * @return the key.
+     */
+    public ResourceLocation getRegistryName()
+    {
+        return new ResourceLocation(Constants.MOD_ID, getHutName());
+    }
+
+    @Override
+    public B registerBlock(final IForgeRegistry<Block> registry)
+    {
+        registry.register(getRegistryName(), this);
+        return (B) this;
+    }
+
+    /**
+     * Check if we got permissions to paste.
+     * @param anchor the anchor of the paste.
+     * @param player the player pasting it.
+     * @param pos the position its pasted at.
+     * @return true if fine.
+     */
+    private boolean canPaste(final Block anchor, final Player player, final BlockPos pos)
+    {
+        final IColony colony = IColonyManager.getInstance().getIColony(player.level(), pos);
+
+        if (colony == null)
+        {
+            if(anchor == ModBlocks.blockHutTownHall)
+            {
+                return true;
+            }
+
+            //  Not in a colony
+            if (IColonyManager.getInstance().getIColonyByOwner(player.level(), player) == null)
+            {
+                MessageUtils.format(MESSAGE_WARNING_TOWN_HALL_NOT_PRESENT).sendTo(player);
+            }
+            else
+            {
+                MessageUtils.format(MESSAGE_WARNING_TOWN_HALL_TOO_FAR_AWAY).sendTo(player);
+            }
+
+            return false;
+        }
+        else if (!colony.getPermissions().hasPermission(player, Action.PLACE_HUTS))
+        {
+            //  No permission to place hut in colony
+            MessageUtils.format(PERMISSION_OPEN_HUT, colony.getName()).sendTo(player);
+            return false;
+        }
+        else
+        {
+            return colony.getBuildingManager().canPlaceAt(anchor, pos, player);
+        }
+    }
+
+    /**
+     * Get the blueprint name.
+     * @return the name.
+     */
+    public String getBlueprintName()
+    {
+        return getBuildingEntry().getRegistryName().getPath();
+    }
+
+    @Override
+    public void registerBlockItem(final IForgeRegistry<Item> registry, final Item.Properties properties)
+    {
+        registry.register(getRegistryName(), new ItemBlockHut(this, properties));
+    }
+}

--- a/src/main/java/com/minecolonies/api/blocks/AbstractBlockHut.java
+++ b/src/main/java/com/minecolonies/api/blocks/AbstractBlockHut.java
@@ -50,11 +50,8 @@ import static com.ldtteam.structurize.blockentities.interfaces.IBlueprintDataPro
 import static com.minecolonies.api.util.constant.TranslationConstants.*;
 
 /**
- * Abstract class for all minecolonies blocks.
- * <p>
- * The method {@link AbstractBlockHut#getName()} is abstract.
- * <p>
- * All AbstractBlockHut[something] should extend this class.
+ * Base class for all Minecolonies Hut Blocks. Hut Blocks are the base blocks for Minecolonies buildings.
+ * Extending this class enables all the blueprint functionalities.
  */
 @SuppressWarnings("PMD.ExcessiveImports")
 public abstract class AbstractBlockHut<B extends AbstractBlockHut<B>> extends AbstractColonyBlock<B> implements

--- a/src/main/java/com/minecolonies/api/blocks/AbstractBlockHut.java
+++ b/src/main/java/com/minecolonies/api/blocks/AbstractBlockHut.java
@@ -21,7 +21,6 @@ import net.minecraft.ChatFormatting;
 import net.minecraft.client.multiplayer.ClientLevel;
 import net.minecraft.client.player.LocalPlayer;
 import net.minecraft.core.BlockPos;
-import net.minecraft.core.Direction;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.network.chat.Component;
 import net.minecraft.network.chat.MutableComponent;
@@ -58,7 +57,7 @@ import static com.minecolonies.api.util.constant.TranslationConstants.*;
  * All AbstractBlockHut[something] should extend this class.
  */
 @SuppressWarnings("PMD.ExcessiveImports")
-public abstract class AbstractBlockHut<B extends AbstractBlockHut<B>> extends AbstractBaseBlockHut<B> implements
+public abstract class AbstractBlockHut<B extends AbstractBlockHut<B>> extends AbstractColonyBlock<B> implements
                                                                                                                         IAnchorBlock,
                                                                                                                         INamedBlueprintAnchorBlock,
                                                                                                                         ILeveledBlueprintAnchorBlock,

--- a/src/main/java/com/minecolonies/api/blocks/AbstractBlockHut.java
+++ b/src/main/java/com/minecolonies/api/blocks/AbstractBlockHut.java
@@ -7,19 +7,13 @@ import com.ldtteam.structurize.util.PlacementSettings;
 import com.minecolonies.api.IMinecoloniesAPI;
 import com.minecolonies.api.MinecoloniesAPIProxy;
 import com.minecolonies.api.blocks.interfaces.IBuildingBrowsableBlock;
-import com.minecolonies.api.blocks.interfaces.ITickableBlockMinecolonies;
 import com.minecolonies.api.colony.IColony;
 import com.minecolonies.api.colony.IColonyManager;
 import com.minecolonies.api.colony.IColonyView;
 import com.minecolonies.api.colony.buildings.IBuilding;
-import com.minecolonies.api.colony.buildings.registry.BuildingEntry;
-import com.minecolonies.api.colony.buildings.views.IBuildingView;
 import com.minecolonies.api.colony.permissions.Action;
-import com.minecolonies.api.entity.ai.workers.util.IBuilderUndestroyable;
 import com.minecolonies.api.items.ItemBlockHut;
 import com.minecolonies.api.tileentities.AbstractTileEntityColonyBuilding;
-import com.minecolonies.api.tileentities.MinecoloniesTileEntities;
-import com.minecolonies.core.tileentities.TileEntityColonyBuilding;
 import com.minecolonies.api.util.*;
 import com.minecolonies.api.util.constant.Constants;
 import com.minecolonies.api.util.constant.TranslationConstants;
@@ -34,26 +28,14 @@ import net.minecraft.network.chat.MutableComponent;
 import net.minecraft.network.chat.Style;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.server.level.ServerPlayer;
-import net.minecraft.world.InteractionHand;
-import net.minecraft.world.InteractionResult;
 import net.minecraft.world.entity.LivingEntity;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.item.Item;
 import net.minecraft.world.item.ItemStack;
-import net.minecraft.world.item.context.BlockPlaceContext;
-import net.minecraft.world.level.BlockGetter;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.*;
 import net.minecraft.world.level.block.entity.BlockEntity;
 import net.minecraft.world.level.block.state.BlockState;
-import net.minecraft.world.level.block.state.StateDefinition;
-import net.minecraft.world.level.block.state.properties.DirectionProperty;
-import net.minecraft.world.level.chunk.LevelChunk;
-import net.minecraft.world.level.material.MapColor;
-import net.minecraft.world.phys.BlockHitResult;
-import net.minecraft.world.phys.shapes.CollisionContext;
-import net.minecraft.world.phys.shapes.Shapes;
-import net.minecraft.world.phys.shapes.VoxelShape;
 import net.minecraftforge.api.distmarker.Dist;
 import net.minecraftforge.api.distmarker.OnlyIn;
 import net.minecraftforge.items.wrapper.InvWrapper;
@@ -62,12 +44,10 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 
 import static com.ldtteam.structurize.blockentities.interfaces.IBlueprintDataProviderBE.*;
-import static com.minecolonies.api.util.constant.BuildingConstants.DEACTIVATED;
 import static com.minecolonies.api.util.constant.TranslationConstants.*;
 
 /**
@@ -78,9 +58,8 @@ import static com.minecolonies.api.util.constant.TranslationConstants.*;
  * All AbstractBlockHut[something] should extend this class.
  */
 @SuppressWarnings("PMD.ExcessiveImports")
-public abstract class AbstractBlockHut<B extends AbstractBlockHut<B>> extends AbstractBlockMinecolonies<B> implements IBuilderUndestroyable,
+public abstract class AbstractBlockHut<B extends AbstractBlockHut<B>> extends AbstractBaseBlockHut<B> implements
                                                                                                                         IAnchorBlock,
-                                                                                                                        ITickableBlockMinecolonies,
                                                                                                                         INamedBlueprintAnchorBlock,
                                                                                                                         ILeveledBlueprintAnchorBlock,
                                                                                                                         IRequirementsBlueprintAnchorBlock,
@@ -90,63 +69,13 @@ public abstract class AbstractBlockHut<B extends AbstractBlockHut<B>> extends Ab
 
 {
     /**
-     * Hardness factor of the pvp mode.
-     */
-    private static final int HARDNESS_PVP_FACTOR = 4;
-
-    /**
-     * The direction the block is facing.
-     */
-    public static final DirectionProperty FACING = HorizontalDirectionalBlock.FACING;
-
-    /**
-     * The default hardness.
-     */
-    public static final float HARDNESS = 10F;
-
-    /**
-     * The default resistance (against explosions).
-     */
-    public static final float RESISTANCE = Float.POSITIVE_INFINITY;
-
-    /**
-     * Smaller shape.
-     */
-    private static final VoxelShape SHAPE = Shapes.box(0.1, 0.1, 0.1, 0.9, 0.9, 0.9);
-
-    /**
-     * The hut's lower-case building-registry-compatible name.
-     */
-    private final String name;
-
-    /**
-     * The timepoint of the last chat warning message
-     */
-    private long lastBreakTickWarn = 0;
-
-    /**
      * Constructor for a hut block.
      * <p>
      * Registers the block, sets the creative tab, as well as the resistance and the hardness.
      */
     public AbstractBlockHut()
     {
-        super(Properties.of().mapColor(MapColor.WOOD).sound(SoundType.WOOD).strength(HARDNESS, RESISTANCE).noOcclusion());
-        this.registerDefaultState(this.defaultBlockState().setValue(FACING, Direction.NORTH));
-        this.name = getHutName();
-    }
-
-    @Override
-    public float getDestroyProgress(final BlockState state, @NotNull final Player player, @NotNull final BlockGetter world, @NotNull final BlockPos pos)
-    {
-        final IBuilding building = IColonyManager.getInstance().getBuilding(player.level(), pos);
-        if (building != null && !building.getChildren().isEmpty() && (player.level().getGameTime() - lastBreakTickWarn) < 100)
-        {
-            lastBreakTickWarn = player.level().getGameTime();
-            MessageUtils.format(HUT_BREAK_WARNING_CHILD_BUILDINGS).sendTo(player);
-        }
-
-        return (MinecoloniesAPIProxy.getInstance().getConfig().getServer().pvp_mode.get() ? 1 / (HARDNESS * HARDNESS_PVP_FACTOR) : 1 / HARDNESS) / 30;
+        super();
     }
 
     /**
@@ -158,151 +87,7 @@ public abstract class AbstractBlockHut<B extends AbstractBlockHut<B>> extends Ab
      */
     public AbstractBlockHut(final Properties properties)
     {
-        super(properties.noOcclusion());
-        this.registerDefaultState(this.defaultBlockState().setValue(FACING, Direction.NORTH));
-        this.name = getHutName();
-    }
-
-    /**
-     * Method to return the name of the block.
-     *
-     * @return Name of the block.
-     */
-    public abstract String getHutName();
-
-    @Nullable
-    @Override
-    public BlockEntity newBlockEntity(@NotNull final BlockPos blockPos, @NotNull final BlockState blockState)
-    {
-        final TileEntityColonyBuilding building = (TileEntityColonyBuilding) MinecoloniesTileEntities.BUILDING.get().create(blockPos, blockState);
-        building.registryName = this.getBuildingEntry().getRegistryName();
-        return building;
-    }
-
-    /**
-     * Method to get the building registry entry.
-     *
-     * @return The building entry.
-     */
-    public abstract BuildingEntry getBuildingEntry();
-
-    @NotNull
-    @Override
-    public VoxelShape getShape(final BlockState state, final BlockGetter worldIn, final BlockPos pos, final CollisionContext context)
-    {
-        return SHAPE;
-    }
-
-    @NotNull
-    @Override
-    public InteractionResult use(
-      final BlockState state,
-      final Level worldIn,
-      final BlockPos pos,
-      final Player player,
-      final InteractionHand hand,
-      final BlockHitResult ray)
-    {
-       /*
-        If the world is client, open the gui of the building
-         */
-        if (worldIn.isClientSide)
-        {
-            if (hand == InteractionHand.OFF_HAND)
-            {
-                return InteractionResult.FAIL;
-            }
-
-            @Nullable final IBuildingView building = IColonyManager.getInstance().getBuildingView(worldIn.dimension(), pos);
-            final LevelChunk chunk = worldIn.getChunkAt(pos);
-            final BlockEntity entity = worldIn.getBlockEntity(pos);
-            if (entity instanceof final TileEntityColonyBuilding te && te.getPositionedTags().containsKey(BlockPos.ZERO) && te.getPositionedTags().get(BlockPos.ZERO).contains(DEACTIVATED))
-            {
-                if (building == null && ColonyUtils.getOwningColony(chunk) == 0)
-                {
-                    MessageUtils.format(MISSING_COLONY).sendTo(player);
-                    return InteractionResult.FAIL;
-                }
-
-                if (building == null && ColonyUtils.getAllClaimingBuildings(chunk).values().stream().flatMap(Collection::stream).noneMatch(p -> p.equals(pos)))
-                {
-                    IColonyManager.getInstance().openReactivationWindow(pos);
-                    return InteractionResult.SUCCESS;
-                }
-            }
-
-            if (building == null)
-            {
-                MessageUtils.format(HUT_BLOCK_MISSING_BUILDING).sendTo(player);
-                return InteractionResult.FAIL;
-            }
-
-            if (building.getColony() == null)
-            {
-                MessageUtils.format(HUT_BLOCK_MISSING_COLONY).sendTo(player);
-                return InteractionResult.FAIL;
-            }
-
-            if (!building.getColony().getPermissions().hasPermission(player, Action.ACCESS_HUTS))
-            {
-                MessageUtils.format(PERMISSION_DENIED).sendTo(player);
-                return InteractionResult.FAIL;
-            }
-
-            building.openGui(player.isShiftKeyDown());
-        }
-        return InteractionResult.SUCCESS;
-    }
-
-    @Nullable
-    @Override
-    public BlockState getStateForPlacement(final BlockPlaceContext context)
-    {
-        @NotNull final Direction facing = (context.getPlayer() == null) ? Direction.NORTH : Direction.fromYRot(context.getPlayer().getYRot());
-        return this.defaultBlockState().setValue(FACING, facing);
-    }
-
-    @NotNull
-    @Override
-    public BlockState rotate(final BlockState state, final Rotation rot)
-    {
-        return state.setValue(FACING, rot.rotate(state.getValue(FACING)));
-    }
-
-    @Override
-    public void setPlacedBy(@NotNull final Level worldIn, @NotNull final BlockPos pos, final BlockState state, final LivingEntity placer, final ItemStack stack)
-    {
-        super.setPlacedBy(worldIn, pos, state, placer, stack);
-
-        /*
-        Only work on server side
-        */
-        if (worldIn.isClientSide)
-        {
-            return;
-        }
-
-        final BlockEntity tileEntity = worldIn.getBlockEntity(pos);
-        if (tileEntity instanceof TileEntityColonyBuilding)
-        {
-            @NotNull final TileEntityColonyBuilding hut = (TileEntityColonyBuilding) tileEntity;
-            if (hut.getBuildingName() != getBuildingEntry().getRegistryName())
-            {
-                hut.registryName = getBuildingEntry().getRegistryName();
-            }
-            @Nullable final IColony colony = IColonyManager.getInstance().getColonyByPosFromWorld(worldIn, hut.getPosition());
-
-            if (colony != null)
-            {
-                colony.getBuildingManager().addNewBuilding(hut, worldIn);
-            }
-        }
-    }
-
-    @Override
-    protected void createBlockStateDefinition(StateDefinition.Builder<Block, BlockState> builder)
-    {
-        builder.add(FACING);
+        super(properties);
     }
 
     /**
@@ -337,22 +122,6 @@ public abstract class AbstractBlockHut<B extends AbstractBlockHut<B>> extends Ab
         }
 
         setPlacedBy(worldIn, pos, state, placer, stack);
-    }
-
-    /**
-     * Get the registry name frm the blck hut.
-     * @return the key.
-     */
-    public ResourceLocation getRegistryName()
-    {
-        return new ResourceLocation(Constants.MOD_ID, getHutName());
-    }
-
-    @Override
-    public B registerBlock(final IForgeRegistry<Block> registry)
-    {
-        registry.register(getRegistryName(), this);
-        return (B) this;
     }
 
     @Override

--- a/src/main/java/com/minecolonies/api/blocks/AbstractColonyBlock.java
+++ b/src/main/java/com/minecolonies/api/blocks/AbstractColonyBlock.java
@@ -47,14 +47,14 @@ import static com.minecolonies.api.util.constant.BuildingConstants.DEACTIVATED;
 import static com.minecolonies.api.util.constant.TranslationConstants.*;
 
 /**
- * Abstract class for all minecolonies blocks.
+ * Abstract class for all minecolonies colony blocks.
  * <p>
- * The method {@link AbstractBaseBlockHut#getName()} is abstract.
+ * The method {@link AbstractColonyBlock#getName()} is abstract.
  * <p>
  * All AbstractBlockHut[something] should extend this class.
  */
 @SuppressWarnings("PMD.ExcessiveImports")
-public abstract class AbstractBaseBlockHut<B extends AbstractBaseBlockHut<B>> extends AbstractBlockMinecolonies<B> implements IBuilderUndestroyable, ITickableBlockMinecolonies
+public abstract class AbstractColonyBlock<B extends AbstractColonyBlock<B>> extends AbstractBlockMinecolonies<B> implements IBuilderUndestroyable, ITickableBlockMinecolonies
 
 {
     /**
@@ -97,7 +97,7 @@ public abstract class AbstractBaseBlockHut<B extends AbstractBaseBlockHut<B>> ex
      * <p>
      * Registers the block, sets the creative tab, as well as the resistance and the hardness.
      */
-    public AbstractBaseBlockHut()
+    public AbstractColonyBlock()
     {
         super(Properties.of().mapColor(MapColor.WOOD).sound(SoundType.WOOD).strength(HARDNESS, RESISTANCE).noOcclusion());
         this.registerDefaultState(this.defaultBlockState().setValue(FACING, Direction.NORTH));
@@ -124,7 +124,7 @@ public abstract class AbstractBaseBlockHut<B extends AbstractBaseBlockHut<B>> ex
      *
      * @param properties custom properties.
      */
-    public AbstractBaseBlockHut(final Properties properties)
+    public AbstractColonyBlock(final Properties properties)
     {
         super(properties.noOcclusion());
         this.registerDefaultState(this.defaultBlockState().setValue(FACING, Direction.NORTH));
@@ -287,57 +287,6 @@ public abstract class AbstractBaseBlockHut<B extends AbstractBaseBlockHut<B>> ex
     {
         registry.register(getRegistryName(), this);
         return (B) this;
-    }
-
-    /**
-     * Check if we got permissions to paste.
-     * @param anchor the anchor of the paste.
-     * @param player the player pasting it.
-     * @param pos the position its pasted at.
-     * @return true if fine.
-     */
-    private boolean canPaste(final Block anchor, final Player player, final BlockPos pos)
-    {
-        final IColony colony = IColonyManager.getInstance().getIColony(player.level(), pos);
-
-        if (colony == null)
-        {
-            if(anchor == ModBlocks.blockHutTownHall)
-            {
-                return true;
-            }
-
-            //  Not in a colony
-            if (IColonyManager.getInstance().getIColonyByOwner(player.level(), player) == null)
-            {
-                MessageUtils.format(MESSAGE_WARNING_TOWN_HALL_NOT_PRESENT).sendTo(player);
-            }
-            else
-            {
-                MessageUtils.format(MESSAGE_WARNING_TOWN_HALL_TOO_FAR_AWAY).sendTo(player);
-            }
-
-            return false;
-        }
-        else if (!colony.getPermissions().hasPermission(player, Action.PLACE_HUTS))
-        {
-            //  No permission to place hut in colony
-            MessageUtils.format(PERMISSION_OPEN_HUT, colony.getName()).sendTo(player);
-            return false;
-        }
-        else
-        {
-            return colony.getBuildingManager().canPlaceAt(anchor, pos, player);
-        }
-    }
-
-    /**
-     * Get the blueprint name.
-     * @return the name.
-     */
-    public String getBlueprintName()
-    {
-        return getBuildingEntry().getRegistryName().getPath();
     }
 
     @Override

--- a/src/main/java/com/minecolonies/api/blocks/AbstractColonyBlock.java
+++ b/src/main/java/com/minecolonies/api/blocks/AbstractColonyBlock.java
@@ -47,11 +47,7 @@ import static com.minecolonies.api.util.constant.BuildingConstants.DEACTIVATED;
 import static com.minecolonies.api.util.constant.TranslationConstants.*;
 
 /**
- * Abstract class for all minecolonies colony blocks.
- * <p>
- * The method {@link AbstractColonyBlock#getName()} is abstract.
- * <p>
- * All AbstractBlockHut[something] should extend this class.
+ * Base class for all blocks that have a functionality within a colony. This applies to both buildings as well as functional blocks like postbox/stash.
  */
 @SuppressWarnings("PMD.ExcessiveImports")
 public abstract class AbstractColonyBlock<B extends AbstractColonyBlock<B>> extends AbstractBlockMinecolonies<B> implements IBuilderUndestroyable, ITickableBlockMinecolonies

--- a/src/main/java/com/minecolonies/api/blocks/ModBlocks.java
+++ b/src/main/java/com/minecolonies/api/blocks/ModBlocks.java
@@ -49,12 +49,10 @@ public final class ModBlocks
     public static AbstractBlockHut<? extends AbstractBlockHut<?>> blockHutStoneSmeltery;
     public static AbstractBlockHut<? extends AbstractBlockHut<?>> blockHutCrusher;
     public static AbstractBlockHut<? extends AbstractBlockHut<?>> blockHutSifter;
-    public static AbstractBlockHut<? extends AbstractBlockHut<?>> blockPostBox;
     public static AbstractBlockHut<? extends AbstractBlockHut<?>> blockHutFlorist;
     public static AbstractBlockHut<? extends AbstractBlockHut<?>> blockHutEnchanter;
     public static AbstractBlockHut<? extends AbstractBlockHut<?>> blockHutUniversity;
     public static AbstractBlockHut<? extends AbstractBlockHut<?>> blockHutHospital;
-    public static AbstractBlockHut<? extends AbstractBlockHut<?>> blockStash;
     public static AbstractBlockHut<? extends AbstractBlockHut<?>> blockHutSchool;
     public static AbstractBlockHut<? extends AbstractBlockHut<?>> blockHutGlassblower;
     public static AbstractBlockHut<? extends AbstractBlockHut<?>> blockHutDyer;
@@ -73,6 +71,9 @@ public final class ModBlocks
     //public static AbstractBlockHut<? extends AbstractBlockHut<?>> blockLargeQuarry;
     public static AbstractBlockHut<? extends AbstractBlockHut<?>> blockHutAlchemist;
     public static AbstractBlockHut<? extends AbstractBlockHut<?>> blockHutKitchen;
+
+    public static AbstractBaseBlockHut<? extends AbstractBaseBlockHut<?>> blockStash;
+    public static AbstractBaseBlockHut<? extends AbstractBaseBlockHut<?>> blockPostBox;
 
     /**
      * Utility blocks.
@@ -120,9 +121,9 @@ public final class ModBlocks
     }
 
     @NotNull
-    public static AbstractBlockHut<?>[] getHuts()
+    public static AbstractBaseBlockHut<?>[] getHuts()
     {
-        return new AbstractBlockHut[] {
+        return new AbstractBaseBlockHut[] {
           blockHutTownHall,
           blockHutHome,
           blockHutTavern,

--- a/src/main/java/com/minecolonies/api/blocks/ModBlocks.java
+++ b/src/main/java/com/minecolonies/api/blocks/ModBlocks.java
@@ -72,8 +72,8 @@ public final class ModBlocks
     public static AbstractBlockHut<? extends AbstractBlockHut<?>> blockHutAlchemist;
     public static AbstractBlockHut<? extends AbstractBlockHut<?>> blockHutKitchen;
 
-    public static AbstractBaseBlockHut<? extends AbstractBaseBlockHut<?>> blockStash;
-    public static AbstractBaseBlockHut<? extends AbstractBaseBlockHut<?>> blockPostBox;
+    public static AbstractColonyBlock<? extends AbstractColonyBlock<?>> blockStash;
+    public static AbstractColonyBlock<? extends AbstractColonyBlock<?>> blockPostBox;
 
     /**
      * Utility blocks.
@@ -121,9 +121,9 @@ public final class ModBlocks
     }
 
     @NotNull
-    public static AbstractBaseBlockHut<?>[] getHuts()
+    public static AbstractColonyBlock<?>[] getHuts()
     {
-        return new AbstractBaseBlockHut[] {
+        return new AbstractColonyBlock[] {
           blockHutTownHall,
           blockHutHome,
           blockHutTavern,

--- a/src/main/java/com/minecolonies/api/colony/buildings/registry/BuildingEntry.java
+++ b/src/main/java/com/minecolonies/api/colony/buildings/registry/BuildingEntry.java
@@ -1,6 +1,7 @@
 package com.minecolonies.api.colony.buildings.registry;
 
 import com.google.common.collect.ImmutableMap;
+import com.minecolonies.api.blocks.AbstractBaseBlockHut;
 import com.minecolonies.api.blocks.AbstractBlockHut;
 import com.minecolonies.api.colony.IColony;
 import com.minecolonies.api.colony.IColonyView;
@@ -27,7 +28,7 @@ import java.util.function.Supplier;
 @SuppressWarnings("PMD.MissingStaticMethodInNonInstantiatableClass") //Use the builder to create one.
 public class BuildingEntry
 {
-    private final AbstractBlockHut<?> buildingBlock;
+    private final AbstractBaseBlockHut<?> buildingBlock;
 
     private final BiFunction<IColony, BlockPos, IBuilding> buildingProducer;
     private final ResourceLocation registryName;
@@ -39,7 +40,7 @@ public class BuildingEntry
      */
     public static final class Builder
     {
-        private AbstractBlockHut<?>                                        buildingBlock;
+        private AbstractBaseBlockHut<?>                                    buildingBlock;
         private BiFunction<IColony, BlockPos, IBuilding>                   buildingProducer;
         private Supplier<BiFunction<IColonyView, BlockPos, IBuildingView>> buildingViewProducer;
         private List<ModuleProducer>                                       buildingModuleProducers = new ArrayList<>();
@@ -51,7 +52,7 @@ public class BuildingEntry
          * @param buildingBlock The block.
          * @return The builder.
          */
-        public Builder setBuildingBlock(final AbstractBlockHut<?> buildingBlock)
+        public Builder setBuildingBlock(final AbstractBaseBlockHut<?> buildingBlock)
         {
             this.buildingBlock = buildingBlock;
             return this;
@@ -127,7 +128,7 @@ public class BuildingEntry
 
     private final Supplier<BiFunction<IColonyView, BlockPos, IBuildingView>> buildingViewProducer;
 
-    public AbstractBlockHut<?> getBuildingBlock()
+    public AbstractBaseBlockHut<?> getBuildingBlock()
     {
         return buildingBlock;
     }
@@ -165,7 +166,7 @@ public class BuildingEntry
 
     private BuildingEntry(
       final ResourceLocation registryName,
-      final AbstractBlockHut<?> buildingBlock,
+      final AbstractBaseBlockHut<?> buildingBlock,
       final BiFunction<IColony, BlockPos, IBuilding> buildingProducer,
       final Supplier<BiFunction<IColonyView, BlockPos, IBuildingView>> buildingViewProducer,
       List<ModuleProducer> buildingModuleProducers)

--- a/src/main/java/com/minecolonies/api/colony/buildings/registry/BuildingEntry.java
+++ b/src/main/java/com/minecolonies/api/colony/buildings/registry/BuildingEntry.java
@@ -1,7 +1,7 @@
 package com.minecolonies.api.colony.buildings.registry;
 
 import com.google.common.collect.ImmutableMap;
-import com.minecolonies.api.blocks.AbstractBaseBlockHut;
+import com.minecolonies.api.blocks.AbstractColonyBlock;
 import com.minecolonies.api.blocks.AbstractBlockHut;
 import com.minecolonies.api.colony.IColony;
 import com.minecolonies.api.colony.IColonyView;
@@ -28,7 +28,7 @@ import java.util.function.Supplier;
 @SuppressWarnings("PMD.MissingStaticMethodInNonInstantiatableClass") //Use the builder to create one.
 public class BuildingEntry
 {
-    private final AbstractBaseBlockHut<?> buildingBlock;
+    private final AbstractColonyBlock<?> buildingBlock;
 
     private final BiFunction<IColony, BlockPos, IBuilding> buildingProducer;
     private final ResourceLocation registryName;
@@ -40,8 +40,8 @@ public class BuildingEntry
      */
     public static final class Builder
     {
-        private AbstractBaseBlockHut<?>                                    buildingBlock;
-        private BiFunction<IColony, BlockPos, IBuilding>                   buildingProducer;
+        private AbstractColonyBlock<?>                   buildingBlock;
+        private BiFunction<IColony, BlockPos, IBuilding> buildingProducer;
         private Supplier<BiFunction<IColonyView, BlockPos, IBuildingView>> buildingViewProducer;
         private List<ModuleProducer>                                       buildingModuleProducers = new ArrayList<>();
         private ResourceLocation                                           registryName;
@@ -52,7 +52,7 @@ public class BuildingEntry
          * @param buildingBlock The block.
          * @return The builder.
          */
-        public Builder setBuildingBlock(final AbstractBaseBlockHut<?> buildingBlock)
+        public Builder setBuildingBlock(final AbstractColonyBlock<?> buildingBlock)
         {
             this.buildingBlock = buildingBlock;
             return this;
@@ -128,7 +128,7 @@ public class BuildingEntry
 
     private final Supplier<BiFunction<IColonyView, BlockPos, IBuildingView>> buildingViewProducer;
 
-    public AbstractBaseBlockHut<?> getBuildingBlock()
+    public AbstractColonyBlock<?> getBuildingBlock()
     {
         return buildingBlock;
     }
@@ -166,7 +166,7 @@ public class BuildingEntry
 
     private BuildingEntry(
       final ResourceLocation registryName,
-      final AbstractBaseBlockHut<?> buildingBlock,
+      final AbstractColonyBlock<?> buildingBlock,
       final BiFunction<IColony, BlockPos, IBuilding> buildingProducer,
       final Supplier<BiFunction<IColonyView, BlockPos, IBuildingView>> buildingViewProducer,
       List<ModuleProducer> buildingModuleProducers)

--- a/src/main/java/com/minecolonies/api/creativetab/ModCreativeTabs.java
+++ b/src/main/java/com/minecolonies/api/creativetab/ModCreativeTabs.java
@@ -1,5 +1,6 @@
 package com.minecolonies.api.creativetab;
 
+import com.minecolonies.api.blocks.AbstractBaseBlockHut;
 import com.minecolonies.api.blocks.AbstractBlockHut;
 import com.minecolonies.api.blocks.ModBlocks;
 import com.minecolonies.api.entity.ModEntities;
@@ -30,7 +31,7 @@ public final class ModCreativeTabs
     public static final RegistryObject<CreativeModeTab> HUTS = TAB_REG.register("mchuts", () -> new CreativeModeTab.Builder(CreativeModeTab.Row.TOP, 1)
                                                                                                       .icon(() -> new ItemStack(ModBlocks.blockHutTownHall))
                                                                                                       .title(Component.translatable("com.minecolonies.creativetab.huts")).displayItems((config, output) -> {
-          for (final AbstractBlockHut<?> hut : ModBlocks.getHuts())
+          for (final AbstractBaseBlockHut<?> hut : ModBlocks.getHuts())
           {
               output.accept(hut);
           }

--- a/src/main/java/com/minecolonies/api/creativetab/ModCreativeTabs.java
+++ b/src/main/java/com/minecolonies/api/creativetab/ModCreativeTabs.java
@@ -1,7 +1,6 @@
 package com.minecolonies.api.creativetab;
 
-import com.minecolonies.api.blocks.AbstractBaseBlockHut;
-import com.minecolonies.api.blocks.AbstractBlockHut;
+import com.minecolonies.api.blocks.AbstractColonyBlock;
 import com.minecolonies.api.blocks.ModBlocks;
 import com.minecolonies.api.entity.ModEntities;
 import com.minecolonies.api.items.ModItems;
@@ -31,7 +30,7 @@ public final class ModCreativeTabs
     public static final RegistryObject<CreativeModeTab> HUTS = TAB_REG.register("mchuts", () -> new CreativeModeTab.Builder(CreativeModeTab.Row.TOP, 1)
                                                                                                       .icon(() -> new ItemStack(ModBlocks.blockHutTownHall))
                                                                                                       .title(Component.translatable("com.minecolonies.creativetab.huts")).displayItems((config, output) -> {
-          for (final AbstractBaseBlockHut<?> hut : ModBlocks.getHuts())
+          for (final AbstractColonyBlock<?> hut : ModBlocks.getHuts())
           {
               output.accept(hut);
           }

--- a/src/main/java/com/minecolonies/api/items/ItemBlockHut.java
+++ b/src/main/java/com/minecolonies/api/items/ItemBlockHut.java
@@ -1,6 +1,6 @@
 package com.minecolonies.api.items;
 
-import com.minecolonies.api.blocks.AbstractBaseBlockHut;
+import com.minecolonies.api.blocks.AbstractColonyBlock;
 import com.minecolonies.api.blocks.AbstractBlockHut;
 import net.minecraft.world.item.BlockItem;
 
@@ -12,7 +12,7 @@ public class ItemBlockHut extends BlockItem
     /**
      * This items block.
      */
-    private AbstractBaseBlockHut<?> block;
+    private AbstractColonyBlock<?> block;
 
     /**
      * Creates a new ItemBlockHut representing the item form of the given {@link AbstractBlockHut}.
@@ -20,7 +20,7 @@ public class ItemBlockHut extends BlockItem
      * @param block   the {@link AbstractBlockHut} this item represents.
      * @param builder the item properties to use.
      */
-    public ItemBlockHut(AbstractBaseBlockHut<?> block, Properties builder)
+    public ItemBlockHut(AbstractColonyBlock<?> block, Properties builder)
     {
         super(block, builder);
         this.block = block;

--- a/src/main/java/com/minecolonies/api/items/ItemBlockHut.java
+++ b/src/main/java/com/minecolonies/api/items/ItemBlockHut.java
@@ -1,5 +1,6 @@
 package com.minecolonies.api.items;
 
+import com.minecolonies.api.blocks.AbstractBaseBlockHut;
 import com.minecolonies.api.blocks.AbstractBlockHut;
 import net.minecraft.world.item.BlockItem;
 
@@ -11,7 +12,7 @@ public class ItemBlockHut extends BlockItem
     /**
      * This items block.
      */
-    private AbstractBlockHut<?> block;
+    private AbstractBaseBlockHut<?> block;
 
     /**
      * Creates a new ItemBlockHut representing the item form of the given {@link AbstractBlockHut}.
@@ -19,7 +20,7 @@ public class ItemBlockHut extends BlockItem
      * @param block   the {@link AbstractBlockHut} this item represents.
      * @param builder the item properties to use.
      */
-    public ItemBlockHut(AbstractBlockHut<?> block, Properties builder)
+    public ItemBlockHut(AbstractBaseBlockHut<?> block, Properties builder)
     {
         super(block, builder);
         this.block = block;

--- a/src/main/java/com/minecolonies/api/research/AbstractResearchProvider.java
+++ b/src/main/java/com/minecolonies/api/research/AbstractResearchProvider.java
@@ -3,6 +3,7 @@ package com.minecolonies.api.research;
 import com.google.gson.JsonArray;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
+import com.minecolonies.api.blocks.AbstractBaseBlockHut;
 import com.minecolonies.api.blocks.AbstractBlockHut;
 import com.minecolonies.api.util.constant.Constants;
 import net.minecraft.data.CachedOutput;
@@ -624,7 +625,7 @@ public abstract class AbstractResearchProvider implements DataProvider
          *                    Manually generated effects can limited to individual tiers based on strength.
          * @return this
          */
-        public Research addEffect(final AbstractBlockHut<?> buildingBlock, int level)
+        public Research addEffect(final AbstractBaseBlockHut<?> buildingBlock, int level)
         {
             final JsonArray effects;
             if(this.json.has("effects") && this.json.get("effects").isJsonArray())
@@ -731,7 +732,7 @@ public abstract class AbstractResearchProvider implements DataProvider
          * See ModBuildings for a list of supported buildings.
          * @param buildingBlock    A Building hut block.  This will auto-generate an unlock effect ID of effects/blockhutname.json.
          */
-        public ResearchEffect(final AbstractBlockHut<?> buildingBlock)
+        public ResearchEffect(final AbstractBaseBlockHut<?> buildingBlock)
         {
             final ResourceLocation registryName = ForgeRegistries.BLOCKS.getKey(buildingBlock);
             this.id = new ResourceLocation(registryName.getNamespace(), "effects/" + registryName.getPath());

--- a/src/main/java/com/minecolonies/api/research/AbstractResearchProvider.java
+++ b/src/main/java/com/minecolonies/api/research/AbstractResearchProvider.java
@@ -3,8 +3,7 @@ package com.minecolonies.api.research;
 import com.google.gson.JsonArray;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
-import com.minecolonies.api.blocks.AbstractBaseBlockHut;
-import com.minecolonies.api.blocks.AbstractBlockHut;
+import com.minecolonies.api.blocks.AbstractColonyBlock;
 import com.minecolonies.api.util.constant.Constants;
 import net.minecraft.data.CachedOutput;
 import net.minecraft.data.DataProvider;
@@ -625,7 +624,7 @@ public abstract class AbstractResearchProvider implements DataProvider
          *                    Manually generated effects can limited to individual tiers based on strength.
          * @return this
          */
-        public Research addEffect(final AbstractBaseBlockHut<?> buildingBlock, int level)
+        public Research addEffect(final AbstractColonyBlock<?> buildingBlock, int level)
         {
             final JsonArray effects;
             if(this.json.has("effects") && this.json.get("effects").isJsonArray())
@@ -732,7 +731,7 @@ public abstract class AbstractResearchProvider implements DataProvider
          * See ModBuildings for a list of supported buildings.
          * @param buildingBlock    A Building hut block.  This will auto-generate an unlock effect ID of effects/blockhutname.json.
          */
-        public ResearchEffect(final AbstractBaseBlockHut<?> buildingBlock)
+        public ResearchEffect(final AbstractColonyBlock<?> buildingBlock)
         {
             final ResourceLocation registryName = ForgeRegistries.BLOCKS.getKey(buildingBlock);
             this.id = new ResourceLocation(registryName.getNamespace(), "effects/" + registryName.getPath());

--- a/src/main/java/com/minecolonies/core/blocks/huts/BlockPostBox.java
+++ b/src/main/java/com/minecolonies/core/blocks/huts/BlockPostBox.java
@@ -1,5 +1,6 @@
 package com.minecolonies.core.blocks.huts;
 
+import com.minecolonies.api.blocks.AbstractBaseBlockHut;
 import com.minecolonies.api.blocks.AbstractBlockHut;
 import com.minecolonies.api.blocks.interfaces.IRSComponentBlock;
 import com.minecolonies.api.colony.buildings.ModBuildings;
@@ -16,7 +17,7 @@ import org.jetbrains.annotations.NotNull;
 /**
  * Hut for the PostBox. No different from {@link AbstractBlockHut}
  */
-public class BlockPostBox extends AbstractBlockHut<BlockPostBox> implements IRSComponentBlock
+public class BlockPostBox extends AbstractBaseBlockHut<BlockPostBox> implements IRSComponentBlock
 {
     private static final VoxelShape SHAPE_NORTH = Block.box(0.0D, 0.0D, 0.0D, 16.0D, 16.0D, 8.0D);
     private static final VoxelShape SHAPE_EAST  = Block.box(8.0D, 0.0D, 0.0D, 16.0D, 16.0D, 16.0D);

--- a/src/main/java/com/minecolonies/core/blocks/huts/BlockPostBox.java
+++ b/src/main/java/com/minecolonies/core/blocks/huts/BlockPostBox.java
@@ -1,6 +1,6 @@
 package com.minecolonies.core.blocks.huts;
 
-import com.minecolonies.api.blocks.AbstractBaseBlockHut;
+import com.minecolonies.api.blocks.AbstractColonyBlock;
 import com.minecolonies.api.blocks.AbstractBlockHut;
 import com.minecolonies.api.blocks.interfaces.IRSComponentBlock;
 import com.minecolonies.api.colony.buildings.ModBuildings;
@@ -17,7 +17,7 @@ import org.jetbrains.annotations.NotNull;
 /**
  * Hut for the PostBox. No different from {@link AbstractBlockHut}
  */
-public class BlockPostBox extends AbstractBaseBlockHut<BlockPostBox> implements IRSComponentBlock
+public class BlockPostBox extends AbstractColonyBlock<BlockPostBox> implements IRSComponentBlock
 {
     private static final VoxelShape SHAPE_NORTH = Block.box(0.0D, 0.0D, 0.0D, 16.0D, 16.0D, 8.0D);
     private static final VoxelShape SHAPE_EAST  = Block.box(8.0D, 0.0D, 0.0D, 16.0D, 16.0D, 16.0D);

--- a/src/main/java/com/minecolonies/core/blocks/huts/BlockStash.java
+++ b/src/main/java/com/minecolonies/core/blocks/huts/BlockStash.java
@@ -1,5 +1,6 @@
 package com.minecolonies.core.blocks.huts;
 
+import com.minecolonies.api.blocks.AbstractBaseBlockHut;
 import com.minecolonies.api.blocks.AbstractBlockHut;
 import com.minecolonies.api.blocks.interfaces.IRSComponentBlock;
 import com.minecolonies.api.colony.IColonyManager;
@@ -29,7 +30,7 @@ import org.jetbrains.annotations.Nullable;
 /**
  * Hut for the Stash. No different from {@link AbstractBlockHut}
  */
-public class BlockStash extends AbstractBlockHut<BlockStash> implements IRSComponentBlock
+public class BlockStash extends AbstractBaseBlockHut<BlockStash> implements IRSComponentBlock
 {
 
     private static final VoxelShape SHAPE_NORTH = Block.box(0.0D, 0.0D, 0.0D, 16.0D, 16.0D, 8.0D);

--- a/src/main/java/com/minecolonies/core/blocks/huts/BlockStash.java
+++ b/src/main/java/com/minecolonies/core/blocks/huts/BlockStash.java
@@ -1,6 +1,6 @@
 package com.minecolonies.core.blocks.huts;
 
-import com.minecolonies.api.blocks.AbstractBaseBlockHut;
+import com.minecolonies.api.blocks.AbstractColonyBlock;
 import com.minecolonies.api.blocks.AbstractBlockHut;
 import com.minecolonies.api.blocks.interfaces.IRSComponentBlock;
 import com.minecolonies.api.colony.IColonyManager;
@@ -30,7 +30,7 @@ import org.jetbrains.annotations.Nullable;
 /**
  * Hut for the Stash. No different from {@link AbstractBlockHut}
  */
-public class BlockStash extends AbstractBaseBlockHut<BlockStash> implements IRSComponentBlock
+public class BlockStash extends AbstractColonyBlock<BlockStash> implements IRSComponentBlock
 {
 
     private static final VoxelShape SHAPE_NORTH = Block.box(0.0D, 0.0D, 0.0D, 16.0D, 16.0D, 8.0D);

--- a/src/main/java/com/minecolonies/core/colony/managers/RegisteredStructureManager.java
+++ b/src/main/java/com/minecolonies/core/colony/managers/RegisteredStructureManager.java
@@ -2,6 +2,7 @@ package com.minecolonies.core.colony.managers;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import com.minecolonies.api.blocks.AbstractBlockHut;
 import com.minecolonies.api.colony.ICitizenData;
 import com.minecolonies.api.colony.IColony;
 import com.minecolonies.api.colony.buildings.*;
@@ -578,14 +579,17 @@ public class RegisteredStructureManager implements IRegisteredStructureManager
                   tileEntity.getPosition()));
 
                 building.setIsMirrored(tileEntity.isMirrored());
-                if (tileEntity.getStructurePack() != null)
+                if (tileEntity.getBlockState().getBlock() instanceof AbstractBlockHut<?>)
                 {
-                    building.setStructurePack(tileEntity.getStructurePack().getName());
-                    building.setBlueprintPath(tileEntity.getBlueprintPath());
-                }
-                else
-                {
-                    building.setStructurePack(colony.getStructurePack());
+                    if (tileEntity.getStructurePack() != null)
+                    {
+                        building.setStructurePack(tileEntity.getStructurePack().getName());
+                        building.setBlueprintPath(tileEntity.getBlueprintPath());
+                    }
+                    else
+                    {
+                        building.setStructurePack(colony.getStructurePack());
+                    }
                 }
 
                 if (world != null && !(building instanceof IRSComponent))

--- a/src/main/java/com/minecolonies/core/tileentities/TileEntityColonyBuilding.java
+++ b/src/main/java/com/minecolonies/core/tileentities/TileEntityColonyBuilding.java
@@ -5,7 +5,7 @@ import com.ldtteam.structurize.storage.StructurePackMeta;
 import com.ldtteam.structurize.storage.StructurePacks;
 import com.ldtteam.structurize.util.BlockInfo;
 import com.ldtteam.structurize.util.RotationMirror;
-import com.minecolonies.api.blocks.AbstractBaseBlockHut;
+import com.minecolonies.api.blocks.AbstractColonyBlock;
 import com.minecolonies.api.blocks.AbstractBlockHut;
 import com.minecolonies.api.colony.IColony;
 import com.minecolonies.api.colony.IColonyManager;
@@ -384,35 +384,38 @@ public class TileEntityColonyBuilding extends AbstractTileEntityColonyBuilding i
             path = compound.getString(TAG_PATH);
         }
 
-        if (packName == null || packName.isEmpty())
+        if (getBlockState().getBlock() instanceof AbstractBlockHut<?>)
         {
-            final List<String> tags = new ArrayList<>(getPositionedTags().getOrDefault(BlockPos.ZERO, new ArrayList<>()));
-            if (!tags.isEmpty())
+            if (packName == null || packName.isEmpty())
             {
-                tags.remove(DEACTIVATED);
+                final List<String> tags = new ArrayList<>(getPositionedTags().getOrDefault(BlockPos.ZERO, new ArrayList<>()));
                 if (!tags.isEmpty())
                 {
-                    packName = BlueprintMapping.getStyleMapping(tags.get(0));
-                    if (path == null || path.isEmpty())
+                    tags.remove(DEACTIVATED);
+                    if (!tags.isEmpty())
                     {
-                        path = BlueprintMapping.getPathMapping(tags.get(0), ((AbstractBlockHut) getBlockState().getBlock()).getBlueprintName()) + "1.blueprint";
+                        packName = BlueprintMapping.getStyleMapping(tags.get(0));
+                        if (path == null || path.isEmpty())
+                        {
+                            path = BlueprintMapping.getPathMapping(tags.get(0), ((AbstractBlockHut<?>) getBlockState().getBlock()).getBlueprintName()) + "1.blueprint";
+                        }
                     }
                 }
+                else if (StructurePacks.selectedPack != null)
+                {
+                    packName = StructurePacks.selectedPack.getName();
+                }
             }
-            else if (StructurePacks.selectedPack != null)
+
+            if (path == null || path.isEmpty() || path.contains("null"))
             {
-                packName = StructurePacks.selectedPack.getName();
+                path = BlueprintMapping.getPathMapping("", ((AbstractBlockHut<?>) getBlockState().getBlock()).getBlueprintName()) + "1.blueprint";
             }
-        }
 
-        if (path == null || path.isEmpty() || path.contains("null"))
-        {
-            path = BlueprintMapping.getPathMapping("", ((AbstractBaseBlockHut) getBlockState().getBlock()).getBlueprintName()) + "1.blueprint";
-        }
-
-        if (!path.endsWith(".blueprint"))
-        {
-            path += ".blueprint";
+            if (!path.endsWith(".blueprint"))
+            {
+                path += ".blueprint";
+            }
         }
 
         this.packMeta = packName;
@@ -567,7 +570,7 @@ public class TileEntityColonyBuilding extends AbstractTileEntityColonyBuilding i
         {
             return registryName;
         }
-        return getBlockState().getBlock() instanceof AbstractBlockHut<?> ? ((AbstractBlockHut<?>) getBlockState().getBlock()).getBuildingEntry().getRegistryName() : null;
+        return getBlockState().getBlock() instanceof AbstractColonyBlock<?> ? ((AbstractColonyBlock<?>) getBlockState().getBlock()).getBuildingEntry().getRegistryName() : null;
     }
 
     @Override

--- a/src/main/java/com/minecolonies/core/tileentities/TileEntityColonyBuilding.java
+++ b/src/main/java/com/minecolonies/core/tileentities/TileEntityColonyBuilding.java
@@ -5,6 +5,7 @@ import com.ldtteam.structurize.storage.StructurePackMeta;
 import com.ldtteam.structurize.storage.StructurePacks;
 import com.ldtteam.structurize.util.BlockInfo;
 import com.ldtteam.structurize.util.RotationMirror;
+import com.minecolonies.api.blocks.AbstractBaseBlockHut;
 import com.minecolonies.api.blocks.AbstractBlockHut;
 import com.minecolonies.api.colony.IColony;
 import com.minecolonies.api.colony.IColonyManager;
@@ -406,7 +407,7 @@ public class TileEntityColonyBuilding extends AbstractTileEntityColonyBuilding i
 
         if (path == null || path.isEmpty() || path.contains("null"))
         {
-            path = BlueprintMapping.getPathMapping("", ((AbstractBlockHut) getBlockState().getBlock()).getBlueprintName()) + "1.blueprint";
+            path = BlueprintMapping.getPathMapping("", ((AbstractBaseBlockHut) getBlockState().getBlock()).getBlueprintName()) + "1.blueprint";
         }
 
         if (!path.endsWith(".blueprint"))


### PR DESCRIPTION
Closes #
Closes #

# Changes proposed in this pull request
- Refactor to remove postbox/stash from the blueprint subclasses. This makes it easier as they're now not normal anchors anymore. + Allows us to detect if they indicate a child block that we might need to mirror for structurize changes
-

## Testing
- [ ] Yes I tested this before submitting it.
- [ ] I also did a multiplayer test.

Review please