### PR TITLE
Guardtower druid

### DIFF
--- a/src/main/java/com/minecolonies/apiimp/initializer/ModBuildingsInitializer.java
+++ b/src/main/java/com/minecolonies/apiimp/initializer/ModBuildingsInitializer.java
@@ -216,7 +216,6 @@ public final class ModBuildingsInitializer
           .setRegistryName(new ResourceLocation(Constants.MOD_ID, ModBuildings.GUARD_TOWER_ID))
           .addBuildingModuleProducer(KNIGHT_TOWER_WORK)
           .addBuildingModuleProducer(RANGER_TOWER_WORK)
-          .addBuildingModuleProducer(DRUID_TOWER_WORK)
           .addBuildingModuleProducer(GUARD_TOOL)
           .addBuildingModuleProducer(GUARD_ENTITY_LIST)
           .addBuildingModuleProducer(GUARD_SETTINGS)


### PR DESCRIPTION
Closes #
Closes #

# Changes proposed in this pull request
- Druids now longer can be hired in guard towers as they are intended to work in groups of guards

## Testing
- [ x] Yes I tested this before submitting it.
- [ ] I also did a multiplayer test.

Review please