### PR TITLE
Fisher stats tweak

### DIFF
--- a/src/main/java/com/minecolonies/core/entity/ai/workers/production/agriculture/EntityAIWorkFisherman.java
+++ b/src/main/java/com/minecolonies/core/entity/ai/workers/production/agriculture/EntityAIWorkFisherman.java
@@ -486,8 +486,6 @@ public class EntityAIWorkFisherman extends AbstractEntityAISkill<JobFisherman, B
         {
             playCaughtFishSound();
             this.incrementActionsDoneAndDecSaturation();
-            worker.getCitizenColonyHandler().getColonyOrRegister().getStatisticsManager().increment(FISH_CAUGHT, worker.getCitizenColonyHandler().getColonyOrRegister().getDay());
-            building.getModule(STATS_MODULE).increment(FISH_CAUGHT);
 
             if (worker.getRandom().nextDouble() < CHANCE_NEW_POND)
             {


### PR DESCRIPTION
Closes observation from stream

# Changes proposed in this pull request
- Eliminate the "Total Catches" (formerly "Fish Caught") stat based on counting successful casts.  Leave the stat based on what the fisher picks up.
- Note that this will not eliminate the already-recorded stats in this category.

## Testing
- [X] Yes I tested this before submitting it.
- [ ] I also did a multiplayer test.

Review please