### PR TITLE
Swap clipboard and map decorators

### DIFF
--- a/src/main/java/com/minecolonies/core/client/render/ColonyMapDecorator.java
+++ b/src/main/java/com/minecolonies/core/client/render/ColonyMapDecorator.java
@@ -3,10 +3,6 @@ package com.minecolonies.core.client.render;
 import com.minecolonies.api.colony.ICitizenDataView;
 import com.minecolonies.api.colony.IColonyManager;
 import com.minecolonies.api.colony.IColonyView;
-import com.minecolonies.api.colony.requestsystem.manager.IRequestManager;
-import com.minecolonies.api.colony.requestsystem.resolver.player.IPlayerRequestResolver;
-import com.minecolonies.api.colony.requestsystem.resolver.retrying.IRetryingRequestResolver;
-import com.minecolonies.api.colony.requestsystem.token.IToken;
 import com.minecolonies.api.util.Log;
 import com.mojang.blaze3d.vertex.PoseStack;
 import net.minecraft.client.Minecraft;
@@ -17,10 +13,7 @@ import net.minecraft.network.chat.Component;
 import net.minecraft.world.item.ItemStack;
 import net.minecraftforge.client.IItemDecorator;
 
-import java.util.HashSet;
-import java.util.Set;
-
-import static com.minecolonies.core.items.ItemClipboard.TAG_COLONY;
+import static com.minecolonies.core.items.ItemColonyMap.TAG_COLONY;
 
 public class ColonyMapDecorator implements IItemDecorator
 {
@@ -51,52 +44,32 @@ public class ColonyMapDecorator implements IItemDecorator
                 {
                     try
                     {
-                        final Set<IToken<?>> asyncRequest = new HashSet<>();
+                        int count = 0;
                         for (final ICitizenDataView view : colonyView.getCitizens().values())
                         {
-                            if (view.getJobView() != null)
+                            if (view.hasBlockingInteractions())
                             {
-                                asyncRequest.addAll(view.getJobView().getAsyncRequests());
+                                count++;
                             }
                         }
 
-                        final IRequestManager requestManager = colonyView.getRequestManager();
-                        if (requestManager != null)
+                        if (count > 0)
                         {
-                            final IPlayerRequestResolver resolver = requestManager.getPlayerResolver();
-                            final IRetryingRequestResolver retryingRequestResolver = requestManager.getRetryingRequestResolver();
-
-                            final Set<IToken<?>> requestTokens = new HashSet<>();
-                            requestTokens.addAll(resolver.getAllAssignedRequests());
-                            requestTokens.addAll(retryingRequestResolver.getAllAssignedRequests());
-
-                            int count = 0;
-                            for (final IToken<?> reqId : requestTokens)
-                            {
-                                if (!asyncRequest.contains(reqId))
-                                {
-                                    count++;
-                                }
-                            }
-
-                            if (count > 0)
-                            {
-                                final PoseStack ps = graphics.pose();
-                                ps.pushPose();
-                                ps.translate(0, 0, 500);
-                                graphics.drawCenteredString(font,
-                                  Component.literal(count + ""),
-                                  xOffset + 15,
-                                  yOffset - 2,
-                                  0xFF4500 | (255 << 24));
-                                ps.popPose();
-                                return true;
-                            }
+                            final PoseStack ps = graphics.pose();
+                            ps.pushPose();
+                            ps.translate(0, 0, 500);
+                            graphics.drawCenteredString(font,
+                              Component.literal(count + ""),
+                              xOffset + 15,
+                              yOffset - 2,
+                              0xFF4500 | (255 << 24));
+                            ps.popPose();
+                            return true;
                         }
                     }
                     catch (Exception e)
                     {
-                        Log.getLogger().error("Something went wrong with the clipboard item decorator", e);
+                        Log.getLogger().error("Something went wrong with the colonymap item decorator", e);
                     }
                 }
             }

--- a/src/main/java/com/minecolonies/core/event/ClientRegistryHandler.java
+++ b/src/main/java/com/minecolonies/core/event/ClientRegistryHandler.java
@@ -264,8 +264,8 @@ public class ClientRegistryHandler
     @SubscribeEvent
     public static void onRegisterItemDecorations(final RegisterItemDecorationsEvent event)
     {
-        event.register(ModItems.clipboard, new ClipBoardDecorator());
         event.register(ModItems.colonyMap, new ColonyMapDecorator());
+        event.register(ModItems.clipboard, new ClipBoardDecorator());
     }
 
     @OnlyIn(Dist.CLIENT)


### PR DESCRIPTION
Closes [discord report](https://discord.com/channels/139070364159311872/1284909613401247785/1388701694178627715)

# Changes proposed in this pull request
- Reverses the item decorators for colony map and clipboard, since they seemed to be backwards.

## Testing
- [ ] Yes I tested this before submitting it.
- [ ] I also did a multiplayer test.

Review please ~(should port)~ (do not port)

The changes are just a hard rename -- there are no actual code changes.  In particular, the exception logging was already correct for *this* way around (not how it was before!).