### PR TITLE
Allow players to pick up their own items thrown over a colony border

### DIFF
--- a/src/main/java/com/minecolonies/core/colony/permissions/ColonyPermissionEventHandler.java
+++ b/src/main/java/com/minecolonies/core/colony/permissions/ColonyPermissionEventHandler.java
@@ -526,6 +526,8 @@ public class ColonyPermissionEventHandler
     @SubscribeEvent
     public void on(final EntityItemPickupEvent event)
     {
+        if (event.getEntity().equals(event.getItem().getOwner())) return;   // always allowed to pick up your own thrown items
+
         checkEventCancelation(Action.PICKUP_ITEM, event.getEntity(), event.getEntity().getCommandSenderWorld(), event, event.getEntity().blockPosition());
     }
 


### PR DESCRIPTION
Closes [discord report](https://discord.com/channels/472875599422291968/473575384445878273/1386918044739309602)

# Changes proposed in this pull request
- Allow players to pick up their own items dropped, thrown, or otherwise travelled into a colony where they do not have "pick up items" permission.

## Testing
- [x] Yes I tested this before submitting it.
- [x] I also did a multiplayer test.

Review please (should port)