### PR TITLE
Simplify providing DO items to builder

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -29,7 +29,7 @@ mappingsVersion=1.20.1
 dataGeneratorsVersion=1.19.3-0.1.54-ALPHA
 blockUI_version=1.20.1-1.0.190-snapshot
 structurize_version=1.20.1-1.0.771-snapshot
-domumOrnamentumVersion=1.20.1-1.0.184-BETA
+domumOrnamentumVersion=1.20.1-1.0.288-snapshot
 multiPistonVersion=1.20-1.2.30-ALPHA
 
 jei_mcversion=1.20.1

--- a/src/main/java/com/minecolonies/core/entity/ai/workers/AbstractEntityAIInteract.java
+++ b/src/main/java/com/minecolonies/core/entity/ai/workers/AbstractEntityAIInteract.java
@@ -1,5 +1,6 @@
 package com.minecolonies.core.entity.ai.workers;
 
+import com.ldtteam.domumornamentum.item.interfaces.IDoItem;
 import com.minecolonies.api.entity.ai.workers.util.IBuilderUndestroyable;
 import com.minecolonies.api.util.BlockPosUtil;
 import com.minecolonies.api.util.InventoryUtils;
@@ -27,6 +28,7 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 import static com.minecolonies.api.research.util.ResearchConstants.BLOCK_BREAK_SPEED;
+import static com.minecolonies.core.placementhandlers.DoBlockPlacementHandler.getCorrectDOItem;
 
 /**
  * This is the base class of all worker AIs. Every AI implements this class with it's job type. There are some utilities within the class: - The AI will clear a full inventory at
@@ -201,7 +203,14 @@ public abstract class AbstractEntityAIInteract<J extends AbstractJob<?, J>, B ex
             //add the drops to the citizen
             for (final ItemStack item : localItems)
             {
-                InventoryUtils.transferItemStackIntoNextBestSlotInItemHandler(item, worker.getInventoryCitizen());
+                if (item.getItem() instanceof IDoItem)
+                {
+                    InventoryUtils.transferItemStackIntoNextBestSlotInItemHandler(getCorrectDOItem(item, curBlockState), worker.getInventoryCitizen());
+                }
+                else
+                {
+                    InventoryUtils.transferItemStackIntoNextBestSlotInItemHandler(item, worker.getInventoryCitizen());
+                }
             }
             onBlockDropReception(localItems);
         }


### PR DESCRIPTION
Closes #
Closes #

# Changes proposed in this pull request
- Builder only requires the "base" do block type for do blocks with many different types
- Builder only obtains this "base" block on mining/replacing them.

This makes it a) Easier for players to craft the items
b) Reduces inventory management overhead for players and workers
c) Less garbage in warehouse

## Testing
- [x] Yes I tested this before submitting it.
- [ ] I also did a multiplayer test.

Review please