### PR TITLE
Add food info to citizen info command.

### DIFF
--- a/src/main/java/com/minecolonies/api/entity/citizen/citizenhandlers/ICitizenFoodHandler.java
+++ b/src/main/java/com/minecolonies/api/entity/citizen/citizenhandlers/ICitizenFoodHandler.java
@@ -5,6 +5,8 @@ import net.minecraft.world.item.Item;
 
 import java.util.Queue;
 
+import com.google.common.collect.ImmutableList;
+
 /**
  * Citizen food handler interface.
  */
@@ -66,4 +68,10 @@ public interface ICitizenFoodHandler
      * @return true if so.
      */
     boolean hasFullFoodHistory();
+
+    /**
+     * Get the list of last eaten food items.
+     * @return the last eaten food items.
+     */
+    ImmutableList<Item> getLastEatenFoods();
 }

--- a/src/main/java/com/minecolonies/api/util/constant/translation/CommandTranslationConstants.java
+++ b/src/main/java/com/minecolonies/api/util/constant/translation/CommandTranslationConstants.java
@@ -40,6 +40,8 @@ public class CommandTranslationConstants
     @NonNls
     public static final String COMMAND_CITIZEN_INFO_JOB                      = "com.minecolonies.command.citizeninfo.job";
     @NonNls
+    public static final String COMMAND_CITIZEN_INFO_FOOD                     = "com.minecolonies.command.citizeninfo.food";
+    @NonNls
     public static final String COMMAND_CITIZEN_INFO_NO_JOB                   = "com.minecolonies.command.citizeninfo.jobnull";
     @NonNls
     public static final String COMMAND_CITIZEN_INFO_ACTIVITY                 = "com.minecolonies.command.citizeninfo.activity";

--- a/src/main/java/com/minecolonies/core/commands/citizencommands/CommandCitizenInfo.java
+++ b/src/main/java/com/minecolonies/core/commands/citizencommands/CommandCitizenInfo.java
@@ -19,6 +19,8 @@ import net.minecraft.network.chat.ClickEvent;
 import net.minecraft.network.chat.Component;
 import net.minecraft.network.chat.Style;
 import net.minecraft.world.entity.Entity;
+import net.minecraft.world.item.Item;
+import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.level.Level;
 
 import java.util.Optional;
@@ -133,6 +135,26 @@ public class CommandCitizenInfo implements IMCColonyOfficerCommand
             final AbstractEntityCitizen entityCitizen = optionalEntityCitizen.get();
             context.getSource()
                 .sendSuccess(() -> Component.literal("Stuck level: " + ((IMinecoloniesNavigator) entityCitizen.getNavigation()).getStuckHandler().getStuckLevel()), false);
+        }
+
+        if (citizenData.getCitizenFoodHandler() != null)
+        {
+            String lastEaten = "";
+
+            for (final Item item : citizenData.getCitizenFoodHandler().getLastEatenFoods())
+            {
+                ItemStack stack = new ItemStack(item);
+                lastEaten = lastEaten + stack.getHoverName().getString() + ", ";
+            }
+
+            final String lastEatenCompiled = lastEaten.substring(0, lastEaten.length() - 2);
+
+            context.getSource()
+                .sendSuccess(() -> Component.translatable(CommandTranslationConstants.COMMAND_CITIZEN_INFO_FOOD,
+                    citizenData.getCitizenFoodHandler().hasFullFoodHistory(),
+                    citizenData.getCitizenFoodHandler().getFoodHappinessStats().quality(),
+                    citizenData.getCitizenFoodHandler().getFoodHappinessStats().diversity(),
+                    lastEatenCompiled), false);
         }
 
         return 1;

--- a/src/main/java/com/minecolonies/core/entity/citizen/citizenhandlers/CitizenFoodHandler.java
+++ b/src/main/java/com/minecolonies/core/entity/citizen/citizenhandlers/CitizenFoodHandler.java
@@ -1,6 +1,7 @@
 package com.minecolonies.core.entity.citizen.citizenhandlers;
 
 import com.google.common.collect.EvictingQueue;
+import com.google.common.collect.ImmutableList;
 import com.minecolonies.api.colony.ICitizenData;
 import com.minecolonies.api.colony.interactionhandling.ChatPriority;
 import com.minecolonies.api.entity.citizen.citizenhandlers.ICitizenFoodHandler;
@@ -161,5 +162,11 @@ public class CitizenFoodHandler implements ICitizenFoodHandler
             return baseModifier;
         }
         return baseModifier * 0.5 * Math.min(2.5, 5.0/getFoodHappinessStats().diversity());
+    }
+
+    
+    public ImmutableList<Item> getLastEatenFoods()
+    {
+        return ImmutableList.copyOf(lastEatenFoods);
     }
 }

--- a/src/main/java/com/minecolonies/core/entity/citizen/citizenhandlers/CitizenFoodHandler.java
+++ b/src/main/java/com/minecolonies/core/entity/citizen/citizenhandlers/CitizenFoodHandler.java
@@ -164,7 +164,7 @@ public class CitizenFoodHandler implements ICitizenFoodHandler
         return baseModifier * 0.5 * Math.min(2.5, 5.0/getFoodHappinessStats().diversity());
     }
 
-    
+    @Override
     public ImmutableList<Item> getLastEatenFoods()
     {
         return ImmutableList.copyOf(lastEatenFoods);

--- a/src/main/resources/assets/minecolonies/lang/manual_en_us.json
+++ b/src/main/resources/assets/minecolonies/lang/manual_en_us.json
@@ -434,6 +434,7 @@
   "com.minecolonies.command.citizeninfo.desc": "§2ID: §f %d §2 Name: §f %s",
   "com.minecolonies.command.citizeninfo.skills": "§2Athletics: §f%s §2Dexterity: §f%s §2Strength: §f%s\n§2Agility: §f%s §2Stamina: §f%s §2Mana: §f%s\n§2Adaptability: §f%s §2Focus: §f%s §2Creativity: §f%s\n§2Knowledge: §f%s §2Intelligence: §f%s",
   "com.minecolonies.command.citizeninfo.job": "§2Job: §f%s",
+  "com.minecolonies.command.citizeninfo.food": "§2Full food history: §f%s, §2Quality: §f%d, §2Diversity: §f%d, §2Last Eaten: §f%s",
   "com.minecolonies.command.citizeninfo.jobnull": "§2Job: §fUnemployed",
   "com.minecolonies.command.citizeninfo.health": "§2Health: §f%s §2Max Health: §f%s",
   "com.minecolonies.command.citizeninfo.activity": "§2Citizen state: §f%s §2Job: §f%s §2Jobstate: §f%s",


### PR DESCRIPTION
Given the prevalence of food related happiness questions I thought having this information available would be helpful.

Closes None

# Changes proposed in this pull request
- Adds quality, diversity and last eaten history to citizens info command output.

## Testing
- [X] Yes I tested this before submitting it.
- [ ] I also did a multiplayer test.

Review please