### PR TITLE
Stat Tooltip Port

### DIFF
--- a/src/main/java/com/minecolonies/core/client/gui/modules/WindowStatsModule.java
+++ b/src/main/java/com/minecolonies/core/client/gui/modules/WindowStatsModule.java
@@ -1,6 +1,7 @@
 package com.minecolonies.core.client.gui.modules;
 
 import com.ldtteam.blockui.Pane;
+import com.ldtteam.blockui.PaneBuilders;
 import com.ldtteam.blockui.controls.Button;
 import com.ldtteam.blockui.controls.ButtonImage;
 import com.ldtteam.blockui.controls.Text;
@@ -190,6 +191,7 @@ public class WindowStatsModule extends AbstractModuleWindow
                 {
                     resourceLabel.setText(Component.translatableEscape(PARTIAL_STATS_MODIFIER_NAME + id, stat));
                 }
+                PaneBuilders.tooltipBuilder().hoverPane(resourceLabel).build().setText(resourceLabel.getText());
             }
         });
 


### PR DESCRIPTION
Add tooltip in case of long stat entries due to item names. (Ported from main.)

Closes None

# Changes proposed in this pull request
- Bring existing functionality from main over to 1.21

## Testing
- [X] Yes I tested this before submitting it.
- [ ] I also did a multiplayer test.

Review please