### PR TITLE
Small pathing/workorder fix

### DIFF
--- a/src/main/java/com/minecolonies/core/entity/ai/combat/TargetAI.java
+++ b/src/main/java/com/minecolonies/core/entity/ai/combat/TargetAI.java
@@ -1,17 +1,18 @@
 package com.minecolonies.core.entity.ai.combat;
 
 import com.minecolonies.api.entity.ai.IStateAI;
-import com.minecolonies.api.entity.ai.statemachine.tickratestatemachine.ITickRateStateMachine;
-import com.minecolonies.api.entity.ai.statemachine.tickratestatemachine.TickingTransition;
 import com.minecolonies.api.entity.ai.combat.CombatAIStates;
 import com.minecolonies.api.entity.ai.combat.threat.IThreatTableEntity;
 import com.minecolonies.api.entity.ai.combat.threat.ThreatTableEntry;
+import com.minecolonies.api.entity.ai.statemachine.tickratestatemachine.ITickRateStateMachine;
+import com.minecolonies.api.entity.ai.statemachine.tickratestatemachine.TickingTransition;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
 import net.minecraft.world.entity.LivingEntity;
 import net.minecraft.world.entity.Mob;
 import net.minecraft.world.entity.monster.Enemy;
 import net.minecraft.world.phys.AABB;
+import net.minecraftforge.common.util.FakePlayer;
 
 import java.util.List;
 
@@ -89,7 +90,7 @@ public class TargetAI<T extends Mob & IThreatTableEntity> implements IStateAI
      */
     public boolean isEntityValidTarget(final LivingEntity target)
     {
-        if (target == user || target == null || !target.isAlive() || !isWithinPersecutionDistance(target))
+        if (target == user || target == null || !target.isAlive() || !isWithinPersecutionDistance(target) || target instanceof FakePlayer)
         {
             return false;
         }

--- a/src/main/java/com/minecolonies/core/entity/ai/workers/AbstractEntityAIStructure.java
+++ b/src/main/java/com/minecolonies/core/entity/ai/workers/AbstractEntityAIStructure.java
@@ -1011,7 +1011,7 @@ public abstract class AbstractEntityAIStructure<J extends AbstractJobStructure<?
      */
     protected boolean isThereAStructureToBuild()
     {
-        if (structurePlacer == null || !structurePlacer.getB().hasBluePrint())
+        if (structurePlacer == null || !structurePlacer.getB().hasBluePrint() || job.getWorkOrder() == null)
         {
             return false;
         }

--- a/src/main/java/com/minecolonies/core/entity/ai/workers/AbstractEntityAIStructureWithWorkOrder.java
+++ b/src/main/java/com/minecolonies/core/entity/ai/workers/AbstractEntityAIStructureWithWorkOrder.java
@@ -111,7 +111,7 @@ public abstract class AbstractEntityAIStructureWithWorkOrder<J extends AbstractJ
             return getState();
         }
 
-        if (job.getWorkOrder().getBlueprint() == null || structurePlacer == null)
+        if (job.getWorkOrder() == null || job.getWorkOrder().getBlueprint() == null || structurePlacer == null)
         {
             loadStructure();
             final IBuilderWorkOrder wo = job.getWorkOrder();

--- a/src/main/java/com/minecolonies/core/entity/pathfinding/navigation/MinecoloniesAdvancedPathNavigate.java
+++ b/src/main/java/com/minecolonies/core/entity/pathfinding/navigation/MinecoloniesAdvancedPathNavigate.java
@@ -268,7 +268,7 @@ public class MinecoloniesAdvancedPathNavigate extends AbstractAdvancedPathNaviga
         }
         super.stop();
 
-        if (dest != null && !dest.equals(BlockPos.ZERO))
+        if (dest != null)
         {
             if (job.getStart().distSqr(dest) > 900 * 900)
             {
@@ -289,6 +289,8 @@ public class MinecoloniesAdvancedPathNavigate extends AbstractAdvancedPathNaviga
 
                     ourEntity.moveTo(dest.getX(), dest.getY(), dest.getZ());
                 }
+
+                pauseTicks = 20 * 300;
                 return null;
             }
         }


### PR DESCRIPTION
Closes #11049
Closes #

# Changes proposed in this pull request
- Fix npe when missing workorder
- Prevent pathfinding to zero and log error instead to avoid high distance pathfinding
- Add fakeplayer as invalid target

## Testing
- [ ] Yes I tested this before submitting it.
- [ ] I also did a multiplayer test.

Review please