### PR TITLE
Manual builder assignment tweaks.

### DIFF
--- a/src/main/java/com/minecolonies/api/colony/workorders/IBuilderWorkOrder.java
+++ b/src/main/java/com/minecolonies/api/colony/workorders/IBuilderWorkOrder.java
@@ -2,6 +2,9 @@ package com.minecolonies.api.colony.workorders;
 
 import com.minecolonies.api.colony.ICitizenData;
 import com.minecolonies.api.colony.IColony;
+
+import net.minecraft.core.BlockPos;
+
 import org.jetbrains.annotations.NotNull;
 
 public interface IBuilderWorkOrder extends IServerWorkOrder
@@ -106,6 +109,15 @@ public interface IBuilderWorkOrder extends IServerWorkOrder
      * @return
      */
     boolean canBuild(@NotNull ICitizenData citizen);
+
+    /**
+     * Checks if a builder may accept this workOrder while ignoring the distance to the builder.
+     *
+     * @param builderLocation position of the builders own hut.
+     * @param builderLevel    level of the builders hut.
+     * @return true if so.
+     */
+    public boolean canBuildIgnoringDistance(@NotNull ICitizenData citizen, @NotNull final BlockPos builderLocation, final int builderLevel);
 
     /**
      * Sets the building stage of the workorder

--- a/src/main/java/com/minecolonies/api/util/constant/TranslationConstants.java
+++ b/src/main/java/com/minecolonies/api/util/constant/TranslationConstants.java
@@ -776,8 +776,16 @@ public final class TranslationConstants
     public static final String MESSAGE_WARNING_TOWN_HALL_NOT_PRESENT  = "tile.blockhut.messagenotownhall";
     @NonNls
     public static final String MESSAGE_WARNING_TOWN_HALL_TOO_FAR_AWAY = "tile.blockhut.messagetoofarfromtownhall";
-
+    @NonNls
+    public static final String MESSAGE_WARNING_NO_WORKER_ASSIGNED = "tile.blockhut.noworkerassigned";
+    @NonNls
+    public static final String MESSAGE_WARNING_ALREADY_CLAIMED = "tile.blockhut.alreadyclaimed";
+    @NonNls
+    public static final String MESSAGE_WARNING_NOTFORBUILDER = "tile.blockhut.notforbuilder";
+    @NonNls
+    public static final String MESSAGE_WARNING_CANNOTBUILD = "tile.blockhut.cannotbuild";
     //</editor-fold>
+
 
     //<editor-fold desc="Other keys">
 

--- a/src/main/java/com/minecolonies/core/colony/workorders/WorkOrderBuilding.java
+++ b/src/main/java/com/minecolonies/core/colony/workorders/WorkOrderBuilding.java
@@ -160,7 +160,7 @@ public class WorkOrderBuilding extends AbstractWorkOrder
         //  - OR the WorkOrder is not farther away than 100 blocks from any builder and not manually assigned
 
         final IBuilding building = citizen.getWorkBuilding();
-        return canBuildIgnoringDistance(building.getPosition(), building.getBuildingLevel())
+        return canBuildIgnoringDistance(citizen, building.getPosition(), building.getBuildingLevel())
                  && (citizen.getWorkBuilding().getPosition().distSqr(getLocation()) <= MAX_DISTANCE_SQ
                  || (isClaimed() && getClaimedBy().equals(building.getPosition())));
     }
@@ -172,7 +172,8 @@ public class WorkOrderBuilding extends AbstractWorkOrder
      * @param builderLevel    level of the builders hut.
      * @return true if so.
      */
-    private boolean canBuildIgnoringDistance(@NotNull final BlockPos builderLocation, final int builderLevel)
+    @Override
+    public boolean canBuildIgnoringDistance(@NotNull ICitizenData citizen, @NotNull final BlockPos builderLocation, final int builderLevel)
     {
         //  A Build WorkOrder may be fulfilled by a Builder as long as any ONE of the following is true:
         //  - The Builder's Work AbstractBuilding is built

--- a/src/main/java/com/minecolonies/core/colony/workorders/WorkOrderDecoration.java
+++ b/src/main/java/com/minecolonies/core/colony/workorders/WorkOrderDecoration.java
@@ -82,6 +82,19 @@ public class WorkOrderDecoration extends AbstractWorkOrder
         return citizen.getJob() instanceof JobBuilder && citizen.getJob().getWorkBuilding().getBuildingLevel() > 0;
     }
 
+    /**
+     * Checks if a builder may accept this workOrder while ignoring the distance to the builder.
+     * <p>
+     * @param position position of the builders own hut.
+     * @param level    level of the builders hut.
+     * @return true if so.
+     */
+    @SuppressWarnings(UNUSED_METHOD_PARAMETERS_SHOULD_BE_REMOVED)
+    public boolean canBuildIgnoringDistance(@NotNull ICitizenData citizen, final BlockPos position, final int level)
+    {
+        return level > 0;
+    }
+
     @Override
     public boolean isValid(final IColony colony)
     {

--- a/src/main/java/com/minecolonies/core/colony/workorders/WorkOrderMiner.java
+++ b/src/main/java/com/minecolonies/core/colony/workorders/WorkOrderMiner.java
@@ -17,7 +17,7 @@ import java.util.function.Consumer;
 
 import static com.minecolonies.api.util.constant.Constants.STORAGE_STYLE;
 import static com.minecolonies.api.util.constant.NbtTagConstants.TAG_POS;
-
+import static com.minecolonies.api.util.constant.Suppression.UNUSED_METHOD_PARAMETERS_SHOULD_BE_REMOVED;
 /**
  * A work order that the build can take to build mine.
  */
@@ -90,6 +90,21 @@ public class WorkOrderMiner extends AbstractWorkOrder
     public boolean canBuild(@NotNull ICitizenData citizen)
     {
         return citizen.getJob() instanceof JobMiner && this.minerBuilding.equals(citizen.getWorkBuilding().getID());
+    }
+
+    /**
+     * Check if a citizen may accept this workOrder while ignoring the distance to the build location.
+     * <p>
+     * @param citizen     the citizen who is trying to build.
+     * @param position    the position of the citizen's work hut.
+     * @param level       the level of that work hut.
+     * @return true if the citizen may accept this work order.
+     */
+    @SuppressWarnings(UNUSED_METHOD_PARAMETERS_SHOULD_BE_REMOVED)
+    @Override
+    public boolean canBuildIgnoringDistance(@NotNull ICitizenData citizen,final BlockPos position, final int level)
+    {
+        return canBuild(citizen);
     }
 
     @Override

--- a/src/main/java/com/minecolonies/core/colony/workorders/WorkOrderPlantationField.java
+++ b/src/main/java/com/minecolonies/core/colony/workorders/WorkOrderPlantationField.java
@@ -10,7 +10,7 @@ import net.minecraft.core.BlockPos;
 import org.jetbrains.annotations.NotNull;
 
 import static com.minecolonies.api.util.constant.TranslationConstants.MESSAGE_NEW_DECORATION_REQUEST;
-
+import static com.minecolonies.api.util.constant.Suppression.UNUSED_METHOD_PARAMETERS_SHOULD_BE_REMOVED;
 /**
  * A work order that the build can take to build plantation fields.
  */
@@ -63,6 +63,21 @@ public class WorkOrderPlantationField extends AbstractWorkOrder
     public boolean canBuild(final @NotNull ICitizenData citizen)
     {
         return citizen.getJob() instanceof JobBuilder;
+    }
+    
+    /**
+     * Check if a citizen may accept this workOrder while ignoring the distance to the build location.
+     * <p>
+     * @param citizen     the citizen who is trying to build.
+     * @param position    the position of the citizen's work hut.
+     * @param level       the level of that work hut.
+     * @return true if the citizen may accept this work order.
+     */
+    @SuppressWarnings(UNUSED_METHOD_PARAMETERS_SHOULD_BE_REMOVED)
+    @Override
+    public boolean canBuildIgnoringDistance(final @NotNull ICitizenData citizen, final BlockPos position, final int level)
+    {
+        return canBuild(citizen);
     }
 
     @Override

--- a/src/main/java/com/minecolonies/core/network/messages/server/colony/building/builder/BuilderSelectWorkOrderMessage.java
+++ b/src/main/java/com/minecolonies/core/network/messages/server/colony/building/builder/BuilderSelectWorkOrderMessage.java
@@ -44,9 +44,17 @@ public class BuilderSelectWorkOrderMessage extends AbstractBuildingServerMessage
         buf.writeInt(workOrder);
     }
 
+    /**
+     * Executes the action of setting a workorder on the builder.
+     *
+     * @param ctxIn            NetworkEvent.Context of the packet.
+     * @param isLogicalServer  Whether the server is logical.
+     * @param colony           Colony the building is in.
+     * @param building         The builder to set the workorder on.
+     */
     @Override
     protected void onExecute(final NetworkEvent.Context ctxIn, final boolean isLogicalServer, final IColony colony, final BuildingBuilder building)
     {
-        building.setWorkOrder(workOrder);
+        building.setWorkOrder(workOrder, ctxIn);
     }
 }

--- a/src/main/resources/assets/minecolonies/lang/manual_en_us.json
+++ b/src/main/resources/assets/minecolonies/lang/manual_en_us.json
@@ -281,6 +281,10 @@
   "tile.blockhut.messagenopermissionplace": "You don't have permission to place huts in %s.",
   "tile.blockhut.messagetoofarfromtownhall": "You cannot place a building outside of your colony! Expand your colony by upgrading the Town Hall and/or building and upgrading Guard Towers and Barracks.",
   "tile.blockhut.messagenotownhall": "You need to place a Town Hall first!",
+  "tile.blockhut.noworkerassigned" : "You cannot assign a work order at a hut where there is no worker.",
+  "tile.blockhut.alreadyclaimed" : "You cannot assign a work order which is already claimed somewhere.",
+  "tile.blockhut.notforbuilder" : "You cannot assign a builder this work order - it is not meant for builders.",
+  "tile.blockhut.cannotbuild" : "You cannot assign a work order to a builder who cannot build it.",
 
   "block.blockhuttownhall.messagemaxsize.config": "%d has reached its max size. Edit the config file to be able to get more.",
   "block.blockhuttownhall.messagemaxsize.research": "%d has reached its max size. You can get more by completing the research in the University.",


### PR DESCRIPTION
Provides in-game messages for situations that prevent manual assignment, and allows the distance limit to be disregarded when manually assigning a job.

Closes #10953 further discussion.

# Changes proposed in this pull request
- Translatable warning messages sent to player when manual build assignment fails.
- Added canBuildIgnoringDistance to IBuilderWorkOrder interface.

## Testing
- [X] Yes I tested this before submitting it.
- [x] I also did a multiplayer test.

Review please