### PR TITLE
Fix assistant hammer clearing

### DIFF
--- a/src/main/java/com/minecolonies/api/colony/workorders/IBuilderWorkOrder.java
+++ b/src/main/java/com/minecolonies/api/colony/workorders/IBuilderWorkOrder.java
@@ -2,6 +2,7 @@ package com.minecolonies.api.colony.workorders;
 
 import com.minecolonies.api.colony.ICitizenData;
 import com.minecolonies.api.colony.IColony;
+import com.minecolonies.core.entity.ai.workers.util.BuildingProgressStage;
 import org.jetbrains.annotations.NotNull;
 
 public interface IBuilderWorkOrder extends IServerWorkOrder
@@ -110,7 +111,7 @@ public interface IBuilderWorkOrder extends IServerWorkOrder
     /**
      * Sets the building stage of the workorder
      *
-     * @param stageIndex
+     * @param stage
      */
-    void setStage(int stageIndex);
+    void setStage(BuildingProgressStage stage);
 }

--- a/src/main/java/com/minecolonies/api/colony/workorders/IWorkOrder.java
+++ b/src/main/java/com/minecolonies/api/colony/workorders/IWorkOrder.java
@@ -2,6 +2,7 @@ package com.minecolonies.api.colony.workorders;
 
 import com.ldtteam.structurize.blueprints.v1.Blueprint;
 import com.minecolonies.api.colony.IColony;
+import com.minecolonies.core.entity.ai.workers.util.BuildingProgressStage;
 import net.minecraft.core.BlockPos;
 import net.minecraft.network.chat.Component;
 import net.minecraft.world.level.Level;
@@ -196,5 +197,5 @@ public interface IWorkOrder
      *
      * @return stage index
      */
-    int getStage();
+    BuildingProgressStage getStage();
 }

--- a/src/main/java/com/minecolonies/core/colony/buildings/AbstractBuildingStructureBuilder.java
+++ b/src/main/java/com/minecolonies/core/colony/buildings/AbstractBuildingStructureBuilder.java
@@ -14,7 +14,7 @@ import com.minecolonies.core.colony.buildings.modules.BuildingResourcesModule;
 import com.minecolonies.core.colony.buildings.modules.WorkerBuildingModule;
 import com.minecolonies.core.colony.buildings.utils.BuilderBucket;
 import com.minecolonies.core.colony.buildings.utils.BuildingBuilderResource;
-import com.minecolonies.core.entity.ai.workers.util.BuildingStructureHandler;
+import com.minecolonies.core.entity.ai.workers.util.BuildingProgressStage;
 import net.minecraft.core.BlockPos;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.nbt.ListTag;
@@ -27,8 +27,8 @@ import org.jetbrains.annotations.Nullable;
 import java.util.*;
 import java.util.function.Predicate;
 
-import static com.minecolonies.api.util.constant.NbtTagConstants.*;
 import static com.minecolonies.api.util.constant.EquipmentLevelConstants.TOOL_LEVEL_WOOD_OR_GOLD;
+import static com.minecolonies.api.util.constant.NbtTagConstants.*;
 
 /**
  * The structureBuilder building.
@@ -53,7 +53,7 @@ public abstract class AbstractBuildingStructureBuilder extends AbstractBuilding
     /**
      * Progress stage of the builder.
      */
-    private BuildingStructureHandler.Stage progressStage;
+    private BuildingProgressStage progressStage;
 
     /**
      * The progress counter of the builder.
@@ -204,7 +204,7 @@ public abstract class AbstractBuildingStructureBuilder extends AbstractBuilding
         if (compound.contains(TAG_PROGRESS_POS))
         {
             progressPos = BlockPosUtil.read(compound, TAG_PROGRESS_POS);
-            progressStage = BuildingStructureHandler.Stage.values()[compound.getInt(TAG_PROGRESS_STAGE)];
+            progressStage = BuildingProgressStage.values()[compound.getInt(TAG_PROGRESS_STAGE)];
         }
 
         if (compound.contains(TAG_FLUIDS_REMOVE))
@@ -350,7 +350,7 @@ public abstract class AbstractBuildingStructureBuilder extends AbstractBuilding
      * @param blockPos the last blockPos.
      * @param stage    the stage to set.
      */
-    public void setProgressPos(final BlockPos blockPos, final BuildingStructureHandler.Stage stage)
+    public void setProgressPos(final BlockPos blockPos, final BuildingProgressStage stage)
     {
         this.progressPos = blockPos;
         if (this.progressCounter > COUNT_TO_STORE_POS || blockPos == null || stage != progressStage)
@@ -371,7 +371,7 @@ public abstract class AbstractBuildingStructureBuilder extends AbstractBuilding
      * @return the current progress and stage.
      */
     @Nullable
-    public Tuple<BlockPos, BuildingStructureHandler.Stage> getProgress()
+    public Tuple<BlockPos, BuildingProgressStage> getProgress()
     {
         if (this.progressPos == null)
         {

--- a/src/main/java/com/minecolonies/core/colony/buildings/modules/BuildingResourcesModule.java
+++ b/src/main/java/com/minecolonies/core/colony/buildings/modules/BuildingResourcesModule.java
@@ -18,7 +18,7 @@ import com.minecolonies.core.colony.buildings.AbstractBuildingStructureBuilder;
 import com.minecolonies.core.colony.buildings.utils.BuilderBucket;
 import com.minecolonies.core.colony.buildings.utils.BuildingBuilderResource;
 import com.minecolonies.core.colony.jobs.AbstractJobStructure;
-import com.minecolonies.core.entity.ai.workers.util.BuildingStructureHandler;
+import com.minecolonies.core.entity.ai.workers.util.BuildingProgressStage;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.network.FriendlyByteBuf;
 import net.minecraft.world.item.ItemStack;
@@ -177,7 +177,7 @@ public class BuildingResourcesModule extends AbstractBuildingModule implements I
     {
         return (buckets.isEmpty()
             || ((AbstractBuildingStructureBuilder) building).getProgress() == null
-            || ((AbstractBuildingStructureBuilder) building).getProgress().getB() == BuildingStructureHandler.Stage.CLEAR) ? null : buckets.getFirst();
+            || ((AbstractBuildingStructureBuilder) building).getProgress().getB() == BuildingProgressStage.CLEAR) ? null : buckets.getFirst();
     }
 
     /**

--- a/src/main/java/com/minecolonies/core/colony/workorders/AbstractWorkOrder.java
+++ b/src/main/java/com/minecolonies/core/colony/workorders/AbstractWorkOrder.java
@@ -13,6 +13,7 @@ import com.minecolonies.api.util.Tuple;
 import com.minecolonies.api.util.constant.Constants;
 import com.minecolonies.core.colony.buildings.workerbuildings.BuildingBuilder;
 import com.minecolonies.core.colony.workorders.view.*;
+import com.minecolonies.core.entity.ai.workers.util.BuildingProgressStage;
 import net.minecraft.core.BlockPos;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.network.FriendlyByteBuf;
@@ -144,7 +145,7 @@ public abstract class AbstractWorkOrder implements IBuilderWorkOrder
     /**
      * The building stage this workorder is in
      */
-    private int stage = 0;
+    private BuildingProgressStage stage = null;
 
     /**
      * The iterator type (building method) of this work order.
@@ -674,7 +675,7 @@ public abstract class AbstractWorkOrder implements IBuilderWorkOrder
 
         if (compound.contains(TAG_STAGE))
         {
-            stage = compound.getInt(TAG_STAGE);
+            stage = BuildingProgressStage.values()[compound.getInt(TAG_STAGE)];
         }
 
         if (compound.contains(TAG_BB))
@@ -709,7 +710,7 @@ public abstract class AbstractWorkOrder implements IBuilderWorkOrder
         compound.putString(TAG_ITERATOR, iteratorType);
         compound.putBoolean(TAG_IS_CLEARED, cleared);
         compound.putBoolean(TAG_IS_REQUESTED, requested);
-        compound.putInt(TAG_STAGE, stage);
+        compound.putInt(TAG_STAGE, stage.ordinal());
 
         if (box != Constants.EMPTY_AABB)
         {
@@ -745,7 +746,7 @@ public abstract class AbstractWorkOrder implements IBuilderWorkOrder
         buf.writeBoolean(isMirrored);
         buf.writeInt(currentLevel);
         buf.writeInt(targetLevel);
-        buf.writeInt(stage);
+        buf.writeInt(stage.ordinal());
         buf.writeDouble(getBoundingBox().minX);
         buf.writeDouble(getBoundingBox().minY);
         buf.writeDouble(getBoundingBox().minZ);
@@ -847,13 +848,13 @@ public abstract class AbstractWorkOrder implements IBuilderWorkOrder
     }
 
     @Override
-    public int getStage()
+    public BuildingProgressStage getStage()
     {
         return stage;
     }
 
     @Override
-    public void setStage(final int stage)
+    public void setStage(final BuildingProgressStage stage)
     {
         if (stage != this.stage)
         {

--- a/src/main/java/com/minecolonies/core/colony/workorders/view/AbstractWorkOrderView.java
+++ b/src/main/java/com/minecolonies/core/colony/workorders/view/AbstractWorkOrderView.java
@@ -8,6 +8,7 @@ import com.minecolonies.api.colony.workorders.WorkOrderType;
 import com.minecolonies.api.util.BlockPosUtil;
 import com.minecolonies.api.util.ColonyUtils;
 import com.minecolonies.api.util.constant.Constants;
+import com.minecolonies.core.entity.ai.workers.util.BuildingProgressStage;
 import net.minecraft.core.BlockPos;
 import net.minecraft.network.FriendlyByteBuf;
 import net.minecraft.world.level.Level;
@@ -82,7 +83,7 @@ public abstract class AbstractWorkOrderView implements IWorkOrderView
     /**
      * The building stage this workorder is in
      */
-    private int stage = 0;
+    private BuildingProgressStage stage = null;
 
     /**
      * Translation key.
@@ -189,7 +190,7 @@ public abstract class AbstractWorkOrderView implements IWorkOrderView
     }
 
     @Override
-    public int getStage()
+    public BuildingProgressStage getStage()
     {
         return stage;
     }
@@ -295,7 +296,7 @@ public abstract class AbstractWorkOrderView implements IWorkOrderView
         isMirrored = buf.readBoolean();
         currentLevel = buf.readInt();
         targetLevel = buf.readInt();
-        stage = buf.readInt();
+        stage = BuildingProgressStage.values()[buf.readInt()];
         box = new AABB(buf.readDouble(), buf.readDouble(), buf.readDouble(), buf.readDouble(), buf.readDouble(), buf.readDouble());
     }
 

--- a/src/main/java/com/minecolonies/core/entity/ai/workers/AbstractEntityAIStructure.java
+++ b/src/main/java/com/minecolonies/core/entity/ai/workers/AbstractEntityAIStructure.java
@@ -30,6 +30,7 @@ import com.minecolonies.core.colony.buildings.modules.BuildingResourcesModule;
 import com.minecolonies.core.colony.buildings.utils.BuilderBucket;
 import com.minecolonies.core.colony.buildings.utils.BuildingBuilderResource;
 import com.minecolonies.core.colony.jobs.AbstractJobStructure;
+import com.minecolonies.core.entity.ai.workers.util.BuildingProgressStage;
 import com.minecolonies.core.entity.ai.workers.util.BuildingStructureHandler;
 import com.minecolonies.core.tileentities.TileEntityDecorationController;
 import net.minecraft.core.BlockPos;
@@ -61,7 +62,7 @@ import static com.minecolonies.api.util.constant.CitizenConstants.*;
 import static com.minecolonies.api.util.constant.Constants.TICKS_SECOND;
 import static com.minecolonies.core.colony.buildings.workerbuildings.BuildingMiner.FILL_BLOCK;
 import static com.minecolonies.core.entity.ai.workers.AbstractEntityAIStructure.ItemCheckResult.*;
-import static com.minecolonies.core.entity.ai.workers.util.BuildingStructureHandler.Stage.*;
+import static com.minecolonies.core.entity.ai.workers.util.BuildingProgressStage.*;
 
 /**
  * This base ai class is used by ai's who need to build entire structures. These structures have to be supplied as schematics files.
@@ -202,7 +203,7 @@ public abstract class AbstractEntityAIStructure<J extends AbstractJobStructure<?
             return IDLE;
         }
 
-        if (structurePlacer.getB().getStage() == null || structurePlacer.getB().getStage() == BuildingStructureHandler.Stage.CLEAR)
+        if (structurePlacer.getB().getStage() == null || structurePlacer.getB().getStage() == BuildingProgressStage.CLEAR)
         {
             pickUpCount = 0;
             return START_WORKING;
@@ -375,7 +376,7 @@ public abstract class AbstractEntityAIStructure<J extends AbstractJobStructure<?
 
         final StructurePhasePlacementResult result;
         final StructurePlacer placer = structurePlacer.getA();
-        final BuildingStructureHandler.Stage currentStage = structurePlacer.getB().getStage();
+        final BuildingProgressStage currentStage = structurePlacer.getB().getStage();
         switch (currentStage)
         {
             case BUILD_SOLID:
@@ -706,7 +707,7 @@ public abstract class AbstractEntityAIStructure<J extends AbstractJobStructure<?
             {
                 structure = new BuildingStructureHandler<>(world,
                     workOrder,
-                  this, new BuildingStructureHandler.Stage[] {REMOVE_WATER, REMOVE});
+                    this, new BuildingProgressStage[] {REMOVE_WATER, REMOVE});
                 building.setTotalStages(2);
             }
             else if ((colonyBuilding != null && (colonyBuilding.getBuildingLevel() > 0 || colonyBuilding.hasParent())) ||
@@ -714,14 +715,14 @@ public abstract class AbstractEntityAIStructure<J extends AbstractJobStructure<?
             {
                 structure = new BuildingStructureHandler<>(world,
                     workOrder,
-                  this, new BuildingStructureHandler.Stage[] {BUILD_SOLID, WEAK_SOLID, CLEAR_WATER, CLEAR_NON_SOLIDS, DECORATE, SPAWN});
+                    this, new BuildingProgressStage[] {BUILD_SOLID, WEAK_SOLID, CLEAR_WATER, CLEAR_NON_SOLIDS, DECORATE, SPAWN});
                 building.setTotalStages(5);
             }
             else
             {
                 structure = new BuildingStructureHandler<>(world,
                     workOrder,
-                  this, new BuildingStructureHandler.Stage[] {CLEAR, BUILD_SOLID, WEAK_SOLID, CLEAR_WATER, CLEAR_NON_SOLIDS, DECORATE, SPAWN});
+                    this, new BuildingProgressStage[] {CLEAR, BUILD_SOLID, WEAK_SOLID, CLEAR_WATER, CLEAR_NON_SOLIDS, DECORATE, SPAWN});
                 building.setTotalStages(6);
             }
 
@@ -903,7 +904,7 @@ public abstract class AbstractEntityAIStructure<J extends AbstractJobStructure<?
      * @param blockPos the progressResult.
      * @param stage    the current stage.
      */
-    public void storeProgressPos(final BlockPos blockPos, final BuildingStructureHandler.Stage stage)
+    public void storeProgressPos(final BlockPos blockPos, final BuildingProgressStage stage)
     {
         /*
          * Override if needed.
@@ -1087,7 +1088,7 @@ public abstract class AbstractEntityAIStructure<J extends AbstractJobStructure<?
      *
      * @return the progress with the current stage.
      */
-    public abstract Tuple<BlockPos, BuildingStructureHandler.Stage> getProgressPos();
+    public abstract Tuple<BlockPos, BuildingProgressStage> getProgressPos();
 
     /**
      * Check if a solid substitution block should be overwritten in a specific case.

--- a/src/main/java/com/minecolonies/core/entity/ai/workers/AbstractEntityAIStructureWithWorkOrder.java
+++ b/src/main/java/com/minecolonies/core/entity/ai/workers/AbstractEntityAIStructureWithWorkOrder.java
@@ -28,7 +28,7 @@ import com.minecolonies.core.colony.eventhooks.buildingEvents.BuildingUpgradedEv
 import com.minecolonies.core.colony.jobs.AbstractJobStructure;
 import com.minecolonies.core.colony.workorders.WorkOrderBuilding;
 import com.minecolonies.core.colony.workorders.WorkOrderMiner;
-import com.minecolonies.core.entity.ai.workers.util.BuildingStructureHandler;
+import com.minecolonies.core.entity.ai.workers.util.BuildingProgressStage;
 import com.minecolonies.core.entity.ai.workers.util.WorkerLoadOnlyStructureHandler;
 import net.minecraft.core.BlockPos;
 import net.minecraft.world.item.ItemStack;
@@ -88,14 +88,14 @@ public abstract class AbstractEntityAIStructureWithWorkOrder<J extends AbstractJ
     }
 
     @Override
-    public void storeProgressPos(final BlockPos blockPos, final BuildingStructureHandler.Stage stage)
+    public void storeProgressPos(final BlockPos blockPos, final BuildingProgressStage stage)
     {
         building.setProgressPos(blockPos, stage);
         worker.getCitizenData().setStatusPosition(blockPos.equals(NULL_POS) ? null : structurePlacer.getB().getProgressPosInWorld(blockPos));
     }
 
     @Override
-    public Tuple<BlockPos, BuildingStructureHandler.Stage> getProgressPos()
+    public Tuple<BlockPos, BuildingProgressStage> getProgressPos()
     {
         return building.getProgress();
     }
@@ -488,7 +488,7 @@ public abstract class AbstractEntityAIStructureWithWorkOrder<J extends AbstractJ
             resetCurrentStructure();
             building.cancelAllRequestsOfCitizen(worker.getCitizenData());
             building.cancelAllRequestsOfCitizen(null);
-            building.setProgressPos(null, BuildingStructureHandler.Stage.CLEAR);
+            building.setProgressPos(null, BuildingProgressStage.CLEAR);
             return true;
         }
         return job.getWorkOrder() != null && (!WorldUtil.isBlockLoaded(world, job.getWorkOrder().getLocation())) && getState() != PICK_UP_RESIDUALS;

--- a/src/main/java/com/minecolonies/core/entity/ai/workers/builder/EntityAIStructureBuilder.java
+++ b/src/main/java/com/minecolonies/core/entity/ai/workers/builder/EntityAIStructureBuilder.java
@@ -16,6 +16,7 @@ import com.minecolonies.core.colony.buildings.workerbuildings.BuildingBuilder;
 import com.minecolonies.core.colony.jobs.JobBuilder;
 import com.minecolonies.core.colony.workorders.WorkOrderBuilding;
 import com.minecolonies.core.entity.ai.workers.AbstractEntityAIStructureWithWorkOrder;
+import com.minecolonies.core.entity.ai.workers.util.BuildingProgressStage;
 import com.minecolonies.core.entity.ai.workers.util.BuildingStructureHandler;
 import com.minecolonies.core.entity.pathfinding.navigation.MinecoloniesAdvancedPathNavigate;
 import com.minecolonies.core.entity.pathfinding.pathjobs.PathJobMoveCloseToXNearY;
@@ -100,7 +101,7 @@ public class EntityAIStructureBuilder extends AbstractEntityAIStructureWithWorkO
         if (!job.hasWorkOrder())
         {
             building.searchWorkOrder();
-            building.setProgressPos(null, BuildingStructureHandler.Stage.CLEAR);
+            building.setProgressPos(null, BuildingProgressStage.CLEAR);
             worker.getCitizenData().setStatusPosition(null);
             return false;
         }

--- a/src/main/java/com/minecolonies/core/entity/ai/workers/production/EntityAIQuarrier.java
+++ b/src/main/java/com/minecolonies/core/entity/ai/workers/production/EntityAIQuarrier.java
@@ -23,6 +23,7 @@ import com.minecolonies.core.colony.interactionhandling.StandardInteraction;
 import com.minecolonies.core.colony.jobs.JobQuarrier;
 import com.minecolonies.core.colony.workorders.WorkOrderMiner;
 import com.minecolonies.core.entity.ai.workers.AbstractEntityAIStructureWithWorkOrder;
+import com.minecolonies.core.entity.ai.workers.util.BuildingProgressStage;
 import com.minecolonies.core.entity.ai.workers.util.BuildingStructureHandler;
 import com.minecolonies.core.entity.ai.workers.util.LayerBlueprintIterator;
 import com.minecolonies.core.entity.ai.workers.util.WorkerLoadOnlyStructureHandler;
@@ -53,7 +54,7 @@ import static com.minecolonies.core.colony.buildings.modules.BuildingModules.STA
 import static com.minecolonies.core.colony.buildings.workerbuildings.BuildingMiner.FILL_BLOCK;
 import static com.minecolonies.core.entity.ai.workers.production.EntityAIStructureMiner.RENDER_META_PICKAXE;
 import static com.minecolonies.core.entity.ai.workers.production.EntityAIStructureMiner.RENDER_META_SHOVEL;
-import static com.minecolonies.core.entity.ai.workers.util.BuildingStructureHandler.Stage.*;
+import static com.minecolonies.core.entity.ai.workers.util.BuildingProgressStage.*;
 
 /**
  * Class which handles the quarrier behaviour.
@@ -230,7 +231,7 @@ public class EntityAIQuarrier extends AbstractEntityAIStructureWithWorkOrder<Job
             final BuildingStructureHandler<JobQuarrier, BuildingMiner> structure;
             structure = new BuildingStructureHandler<>(world,
                 workOrder,
-              this, new BuildingStructureHandler.Stage[] {BUILD_SOLID, DECORATE, CLEAR});
+                this, new BuildingProgressStage[] {BUILD_SOLID, DECORATE, CLEAR});
             building.setTotalStages(3);
 
             if (!structure.hasBluePrint())

--- a/src/main/java/com/minecolonies/core/entity/ai/workers/production/EntityAIStructureMiner.java
+++ b/src/main/java/com/minecolonies/core/entity/ai/workers/production/EntityAIStructureMiner.java
@@ -17,7 +17,7 @@ import com.minecolonies.core.colony.interactionhandling.StandardInteraction;
 import com.minecolonies.core.colony.jobs.JobMiner;
 import com.minecolonies.core.colony.workorders.WorkOrderMiner;
 import com.minecolonies.core.entity.ai.workers.AbstractEntityAIStructureWithWorkOrder;
-import com.minecolonies.core.entity.ai.workers.util.BuildingStructureHandler;
+import com.minecolonies.core.entity.ai.workers.util.BuildingProgressStage;
 import com.minecolonies.core.entity.ai.workers.util.MineNode;
 import com.minecolonies.core.entity.ai.workers.util.MinerLevel;
 import com.minecolonies.core.util.AdvancementUtils;
@@ -1031,7 +1031,7 @@ public class EntityAIStructureMiner extends AbstractEntityAIStructureWithWorkOrd
             job.setWorkOrder(null);
             resetCurrentStructure();
             building.cancelAllRequestsOfCitizen(worker.getCitizenData());
-            building.setProgressPos(null, BuildingStructureHandler.Stage.CLEAR);
+            building.setProgressPos(null, BuildingProgressStage.CLEAR);
             return true;
         }
 

--- a/src/main/java/com/minecolonies/core/entity/ai/workers/util/BuildingProgressStage.java
+++ b/src/main/java/com/minecolonies/core/entity/ai/workers/util/BuildingProgressStage.java
@@ -1,0 +1,17 @@
+package com.minecolonies.core.entity.ai.workers.util;
+
+/**
+ * The different stages a StructureIterator building process can be in.
+ */
+public enum BuildingProgressStage
+{
+    CLEAR,
+    BUILD_SOLID,
+    CLEAR_WATER,
+    CLEAR_NON_SOLIDS,
+    DECORATE,
+    SPAWN,
+    REMOVE,
+    REMOVE_WATER,
+    WEAK_SOLID,
+}

--- a/src/main/java/com/minecolonies/core/entity/ai/workers/util/BuildingStructureHandler.java
+++ b/src/main/java/com/minecolonies/core/entity/ai/workers/util/BuildingStructureHandler.java
@@ -60,7 +60,7 @@ public class BuildingStructureHandler<J extends AbstractJobStructure<?, J>, B ex
     /**
      * The total number of stages.
      */
-    private final Stage[] stages;
+    private final BuildingProgressStage[] stages;
 
     /**
      * The building associated with this placement.
@@ -70,7 +70,7 @@ public class BuildingStructureHandler<J extends AbstractJobStructure<?, J>, B ex
     /**
      * The current structure stage.
      */
-    private int stage;
+    private int stage = 0;
 
     /**
      * The respective workorder used for placement
@@ -88,7 +88,7 @@ public class BuildingStructureHandler<J extends AbstractJobStructure<?, J>, B ex
       final Level world,
         final IWorkOrder workOrder,
       final AbstractEntityAIStructure<J, B> entityAIStructure,
-      final Stage[] stages)
+        final BuildingProgressStage[] stages)
     {
         super(world,
             workOrder.getLocation(),
@@ -98,7 +98,16 @@ public class BuildingStructureHandler<J extends AbstractJobStructure<?, J>, B ex
         this.workOrder = (IBuilderWorkOrder) workOrder;
         this.structureAI = entityAIStructure;
         this.stages = stages;
-        this.stage = workOrder.getStage();
+
+        for (int i = 0; i < stages.length; i++)
+        {
+            final BuildingProgressStage stage = stages[i];
+            if (stage == workOrder.getStage())
+            {
+                this.stage = i;
+                break;
+            }
+        }
     }
 
     /**
@@ -119,7 +128,7 @@ public class BuildingStructureHandler<J extends AbstractJobStructure<?, J>, B ex
      * @return the current Stage.
      */
     @Nullable
-    public Stage getStage()
+    public BuildingProgressStage getStage()
     {
         if (this.stage >= stages.length)
         {
@@ -141,14 +150,14 @@ public class BuildingStructureHandler<J extends AbstractJobStructure<?, J>, B ex
      *
      * @param stage the stage to set.
      */
-    public void setStage(final Stage stage)
+    public void setStage(final BuildingProgressStage stage)
     {
         for (int i = 0; i < stages.length; i++)
         {
             if (stages[i] == stage)
             {
                 this.stage = i;
-                workOrder.setStage(i);
+                workOrder.setStage(stage);
                 return;
             }
         }
@@ -303,7 +312,7 @@ public class BuildingStructureHandler<J extends AbstractJobStructure<?, J>, B ex
     @Override
     public boolean allowReplace()
     {
-        return getStage() != null && getStage() != Stage.CLEAR;
+        return getStage() != null && getStage() != BuildingProgressStage.CLEAR;
     }
 
     @Override
@@ -350,21 +359,5 @@ public class BuildingStructureHandler<J extends AbstractJobStructure<?, J>, B ex
         return (block1 == Blocks.GRASS_BLOCK && block2 == Blocks.DIRT)
                  || (block2 == Blocks.GRASS_BLOCK && block1 == Blocks.DIRT)
                  || (block1 == ModBlocks.blockRack && block2 == ModBlocks.blockRack);
-    }
-
-    /**
-     * The different stages a StructureIterator building process can be in.
-     */
-    public enum Stage
-    {
-        CLEAR,
-        BUILD_SOLID,
-        CLEAR_WATER,
-        CLEAR_NON_SOLIDS,
-        DECORATE,
-        SPAWN,
-        REMOVE,
-        REMOVE_WATER,
-        WEAK_SOLID,
     }
 }

--- a/src/main/java/com/minecolonies/core/items/ItemAssistantHammer.java
+++ b/src/main/java/com/minecolonies/core/items/ItemAssistantHammer.java
@@ -21,7 +21,7 @@ import com.minecolonies.core.Network;
 import com.minecolonies.core.colony.buildings.modules.BuildingModules;
 import com.minecolonies.core.colony.buildings.workerbuildings.BuildingMiner;
 import com.minecolonies.core.colony.interactionhandling.SimpleNotificationInteraction;
-import com.minecolonies.core.entity.ai.workers.util.BuildingStructureHandler;
+import com.minecolonies.core.entity.ai.workers.util.BuildingProgressStage;
 import com.minecolonies.core.network.messages.server.PlayerAssistantBuildRequestMessage;
 import com.minecolonies.core.placementhandlers.SolidPlaceholderPlacementHandler;
 import net.minecraft.ChatFormatting;
@@ -136,8 +136,8 @@ public class ItemAssistantHammer extends AbstractItemMinecolonies
     {
         if (workOrder.isClaimed())
         {
-            final BuildingStructureHandler.Stage stage = BuildingStructureHandler.Stage.values()[workOrder.getStage()];
-            if (stage == BuildingStructureHandler.Stage.CLEAR || stage == BuildingStructureHandler.Stage.CLEAR_NON_SOLIDS)
+            final BuildingProgressStage stage = workOrder.getStage();
+            if (stage == BuildingProgressStage.CLEAR || stage == BuildingProgressStage.CLEAR_NON_SOLIDS)
             {
                 player.displayClientMessage(Component.translatable("item.minecolonies.assistanthammer.notcleared"), true);
                 return;


### PR DESCRIPTION
Closes #10957
Closes #

# Changes proposed in this pull request
- Fix the assistant hammer requesting to wait for the builder clearing for leveling up buildings
- The enum for the building progress is now named BuildingProgressStage and got moved into its own class

## Testing
- [ x] Yes I tested this before submitting it.
- [ ] I also did a multiplayer test.

Review please