### PR TITLE
Assistant hammer fixes:

### DIFF
--- a/src/main/java/com/minecolonies/core/entity/ai/workers/AbstractEntityAIStructure.java
+++ b/src/main/java/com/minecolonies/core/entity/ai/workers/AbstractEntityAIStructure.java
@@ -15,7 +15,7 @@ import com.minecolonies.api.colony.buildings.IBuilding;
 import com.minecolonies.api.colony.requestsystem.request.IRequest;
 import com.minecolonies.api.colony.requestsystem.requestable.IDeliverable;
 import com.minecolonies.api.colony.requestsystem.requestable.Stack;
-import com.minecolonies.api.colony.workorders.IWorkOrder;
+import com.minecolonies.api.colony.workorders.IBuilderWorkOrder;
 import com.minecolonies.api.crafting.ItemStorage;
 import com.minecolonies.api.entity.ai.statemachine.AIEventTarget;
 import com.minecolonies.api.entity.ai.statemachine.AITarget;
@@ -686,7 +686,7 @@ public abstract class AbstractEntityAIStructure<J extends AbstractJobStructure<?
      * @param isMirrored  is the structure mirroed?
      * @param removal     if removal step.
      */
-    public void loadStructure(@NotNull final IWorkOrder workOrder, final BlockPos position, final boolean removal)
+    public void loadStructure(@NotNull final IBuilderWorkOrder workOrder, final BlockPos position, final boolean removal)
     {
         this.loadingBlueprint = true;
         workOrder.loadBlueprint(world, (blueprint -> {

--- a/src/main/java/com/minecolonies/core/entity/ai/workers/production/EntityAIQuarrier.java
+++ b/src/main/java/com/minecolonies/core/entity/ai/workers/production/EntityAIQuarrier.java
@@ -10,7 +10,7 @@ import com.ldtteam.structurize.util.PlacementSettings;
 import com.minecolonies.api.colony.IColonyManager;
 import com.minecolonies.api.colony.buildings.IBuilding;
 import com.minecolonies.api.colony.interactionhandling.ChatPriority;
-import com.minecolonies.api.colony.workorders.IWorkOrder;
+import com.minecolonies.api.colony.workorders.IBuilderWorkOrder;
 import com.minecolonies.api.entity.ai.statemachine.AITarget;
 import com.minecolonies.api.entity.ai.statemachine.states.IAIState;
 import com.minecolonies.api.entity.citizen.VisibleCitizenStatus;
@@ -213,7 +213,7 @@ public class EntityAIQuarrier extends AbstractEntityAIStructureWithWorkOrder<Job
 
     @Override
     public void loadStructure(
-      @NotNull final IWorkOrder workOrder,
+        @NotNull final IBuilderWorkOrder workOrder,
       final BlockPos position,
       final boolean removal)
     {

--- a/src/main/java/com/minecolonies/core/entity/ai/workers/util/BuildingStructureHandler.java
+++ b/src/main/java/com/minecolonies/core/entity/ai/workers/util/BuildingStructureHandler.java
@@ -109,6 +109,8 @@ public class BuildingStructureHandler<J extends AbstractJobStructure<?, J>, B ex
                 break;
             }
         }
+
+        this.workOrder.setStage(getStage());
     }
 
     /**


### PR DESCRIPTION
Closes #11050
Closes #

# Changes proposed in this pull request
Assistant hammer fixes:
- does now reduce the used block in the builders resource list
- Improve logic with clearing step not properly notifying players
- Clientside inventory no longer is desynced when the server denies the placement

## Testing
- [x ] Yes I tested this before submitting it.
- [ x] I also did a multiplayer test.

Review please