### PR TITLE
feat(commands): introduce /mc query command with initial 'idlebuilders' query

### DIFF
--- a/src/main/java/com/minecolonies/core/commands/EntryPoint.java
+++ b/src/main/java/com/minecolonies/core/commands/EntryPoint.java
@@ -3,6 +3,7 @@ package com.minecolonies.core.commands;
 import com.minecolonies.api.util.constant.Constants;
 import com.minecolonies.core.commands.citizencommands.*;
 import com.minecolonies.core.commands.colonycommands.*;
+import com.minecolonies.core.commands.querycommands.*;
 import com.minecolonies.core.commands.colonycommands.requestsystem.CommandRSReset;
 import com.minecolonies.core.commands.colonycommands.requestsystem.CommandRSResetAll;
 import com.minecolonies.core.commands.generalcommands.*;
@@ -79,6 +80,12 @@ public class EntryPoint
             .addNode(new CommandTrackType().build());
 
         /*
+        * Query commands subtree
+         */
+        final CommandTree queryCommands = new CommandTree("query")
+            .addNode(new CommandQueryIdleBuilders().build());
+
+        /*
          * Root minecolonies command tree, all subtrees are added here.
          */
         final CommandTree minecoloniesRoot = new CommandTree(Constants.MOD_ID)
@@ -86,6 +93,7 @@ public class EntryPoint
             .addNode(colonyCommands)
             .addNode(new CommandHomeTeleport().build())
             .addNode(citizenCommands)
+            .addNode(queryCommands)
             .addNode(new CommandWhereAmI().build())
             .addNode(new CommandWhoAmI().build())
             .addNode(new CommandGetRanks().build())
@@ -106,6 +114,7 @@ public class EntryPoint
             .addNode(colonyCommands)
             .addNode(new CommandHomeTeleport().build())
             .addNode(citizenCommands)
+            .addNode(queryCommands)
             .addNode(new CommandWhereAmI().build())
             .addNode(new CommandWhoAmI().build())
             .addNode(new CommandGetRanks().build())

--- a/src/main/java/com/minecolonies/core/commands/querycommands/CommandQueryIdleBuilders.java
+++ b/src/main/java/com/minecolonies/core/commands/querycommands/CommandQueryIdleBuilders.java
@@ -1,0 +1,145 @@
+package com.minecolonies.core.commands.querycommands;
+
+import com.minecolonies.api.colony.ICitizenData;
+import com.minecolonies.api.colony.IColony;
+import com.minecolonies.api.colony.IColonyManager;
+import com.minecolonies.api.util.constant.translation.CommandTranslationConstants;
+import com.minecolonies.core.colony.jobs.JobBuilder;
+import com.minecolonies.core.commands.commandTypes.IMCColonyOfficerCommand;
+import com.mojang.brigadier.context.CommandContext;
+import net.minecraft.commands.CommandSourceStack;
+import net.minecraft.core.BlockPos;
+import net.minecraft.network.chat.ClickEvent;
+import net.minecraft.network.chat.Component;
+import net.minecraft.network.chat.Style;
+import net.minecraft.world.entity.Entity;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.ArrayList;
+
+
+
+/**
+ * Displays the list of builders in the colony that currently have not taken on a build job and are idle.
+ */
+public class CommandQueryIdleBuilders implements IMCColonyOfficerCommand
+{
+    /**
+     * What happens when the command is executed.
+     *
+     * @param context the context of the command execution
+     */
+    @Override
+    public int onExecute(final CommandContext<CommandSourceStack> context)
+    {
+        final Entity sender = context.getSource().getEntity();
+
+        if (sender == null)
+            return 0;
+
+        // Colony
+        BlockPos playerPos = sender.blockPosition();
+        IColony colony = IColonyManager.getInstance().getClosestColony(sender.level(), playerPos);
+
+        if (colony == null || !IColonyManager.getInstance().isCoordinateInAnyColony(sender.level(), playerPos)) {
+            context.getSource().sendSuccess(() ->
+                Component.literal("❌ You are not currently in a colony."), false);
+            return 0;
+        }
+
+
+        final Collection<ICitizenData> allCitizens = colony.getCitizenManager().getCitizens();
+
+        if (allCitizens == null)
+        {
+            context.getSource().sendSuccess(() -> Component.translatable(CommandTranslationConstants.COMMAND_CITIZEN_NOT_FOUND), false);
+            return 0;
+        }
+
+
+        // Identify all citizens with a builder job
+        final List<ICitizenData> builderCitizens = new ArrayList<>();
+
+        for (final ICitizenData citizen : allCitizens)
+        {
+            if (citizen.getJob() instanceof JobBuilder)
+            {
+                builderCitizens.add(citizen);
+            }
+        }
+
+
+        // then we can check each builder's job status
+        final List<ICitizenData> idleBuilders = new ArrayList<>();
+
+        for (final ICitizenData builder : builderCitizens)
+        {
+            final JobBuilder job = (JobBuilder) builder.getJob();
+
+            // If the builder has no work order, consider them idle
+            if (!job.hasWorkOrder())
+            {
+                idleBuilders.add(builder);
+            }
+        }
+
+
+        // for any builders that are 'idle' we will report their name and their building location
+        //  and if all builders are busy we will just say "✅ All builders currently have active building assignments."
+        if (idleBuilders.isEmpty())
+        {
+            context.getSource().sendSuccess(
+                () -> Component.literal("✅ All builders currently have active building assignments."),
+                false
+            );
+        }
+        else
+        {
+            context.getSource().sendSuccess(
+                () -> Component.literal("⚠️ Idle builders detected:"),
+                false
+            );
+
+            for (final ICitizenData builder : idleBuilders)
+            {
+                // Get the work building; skip this builder if it's missing (just in case)
+                if (builder.getWorkBuilding() == null)
+                    continue;
+
+                final BlockPos pos = builder.getWorkBuilding().getPosition();
+                context.getSource().sendSuccess(
+                    () -> Component.literal("- " + builder.getName() +
+                            " at [" + pos.getX() + ", " + pos.getY() + ", " + pos.getZ() + "]")
+                        .withStyle(styleWithTeleport(pos)),
+                    false
+                );
+            }
+        }
+
+        return 1;
+    }
+
+    /**
+     * Name string of the command.
+     * Used as the subcommand: /mc query idlebuilders
+     */
+    @Override
+    public String getName()
+    {
+        return "idlebuilders";
+    }
+
+
+    /**
+     * Creates a style with clickable teleport
+     *
+     * @param pos the position to teleport to
+     * @return the style with a click event
+     */
+    private static Style styleWithTeleport(final BlockPos pos)
+    {
+        return Style.EMPTY.withClickEvent(new ClickEvent(ClickEvent.Action.RUN_COMMAND, "/tp " + pos.getX() + " " + pos.getY() + " " + pos.getZ()));
+    }
+}
+


### PR DESCRIPTION
# Changes proposed in this pull request
This PR introduces a new `/mc query` command subtree designed to support queries for players and admins.

Please note - this is my first PR ever.  Add all the caveats that might go along with that.  I have no real JAVA experience (but have considerable experience in other languages) and I wanted to set a goal to learn how to develop a mod and I thought contributing something I thought would be useful in one of my favorite modpacks would be a good place to start.  

I did my best to match your structure and style so that there isn't any pain for you there, but definitely welcome to any feedback you might have on my approach.  Thanks.

**New command:**
`/mc query idlebuilders`
Reports a list of builder citizens who currently have no active work orders and are therefore idle. Each entry includes a clickable teleport link to the citizen’s builder hut.  Justification:  I always do a lot of unassigned build commands, but many times a building will only be close enough for a single builder to ever get assigned this build automatically. As a result you might end up with a builder or 2 just hiding in their huts because there is nothing to assign to them (even though there are lots of things set to build).

**Design Notes:**
Adds a new class: `CommandQueryIdleBuilders`

Uses `getClosestColony(...)` and `isCoordinateInAnyColony(...)` to determine the relevant colony context based on the player’s current position.

Duplicates the `styleWithTeleport() `method (originally in `CommandCitizenInfo.java`) for generating clickable `/tp` links.  I thought about just creating a public version, but that seemed beyond scope of this PR, but this could be made a shared utility in a future refactor.

**Future extensions could include:** (but I didn't want to go here without your interest).  
I am sure others may have more creative ideas than me, but a couple that I quickly though might be useful:
-  `/mc query vacancies`: Report houses which have an open bed
-  `/mc query workdistance <blockdistance>` : Identify citizens whose home/work distance exceeds a threshold.


## Testing
- [X] Yes I tested this before submitting it.
- [ ] I also did a multiplayer test.

Review please
Appreciate any comments or feedback you might be able to provide.