### PR TITLE
Safe removal of add-on jobs and buildings.

### DIFF
--- a/src/main/java/com/minecolonies/core/colony/buildings/registry/BuildingDataManager.java
+++ b/src/main/java/com/minecolonies/core/colony/buildings/registry/BuildingDataManager.java
@@ -22,8 +22,6 @@ import org.jetbrains.annotations.NotNull;
 import static com.minecolonies.api.util.constant.NbtTagConstants.TAG_BUILDING_TYPE;
 import static com.minecolonies.api.util.constant.NbtTagConstants.TAG_LOCATION;
 
-import java.util.Optional;
-
 public class BuildingDataManager implements IBuildingDataManager
 {
     @Override

--- a/src/main/java/com/minecolonies/core/colony/buildings/registry/BuildingDataManager.java
+++ b/src/main/java/com/minecolonies/core/colony/buildings/registry/BuildingDataManager.java
@@ -22,6 +22,8 @@ import org.jetbrains.annotations.NotNull;
 import static com.minecolonies.api.util.constant.NbtTagConstants.TAG_BUILDING_TYPE;
 import static com.minecolonies.api.util.constant.NbtTagConstants.TAG_LOCATION;
 
+import java.util.Optional;
+
 public class BuildingDataManager implements IBuildingDataManager
 {
     @Override
@@ -31,6 +33,11 @@ public class BuildingDataManager implements IBuildingDataManager
         final BlockPos pos = BlockPosUtil.read(compound, TAG_LOCATION);
 
         IBuilding building = this.createFrom(colony, pos, type);
+
+        if (building == null)
+        {
+            return null;
+        }
 
         try
         {

--- a/src/main/java/com/minecolonies/core/colony/jobs/registry/JobDataManager.java
+++ b/src/main/java/com/minecolonies/core/colony/jobs/registry/JobDataManager.java
@@ -26,9 +26,26 @@ public final class JobDataManager implements IJobDataManager
     public IJob<?> createFrom(
       final ICitizenData citizen, @NotNull final CompoundTag compound)
     {
+        String jobTypeName = compound.getString(NbtTagConstants.TAG_JOB_TYPE);
+
         final ResourceLocation jobType =
-          compound.contains(NbtTagConstants.TAG_JOB_TYPE) ? new ResourceLocation(compound.getString(NbtTagConstants.TAG_JOB_TYPE)) : ModJobs.PLACEHOLDER_ID;
-        final IJob<?> job = Optional.ofNullable(IJobRegistry.getInstance().getValue(jobType)).map(r -> r.produceJob(citizen)).orElse(null);
+          compound.contains(NbtTagConstants.TAG_JOB_TYPE) ? new ResourceLocation(jobTypeName) : ModJobs.PLACEHOLDER_ID;
+
+        if (jobType == null)
+        {
+            Log.getLogger().error(String.format("Unknown job type '%s'.", jobTypeName), new Exception());
+            return null;
+        }
+
+        JobEntry jobEntry = IJobRegistry.getInstance().getValue(jobType);
+
+        if (jobEntry == null)
+        {
+            Log.getLogger().error(String.format("Unknown job entry for type '%s'.", jobTypeName), new Exception());
+            return null;
+        }
+
+        final IJob<?> job = Optional.ofNullable(jobEntry).map(r -> r.produceJob(citizen)).orElse(null);
 
         if (job != null)
         {


### PR DESCRIPTION
Closes None

# Changes proposed in this pull request
- Adjust the error handling of restoring a saved game such that if an add-on mod is removed (say... Trade Post) the colony doesn't become corrupted by the unrecognized buildings and jobs that it included.  This will log the errors, but just leave the citizens unemployed instead of corrupting the load process.
-

## Testing
- [X] Yes I tested this before submitting it.
- [ ] I also did a multiplayer test.

Review please