### PR TITLE
Make construction tape not being able to catch on fire

### DIFF
--- a/src/main/java/com/minecolonies/core/blocks/decorative/BlockConstructionTape.java
+++ b/src/main/java/com/minecolonies/core/blocks/decorative/BlockConstructionTape.java
@@ -49,7 +49,6 @@ public class BlockConstructionTape extends AbstractBlockMinecoloniesConstruction
                 .sound(SoundType.WOOD)
                 .replaceable()
                 .pushReaction(PushReaction.DESTROY)
-                .ignitedByLava()
                 .isRedstoneConductor((state, getter, pos) -> false)
                 .forceSolidOff()
                 .strength(0.0f).noCollission().noLootTable());


### PR DESCRIPTION
Closes #10115 

# Changes proposed in this pull request
- Remove the "ignited by lava" or "flammable" option entirely

## Testing
- [ ] Yes I tested this before submitting it.
- [ ] I also did a multiplayer test.

Review please