### PR TITLE
Safe removal of add-on jobs and buildings.

### DIFF
--- a/src/main/java/com/minecolonies/core/colony/buildings/registry/BuildingDataManager.java
+++ b/src/main/java/com/minecolonies/core/colony/buildings/registry/BuildingDataManager.java
@@ -23,6 +23,8 @@ import org.jetbrains.annotations.NotNull;
 import static com.minecolonies.api.util.constant.NbtTagConstants.TAG_BUILDING_TYPE;
 import static com.minecolonies.api.util.constant.NbtTagConstants.TAG_LOCATION;
 
+import java.util.Optional;
+
 public class BuildingDataManager implements IBuildingDataManager
 {
     @Override
@@ -32,6 +34,11 @@ public class BuildingDataManager implements IBuildingDataManager
         final BlockPos pos = BlockPosUtil.read(compound, TAG_LOCATION);
 
         IBuilding building = this.createFrom(colony, pos, type);
+
+        if (building == null)
+        {
+            return null;
+        }
 
         try
         {
@@ -56,8 +63,8 @@ public class BuildingDataManager implements IBuildingDataManager
     @Override
     public IBuilding createFrom(final IColony colony, final BlockPos position, final ResourceLocation buildingName)
     {
-        final BuildingEntry entry = IBuildingRegistry.getInstance().get(buildingName);
-        if (entry == null)
+        final Optional<BuildingEntry> entry = IBuildingRegistry.getInstance().getOptional(buildingName);
+        if (entry == null || entry.isEmpty())
         {
             if (buildingName.getPath().equals("home"))
             {
@@ -66,7 +73,7 @@ public class BuildingDataManager implements IBuildingDataManager
             Log.getLogger().error(String.format("Unknown building type '%s'.", buildingName), new Exception());
             return null;
         }
-        return entry.produceBuilding(position, colony);
+        return entry.get().produceBuilding(position, colony);
     }
 
     @Override

--- a/src/main/java/com/minecolonies/core/colony/jobs/registry/JobDataManager.java
+++ b/src/main/java/com/minecolonies/core/colony/jobs/registry/JobDataManager.java
@@ -26,9 +26,26 @@ public final class JobDataManager implements IJobDataManager
     @Override
     public IJob<?> createFrom(final ICitizenData citizen, @NotNull final CompoundTag compound, @NotNull final HolderLookup.Provider provider)
     {
+        String jobTypeName = compound.getString(NbtTagConstants.TAG_JOB_TYPE);
+
         final ResourceLocation jobType =
-          compound.contains(NbtTagConstants.TAG_JOB_TYPE) ? ResourceLocation.parse(compound.getString(NbtTagConstants.TAG_JOB_TYPE)) : ModJobs.PLACEHOLDER_ID;
-        final IJob<?> job = Optional.ofNullable(IJobRegistry.getInstance().get(jobType)).map(r -> r.produceJob(citizen)).orElse(null);
+          compound.contains(NbtTagConstants.TAG_JOB_TYPE) ? ResourceLocation.parse(jobTypeName) : ModJobs.PLACEHOLDER_ID;
+
+        if (jobType == null)
+        {
+            Log.getLogger().error(String.format("Unknown job type '%s'.", jobTypeName), new Exception());
+            return null;
+        }
+
+        Optional<JobEntry> jobEntry = IJobRegistry.getInstance().getOptional(jobType);
+
+        if (jobEntry == null || jobEntry.isEmpty())
+        {
+            Log.getLogger().error(String.format("Unknown job entry for type '%s'.", jobTypeName), new Exception());
+            return null;
+        }
+
+        final IJob<?> job = Optional.ofNullable(jobEntry.get()).map(r -> r.produceJob(citizen)).orElse(null);
 
         if (job != null)
         {


### PR DESCRIPTION
Closes None

# Changes proposed in this pull request
- Adjust the error handling of restoring a saved game such that if an add-on mod is removed (say... Trade Post) the colony doesn't become corrupted by the unrecognized buildings and jobs that it included.  This will log the errors, but just leave the citizens unemployed instead of corrupting the load process.
- This is the port associated with the addon_mod_removal pull request made of of main.

## Testing
- [X] Yes I tested this before submitting it.
- [ ] I also did a multiplayer test.

Review please