### PR TITLE
Tavern wasn't spawning anything but gold and iron tier visitors

### DIFF
--- a/src/main/java/com/minecolonies/core/datalistener/RecruitmentItemsListener.java
+++ b/src/main/java/com/minecolonies/core/datalistener/RecruitmentItemsListener.java
@@ -5,9 +5,7 @@ import com.google.gson.GsonBuilder;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import com.minecolonies.api.util.Log;
-import com.minecolonies.api.util.MathUtils;
 import com.minecolonies.api.util.constant.ColonyConstants;
-import com.minecolonies.api.util.constant.Constants;
 import net.minecraft.core.registries.BuiltInRegistries;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.server.packs.resources.ResourceManager;
@@ -92,17 +90,7 @@ public class RecruitmentItemsListener extends SimpleJsonResourceReloadListener
     @Nullable
     public static RecruitCost getRandomRecruitCost(final int buildingLevel)
     {
-        // Number between 1-9
-        final int limit = 3 * buildingLevel + 1;
-        int rarity = (int) MathUtils.RANDOM.nextGaussian(limit/2.0,0.5);
-        if (rarity <= 0)
-        {
-            rarity = 1;
-        }
-        else if (rarity >= limit)
-        {
-            rarity = limit - 1;
-        }
+        final int rarity = ColonyConstants.rand.nextInt(1, 3 * buildingLevel + 1);
         final List<RecruitCost> recruitCostsAtTier = RECRUIT_COSTS.get(rarity);
         return recruitCostsAtTier.get(ColonyConstants.rand.nextInt(recruitCostsAtTier.size()));
     }


### PR DESCRIPTION
Closes [discord report](https://discord.com/channels/139070364159311872/1284909613401247785/1405481982686658581)

# Changes proposed in this pull request
- In the previous method, let's say we had a max tavern, limit is 10. The gaussian method was incapable of ever providing a good enough random. What happened is you have a mean of 5, a deviation of 0.5, so you can only get numbers between 4.5 and 5.5. This means that at max level, every visitor is either gold or iron boots. Diamond and netherite are simply impossible.
- New situation uses the same limit as before, but uses a regular nextInt call to grab a random rarity between 1-9, this way we're back to the old situation where any rarity between 1-[limit] is possible at any level of the tavern, so you get more variety.

## Testing
- [ ] Yes I tested this before submitting it.
- [ ] I also did a multiplayer test.

Review please