### PR TITLE
Debugging enhancements for AI and pathfinding

### DIFF
--- a/src/main/java/com/minecolonies/api/entity/ai/ITickingStateAI.java
+++ b/src/main/java/com/minecolonies/api/entity/ai/ITickingStateAI.java
@@ -1,6 +1,8 @@
 package com.minecolonies.api.entity.ai;
 
+import com.minecolonies.api.entity.ai.statemachine.states.IAIState;
 import com.minecolonies.api.entity.ai.statemachine.states.IState;
+import com.minecolonies.api.entity.ai.statemachine.tickratestatemachine.ITickRateStateMachine;
 
 /**
  * Interface for ticking AI's
@@ -11,6 +13,13 @@ public interface ITickingStateAI
      * Ticks the ai
      */
     public void tick();
+
+    /**
+     * Get the statemachine of the AI
+     *
+     * @return statemachine
+     */
+    ITickRateStateMachine<IAIState> getStateAI();
 
     /**
      * Called when the AI get removed

--- a/src/main/java/com/minecolonies/api/entity/ai/statemachine/AIEventTarget.java
+++ b/src/main/java/com/minecolonies/api/entity/ai/statemachine/AIEventTarget.java
@@ -2,11 +2,10 @@ package com.minecolonies.api.entity.ai.statemachine;
 
 import com.minecolonies.api.entity.ai.statemachine.states.AIBlockingEventType;
 import com.minecolonies.api.entity.ai.statemachine.states.IState;
+import com.minecolonies.api.entity.ai.statemachine.tickratestatemachine.IBooleanConditionSupplier;
+import com.minecolonies.api.entity.ai.statemachine.tickratestatemachine.IStateSupplier;
 import com.minecolonies.api.entity.ai.statemachine.tickratestatemachine.TickingEvent;
 import org.jetbrains.annotations.NotNull;
-
-import java.util.function.BooleanSupplier;
-import java.util.function.Supplier;
 
 /**
  * Special AI Targets which are used for preState cecks and limits. They are checked before normal AITargets always
@@ -23,15 +22,15 @@ public class AIEventTarget<S extends IState> extends TickingEvent<S>
      */
     public AIEventTarget(
       @NotNull final AIBlockingEventType eventType,
-      @NotNull final BooleanSupplier predicate,
-      @NotNull final Supplier<S> action, final int tickRate)
+        @NotNull final IBooleanConditionSupplier predicate,
+        @NotNull final IStateSupplier<S> action, final int tickRate)
     {
         super(eventType, predicate, action, tickRate);
     }
 
     public AIEventTarget(
       @NotNull final AIBlockingEventType eventType,
-      @NotNull final BooleanSupplier predicate,
+        @NotNull final IBooleanConditionSupplier predicate,
       @NotNull final S IAIState,
       final int tickRate)
     {
@@ -40,7 +39,7 @@ public class AIEventTarget<S extends IState> extends TickingEvent<S>
 
     public AIEventTarget(
       @NotNull final AIBlockingEventType eventType,
-      @NotNull final Supplier<S> action,
+        @NotNull final IStateSupplier<S> action,
       final int tickRate)
     {
         super(eventType, () -> true, action, tickRate);

--- a/src/main/java/com/minecolonies/api/entity/ai/statemachine/AIOneTimeEventTarget.java
+++ b/src/main/java/com/minecolonies/api/entity/ai/statemachine/AIOneTimeEventTarget.java
@@ -2,11 +2,10 @@ package com.minecolonies.api.entity.ai.statemachine;
 
 import com.minecolonies.api.entity.ai.statemachine.states.AIBlockingEventType;
 import com.minecolonies.api.entity.ai.statemachine.states.IState;
+import com.minecolonies.api.entity.ai.statemachine.tickratestatemachine.IBooleanConditionSupplier;
+import com.minecolonies.api.entity.ai.statemachine.tickratestatemachine.IStateSupplier;
 import com.minecolonies.api.entity.ai.statemachine.tickratestatemachine.TickingOneTimeEvent;
 import org.jetbrains.annotations.NotNull;
-
-import java.util.function.BooleanSupplier;
-import java.util.function.Supplier;
 
 /**
  * One time usage AITarget, unregisters itself after usage
@@ -19,7 +18,7 @@ public class AIOneTimeEventTarget<S extends IState> extends TickingOneTimeEvent<
      * @param predicate which has to be true to execute
      * @param action    Supplier for the state to transition into
      */
-    public AIOneTimeEventTarget(@NotNull final BooleanSupplier predicate, @NotNull final Supplier<S> action)
+    public AIOneTimeEventTarget(@NotNull final IBooleanConditionSupplier predicate, @NotNull final IStateSupplier<S> action)
     {
         super(AIBlockingEventType.EVENT, predicate, action, 1);
     }
@@ -30,7 +29,7 @@ public class AIOneTimeEventTarget<S extends IState> extends TickingOneTimeEvent<
      * @param predicate which has to be true to execute
      * @param state     state to transition into
      */
-    public AIOneTimeEventTarget(@NotNull final BooleanSupplier predicate, @NotNull final S state)
+    public AIOneTimeEventTarget(@NotNull final IBooleanConditionSupplier predicate, @NotNull final S state)
     {
         super(AIBlockingEventType.EVENT, predicate, () -> state, 1);
     }
@@ -40,7 +39,7 @@ public class AIOneTimeEventTarget<S extends IState> extends TickingOneTimeEvent<
      *
      * @param action Supplier for the state to transition into
      */
-    public AIOneTimeEventTarget(@NotNull final Supplier<S> action)
+    public AIOneTimeEventTarget(@NotNull final IStateSupplier<S> action)
     {
         super(AIBlockingEventType.EVENT, () -> true, action, 1);
     }

--- a/src/main/java/com/minecolonies/api/entity/ai/statemachine/AITarget.java
+++ b/src/main/java/com/minecolonies/api/entity/ai/statemachine/AITarget.java
@@ -1,12 +1,11 @@
 package com.minecolonies.api.entity.ai.statemachine;
 
 import com.minecolonies.api.entity.ai.statemachine.states.IState;
+import com.minecolonies.api.entity.ai.statemachine.tickratestatemachine.IBooleanConditionSupplier;
+import com.minecolonies.api.entity.ai.statemachine.tickratestatemachine.IStateSupplier;
 import com.minecolonies.api.entity.ai.statemachine.tickratestatemachine.TickingTransition;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
-
-import java.util.function.BooleanSupplier;
-import java.util.function.Supplier;
 
 /**
  * A simple target the AI tries to accomplish. It has a state matcher, so it only gets executed on matching state. It has a tester function to make more checks to tell if execution
@@ -24,8 +23,8 @@ public class AITarget<S extends IState> extends TickingTransition<S>
      */
     public AITarget(
       @NotNull final S state,
-      @NotNull final BooleanSupplier predicate,
-      @NotNull final Supplier<S> action,
+        @NotNull final IBooleanConditionSupplier predicate,
+        @NotNull final IStateSupplier<S> action,
       final int tickRate)
     {
         super(state, predicate, action, tickRate);
@@ -39,8 +38,8 @@ public class AITarget<S extends IState> extends TickingTransition<S>
      * @param tickRate  the tick rate.
      */
     protected AITarget(
-      @NotNull final BooleanSupplier predicate,
-      @NotNull final Supplier<S> action,
+        @NotNull final IBooleanConditionSupplier predicate,
+        @NotNull final IStateSupplier<S> action,
       final int tickRate)
     {
         super(predicate, action, tickRate);
@@ -65,7 +64,7 @@ public class AITarget<S extends IState> extends TickingTransition<S>
      * @param action   the action to apply
      * @param tickRate the tick rate.
      */
-    public AITarget(@NotNull final S state, @NotNull final Supplier<S> action, final int tickRate)
+    public AITarget(@NotNull final S state, @NotNull final IStateSupplier<S> action, final int tickRate)
     {
         this(state, () -> true, action, tickRate);
     }

--- a/src/main/java/com/minecolonies/api/entity/ai/statemachine/basestatemachine/BasicEvent.java
+++ b/src/main/java/com/minecolonies/api/entity/ai/statemachine/basestatemachine/BasicEvent.java
@@ -2,11 +2,10 @@ package com.minecolonies.api.entity.ai.statemachine.basestatemachine;
 
 import com.minecolonies.api.entity.ai.statemachine.states.IAIState;
 import com.minecolonies.api.entity.ai.statemachine.states.IStateEventType;
+import com.minecolonies.api.entity.ai.statemachine.tickratestatemachine.IBooleanConditionSupplier;
+import com.minecolonies.api.entity.ai.statemachine.tickratestatemachine.IStateSupplier;
 import com.minecolonies.api.entity.ai.statemachine.transitions.IStateMachineEvent;
 import org.jetbrains.annotations.NotNull;
-
-import java.util.function.BooleanSupplier;
-import java.util.function.Supplier;
 
 /**
  * Basic event for statemachines, consists of a condition and a statesupplier to transition the statemachine into. Events are always executed before any state transitions happen.
@@ -20,8 +19,8 @@ public class BasicEvent extends BasicTransition<IAIState> implements IStateMachi
 
     public BasicEvent(
       @NotNull final IStateEventType eventType,
-      @NotNull final BooleanSupplier condition,
-      @NotNull final Supplier<IAIState> nextState)
+        @NotNull final IBooleanConditionSupplier condition,
+        @NotNull final IStateSupplier<IAIState> nextState)
     {
         super(condition, nextState);
         this.eventType = eventType;

--- a/src/main/java/com/minecolonies/api/entity/ai/statemachine/basestatemachine/BasicTransition.java
+++ b/src/main/java/com/minecolonies/api/entity/ai/statemachine/basestatemachine/BasicTransition.java
@@ -1,12 +1,18 @@
 package com.minecolonies.api.entity.ai.statemachine.basestatemachine;
 
 import com.minecolonies.api.entity.ai.statemachine.states.IState;
+import com.minecolonies.api.entity.ai.statemachine.tickratestatemachine.IBooleanConditionSupplier;
+import com.minecolonies.api.entity.ai.statemachine.tickratestatemachine.IStateSupplier;
 import com.minecolonies.api.entity.ai.statemachine.transitions.IStateMachineTransition;
+import com.minecolonies.api.util.Log;
+import net.minecraft.ChatFormatting;
+import net.minecraft.network.chat.Component;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
-import java.util.function.BooleanSupplier;
-import java.util.function.Supplier;
+import java.io.Serializable;
+import java.lang.invoke.SerializedLambda;
+import java.lang.reflect.Method;
 
 /**
  * Basic Transition class for statemachines. Consists of a state the transition applies in, a statesupplier which determines its next state and a condition which has to be true to
@@ -24,13 +30,18 @@ public class BasicTransition<S extends IState> implements IStateMachineTransitio
      * The condition which needs to be met to transition
      */
     @NotNull
-    private final BooleanSupplier condition;
+    private final IBooleanConditionSupplier condition;
 
     /**
      * The next state we transition into
      */
     @NotNull
-    private final Supplier<S> nextState;
+    private final IStateSupplier<S> nextState;
+
+    /**
+     * The name of the transition
+     */
+    private final Component name;
 
     /**
      * Creating a new transition from State A to B under condition C
@@ -39,11 +50,17 @@ public class BasicTransition<S extends IState> implements IStateMachineTransitio
      * @param condition Condition C
      * @param nextState State B
      */
-    public BasicTransition(@NotNull final S state, @NotNull final BooleanSupplier condition, @NotNull final Supplier<S> nextState)
+    public BasicTransition(@NotNull final S state, @NotNull final IBooleanConditionSupplier condition, @NotNull final IStateSupplier<S> nextState)
     {
         this.state = state;
         this.condition = condition;
         this.nextState = nextState;
+
+        name = Component.literal(state.toString()).withStyle(ChatFormatting.GOLD).append(Component.literal(":"))
+            .append(Component.literal(getMethodName(condition))
+                .withStyle(ChatFormatting.BLUE)
+                .append(Component.literal(":"))
+                .append(Component.literal(getMethodName(nextState)).withStyle(ChatFormatting.AQUA)));
     }
 
     /**
@@ -52,11 +69,17 @@ public class BasicTransition<S extends IState> implements IStateMachineTransitio
      * @param condition the condition.
      * @param nextState the next state to go to.
      */
-    protected BasicTransition(@NotNull final BooleanSupplier condition, @NotNull final Supplier<S> nextState)
+    protected BasicTransition(@NotNull final IBooleanConditionSupplier condition, @NotNull final IStateSupplier<S> nextState)
     {
         this.state = null;
         this.condition = condition;
         this.nextState = nextState;
+
+        name = Component.literal(getClass().getSimpleName()).withStyle(ChatFormatting.RED).append(Component.literal(":"))
+            .append(Component.literal(getMethodName(condition))
+                .withStyle(ChatFormatting.BLUE)
+                .append(Component.literal(":"))
+                .append(Component.literal(getMethodName(nextState)).withStyle(ChatFormatting.AQUA)));
     }
 
     /**
@@ -64,6 +87,7 @@ public class BasicTransition<S extends IState> implements IStateMachineTransitio
      *
      * @return IAIState
      */
+    @Override
     public S getState()
     {
         return state;
@@ -74,6 +98,7 @@ public class BasicTransition<S extends IState> implements IStateMachineTransitio
      *
      * @return next AI state
      */
+    @Override
     public S getNextState()
     {
         return nextState.get();
@@ -82,8 +107,42 @@ public class BasicTransition<S extends IState> implements IStateMachineTransitio
     /**
      * Check if the condition of this transition applies
      */
+    @Override
     public boolean checkCondition()
     {
         return condition.getAsBoolean();
+    }
+
+    @Override
+    public Component getName()
+    {
+        return name;
+    }
+
+    /**
+     * Reflection util for generating a name for the method refs used by transitions, until we properly name them all
+     */
+    public static String getMethodName(Serializable lambda)
+    {
+        try
+        {
+            // Reflectively access the writeReplace method
+            Method writeReplace = lambda.getClass().getDeclaredMethod("writeReplace");
+            writeReplace.setAccessible(true);
+            SerializedLambda serializedLambda = (SerializedLambda) writeReplace.invoke(lambda);
+            String name = serializedLambda.getImplMethodName(); // Method name, e.g., "structureStep"
+            if (name.contains("lambda"))
+            {
+                return "()";
+            }
+
+            return name;
+        }
+        catch (Exception e)
+        {
+            Log.getLogger().warn("Failed to extract method name from lambda", e);
+        }
+
+        return "Unknown";
     }
 }

--- a/src/main/java/com/minecolonies/api/entity/ai/statemachine/basestatemachine/IStateMachine.java
+++ b/src/main/java/com/minecolonies/api/entity/ai/statemachine/basestatemachine/IStateMachine.java
@@ -2,6 +2,7 @@ package com.minecolonies.api.entity.ai.statemachine.basestatemachine;
 
 import com.minecolonies.api.entity.ai.statemachine.states.IState;
 import com.minecolonies.api.entity.ai.statemachine.transitions.IStateMachineTransition;
+import net.minecraft.network.chat.Component;
 import org.jetbrains.annotations.NotNull;
 
 /**
@@ -42,8 +43,8 @@ public interface IStateMachine<T extends IStateMachineTransition<S>, S extends I
     /**
      * Change the state to the next
      *
-     * @param transition the next transition.
-     * @return true if transitioned.
+     * @param transition the transition providing the state change
+     * @return true if the transition provided a state to change to, false on null
      */
     boolean transitionToNext(@NotNull final T transition);
 
@@ -58,4 +59,19 @@ public interface IStateMachine<T extends IStateMachineTransition<S>, S extends I
      * Reset the statemachine to the start
      */
     void reset();
+
+    /**
+     * Set whether the state history is tracked
+     *
+     * @param enabled
+     * @param memorySize amount of entries kept
+     */
+    void setHistoryEnabled(boolean enabled, final int memorySize);
+
+    /**
+     * Get the state transition history for display
+     *
+     * @return
+     */
+    Component getHistory();
 }

--- a/src/main/java/com/minecolonies/api/entity/ai/statemachine/tickratestatemachine/IBooleanConditionSupplier.java
+++ b/src/main/java/com/minecolonies/api/entity/ai/statemachine/tickratestatemachine/IBooleanConditionSupplier.java
@@ -1,0 +1,19 @@
+package com.minecolonies.api.entity.ai.statemachine.tickratestatemachine;
+
+import java.io.Serializable;
+
+/**
+ * Serializeable version of a boolean supplier for AI transitions, used for name generation
+ *
+ * @param <T>
+ */
+@FunctionalInterface
+public interface IBooleanConditionSupplier extends Serializable
+{
+    /**
+     * Gets a result.
+     *
+     * @return a result
+     */
+    boolean getAsBoolean();
+}

--- a/src/main/java/com/minecolonies/api/entity/ai/statemachine/tickratestatemachine/IStateSupplier.java
+++ b/src/main/java/com/minecolonies/api/entity/ai/statemachine/tickratestatemachine/IStateSupplier.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2012, 2013, Oracle and/or its affiliates. All rights reserved.
+ * ORACLE PROPRIETARY/CONFIDENTIAL. Use is subject to license terms.
+ *
+ *
+ *
+ *
+ *
+ *
+ *
+ *
+ *
+ *
+ *
+ *
+ *
+ *
+ *
+ *
+ *
+ *
+ *
+ *
+ */
+package com.minecolonies.api.entity.ai.statemachine.tickratestatemachine;
+
+import java.io.Serializable;
+
+/**
+ * Serializeable version of a supplier for AI states, used for name generation
+ *
+ * @param <T>
+ */
+@FunctionalInterface
+public interface IStateSupplier<T> extends Serializable
+{
+    /**
+     * Gets a result.
+     *
+     * @return a result
+     */
+    T get();
+}

--- a/src/main/java/com/minecolonies/api/entity/ai/statemachine/tickratestatemachine/IStateSupplier.java
+++ b/src/main/java/com/minecolonies/api/entity/ai/statemachine/tickratestatemachine/IStateSupplier.java
@@ -1,27 +1,3 @@
-/*
- * Copyright (c) 2012, 2013, Oracle and/or its affiliates. All rights reserved.
- * ORACLE PROPRIETARY/CONFIDENTIAL. Use is subject to license terms.
- *
- *
- *
- *
- *
- *
- *
- *
- *
- *
- *
- *
- *
- *
- *
- *
- *
- *
- *
- *
- */
 package com.minecolonies.api.entity.ai.statemachine.tickratestatemachine;
 
 import java.io.Serializable;

--- a/src/main/java/com/minecolonies/api/entity/ai/statemachine/tickratestatemachine/TickingEvent.java
+++ b/src/main/java/com/minecolonies/api/entity/ai/statemachine/tickratestatemachine/TickingEvent.java
@@ -5,9 +5,6 @@ import com.minecolonies.api.entity.ai.statemachine.states.IStateEventType;
 import com.minecolonies.api.entity.ai.statemachine.transitions.IStateMachineEvent;
 import org.jetbrains.annotations.NotNull;
 
-import java.util.function.BooleanSupplier;
-import java.util.function.Supplier;
-
 /**
  * Event with a tickrate for a statemachine using a tickrate.
  */
@@ -28,8 +25,8 @@ public class TickingEvent<S extends IState> extends TickingTransition<S> impleme
      */
     protected TickingEvent(
       @NotNull final IStateEventType eventType,
-      @NotNull final BooleanSupplier condition,
-      @NotNull final Supplier<S> nextState,
+        @NotNull final IBooleanConditionSupplier condition,
+        @NotNull final IStateSupplier<S> nextState,
       final int tickRate)
     {
         super(condition, nextState, tickRate);

--- a/src/main/java/com/minecolonies/api/entity/ai/statemachine/tickratestatemachine/TickingOneTimeEvent.java
+++ b/src/main/java/com/minecolonies/api/entity/ai/statemachine/tickratestatemachine/TickingOneTimeEvent.java
@@ -5,9 +5,6 @@ import com.minecolonies.api.entity.ai.statemachine.states.IStateEventType;
 import com.minecolonies.api.entity.ai.statemachine.transitions.IStateMachineOneTimeEvent;
 import org.jetbrains.annotations.NotNull;
 
-import java.util.function.BooleanSupplier;
-import java.util.function.Supplier;
-
 /**
  * One time event that can be checked at the given tickrate, one time events are removed after causing a state transition. (Even when transitioning into the same state again)
  */
@@ -23,8 +20,8 @@ public class TickingOneTimeEvent<S extends IState> extends TickingEvent<S> imple
      */
     protected TickingOneTimeEvent(
       @NotNull final IStateEventType eventType,
-      @NotNull final BooleanSupplier condition,
-      @NotNull final Supplier<S> nextState,
+        @NotNull final IBooleanConditionSupplier condition,
+        @NotNull final IStateSupplier<S> nextState,
       final int tickRate)
     {
         super(eventType, condition, nextState, tickRate);

--- a/src/main/java/com/minecolonies/api/entity/ai/statemachine/tickratestatemachine/TickingTransition.java
+++ b/src/main/java/com/minecolonies/api/entity/ai/statemachine/tickratestatemachine/TickingTransition.java
@@ -4,9 +4,6 @@ import com.minecolonies.api.entity.ai.statemachine.basestatemachine.BasicTransit
 import com.minecolonies.api.entity.ai.statemachine.states.IState;
 import org.jetbrains.annotations.NotNull;
 
-import java.util.function.BooleanSupplier;
-import java.util.function.Supplier;
-
 import static com.minecolonies.api.entity.ai.statemachine.tickratestatemachine.TickRateConstants.MAX_AI_TICKRATE;
 import static com.minecolonies.api.entity.ai.statemachine.tickratestatemachine.TickRateConstants.MAX_TICKRATE_VARIANT;
 
@@ -42,8 +39,8 @@ public class TickingTransition<S extends IState> extends BasicTransition<S> impl
      */
     public TickingTransition(
       @NotNull final S state,
-      @NotNull final BooleanSupplier condition,
-      @NotNull final Supplier<S> nextState,
+        @NotNull final IBooleanConditionSupplier condition,
+        @NotNull final IStateSupplier<S> nextState,
       final int tickRate)
     {
         super(state, condition, nextState);
@@ -70,8 +67,8 @@ public class TickingTransition<S extends IState> extends BasicTransition<S> impl
      * @param tickRate  The expected tickrate at which this transition should be checked.
      */
     public TickingTransition(
-      @NotNull final BooleanSupplier condition,
-      @NotNull final Supplier<S> nextState,
+        @NotNull final IBooleanConditionSupplier condition,
+        @NotNull final IStateSupplier<S> nextState,
       final int tickRate)
     {
         super(condition, nextState);

--- a/src/main/java/com/minecolonies/api/entity/ai/statemachine/transitions/IStateMachineTransition.java
+++ b/src/main/java/com/minecolonies/api/entity/ai/statemachine/transitions/IStateMachineTransition.java
@@ -1,6 +1,7 @@
 package com.minecolonies.api.entity.ai.statemachine.transitions;
 
 import com.minecolonies.api.entity.ai.statemachine.states.IState;
+import net.minecraft.network.chat.Component;
 
 /**
  * Transition type for Statemachines
@@ -27,4 +28,11 @@ public interface IStateMachineTransition<S extends IState>
      * @return true if ready to transition to next state
      */
     boolean checkCondition();
+
+    /**
+     * Get the name of this transition
+     *
+     * @return name
+     */
+    Component getName();
 }

--- a/src/main/java/com/minecolonies/apiimp/initializer/ModBuildingsInitializer.java
+++ b/src/main/java/com/minecolonies/apiimp/initializer/ModBuildingsInitializer.java
@@ -216,7 +216,6 @@ public final class ModBuildingsInitializer
           .setRegistryName(new ResourceLocation(Constants.MOD_ID, ModBuildings.GUARD_TOWER_ID))
           .addBuildingModuleProducer(KNIGHT_TOWER_WORK)
           .addBuildingModuleProducer(RANGER_TOWER_WORK)
-          .addBuildingModuleProducer(DRUID_TOWER_WORK)
           .addBuildingModuleProducer(GUARD_TOOL)
           .addBuildingModuleProducer(GUARD_ENTITY_LIST)
           .addBuildingModuleProducer(GUARD_SETTINGS)

--- a/src/main/java/com/minecolonies/core/client/gui/citizen/AbstractWindowCitizen.java
+++ b/src/main/java/com/minecolonies/core/client/gui/citizen/AbstractWindowCitizen.java
@@ -8,6 +8,8 @@ import com.minecolonies.api.colony.buildings.views.IBuildingView;
 import com.minecolonies.core.Network;
 import com.minecolonies.core.client.gui.AbstractWindowRequestTree;
 import com.minecolonies.core.colony.buildings.views.AbstractBuildingView;
+import com.minecolonies.core.debug.DebugPlayerManager;
+import com.minecolonies.core.debug.gui.DebugWindowCitizen;
 import com.minecolonies.core.network.messages.server.colony.OpenInventoryMessage;
 import net.minecraft.client.Minecraft;
 import net.minecraft.network.chat.Component;
@@ -46,6 +48,15 @@ public abstract class AbstractWindowCitizen extends AbstractWindowRequestTree
         registerButton("familyTab", () -> new FamilyWindowCitizen(citizen).open());
         registerButton("familyIcon", () -> new FamilyWindowCitizen(citizen).open());
         PaneBuilders.tooltipBuilder().hoverPane(findPaneByID("familyIcon")).build().setText(Component.translatable("com.minecolonies.coremod.gui.citizen.family"));
+
+        if (DebugPlayerManager.hasDebugEnabled(mc.player))
+        {
+            findPaneByID("debugTab").setVisible(true);
+            findPaneByID("debugIcon").setVisible(true);
+            registerButton("debugTab", () -> new DebugWindowCitizen(citizen).open());
+            registerButton("debugIcon", () -> new DebugWindowCitizen(citizen).open());
+            PaneBuilders.tooltipBuilder().hoverPane(findPaneByID("debugIcon")).build().setText(Component.translatable("com.minecolonies.coremod.debug.gui.tabicon"));
+        }
 
         final IBuildingView building = colony.getBuilding(citizen.getWorkBuilding());
 

--- a/src/main/java/com/minecolonies/core/client/gui/citizen/AbstractWindowCitizen.java
+++ b/src/main/java/com/minecolonies/core/client/gui/citizen/AbstractWindowCitizen.java
@@ -55,7 +55,7 @@ public abstract class AbstractWindowCitizen extends AbstractWindowRequestTree
             findPaneByID("debugIcon").setVisible(true);
             registerButton("debugTab", () -> new DebugWindowCitizen(citizen).open());
             registerButton("debugIcon", () -> new DebugWindowCitizen(citizen).open());
-            PaneBuilders.tooltipBuilder().hoverPane(findPaneByID("debugIcon")).build().setText(Component.translatable("com.minecolonies.coremod.debug.gui.tabicon"));
+            PaneBuilders.singleLineTooltip(Component.translatable("com.minecolonies.coremod.debug.gui.tabicon"), findPaneByID("debugIcon"));
         }
 
         final IBuildingView building = colony.getBuilding(citizen.getWorkBuilding());

--- a/src/main/java/com/minecolonies/core/colony/workorders/AbstractWorkOrder.java
+++ b/src/main/java/com/minecolonies/core/colony/workorders/AbstractWorkOrder.java
@@ -387,6 +387,11 @@ public abstract class AbstractWorkOrder implements IBuilderWorkOrder
     @Override
     public final void setClaimedBy(BlockPos claimedBy)
     {
+        if (this.claimedBy != BlockPos.ZERO && !this.claimedBy.equals(claimedBy) && claimedBy != null)
+        {
+            Log.getLogger().warn("Claiming an already claimed workorder! " + claimedBy + " " + this, new Exception());
+        }
+
         changed = true;
         this.claimedBy = claimedBy;
         if (claimedBy == null)

--- a/src/main/java/com/minecolonies/core/commands/EntryPoint.java
+++ b/src/main/java/com/minecolonies/core/commands/EntryPoint.java
@@ -7,6 +7,7 @@ import com.minecolonies.core.commands.colonycommands.requestsystem.CommandRSRese
 import com.minecolonies.core.commands.colonycommands.requestsystem.CommandRSResetAll;
 import com.minecolonies.core.commands.generalcommands.*;
 import com.minecolonies.core.commands.killcommands.*;
+import com.minecolonies.core.debug.command.CommandToggleDebug;
 import com.mojang.brigadier.CommandDispatcher;
 import net.minecraft.commands.CommandSourceStack;
 
@@ -114,6 +115,7 @@ public class EntryPoint
             .addNode(new CommandBackup().build())
             .addNode(new CommandResetPlayerSupplies().build())
             .addNode(new CommandHelp().build())
+            .addNode(new CommandToggleDebug().build())
             .addNode(new CommandPruneWorld().build());
 
         // Adds all command trees to the dispatcher to register the commands.

--- a/src/main/java/com/minecolonies/core/commands/citizencommands/CommandCitizenInfo.java
+++ b/src/main/java/com/minecolonies/core/commands/citizencommands/CommandCitizenInfo.java
@@ -124,9 +124,9 @@ public class CommandCitizenInfo implements IMCColonyOfficerCommand
                 final AbstractEntityCitizen entityCitizen = optionalEntityCitizen.get();
                 context.getSource()
                     .sendSuccess(() -> Component.translatable(CommandTranslationConstants.COMMAND_CITIZEN_INFO_ACTIVITY,
-                        ((EntityCitizen) entityCitizen).getCitizenAI().getState(),
+                        ((EntityCitizen) entityCitizen).getCitizenAI().getHistory(),
                         entityCitizen.getCitizenJobHandler().getColonyJob().getNameTagDescription(),
-                        entityCitizen.getCitizenJobHandler().getWorkAI().getState()), false);
+                        entityCitizen.getCitizenJobHandler().getWorkAI().getStateAI().getHistory()), false);
             }
         }
 

--- a/src/main/java/com/minecolonies/core/debug/DebugPlayerManager.java
+++ b/src/main/java/com/minecolonies/core/debug/DebugPlayerManager.java
@@ -1,0 +1,70 @@
+package com.minecolonies.core.debug;
+
+import com.minecolonies.core.entity.pathfinding.PathfindingUtils;
+import net.minecraft.world.entity.player.Player;
+import net.minecraftforge.fml.loading.FMLEnvironment;
+
+import java.util.HashSet;
+import java.util.Set;
+import java.util.UUID;
+
+/**
+ * Debug manager to keep track of players having debug mode enabled
+ */
+public class DebugPlayerManager
+{
+    /**
+     * Set of players currently added to debug info
+     */
+    private static Set<UUID> debugPlayers = new HashSet<>();
+
+    /**
+     * Check if debugging is enabled for the player
+     *
+     * @param player
+     * @return
+     */
+    public static boolean hasDebugEnabled(final Player player)
+    {
+        return !FMLEnvironment.production || debugPlayers.contains(player.getUUID());
+    }
+
+    /**
+     * Toggles debugging for the given player
+     *
+     * @param player
+     * @return
+     */
+    public static boolean toggleDebugModeFor(final UUID player)
+    {
+        if (debugPlayers.contains(player))
+        {
+            debugPlayers.remove(player);
+            PathfindingUtils.trackingMap.remove(player);
+            return false;
+        }
+        else
+        {
+            debugPlayers.add(player);
+            return true;
+        }
+    }
+
+    /**
+     * Toggles debugging for the given player
+     *
+     * @param player
+     * @return
+     */
+    public static void setDebugModeFor(final UUID player, boolean enable)
+    {
+        if (!enable)
+        {
+            debugPlayers.remove(player);
+        }
+        else
+        {
+            debugPlayers.add(player);
+        }
+    }
+}

--- a/src/main/java/com/minecolonies/core/debug/command/CommandToggleDebug.java
+++ b/src/main/java/com/minecolonies/core/debug/command/CommandToggleDebug.java
@@ -1,0 +1,82 @@
+package com.minecolonies.core.debug.command;
+
+import com.minecolonies.core.Network;
+import com.minecolonies.core.commands.commandTypes.IMCCommand;
+import com.minecolonies.core.commands.commandTypes.IMCOPCommand;
+import com.minecolonies.core.debug.DebugPlayerManager;
+import com.minecolonies.core.debug.messages.DebugEnableMessage;
+import com.mojang.authlib.GameProfile;
+import com.mojang.brigadier.builder.LiteralArgumentBuilder;
+import com.mojang.brigadier.context.CommandContext;
+import com.mojang.brigadier.exceptions.CommandSyntaxException;
+import net.minecraft.ChatFormatting;
+import net.minecraft.commands.CommandSourceStack;
+import net.minecraft.commands.arguments.GameProfileArgument;
+import net.minecraft.network.chat.Component;
+import net.minecraft.server.level.ServerPlayer;
+
+import static com.minecolonies.core.commands.CommandArgumentNames.PLAYERNAME_ARG;
+
+/**
+ * Command to toggle debug mode for a given player
+ */
+public class CommandToggleDebug implements IMCOPCommand
+{
+    @Override
+    public int onExecute(final CommandContext<CommandSourceStack> context)
+    {
+        GameProfile profile;
+        try
+        {
+            profile = GameProfileArgument.getGameProfiles(context, PLAYERNAME_ARG).stream().findFirst().orElse(null);
+        }
+        catch (CommandSyntaxException e)
+        {
+            return 0;
+        }
+
+        final boolean enabled = DebugPlayerManager.toggleDebugModeFor(profile.getId());
+
+        if (enabled)
+        {
+            context.getSource().sendSuccess(() -> Component.literal("Enabled minecolonies debugging for:" + profile.getName()).withStyle(ChatFormatting.GREEN), true);
+        }
+        else
+        {
+            context.getSource().sendSuccess(() -> Component.literal("Disabled minecolonies debugging for:" + profile.getName()).withStyle(ChatFormatting.RED), true);
+        }
+
+        final ServerPlayer player = context.getSource().getServer().getPlayerList().getPlayer(profile.getId());
+        if (player != null)
+        {
+            if (enabled)
+            {
+                Network.getNetwork().sendToPlayer(new DebugEnableMessage(true), player);
+                player.sendSystemMessage(Component.literal("Enabled minecolonies debugging").withStyle(ChatFormatting.GREEN));
+            }
+            else
+            {
+                Network.getNetwork().sendToPlayer(new DebugEnableMessage(false), player);
+                player.sendSystemMessage(Component.literal("Disabled minecolonies debugging").withStyle(ChatFormatting.RED));
+            }
+        }
+
+        return 1;
+    }
+
+    /**
+     * Name string of the command.
+     */
+    @Override
+    public String getName()
+    {
+        return "toggleDebugging";
+    }
+
+    @Override
+    public LiteralArgumentBuilder<CommandSourceStack> build()
+    {
+        return IMCCommand.newLiteral(getName())
+            .then(IMCCommand.newArgument(PLAYERNAME_ARG, GameProfileArgument.gameProfile()).executes(this::checkPreConditionAndExecute));
+    }
+}

--- a/src/main/java/com/minecolonies/core/debug/gui/DebugWindowCitizen.java
+++ b/src/main/java/com/minecolonies/core/debug/gui/DebugWindowCitizen.java
@@ -58,12 +58,6 @@ public class DebugWindowCitizen extends AbstractWindowSkeleton
     }
 
     @Override
-    public void onOpened()
-    {
-        super.onOpened();
-    }
-
-    @Override
     public void onUpdate()
     {
         super.onUpdate();

--- a/src/main/java/com/minecolonies/core/debug/gui/DebugWindowCitizen.java
+++ b/src/main/java/com/minecolonies/core/debug/gui/DebugWindowCitizen.java
@@ -1,0 +1,72 @@
+package com.minecolonies.core.debug.gui;
+
+import com.ldtteam.blockui.controls.Button;
+import com.ldtteam.blockui.controls.Text;
+import com.minecolonies.api.colony.ICitizenDataView;
+import com.minecolonies.api.util.constant.Constants;
+import com.minecolonies.core.Network;
+import com.minecolonies.core.client.gui.AbstractWindowSkeleton;
+import com.minecolonies.core.debug.messages.DebugEnablePathfindingMessage;
+import com.minecolonies.core.debug.messages.QueryCitizenAIHistoryMessage;
+import net.minecraft.network.chat.Component;
+import net.minecraft.network.chat.MutableComponent;
+
+/**
+ * Debug window for citizens
+ */
+public class DebugWindowCitizen extends AbstractWindowSkeleton
+{
+    /**
+     * Static data holder for responses for now, TODO: rework with citizen modules
+     */
+    public static MutableComponent outputMessage = Component.empty();
+
+    /**
+     * Assigned citizen.
+     */
+    private final ICitizenDataView citizen;
+
+    /**
+     * Whether pathfinding tracking is enabled(not synced!)
+     */
+    private static boolean trackingDebug = false;
+
+    public DebugWindowCitizen(final ICitizenDataView citizen)
+    {
+        super(Constants.MOD_ID + ":gui/citizen/debug.xml");
+        if (outputMessage == Component.empty())
+        {
+            outputMessage = Component.literal("Enabled Citizen AI History!");
+        }
+
+        this.citizen = citizen;
+
+        findPaneOfTypeByID("citizenid", Text.class).setText(Component.literal("Citizen ID:" + citizen.getId()));
+        findPaneOfTypeByID("colonyid", Text.class).setText(Component.literal("Colony ID:" + citizen.getColonyId()));
+        findPaneOfTypeByID("aihistory", Button.class).setHandler(b -> Network.getNetwork().sendToServer(new QueryCitizenAIHistoryMessage(citizen)));
+        findPaneOfTypeByID("pathfinding", Button.class).setHandler(b -> {
+            trackingDebug = !trackingDebug;
+            if (trackingDebug)
+            {
+                outputMessage = Component.literal("Receiving pathfinding data");
+            }
+
+            Network.getNetwork().sendToServer(new DebugEnablePathfindingMessage(citizen, trackingDebug));
+            findPaneOfTypeByID("pathfinding", Button.class).setText(Component.literal((trackingDebug ? "disable Pathfinding tracking" : "enable Pathfinding tracking")));
+        });
+        findPaneOfTypeByID("pathfinding", Button.class).setText(Component.literal((trackingDebug ? "disable Pathfinding tracking" : "enable Pathfinding tracking")));
+    }
+
+    @Override
+    public void onOpened()
+    {
+        super.onOpened();
+    }
+
+    @Override
+    public void onUpdate()
+    {
+        super.onUpdate();
+        findPaneOfTypeByID("output", Text.class).setText(outputMessage);
+    }
+}

--- a/src/main/java/com/minecolonies/core/debug/messages/DebugEnableMessage.java
+++ b/src/main/java/com/minecolonies/core/debug/messages/DebugEnableMessage.java
@@ -1,0 +1,56 @@
+package com.minecolonies.core.debug.messages;
+
+import com.minecolonies.api.network.IMessage;
+import com.minecolonies.core.debug.DebugPlayerManager;
+import net.minecraft.client.Minecraft;
+import net.minecraft.network.FriendlyByteBuf;
+import net.minecraftforge.fml.LogicalSide;
+import net.minecraftforge.network.NetworkEvent;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+/**
+ * Enables debug mode for the client
+ */
+public class DebugEnableMessage implements IMessage
+{
+    /**
+     * Whether to enable or disable debug mode
+     */
+    private boolean enable = true;
+
+    public DebugEnableMessage()
+    {
+        super();
+    }
+
+    public DebugEnableMessage(final boolean enable)
+    {
+        this.enable = enable;
+    }
+
+    @Override
+    public void fromBytes(@NotNull final FriendlyByteBuf buf)
+    {
+        enable = buf.readBoolean();
+    }
+
+    @Override
+    public void toBytes(@NotNull final FriendlyByteBuf buf)
+    {
+        buf.writeBoolean(enable);
+    }
+
+    @Nullable
+    @Override
+    public LogicalSide getExecutionSide()
+    {
+        return LogicalSide.CLIENT;
+    }
+
+    @Override
+    public void onExecute(final NetworkEvent.Context ctxIn, final boolean isLogicalServer)
+    {
+        DebugPlayerManager.setDebugModeFor(Minecraft.getInstance().player.getUUID(), enable);
+    }
+}

--- a/src/main/java/com/minecolonies/core/debug/messages/DebugEnablePathfindingMessage.java
+++ b/src/main/java/com/minecolonies/core/debug/messages/DebugEnablePathfindingMessage.java
@@ -1,0 +1,79 @@
+package com.minecolonies.core.debug.messages;
+
+import com.minecolonies.api.colony.ICitizenData;
+import com.minecolonies.api.colony.ICitizenDataView;
+import com.minecolonies.api.colony.IColony;
+import com.minecolonies.core.debug.DebugPlayerManager;
+import com.minecolonies.core.entity.pathfinding.PathfindingUtils;
+import com.minecolonies.core.network.messages.server.AbstractColonyServerMessage;
+import net.minecraft.network.FriendlyByteBuf;
+import net.minecraft.world.entity.player.Player;
+import net.minecraftforge.network.NetworkEvent;
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * Message to toggle pathfinding debug for a specific citizen
+ */
+public class DebugEnablePathfindingMessage extends AbstractColonyServerMessage
+{
+    /**
+     * Citizen id
+     */
+    private int id;
+
+    /**
+     * Whether to enable or disable pathfinding tracking
+     */
+    private boolean enable = false;
+
+    public DebugEnablePathfindingMessage()
+    {
+        super();
+    }
+
+    public DebugEnablePathfindingMessage(final ICitizenDataView citizen, final boolean enable)
+    {
+        super(citizen.getColony());
+        this.id = citizen.getId();
+        this.enable = enable;
+    }
+
+    @Override
+    public void fromBytesOverride(@NotNull final FriendlyByteBuf buf)
+    {
+        this.id = buf.readInt();
+        enable = buf.readBoolean();
+    }
+
+    @Override
+    public void toBytesOverride(@NotNull final FriendlyByteBuf buf)
+    {
+        buf.writeInt(id);
+        buf.writeBoolean(enable);
+    }
+
+    @Override
+    public void onExecute(final NetworkEvent.Context ctxIn, final boolean isLogicalServer, final IColony colony)
+    {
+        final Player player = ctxIn.getSender();
+        if (player == null || !DebugPlayerManager.hasDebugEnabled(player))
+        {
+            return;
+        }
+
+        final ICitizenData citizen = colony.getCitizenManager().getCivilian(id);
+        if (citizen == null || !citizen.getEntity().isPresent())
+        {
+            return;
+        }
+
+        if (enable)
+        {
+            PathfindingUtils.trackingMap.put(player.getUUID(), citizen.getUUID());
+        }
+        else
+        {
+            PathfindingUtils.trackingMap.remove(player.getUUID());
+        }
+    }
+}

--- a/src/main/java/com/minecolonies/core/debug/messages/DebugOutputMessage.java
+++ b/src/main/java/com/minecolonies/core/debug/messages/DebugOutputMessage.java
@@ -1,0 +1,71 @@
+package com.minecolonies.core.debug.messages;
+
+import com.minecolonies.api.network.IMessage;
+import com.minecolonies.core.debug.gui.DebugWindowCitizen;
+import net.minecraft.network.FriendlyByteBuf;
+import net.minecraft.network.chat.Component;
+import net.minecraftforge.fml.LogicalSide;
+import net.minecraftforge.network.NetworkEvent;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+/**
+ * Message for sending debug text to the client. Used for citizen debug window for now
+ */
+public class DebugOutputMessage implements IMessage
+{
+    /**
+     * The debug information to be displayed in the output
+     */
+    private Component debugInfo;
+
+    /**
+     * Whether to clear the output first
+     */
+    private boolean clear = false;
+
+    public DebugOutputMessage()
+    {
+        super();
+    }
+
+    public DebugOutputMessage(final Component message, final boolean clear)
+    {
+        this.debugInfo = message;
+        this.clear = clear;
+    }
+
+    @Override
+    public void fromBytes(@NotNull final FriendlyByteBuf buf)
+    {
+        debugInfo = buf.readComponent();
+        clear = buf.readBoolean();
+    }
+
+    @Override
+    public void toBytes(@NotNull final FriendlyByteBuf buf)
+    {
+        buf.writeComponent(debugInfo);
+        buf.writeBoolean(clear);
+    }
+
+    @Nullable
+    @Override
+    public LogicalSide getExecutionSide()
+    {
+        return LogicalSide.CLIENT;
+    }
+
+    @Override
+    public void onExecute(final NetworkEvent.Context ctxIn, final boolean isLogicalServer)
+    {
+        if (clear)
+        {
+            DebugWindowCitizen.outputMessage = Component.literal("").append(debugInfo);
+        }
+        else
+        {
+            DebugWindowCitizen.outputMessage.append(Component.literal("\n")).append(debugInfo);
+        }
+    }
+}

--- a/src/main/java/com/minecolonies/core/debug/messages/QueryCitizenAIHistoryMessage.java
+++ b/src/main/java/com/minecolonies/core/debug/messages/QueryCitizenAIHistoryMessage.java
@@ -1,0 +1,77 @@
+package com.minecolonies.core.debug.messages;
+
+import com.minecolonies.api.colony.ICitizenData;
+import com.minecolonies.api.colony.ICitizenDataView;
+import com.minecolonies.api.colony.IColony;
+import com.minecolonies.core.Network;
+import com.minecolonies.core.debug.DebugPlayerManager;
+import com.minecolonies.core.entity.citizen.EntityCitizen;
+import com.minecolonies.core.network.messages.server.AbstractColonyServerMessage;
+import net.minecraft.network.FriendlyByteBuf;
+import net.minecraft.network.chat.Component;
+import net.minecraft.network.chat.MutableComponent;
+import net.minecraft.world.entity.player.Player;
+import net.minecraftforge.network.NetworkEvent;
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * Message to query ai history from the server
+ */
+public class QueryCitizenAIHistoryMessage extends AbstractColonyServerMessage
+{
+    /**
+     * Citizen id
+     */
+    private int id;
+
+    public QueryCitizenAIHistoryMessage()
+    {
+        super();
+    }
+
+    public QueryCitizenAIHistoryMessage(final ICitizenDataView citizen)
+    {
+        super(citizen.getColony());
+        this.id = citizen.getId();
+    }
+
+    @Override
+    public void fromBytesOverride(@NotNull final FriendlyByteBuf buf)
+    {
+        this.id = buf.readInt();
+    }
+
+    @Override
+    public void toBytesOverride(@NotNull final FriendlyByteBuf buf)
+    {
+        buf.writeInt(id);
+    }
+
+    @Override
+    public void onExecute(final NetworkEvent.Context ctxIn, final boolean isLogicalServer, final IColony colony)
+    {
+        final Player player = ctxIn.getSender();
+        if (player == null || !DebugPlayerManager.hasDebugEnabled(player))
+        {
+            return;
+        }
+
+        final ICitizenData citizen = colony.getCitizenManager().getCivilian(id);
+        if (citizen == null || !citizen.getEntity().isPresent())
+        {
+            return;
+        }
+
+        if (citizen.getEntity().get() instanceof EntityCitizen entityCitizen)
+        {
+            MutableComponent message = Component.literal("Citizen AI: ").append(entityCitizen.getCitizenAI().getHistory());
+
+            if (entityCitizen.getCitizenJobHandler().getColonyJob() != null)
+            {
+                message.append(Component.literal("Job AI: ").append(entityCitizen.getCitizenJobHandler().getWorkAI().getStateAI().getHistory()));
+            }
+
+            Network.getNetwork().sendToPlayer(new DebugOutputMessage(message, true), ctxIn.getSender());
+        }
+    }
+}

--- a/src/main/java/com/minecolonies/core/entity/ai/workers/AbstractAISkeleton.java
+++ b/src/main/java/com/minecolonies/core/entity/ai/workers/AbstractAISkeleton.java
@@ -126,11 +126,7 @@ public abstract class AbstractAISkeleton<J extends IJob<?>> implements ITickingS
         worker.setRenderMetadata("");
     }
 
-    /**
-     * Get the statemachine of the AI
-     *
-     * @return statemachine
-     */
+    @Override
     public ITickRateStateMachine<IAIState> getStateAI()
     {
         return stateMachine;

--- a/src/main/java/com/minecolonies/core/entity/citizen/EntityCitizen.java
+++ b/src/main/java/com/minecolonies/core/entity/citizen/EntityCitizen.java
@@ -51,6 +51,7 @@ import com.minecolonies.core.colony.jobs.JobKnight;
 import com.minecolonies.core.colony.jobs.JobNetherWorker;
 import com.minecolonies.core.colony.jobs.JobRanger;
 import com.minecolonies.core.datalistener.DiseasesListener;
+import com.minecolonies.core.debug.DebugPlayerManager;
 import com.minecolonies.core.entity.ai.minimal.*;
 import com.minecolonies.core.entity.ai.workers.AbstractEntityAIBasic;
 import com.minecolonies.core.entity.ai.workers.CitizenAI;
@@ -395,13 +396,24 @@ public class EntityCitizen extends AbstractEntityCitizen implements IThreatTable
             final ColonyViewCitizenViewMessage message = new ColonyViewCitizenViewMessage((Colony) getCitizenData().getColony(), getCitizenData());
             Network.getNetwork().sendToPlayer(message, (ServerPlayer) player);
 
-            if (citizenData.getJob() != null)
+            if (DebugPlayerManager.hasDebugEnabled(player))
             {
-                ((AbstractEntityAIBasic) citizenData.getJob().getWorkerAI()).setDelay(TICKS_SECOND * 3);
+                getCitizenAI().setHistoryEnabled(true, 20);
+                if (getCitizenJobHandler().getColonyJob() != null)
+                {
+                    getCitizenJobHandler().getWorkAI().getStateAI().setHistoryEnabled(true, 20);
+                }
             }
+            else
+            {
+                if (citizenData.getJob() != null)
+                {
+                    ((AbstractEntityAIBasic) citizenData.getJob().getWorkerAI()).setDelay(TICKS_SECOND * 3);
+                }
 
-            getNavigation().stop();
-            getLookControl().setLookAt(player);
+                getNavigation().stop();
+                getLookControl().setLookAt(player);
+            }
         }
 
         return InteractionResult.SUCCESS;

--- a/src/main/java/com/minecolonies/core/entity/pathfinding/pathjobs/PathJobRandomPos.java
+++ b/src/main/java/com/minecolonies/core/entity/pathfinding/pathjobs/PathJobRandomPos.java
@@ -9,7 +9,6 @@ import com.minecolonies.core.entity.pathfinding.pathresults.PathResult;
 import net.minecraft.core.BlockPos;
 import net.minecraft.world.entity.Mob;
 import net.minecraft.world.level.Level;
-import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.phys.AABB;
 import org.jetbrains.annotations.NotNull;
 
@@ -163,6 +162,7 @@ public class PathJobRandomPos extends AbstractPathJob implements IDestinationPat
         this.maxDistToDest = -1;
         this.preferInside = preferInside;
         this.destination = BlockPosUtil.getRandomPosAround(start, minDistFromStart);
+        maxNodes = restrictionBox == null ? 2000 : 1000;
     }
 
     /**

--- a/src/main/java/com/minecolonies/core/entity/pathfinding/pathresults/PathResult.java
+++ b/src/main/java/com/minecolonies/core/entity/pathfinding/pathresults/PathResult.java
@@ -1,9 +1,13 @@
 package com.minecolonies.core.entity.pathfinding.pathresults;
 
 import com.minecolonies.api.util.Log;
+import com.minecolonies.core.Network;
+import com.minecolonies.core.debug.messages.DebugOutputMessage;
 import com.minecolonies.core.entity.pathfinding.PathFindingStatus;
 import com.minecolonies.core.entity.pathfinding.PathfindingUtils;
 import com.minecolonies.core.entity.pathfinding.pathjobs.AbstractPathJob;
+import net.minecraft.ChatFormatting;
+import net.minecraft.network.chat.Component;
 import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.level.pathfinder.Path;
@@ -284,7 +288,18 @@ public class PathResult<T extends AbstractPathJob>
 
             if (!watchers.isEmpty())
             {
-                Log.getLogger().info(" Finished pathjob:" + job + " reaches: " + path.canReach() + " path target:" + path.getTarget());
+                final Component debugInfo = Component.literal(" Finished pathjob:")
+                    .withStyle(ChatFormatting.GRAY)
+                    .append(Component.literal(job.toString()))
+                    .append(Component.literal(" reaches: " + path.canReach())
+                        .withStyle(path.canReach() ? ChatFormatting.GREEN : ChatFormatting.RED)
+                        .append(Component.literal(" path target:" + path.getTarget()).withStyle(ChatFormatting.BLUE)));
+                Log.getLogger().info(debugInfo.getString());
+
+                for (final ServerPlayer player : watchers)
+                {
+                    Network.getNetwork().sendToPlayer(new DebugOutputMessage(debugInfo, false), player);
+                }
             }
         }
         catch (InterruptedException | ExecutionException e)

--- a/src/main/java/com/minecolonies/core/network/NetworkChannel.java
+++ b/src/main/java/com/minecolonies/core/network/NetworkChannel.java
@@ -7,6 +7,10 @@ import com.minecolonies.api.network.IMessage;
 import com.minecolonies.api.util.Log;
 import com.minecolonies.api.util.constant.Constants;
 import com.minecolonies.core.colony.crafting.CustomRecipeManagerMessage;
+import com.minecolonies.core.debug.messages.DebugEnableMessage;
+import com.minecolonies.core.debug.messages.DebugEnablePathfindingMessage;
+import com.minecolonies.core.debug.messages.DebugOutputMessage;
+import com.minecolonies.core.debug.messages.QueryCitizenAIHistoryMessage;
 import com.minecolonies.core.network.messages.PermissionsMessage;
 import com.minecolonies.core.network.messages.client.*;
 import com.minecolonies.core.network.messages.client.colony.*;
@@ -264,6 +268,12 @@ public class NetworkChannel
 
         // Assistant block place request
         registerMessage(++idx, PlayerAssistantBuildRequestMessage.class, PlayerAssistantBuildRequestMessage::new);
+
+        // Debug messages
+        registerMessage(++idx, QueryCitizenAIHistoryMessage.class, QueryCitizenAIHistoryMessage::new);
+        registerMessage(++idx, DebugEnablePathfindingMessage.class, DebugEnablePathfindingMessage::new);
+        registerMessage(++idx, DebugOutputMessage.class, DebugOutputMessage::new);
+        registerMessage(++idx, DebugEnableMessage.class, DebugEnableMessage::new);
     }
 
     private void setupInternalMessages()

--- a/src/main/resources/assets/minecolonies/gui/citizen/debug.xml
+++ b/src/main/resources/assets/minecolonies/gui/citizen/debug.xml
@@ -1,0 +1,14 @@
+<window size="400 244"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/ldtteam/BlockUI/version/1.20.1/src/main/resources/assets/blockui/gui/block_ui.xsd">
+    <image source="minecolonies:textures/gui/builderhut/builder_paper_wide2.png" size="400 244"/>
+    <text id="citizenid" visible="true" size="70 13" pos="10 15" color="black"/>
+    <text id="colonyid" visible="true" size="70 13" pos="10 25" color="black"/>
+    <scrollgroup id="buttonlist" pos="10 45" size="155 30">
+        <button id="aihistory" size="100% 13" pos="0 0" label="query AI History"/>
+        <button id="pathfinding" size="100% 13" pos="0 0" label="enable Pathfinding tracking"/>
+    </scrollgroup>
+    <scrollgroup size="380 150" pos="10 75" visible="true">
+        <text id="output" visible="true" size="100% 10000" pos="5 5" color="black" textalign="TOP_LEFT"/>
+    </scrollgroup>
+</window>

--- a/src/main/resources/assets/minecolonies/gui/citizen/nav.xml
+++ b/src/main/resources/assets/minecolonies/gui/citizen/nav.xml
@@ -29,5 +29,10 @@
     <button id="jobIcon" size="20 20" pos="5 173" visible="false"
                  source="minecolonies:textures/gui/modules/main.png"/>
 
+    <button id="debugTab" size="32 26" pos="0 196" visible="false"
+            source="minecolonies:textures/gui/modules/tab_side3.png"/>
+    <button id="debugIcon" size="20 20" pos="5 199" visible="false"
+            source="minecolonies:textures/gui/modules/settings.png"/>
+
     <image source="minecolonies:textures/gui/citizen/colonist_paper.png" size="190 244" pos="20 0"/>
 </window>

--- a/src/main/resources/assets/minecolonies/lang/manual_en_us.json
+++ b/src/main/resources/assets/minecolonies/lang/manual_en_us.json
@@ -2958,5 +2958,7 @@
   "com.minecolonies.core.gui.connectionevent.disconnected": "§6Severed Ties with your Colony!",
   "com.minecolonies.core.item.sign.connected": "Successfully connected sign %s to %s",
   "com.minecolonies.core.item.sign.disrupted": "Connection to Sign at %s disrupted",
-  "com.minecolonies.core.colonyconnection.path.failure": "Couldn't Path from %s to %s"
+  "com.minecolonies.core.colonyconnection.path.failure": "Couldn't Path from %s to %s",
+
+  "com.minecolonies.coremod.debug.gui.tabicon": "Debugging Options"
 }


### PR DESCRIPTION
# Changes proposed in this pull request
Introduces a new debug feature:
- All AI can now enable a history of state changes, allowing for much easier debugging of AI transitions.
- AI History is by default enabled in dev env
- There is now a new manager for handling player's debug mode, which can be enabled/disabled for a player via the new command /mc toggleDebugging <name>
- Debug mode also allows accessing a newly added debug screen on the citizens, which has buttons for showing the server AI history and allows to toggle pathfinding tracking directly on the citizen.

<img width="435" height="692" alt="image" src="https://github.com/user-attachments/assets/5b80ae23-91a1-40c3-82ac-1e19443546e9" />
<img width="1085" height="553" alt="image" src="https://github.com/user-attachments/assets/3d1f32c3-1f17-4e6e-908c-53d7d4484829" />
<img width="1108" height="466" alt="image" src="https://github.com/user-attachments/assets/a0404270-7109-463d-a00f-5fe2fb289809" />


## Testing
- [ x] Yes I tested this before submitting it.
- [x ] I also did a multiplayer test.

Review please