### PR TITLE
Allow external building module icon

### DIFF
--- a/src/main/java/com/minecolonies/api/colony/buildings/modules/IBuildingModuleView.java
+++ b/src/main/java/com/minecolonies/api/colony/buildings/modules/IBuildingModuleView.java
@@ -4,9 +4,14 @@ import com.ldtteam.blockui.views.BOWindow;
 import com.minecolonies.api.colony.IColonyView;
 import com.minecolonies.api.colony.buildings.registry.BuildingEntry;
 import com.minecolonies.api.colony.buildings.views.IBuildingView;
+import com.minecolonies.api.util.constant.Constants;
+
 import net.minecraft.network.FriendlyByteBuf;
+import net.minecraft.resources.ResourceLocation;
 import net.minecraftforge.api.distmarker.Dist;
 import net.minecraftforge.api.distmarker.OnlyIn;
+
+import org.apache.http.annotation.Obsolete;
 import org.jetbrains.annotations.NotNull;
 
 /**
@@ -42,10 +47,24 @@ public interface IBuildingModuleView
 
     /**
      * Get the icon string for the module view.
+     * @Deprecated in favor of getIconResourceLocation
      * @return the icon identifier.
      */
-    String getIcon();
+    @Deprecated
+    default String getIcon()
+    {
+        return "custom";
+    }
 
+    /**
+     * Get the resource location of the icon for the module view.
+     * @return the resource location.
+     */
+    default ResourceLocation getIconResourceLocation()
+    {
+        return new ResourceLocation(Constants.MOD_ID, "textures/gui/modules/" + getIcon() + ".png");
+    }
+    
     /**
      * Get the lang string for the title.
      * @return the lang string.

--- a/src/main/java/com/minecolonies/core/client/gui/AbstractModuleWindow.java
+++ b/src/main/java/com/minecolonies/core/client/gui/AbstractModuleWindow.java
@@ -5,6 +5,7 @@ import com.ldtteam.blockui.controls.ButtonImage;
 import com.minecolonies.api.colony.buildings.modules.IBuildingModuleView;
 import com.minecolonies.api.colony.buildings.modules.IModuleWindow;
 import com.minecolonies.api.colony.buildings.views.IBuildingView;
+import com.minecolonies.api.util.constant.Constants;
 import com.minecolonies.core.colony.buildings.views.AbstractBuildingView;
 import net.minecraft.client.resources.sounds.SimpleSoundInstance;
 import net.minecraft.network.chat.Component;
@@ -89,7 +90,7 @@ public abstract class AbstractModuleWindow extends AbstractWindowSkeleton implem
 
             final String icon = view.getIcon();
             final ButtonImage iconImage = new ButtonImage();
-            iconImage.setImage(new ResourceLocation("minecolonies:textures/gui/modules/" + icon + ".png"), false);
+            iconImage.setImage(resourceForIcon(icon), false);
             iconImage.setSize(20, 20);
             iconImage.setID(icon);
             iconImage.setPosition(-15, 13 + offset);
@@ -105,5 +106,31 @@ public abstract class AbstractModuleWindow extends AbstractWindowSkeleton implem
 
             PaneBuilders.tooltipBuilder().hoverPane(iconImage).build().setText(Component.translatable(view.getDesc().toLowerCase(Locale.US)));
         }
+    }
+
+    /**
+     * Tries to interpret the given string as a resource location.
+     * If it cannot, it creates a resource location with the given string as path
+     * in the "minecolonies:textures/gui/modules/" namespace in a backwards-compatible way..
+     * @param icon the string to parse or convert into a resource location.
+     * @return the parsed or created resource location.
+     */
+    protected ResourceLocation resourceForIcon(String icon)
+    {
+        ResourceLocation loc = null;
+        
+        if (icon.indexOf(ResourceLocation.NAMESPACE_SEPARATOR, 0) > 0)
+        {
+            loc = ResourceLocation.tryParse(icon);
+        }
+
+        if (loc == null) 
+        { 
+            loc = new ResourceLocation(
+                    Constants.MOD_ID,
+                    "textures/gui/modules/" + icon + ".png");
+        }
+
+        return loc;
     }
 }

--- a/src/main/java/com/minecolonies/core/client/gui/AbstractModuleWindow.java
+++ b/src/main/java/com/minecolonies/core/client/gui/AbstractModuleWindow.java
@@ -88,11 +88,11 @@ public abstract class AbstractModuleWindow extends AbstractWindowSkeleton implem
                 view.getWindow().open();
             });
 
-            final String icon = view.getIcon();
+            final ResourceLocation icon = view.getIconResourceLocation();
             final ButtonImage iconImage = new ButtonImage();
-            iconImage.setImage(resourceForIcon(icon), false);
+            iconImage.setImage(icon, false);
             iconImage.setSize(20, 20);
-            iconImage.setID(icon);
+            iconImage.setID(icon.getPath());
             iconImage.setPosition(-15, 13 + offset);
             iconImage.setHandler(button -> {
                 mc.getSoundManager().play(SimpleSoundInstance.forUI(SoundEvents.BOOK_PAGE_TURN, 1.0F));
@@ -106,31 +106,5 @@ public abstract class AbstractModuleWindow extends AbstractWindowSkeleton implem
 
             PaneBuilders.tooltipBuilder().hoverPane(iconImage).build().setText(Component.translatable(view.getDesc().toLowerCase(Locale.US)));
         }
-    }
-
-    /**
-     * Tries to interpret the given string as a resource location.
-     * If it cannot, it creates a resource location with the given string as path
-     * in the "minecolonies:textures/gui/modules/" namespace in a backwards-compatible way..
-     * @param icon the string to parse or convert into a resource location.
-     * @return the parsed or created resource location.
-     */
-    protected ResourceLocation resourceForIcon(String icon)
-    {
-        ResourceLocation loc = null;
-        
-        if (icon.indexOf(ResourceLocation.NAMESPACE_SEPARATOR, 0) > 0)
-        {
-            loc = ResourceLocation.tryParse(icon);
-        }
-
-        if (loc == null) 
-        { 
-            loc = new ResourceLocation(
-                    Constants.MOD_ID,
-                    "textures/gui/modules/" + icon + ".png");
-        }
-
-        return loc;
     }
 }

--- a/src/main/java/com/minecolonies/core/colony/buildings/moduleviews/BuildingResourcesModuleView.java
+++ b/src/main/java/com/minecolonies/core/colony/buildings/moduleviews/BuildingResourcesModuleView.java
@@ -6,6 +6,7 @@ import com.minecolonies.api.util.constant.Constants;
 import com.minecolonies.core.client.gui.modules.WindowBuilderResModule;
 import com.minecolonies.core.colony.buildings.utils.BuildingBuilderResource;
 import net.minecraft.network.FriendlyByteBuf;
+import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.item.ItemStack;
 import net.minecraftforge.api.distmarker.Dist;
 import net.minecraftforge.api.distmarker.OnlyIn;
@@ -126,9 +127,9 @@ public class BuildingResourcesModuleView extends AbstractBuildingModuleView
     }
 
     @Override
-    public String getIcon()
+    public ResourceLocation getIconResourceLocation()
     {
-        return "inventory";
+        return new ResourceLocation(Constants.MOD_ID, "textures/gui/modules/inventory.png");
     }
 
     @Override

--- a/src/main/java/com/minecolonies/core/colony/buildings/moduleviews/BuildingStatisticsModuleView.java
+++ b/src/main/java/com/minecolonies/core/colony/buildings/moduleviews/BuildingStatisticsModuleView.java
@@ -3,9 +3,12 @@ package com.minecolonies.core.colony.buildings.moduleviews;
 import com.ldtteam.blockui.views.BOWindow;
 import com.minecolonies.api.colony.buildings.modules.AbstractBuildingModuleView;
 import com.minecolonies.api.colony.managers.interfaces.IStatisticsManager;
+import com.minecolonies.api.util.constant.Constants;
 import com.minecolonies.core.client.gui.modules.WindowStatsModule;
 import com.minecolonies.core.colony.managers.StatisticsManager;
 import net.minecraft.network.FriendlyByteBuf;
+import net.minecraft.resources.ResourceLocation;
+
 import org.jetbrains.annotations.NotNull;
 
 /**
@@ -31,9 +34,9 @@ public class BuildingStatisticsModuleView extends AbstractBuildingModuleView
     }
 
     @Override
-    public String getIcon()
+    public ResourceLocation getIconResourceLocation()
     {
-        return "stats";
+        return new ResourceLocation(Constants.MOD_ID, "textures/gui/modules/stats.png");
     }
 
     @Override

--- a/src/main/java/com/minecolonies/core/colony/buildings/moduleviews/CourierAssignmentModuleView.java
+++ b/src/main/java/com/minecolonies/core/colony/buildings/moduleviews/CourierAssignmentModuleView.java
@@ -14,6 +14,8 @@ import com.minecolonies.core.client.gui.modules.SpecialAssignmentModuleWindow;
 import com.minecolonies.core.network.messages.server.colony.building.CourierHiringModeMessage;
 import com.minecolonies.core.network.messages.server.colony.building.HireFireMessage;
 import net.minecraft.network.FriendlyByteBuf;
+import net.minecraft.resources.ResourceLocation;
+
 import org.jetbrains.annotations.NotNull;
 
 import java.util.ArrayList;
@@ -69,9 +71,9 @@ public class CourierAssignmentModuleView extends AbstractBuildingModuleView impl
     }
 
     @Override
-    public String getIcon()
+    public ResourceLocation getIconResourceLocation()
     {
-        return "entity";
+        return new ResourceLocation(Constants.MOD_ID, "textures/gui/modules/entity.png");
     }
 
     @Override

--- a/src/main/java/com/minecolonies/core/colony/buildings/moduleviews/CraftingModuleView.java
+++ b/src/main/java/com/minecolonies/core/colony/buildings/moduleviews/CraftingModuleView.java
@@ -15,6 +15,7 @@ import com.minecolonies.core.network.messages.server.colony.building.OpenCraftin
 import net.minecraft.client.Minecraft;
 import net.minecraft.core.BlockPos;
 import net.minecraft.network.FriendlyByteBuf;
+import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.MenuProvider;
 import net.minecraftforge.api.distmarker.Dist;
 import net.minecraftforge.api.distmarker.OnlyIn;
@@ -182,9 +183,9 @@ public class CraftingModuleView extends AbstractBuildingModuleView
     }
 
     @Override
-    public String getIcon()
+    public ResourceLocation getIconResourceLocation()
     {
-        return id;
+        return new ResourceLocation(Constants.MOD_ID, "textures/gui/modules/" + id + ".png");
     }
 
     @Override

--- a/src/main/java/com/minecolonies/core/colony/buildings/moduleviews/EnchanterStationsModuleView.java
+++ b/src/main/java/com/minecolonies/core/colony/buildings/moduleviews/EnchanterStationsModuleView.java
@@ -2,10 +2,12 @@ package com.minecolonies.core.colony.buildings.moduleviews;
 
 import com.ldtteam.blockui.views.BOWindow;
 import com.minecolonies.api.colony.buildings.modules.AbstractBuildingModuleView;
+import com.minecolonies.api.util.constant.Constants;
 import com.minecolonies.core.Network;
 import com.minecolonies.core.client.gui.modules.EnchanterStationModuleWindow;
 import com.minecolonies.core.network.messages.server.colony.building.enchanter.EnchanterWorkerSetMessage;
 import net.minecraft.network.FriendlyByteBuf;
+import net.minecraft.resources.ResourceLocation;
 import net.minecraft.core.BlockPos;
 import net.minecraftforge.api.distmarker.Dist;
 import net.minecraftforge.api.distmarker.OnlyIn;
@@ -72,11 +74,11 @@ public class EnchanterStationsModuleView extends AbstractBuildingModuleView
     }
 
     @Override
-    public String getIcon()
+    public ResourceLocation getIconResourceLocation()
     {
-        return "entity";
+        return new ResourceLocation(Constants.MOD_ID, "textures/gui/modules/entity.png");
     }
-
+    
     @Override
     public String getDesc()
     {

--- a/src/main/java/com/minecolonies/core/colony/buildings/moduleviews/EntityListModuleView.java
+++ b/src/main/java/com/minecolonies/core/colony/buildings/moduleviews/EntityListModuleView.java
@@ -123,8 +123,8 @@ public class EntityListModuleView extends AbstractBuildingModuleView implements 
     }
 
     @Override
-    public String getIcon()
+    public ResourceLocation getIconResourceLocation()
     {
-        return "workers";
+        return new ResourceLocation(Constants.MOD_ID, "textures/gui/modules/workers.png");
     }
 }

--- a/src/main/java/com/minecolonies/core/colony/buildings/moduleviews/ExpeditionLogModuleView.java
+++ b/src/main/java/com/minecolonies/core/colony/buildings/moduleviews/ExpeditionLogModuleView.java
@@ -2,9 +2,11 @@ package com.minecolonies.core.colony.buildings.moduleviews;
 
 import com.ldtteam.blockui.views.BOWindow;
 import com.minecolonies.api.colony.buildings.modules.AbstractBuildingModuleView;
+import com.minecolonies.api.util.constant.Constants;
 import com.minecolonies.core.client.gui.modules.ExpeditionLogModuleWindow;
 import com.minecolonies.core.colony.buildings.modules.expedition.ExpeditionLog;
 import net.minecraft.network.FriendlyByteBuf;
+import net.minecraft.resources.ResourceLocation;
 import net.minecraftforge.api.distmarker.Dist;
 import net.minecraftforge.api.distmarker.OnlyIn;
 import org.jetbrains.annotations.NotNull;
@@ -55,9 +57,9 @@ public class ExpeditionLogModuleView extends AbstractBuildingModuleView
     }
 
     @Override
-    public String getIcon()
+    public ResourceLocation getIconResourceLocation()
     {
-        return "sword";
+        return new ResourceLocation(Constants.MOD_ID, "textures/gui/modules/sword.png");
     }
 
     @Override

--- a/src/main/java/com/minecolonies/core/colony/buildings/moduleviews/FieldsModuleView.java
+++ b/src/main/java/com/minecolonies/core/colony/buildings/moduleviews/FieldsModuleView.java
@@ -2,6 +2,7 @@ package com.minecolonies.core.colony.buildings.moduleviews;
 
 import com.minecolonies.api.colony.buildings.modules.AbstractBuildingModuleView;
 import com.minecolonies.api.colony.buildings.views.IBuildingView;
+import com.minecolonies.api.util.constant.Constants;
 import com.minecolonies.api.colony.buildingextensions.IBuildingExtension;
 import com.minecolonies.core.Network;
 import com.minecolonies.core.network.messages.server.colony.building.fields.AssignFieldMessage;
@@ -9,6 +10,8 @@ import com.minecolonies.core.network.messages.server.colony.building.fields.Assi
 import net.minecraft.network.FriendlyByteBuf;
 import net.minecraft.network.chat.Component;
 import net.minecraft.network.chat.MutableComponent;
+import net.minecraft.resources.ResourceLocation;
+
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -41,9 +44,9 @@ public abstract class FieldsModuleView extends AbstractBuildingModuleView
     }
 
     @Override
-    public String getIcon()
+    public ResourceLocation getIconResourceLocation()
     {
-        return "field";
+        return new ResourceLocation(Constants.MOD_ID, "textures/gui/modules/field.png");
     }
 
     @Override

--- a/src/main/java/com/minecolonies/core/colony/buildings/moduleviews/GraveyardManagementModuleView.java
+++ b/src/main/java/com/minecolonies/core/colony/buildings/moduleviews/GraveyardManagementModuleView.java
@@ -2,9 +2,11 @@ package com.minecolonies.core.colony.buildings.moduleviews;
 
 import com.ldtteam.blockui.views.BOWindow;
 import com.minecolonies.api.colony.buildings.modules.AbstractBuildingModuleView;
+import com.minecolonies.api.util.constant.Constants;
 import com.minecolonies.core.tileentities.TileEntityGrave;
 import com.minecolonies.core.client.gui.modules.GraveyardManagementWindow;
 import net.minecraft.network.FriendlyByteBuf;
+import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.level.block.entity.BlockEntity;
 import net.minecraft.core.BlockPos;
 import net.minecraftforge.api.distmarker.Dist;
@@ -56,9 +58,9 @@ public class GraveyardManagementModuleView extends AbstractBuildingModuleView
     }
 
     @Override
-    public String getIcon()
+    public ResourceLocation getIconResourceLocation()
     {
-        return "grave";
+        return new ResourceLocation(Constants.MOD_ID, "textures/gui/modules/grave.png");
     }
 
     @Override

--- a/src/main/java/com/minecolonies/core/colony/buildings/moduleviews/ItemListModuleView.java
+++ b/src/main/java/com/minecolonies/core/colony/buildings/moduleviews/ItemListModuleView.java
@@ -9,6 +9,8 @@ import com.minecolonies.core.Network;
 import com.minecolonies.core.client.gui.modules.ItemListModuleWindow;
 import com.minecolonies.core.network.messages.server.colony.building.AssignFilterableItemMessage;
 import net.minecraft.network.FriendlyByteBuf;
+import net.minecraft.resources.ResourceLocation;
+
 import com.minecolonies.core.network.messages.server.colony.building.ResetFilterableItemMessage;
 import net.minecraftforge.api.distmarker.Dist;
 import net.minecraftforge.api.distmarker.OnlyIn;
@@ -142,8 +144,8 @@ public class ItemListModuleView extends AbstractBuildingModuleView implements II
     }
 
     @Override
-    public String getIcon()
+    public ResourceLocation getIconResourceLocation()
     {
-        return this.getId();
+        return new ResourceLocation(Constants.MOD_ID, "textures/gui/modules/" + this.getId() + ".png");
     }
 }

--- a/src/main/java/com/minecolonies/core/colony/buildings/moduleviews/LivingBuildingModuleView.java
+++ b/src/main/java/com/minecolonies/core/colony/buildings/moduleviews/LivingBuildingModuleView.java
@@ -3,7 +3,10 @@ package com.minecolonies.core.colony.buildings.moduleviews;
 import com.ldtteam.blockui.views.BOWindow;
 import com.minecolonies.api.colony.buildings.HiringMode;
 import com.minecolonies.api.colony.buildings.modules.AbstractBuildingModuleView;
+import com.minecolonies.api.util.constant.Constants;
+
 import net.minecraft.network.FriendlyByteBuf;
+import net.minecraft.resources.ResourceLocation;
 import net.minecraftforge.api.distmarker.Dist;
 import net.minecraftforge.api.distmarker.OnlyIn;
 import org.jetbrains.annotations.NotNull;
@@ -92,9 +95,9 @@ public class LivingBuildingModuleView extends AbstractBuildingModuleView
     }
 
     @Override
-    public String getIcon()
+    public ResourceLocation getIconResourceLocation()
     {
-        return null;
+        return new ResourceLocation(Constants.MOD_ID, "textures/gui/modules/custom.png");
     }
 
     public boolean isPageVisible() {return false;}

--- a/src/main/java/com/minecolonies/core/colony/buildings/moduleviews/MinerAssignmentModuleView.java
+++ b/src/main/java/com/minecolonies/core/colony/buildings/moduleviews/MinerAssignmentModuleView.java
@@ -14,6 +14,8 @@ import com.minecolonies.core.client.gui.modules.SpecialAssignmentModuleWindow;
 import com.minecolonies.core.network.messages.server.colony.building.HireFireMessage;
 import com.minecolonies.core.network.messages.server.colony.building.QuarryHiringModeMessage;
 import net.minecraft.network.FriendlyByteBuf;
+import net.minecraft.resources.ResourceLocation;
+
 import org.jetbrains.annotations.NotNull;
 
 import java.util.ArrayList;
@@ -69,9 +71,9 @@ public class MinerAssignmentModuleView extends AbstractBuildingModuleView implem
     }
 
     @Override
-    public String getIcon()
+    public ResourceLocation getIconResourceLocation()
     {
-        return "entity";
+        return new ResourceLocation(Constants.MOD_ID, "textures/gui/modules/entity.png");
     }
 
     @Override

--- a/src/main/java/com/minecolonies/core/colony/buildings/moduleviews/MinerGuardAssignModuleView.java
+++ b/src/main/java/com/minecolonies/core/colony/buildings/moduleviews/MinerGuardAssignModuleView.java
@@ -2,8 +2,10 @@ package com.minecolonies.core.colony.buildings.moduleviews;
 
 import com.ldtteam.blockui.views.BOWindow;
 import com.minecolonies.api.colony.buildings.modules.AbstractBuildingModuleView;
+import com.minecolonies.api.util.constant.Constants;
 import com.minecolonies.core.client.gui.modules.WindowMineGuardModule;
 import net.minecraft.network.FriendlyByteBuf;
+import net.minecraft.resources.ResourceLocation;
 import net.minecraftforge.api.distmarker.Dist;
 import net.minecraftforge.api.distmarker.OnlyIn;
 import org.jetbrains.annotations.NotNull;
@@ -27,11 +29,11 @@ public class MinerGuardAssignModuleView extends AbstractBuildingModuleView
     }
 
     @Override
-    public String getIcon()
+    public ResourceLocation getIconResourceLocation()
     {
-        return "sword";
+        return new ResourceLocation(Constants.MOD_ID, "textures/gui/modules/sword.png");
     }
-
+    
     @Override
     public String getDesc()
     {

--- a/src/main/java/com/minecolonies/core/colony/buildings/moduleviews/MinerLevelManagementModuleView.java
+++ b/src/main/java/com/minecolonies/core/colony/buildings/moduleviews/MinerLevelManagementModuleView.java
@@ -4,8 +4,11 @@ import com.ldtteam.blockui.views.BOWindow;
 import com.minecolonies.api.colony.buildings.modules.AbstractBuildingModuleView;
 import com.minecolonies.api.colony.jobs.ModJobs;
 import com.minecolonies.api.colony.workorders.IWorkOrderView;
+import com.minecolonies.api.util.constant.Constants;
 import com.minecolonies.core.client.gui.modules.WindowHutMinerModule;
 import net.minecraft.network.FriendlyByteBuf;
+import net.minecraft.resources.ResourceLocation;
+
 import com.minecolonies.core.colony.workorders.view.WorkOrderMinerView;
 import com.minecolonies.core.colony.workorders.AbstractWorkOrder;
 import net.minecraft.util.Tuple;
@@ -68,9 +71,9 @@ public class MinerLevelManagementModuleView extends AbstractBuildingModuleView
     }
 
     @Override
-    public String getIcon()
+    public ResourceLocation getIconResourceLocation()
     {
-        return "info";
+        return new ResourceLocation(Constants.MOD_ID, "textures/gui/modules/info.png");
     }
 
     @Override

--- a/src/main/java/com/minecolonies/core/colony/buildings/moduleviews/MinimumStockModuleView.java
+++ b/src/main/java/com/minecolonies/core/colony/buildings/moduleviews/MinimumStockModuleView.java
@@ -5,8 +5,10 @@ import com.minecolonies.api.colony.buildings.modules.AbstractBuildingModuleView;
 import com.minecolonies.api.colony.buildings.modules.IMinimumStockModuleView;
 import com.minecolonies.api.crafting.ItemStorage;
 import com.minecolonies.api.util.Tuple;
+import com.minecolonies.api.util.constant.Constants;
 import com.minecolonies.core.client.gui.modules.MinimumStockModuleWindow;
 import net.minecraft.network.FriendlyByteBuf;
+import net.minecraft.resources.ResourceLocation;
 import net.minecraftforge.api.distmarker.Dist;
 import net.minecraftforge.api.distmarker.OnlyIn;
 import org.jetbrains.annotations.NotNull;
@@ -65,9 +67,9 @@ public class MinimumStockModuleView extends AbstractBuildingModuleView  implemen
     }
 
     @Override
-    public String getIcon()
+    public ResourceLocation getIconResourceLocation()
     {
-        return "stock";
+        return new ResourceLocation(Constants.MOD_ID, "textures/gui/modules/stock.png");
     }
 
     @Override

--- a/src/main/java/com/minecolonies/core/colony/buildings/moduleviews/RequestTaskModuleView.java
+++ b/src/main/java/com/minecolonies/core/colony/buildings/moduleviews/RequestTaskModuleView.java
@@ -6,6 +6,7 @@ import com.minecolonies.api.colony.requestsystem.token.IToken;
 import com.minecolonies.api.util.constant.Constants;
 import com.minecolonies.core.client.gui.modules.WindowHutRequestTaskModule;
 import net.minecraft.network.FriendlyByteBuf;
+import net.minecraft.resources.ResourceLocation;
 import net.minecraftforge.api.distmarker.Dist;
 import net.minecraftforge.api.distmarker.OnlyIn;
 import org.jetbrains.annotations.NotNull;
@@ -31,9 +32,9 @@ public abstract class RequestTaskModuleView extends AbstractBuildingModuleView
     }
 
     @Override
-    public String getIcon()
+    public ResourceLocation getIconResourceLocation()
     {
-        return "info";
+        return new ResourceLocation(Constants.MOD_ID, "textures/gui/modules/info.png");
     }
 
     @Override

--- a/src/main/java/com/minecolonies/core/colony/buildings/moduleviews/RestaurantMenuModuleView.java
+++ b/src/main/java/com/minecolonies/core/colony/buildings/moduleviews/RestaurantMenuModuleView.java
@@ -3,9 +3,11 @@ package com.minecolonies.core.colony.buildings.moduleviews;
 import com.ldtteam.blockui.views.BOWindow;
 import com.minecolonies.api.colony.buildings.modules.AbstractBuildingModuleView;
 import com.minecolonies.api.crafting.ItemStorage;
+import com.minecolonies.api.util.constant.Constants;
 import com.minecolonies.api.util.constant.translation.RequestSystemTranslationConstants;
 import com.minecolonies.core.client.gui.modules.RestaurantMenuModuleWindow;
 import net.minecraft.network.FriendlyByteBuf;
+import net.minecraft.resources.ResourceLocation;
 import net.minecraftforge.api.distmarker.Dist;
 import net.minecraftforge.api.distmarker.OnlyIn;
 import org.jetbrains.annotations.NotNull;
@@ -45,9 +47,9 @@ public class RestaurantMenuModuleView extends AbstractBuildingModuleView
     }
 
     @Override
-    public String getIcon()
+    public ResourceLocation getIconResourceLocation()
     {
-        return FOOD_EXCLUSION_LIST;
+        return new ResourceLocation(Constants.MOD_ID, "textures/gui/modules/" + FOOD_EXCLUSION_LIST + ".png");
     }
 
     @Override

--- a/src/main/java/com/minecolonies/core/colony/buildings/moduleviews/SettingsModuleView.java
+++ b/src/main/java/com/minecolonies/core/colony/buildings/moduleviews/SettingsModuleView.java
@@ -96,9 +96,9 @@ public class SettingsModuleView extends AbstractBuildingModuleView implements IS
     }
 
     @Override
-    public String getIcon()
+    public ResourceLocation getIconResourceLocation()
     {
-        return "settings";
+        return new ResourceLocation(Constants.MOD_ID, "textures/gui/modules/settings.png");
     }
 
     @Override

--- a/src/main/java/com/minecolonies/core/colony/buildings/moduleviews/ToolModuleView.java
+++ b/src/main/java/com/minecolonies/core/colony/buildings/moduleviews/ToolModuleView.java
@@ -6,6 +6,7 @@ import com.minecolonies.api.util.constant.Constants;
 import com.minecolonies.core.client.gui.modules.ToolModuleWindow;
 import net.minecraft.world.item.Item;
 import net.minecraft.network.FriendlyByteBuf;
+import net.minecraft.resources.ResourceLocation;
 import net.minecraftforge.api.distmarker.Dist;
 import net.minecraftforge.api.distmarker.OnlyIn;
 import org.jetbrains.annotations.NotNull;
@@ -50,9 +51,9 @@ public class ToolModuleView extends AbstractBuildingModuleView
     }
 
     @Override
-    public String getIcon()
+    public ResourceLocation getIconResourceLocation()
     {
-        return "scepter";
+        return new ResourceLocation(Constants.MOD_ID, "textures/gui/modules/scepter.png");
     }
 
     /**

--- a/src/main/java/com/minecolonies/core/colony/buildings/moduleviews/UniversityResearchModuleView.java
+++ b/src/main/java/com/minecolonies/core/colony/buildings/moduleviews/UniversityResearchModuleView.java
@@ -2,8 +2,10 @@ package com.minecolonies.core.colony.buildings.moduleviews;
 
 import com.ldtteam.blockui.views.BOWindow;
 import com.minecolonies.api.colony.buildings.modules.AbstractBuildingModuleView;
+import com.minecolonies.api.util.constant.Constants;
 import com.minecolonies.core.client.gui.modules.UniversityModuleWindow;
 import net.minecraft.network.FriendlyByteBuf;
+import net.minecraft.resources.ResourceLocation;
 import net.minecraftforge.api.distmarker.Dist;
 import net.minecraftforge.api.distmarker.OnlyIn;
 import org.jetbrains.annotations.NotNull;
@@ -27,9 +29,9 @@ public class UniversityResearchModuleView extends AbstractBuildingModuleView
     }
 
     @Override
-    public String getIcon()
+    public ResourceLocation getIconResourceLocation()
     {
-        return "info";
+        return new ResourceLocation(Constants.MOD_ID, "textures/gui/modules/info.png");
     }
 
     @Override

--- a/src/main/java/com/minecolonies/core/colony/buildings/moduleviews/WarehouseOptionsModuleView.java
+++ b/src/main/java/com/minecolonies/core/colony/buildings/moduleviews/WarehouseOptionsModuleView.java
@@ -2,8 +2,10 @@ package com.minecolonies.core.colony.buildings.moduleviews;
 
 import com.ldtteam.blockui.views.BOWindow;
 import com.minecolonies.api.colony.buildings.modules.AbstractBuildingModuleView;
+import com.minecolonies.api.util.constant.Constants;
 import com.minecolonies.core.client.gui.modules.WarehouseOptionsModuleWindow;
 import net.minecraft.network.FriendlyByteBuf;
+import net.minecraft.resources.ResourceLocation;
 import net.minecraftforge.api.distmarker.Dist;
 import net.minecraftforge.api.distmarker.OnlyIn;
 import org.jetbrains.annotations.NotNull;
@@ -38,9 +40,9 @@ public class WarehouseOptionsModuleView extends AbstractBuildingModuleView
     }
 
     @Override
-    public String getIcon()
+    public ResourceLocation getIconResourceLocation()
     {
-        return "settings";
+        return new ResourceLocation(Constants.MOD_ID, "textures/gui/modules/settings.png");
     }
 
     /**

--- a/src/main/java/com/minecolonies/core/colony/buildings/moduleviews/WorkOrderListModuleView.java
+++ b/src/main/java/com/minecolonies/core/colony/buildings/moduleviews/WorkOrderListModuleView.java
@@ -5,6 +5,7 @@ import com.minecolonies.api.colony.buildings.modules.AbstractBuildingModuleView;
 import com.minecolonies.api.util.constant.Constants;
 import com.minecolonies.core.client.gui.modules.WorkOrderModuleWindow;
 import net.minecraft.network.FriendlyByteBuf;
+import net.minecraft.resources.ResourceLocation;
 import net.minecraftforge.api.distmarker.Dist;
 import net.minecraftforge.api.distmarker.OnlyIn;
 import org.jetbrains.annotations.NotNull;
@@ -42,8 +43,8 @@ public class WorkOrderListModuleView extends AbstractBuildingModuleView
     }
 
     @Override
-    public String getIcon()
+    public ResourceLocation getIconResourceLocation()
     {
-        return "info";
+        return new ResourceLocation(Constants.MOD_ID, "textures/gui/modules/info.png");
     }
 }

--- a/src/main/java/com/minecolonies/core/colony/buildings/moduleviews/WorkerBuildingModuleView.java
+++ b/src/main/java/com/minecolonies/core/colony/buildings/moduleviews/WorkerBuildingModuleView.java
@@ -7,12 +7,15 @@ import com.minecolonies.api.colony.buildings.modules.AbstractBuildingModuleView;
 import com.minecolonies.api.colony.buildings.modules.IAssignmentModuleView;
 import com.minecolonies.api.colony.jobs.registry.JobEntry;
 import com.minecolonies.api.entity.citizen.Skill;
+import com.minecolonies.api.util.constant.Constants;
 import com.minecolonies.core.Network;
 import com.minecolonies.core.client.gui.huts.WindowHutWorkerModulePlaceholder;
 import com.minecolonies.core.network.messages.server.colony.building.HireFireMessage;
 import com.minecolonies.core.network.messages.server.colony.building.worker.BuildingHiringModeMessage;
 import net.minecraft.network.FriendlyByteBuf;
 import net.minecraft.network.chat.Component;
+import net.minecraft.resources.ResourceLocation;
+
 import org.jetbrains.annotations.NotNull;
 
 import java.util.ArrayList;
@@ -97,9 +100,9 @@ public class WorkerBuildingModuleView extends AbstractBuildingModuleView impleme
     }
 
     @Override
-    public String getIcon()
+    public ResourceLocation getIconResourceLocation()
     {
-        return "";
+        return new ResourceLocation(Constants.MOD_ID, "textures/gui/modules/custom.png");
     }
 
     @Override


### PR DESCRIPTION
Closes None

# Changes proposed in this pull request
- Slight refactoring of AbstractModuleWindow allows add-on mods to specify their own icon for building modules while remaining backwards-compatible to current usage.
-

## Testing
- [X] Yes I tested this before submitting it.
- [ ] I also did a multiplayer test.

Review please