### PR TITLE
Fix herder item stack request corruption

### DIFF
--- a/src/main/java/com/minecolonies/api/colony/requestsystem/requestable/Stack.java
+++ b/src/main/java/com/minecolonies/api/colony/requestsystem/requestable/Stack.java
@@ -224,7 +224,7 @@ public class Stack implements IConcreteDeliverable
 
         if (stack.isEmpty())
         {
-            Log.getLogger().error("Deserialized bad stack", compound.toString());
+            Log.getLogger().error("Deserialized bad stack: {}", compound.toString());
         }
 
         return new Stack(stack, matchMeta, matchNBT, result, count, minCount, canBeResolved);
@@ -274,7 +274,7 @@ public class Stack implements IConcreteDeliverable
 
         if (stack.isEmpty())
         {
-            Log.getLogger().error("Deserialized bad stack", stack.toString());
+            Log.getLogger().error("Deserialized bad stack {}", stack.toString());
         }
 
         return new Stack(stack, matchMeta, matchNBT, result, count, minCount, canBeResolved);

--- a/src/main/java/com/minecolonies/api/colony/requestsystem/requestable/Stack.java
+++ b/src/main/java/com/minecolonies/api/colony/requestsystem/requestable/Stack.java
@@ -161,10 +161,15 @@ public class Stack implements IConcreteDeliverable
     {
         if (ItemStackUtils.isEmpty(stack))
         {
-            Log.getLogger().error("Created Empty Stack:" + stack, new Exception());
+            Log.getLogger().error("Created Empty Stack: {}", stack, new Exception());
         }
 
-        this.theStack = stack.copy();
+        if (stack.getCount() != 1 && stack.getCount() != count)
+        {
+            Log.getLogger().warn("Stack count mismatch (stack={}, count={}). ItemStack's count will be ignored.", stack, count, new Exception("Stack constructor"));
+        }
+
+        this.theStack = stack.copyWithCount(1);
         this.matchDamage = matchDamage;
         this.matchNBT = matchNBT;
         this.result = result;

--- a/src/main/java/com/minecolonies/api/crafting/ItemStorage.java
+++ b/src/main/java/com/minecolonies/api/crafting/ItemStorage.java
@@ -71,6 +71,17 @@ public class ItemStorage
     /**
      * Creates an instance of the storage.
      *
+     * @param stack             the stack.
+     * @param amount            the amount.
+     */
+    public ItemStorage(@NotNull final ItemStack stack, final int amount)
+    {
+        this(stack, amount, false, false);
+    }
+
+    /**
+     * Creates an instance of the storage.
+     *
      * @param stack                the stack.
      * @param ignoreDamageValue    should the damage value be ignored?
      * @param shouldIgnoreNBTValue should the nbt value be ignored?

--- a/src/main/java/com/minecolonies/api/util/ItemStackUtils.java
+++ b/src/main/java/com/minecolonies/api/util/ItemStackUtils.java
@@ -474,7 +474,7 @@ public final class ItemStackUtils
     }
 
     /**
-     * get the size of the stac
+     * get the size of the stack
      *
      * @param stack to get the size from
      * @return the size of the stack

--- a/src/main/java/com/minecolonies/core/entity/ai/workers/production/herders/AbstractEntityAIHerder.java
+++ b/src/main/java/com/minecolonies/core/entity/ai/workers/production/herders/AbstractEntityAIHerder.java
@@ -314,7 +314,7 @@ public abstract class AbstractEntityAIHerder<J extends AbstractJob<?, J>, B exte
 
         for (final ItemStack item : getExtraItemsNeeded())
         {
-            checkIfRequestForItemExistOrCreateAsync(item);
+            checkIfRequestForItemExistOrCreateAsync(item.copyWithCount(1), item.getCount(), item.getCount());
         }
 
         return DECIDE;

--- a/src/main/java/com/minecolonies/core/entity/ai/workers/production/herders/AbstractEntityAIHerder.java
+++ b/src/main/java/com/minecolonies/core/entity/ai/workers/production/herders/AbstractEntityAIHerder.java
@@ -1,5 +1,6 @@
 package com.minecolonies.core.entity.ai.workers.production.herders;
 
+import com.minecolonies.api.crafting.ItemStorage;
 import com.minecolonies.api.entity.ai.statemachine.AITarget;
 import com.minecolonies.api.entity.ai.statemachine.states.IAIState;
 import com.minecolonies.api.entity.citizen.VisibleCitizenStatus;
@@ -178,7 +179,7 @@ public abstract class AbstractEntityAIHerder<J extends AbstractJob<?, J>, B exte
      * @return a list of items needed or empty.
      */
     @NotNull
-    public List<ItemStack> getExtraItemsNeeded()
+    public List<ItemStorage> getExtraItemsNeeded()
     {
         return new ArrayList<>();
     }
@@ -312,9 +313,9 @@ public abstract class AbstractEntityAIHerder<J extends AbstractJob<?, J>, B exte
             checkIfRequestForItemExistOrCreateAsync(breedingItem, breedingItem.getCount() * EXTRA_BREEDING_ITEMS_REQUEST, breedingItem.getCount());
         }
 
-        for (final ItemStack item : getExtraItemsNeeded())
+        for (final ItemStorage items : getExtraItemsNeeded())
         {
-            checkIfRequestForItemExistOrCreateAsync(item.copyWithCount(1), item.getCount(), item.getCount());
+            checkIfRequestForItemExistOrCreateAsync(items.getItemStack(), items.getAmount(), items.getAmount());
         }
 
         return DECIDE;

--- a/src/main/java/com/minecolonies/core/entity/ai/workers/production/herders/EntityAIWorkCowboy.java
+++ b/src/main/java/com/minecolonies/core/entity/ai/workers/production/herders/EntityAIWorkCowboy.java
@@ -114,22 +114,19 @@ public class EntityAIWorkCowboy extends AbstractEntityAIHerder<JobCowboy, Buildi
         return result;
     }
 
-    @NotNull
     @Override
-    public List<ItemStack> getExtraItemsNeeded()
+    public @NotNull List<ItemStorage> getExtraItemsNeeded()
     {
-        final List<ItemStack> list = super.getExtraItemsNeeded();
+        final List<ItemStorage> list = super.getExtraItemsNeeded();
         if (building != null && building.getFirstModuleOccurance(BuildingCowboy.HerdingModule.class).canTryToMilk() &&
               !searchForAnimals(a -> a instanceof Cow && !(a instanceof MushroomCow)).isEmpty())
         {
-            final ItemStack stack = building.getMilkInputItem().copy();
-            stack.setCount(building.getSetting(MILKING_AMOUNT).getValue());
-            list.add(stack);
+            list.add(new ItemStorage(building.getMilkInputItem().copy(), building.getSetting(MILKING_AMOUNT).getValue()));
         }
         if (building != null && building.getFirstModuleOccurance(BuildingCowboy.HerdingModule.class).canTryToStew() &&
               !searchForAnimals(a -> a instanceof MushroomCow).isEmpty())
         {
-            list.add(new ItemStack(Items.BOWL));
+            list.add(new ItemStorage(Items.BOWL));
         }
         return list;
     }


### PR DESCRIPTION
Closes #10884 

# Changes proposed in this pull request

- Prevent item stack corruption in herder AI by requesting single-item stacks alongside the count parameter instead of an oversized stack that get corrupted during network transmission. (Inspired by the postbox)

- Use placeholder values in error logging for deserialization issues.

## Testing
- [x] Yes I tested this before submitting it.
- [ ] I also did a multiplayer test.

Review please