### PR TITLE
Fix nether miner not going on expeditions [1.21]

### DIFF
--- a/src/main/java/com/minecolonies/core/colony/buildings/workerbuildings/BuildingNetherWorker.java
+++ b/src/main/java/com/minecolonies/core/colony/buildings/workerbuildings/BuildingNetherWorker.java
@@ -14,9 +14,7 @@ import com.minecolonies.core.colony.buildings.modules.MinimumStockModule;
 import com.minecolonies.core.colony.buildings.modules.settings.BoolSetting;
 import com.minecolonies.core.colony.buildings.modules.settings.SettingKey;
 import net.minecraft.core.BlockPos;
-import net.minecraft.core.Holder;
 import net.minecraft.core.HolderLookup;
-import net.minecraft.core.registries.BuiltInRegistries;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.util.Tuple;
@@ -251,6 +249,16 @@ public class BuildingNetherWorker extends AbstractBuilding
             return portalLocation.above();
         }
         return null;
+    }
+
+    /**
+     * Get the tagged location where the worker can hide while "away" in the nether
+     *
+     * @return the tagged location, null if not available.
+     */
+    public BlockPos getVaultLocation()
+    {
+        return getFirstLocationFromTag("vault");
     }
 
     /**

--- a/src/main/java/com/minecolonies/core/colony/buildings/workerbuildings/BuildingNetherWorker.java
+++ b/src/main/java/com/minecolonies/core/colony/buildings/workerbuildings/BuildingNetherWorker.java
@@ -14,7 +14,9 @@ import com.minecolonies.core.colony.buildings.modules.MinimumStockModule;
 import com.minecolonies.core.colony.buildings.modules.settings.BoolSetting;
 import com.minecolonies.core.colony.buildings.modules.settings.SettingKey;
 import net.minecraft.core.BlockPos;
+import net.minecraft.core.Holder;
 import net.minecraft.core.HolderLookup;
+import net.minecraft.core.registries.BuiltInRegistries;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.util.Tuple;
@@ -249,16 +251,6 @@ public class BuildingNetherWorker extends AbstractBuilding
             return portalLocation.above();
         }
         return null;
-    }
-
-    /**
-     * Get the tagged location where the worker can hide while "away" in the nether
-     *
-     * @return the tagged location, null if not available.
-     */
-    public BlockPos getVaultLocation()
-    {
-        return getFirstLocationFromTag("vault");
     }
 
     /**

--- a/src/main/java/com/minecolonies/core/entity/ai/workers/production/EntityAIWorkNether.java
+++ b/src/main/java/com/minecolonies/core/entity/ai/workers/production/EntityAIWorkNether.java
@@ -19,23 +19,21 @@ import com.minecolonies.api.equipment.ModEquipmentTypes;
 import com.minecolonies.api.equipment.registry.EquipmentTypeEntry;
 import com.minecolonies.api.items.component.AdventureData;
 import com.minecolonies.api.util.*;
-import com.minecolonies.core.MineColonies;
 import com.minecolonies.core.colony.buildings.modules.ExpeditionLogModule;
 import com.minecolonies.core.colony.buildings.modules.expedition.ExpeditionLog;
 import com.minecolonies.core.colony.buildings.workerbuildings.BuildingNetherWorker;
 import com.minecolonies.core.colony.jobs.JobNetherWorker;
 import com.minecolonies.core.entity.ai.workers.crafting.AbstractEntityAICrafting;
 import com.minecolonies.core.items.ItemAdventureToken;
+import com.minecolonies.core.util.TeleportHelper;
 import com.minecolonies.core.util.citizenutils.CitizenItemUtils;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
 import net.minecraft.network.chat.Component;
 import net.minecraft.server.level.ServerLevel;
-import net.minecraft.nbt.CompoundTag;
 import net.minecraft.sounds.SoundEvents;
 import net.minecraft.util.RandomSource;
 import net.minecraft.world.damagesource.DamageSource;
-import net.minecraft.world.entity.Entity;
 import net.minecraft.world.entity.EntityType;
 import net.minecraft.world.entity.EquipmentSlot;
 import net.minecraft.world.entity.LivingEntity;
@@ -47,6 +45,8 @@ import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.portal.PortalShape;
 import net.minecraft.world.level.storage.loot.LootParams;
 import net.minecraft.world.level.storage.loot.LootTable;
+import net.minecraft.world.scores.Objective;
+import net.minecraft.world.scores.criteria.ObjectiveCriteria;
 import net.neoforged.neoforge.common.ItemAbilities;
 import net.neoforged.neoforge.items.IItemHandler;
 import org.jetbrains.annotations.NotNull;
@@ -62,7 +62,6 @@ import static com.minecolonies.api.research.util.ResearchConstants.SATLIMIT;
 import static com.minecolonies.api.util.constant.CitizenConstants.*;
 import static com.minecolonies.api.util.constant.EquipmentLevelConstants.*;
 import static com.minecolonies.api.util.constant.GuardConstants.*;
-import static com.minecolonies.api.util.constant.NbtTagConstants.*;
 import static com.minecolonies.api.util.constant.StatisticsConstants.ITEMS_DISCOVERED;
 import static com.minecolonies.api.util.constant.StatisticsConstants.TRIPS_COMPLETED;
 import static com.minecolonies.api.util.constant.StatisticsConstants.MINER_DEATHS;
@@ -76,6 +75,16 @@ public class EntityAIWorkNether extends AbstractEntityAICrafting<JobNetherWorker
      * Delay for each of the crafting operations.
      */
     private static final int TICK_DELAY = 40;
+
+    /**
+     * Objective to use to pass the hut level to the loottable
+     */
+    private static final String OBJECTIVE_HUT_LEVEL = "HutLevel";
+
+    /**
+     * Objective to use to pass the worker's secondary skill level to the loottable
+     */
+    private static final String OBJECTIVE_SECONDARY_SKILL = "SecSkillLevel";
 
     /**
      * Multiplier for damage reduction.
@@ -151,6 +160,12 @@ public class EntityAIWorkNether extends AbstractEntityAICrafting<JobNetherWorker
     }
 
     @Override
+    public boolean hasWorkToDo()
+    {
+        return super.hasWorkToDo() || building.isReadyForTrip();
+    }
+
+    @Override
     public Class<BuildingNetherWorker> getExpectedBuildingClass()
     {
         return BuildingNetherWorker.class;
@@ -171,33 +186,50 @@ public class EntityAIWorkNether extends AbstractEntityAICrafting<JobNetherWorker
     private void goToVault()
     {
         worker.playSound(SoundEvents.PORTAL_TRIGGER, worker.getRandom().nextFloat() * 0.5F + 0.25F, 0.25F);
-        worker.getCitizenData().getColony().getTravellingManager().startTravellingTo(
-            worker.getCitizenData(),
-            building.getPortalLocation(),
-            job.getCraftedResults().size() * 20 //One second of travelling time per item, task or adventure that we complete, maybe parameterize in the config.
-        );
+        worker.setInvisible(true);
+        worker.setSilent(true);
+        BlockPos vaultPos = building.getVaultLocation();
+        if (vaultPos != null)
+        {
+            TeleportHelper.teleportCitizen(worker, world, vaultPos);
+        }
+    }
 
-        worker.remove(Entity.RemovalReason.DISCARDED);
+    private void returnFromVault(final boolean force)
+    {
+        BlockPos vaultPos = building.getVaultLocation();
+        BlockPos portalPos = building.getPortalLocation();
+        if (portalPos != null && vaultPos != null && EntityUtils.isLivingAtSite(worker, vaultPos.getX(), vaultPos.getY(), vaultPos.getZ(), 2))
+        {
+            TeleportHelper.teleportCitizen(worker, world, portalPos);
+            worker.setSilent(false);
+            worker.playSound(SoundEvents.PORTAL_TRIGGER, worker.getRandom().nextFloat() * 0.5F + 0.25F, 0.25F);
+
+            if (!force)
+            {
+                return;
+            }
+        }
+        worker.setInvisible(false);
+        worker.setSilent(false);
     }
 
     @Override
     protected IAIState decide()
     {
-        //Check if we are traveling, we don't spawn an entity if we are traveling.
-        if (worker.getCitizenData().getColony().getTravellingManager().isTravelling(worker.getCitizenData()) || job.isInNether())
+        if (job.isInNether())
         {
+            if (!worker.isInvisible())
+            {
+                goToVault();
+            }
             return NETHER_AWAY;
         }
 
-        //Now check if travelling finished.
-        final Optional<BlockPos> travelingTarget = worker.getCitizenData().getColony().getTravellingManager().getTravellingTargetFor(worker.getCitizenData());
-        if (travelingTarget.isPresent())
+        if (worker.isInvisible())
         {
-            worker.getCitizenData().setNextRespawnPosition(EntityUtils.getSpawnPoint(job.getColony().getWorld(), travelingTarget.get()));
-            worker.getCitizenData().updateEntityIfNecessary();
+            returnFromVault(true);
         }
-
-        job.setInNether(false);
 
         IAIState crafterState = super.decide();
 
@@ -329,6 +361,23 @@ public class EntityAIWorkNether extends AbstractEntityAICrafting<JobNetherWorker
             return IDLE;
         }
 
+        // Set up Objectives and scores.
+        if (world.getScoreboard().getObjective(OBJECTIVE_HUT_LEVEL) == null)
+        {
+            world.getScoreboard().addObjective(OBJECTIVE_HUT_LEVEL, ObjectiveCriteria.DUMMY, Component.literal("Worker Building Level"), ObjectiveCriteria.RenderType.INTEGER, false, null);
+        }
+        if (world.getScoreboard().getObjective(OBJECTIVE_SECONDARY_SKILL) == null)
+        {
+            world.getScoreboard()
+              .addObjective(OBJECTIVE_SECONDARY_SKILL, ObjectiveCriteria.DUMMY, Component.literal("Worker Secondary Skill Level"), ObjectiveCriteria.RenderType.INTEGER, false, null);
+        }
+        final Objective hutLevelObjective = world.getScoreboard().getObjective(OBJECTIVE_HUT_LEVEL);
+        final Objective secondarySkillLevelObjective = world.getScoreboard().getObjective(OBJECTIVE_SECONDARY_SKILL);
+
+        world.getScoreboard().getOrCreatePlayerScore(worker, hutLevelObjective).set(building.getBuildingLevel());
+        world.getScoreboard().getOrCreatePlayerScore(worker, secondarySkillLevelObjective).set(getSecondarySkillLevel());
+
+
         final ExpeditionLog expeditionLog = building.getFirstModuleOccurance(ExpeditionLogModule.class).getLog();
         expeditionLog.reset();
         expeditionLog.setStatus(ExpeditionLog.Status.STARTING);
@@ -345,6 +394,7 @@ public class EntityAIWorkNether extends AbstractEntityAICrafting<JobNetherWorker
                 {
                     return getState();
                 }
+                goToVault();
                 building.recordTrip();
                 job.setInNether(true);
 
@@ -375,187 +425,202 @@ public class EntityAIWorkNether extends AbstractEntityAICrafting<JobNetherWorker
      */
     protected IAIState stayInNether()
     {
+        if (building.getVaultLocation() == null)
+        {
+            //Ensure we stay put in the portal
+            final BlockPos portal = building.getPortalLocation();
+            if (portal != null && !walkToWorkPos(portal))
+            {
+                return getState();
+            }
+            if (!worker.isInvisible())
+            {
+                worker.setInvisible(true);
+            }
+        }
+
         final ExpeditionLog expeditionLog = building.getFirstModuleOccurance(ExpeditionLogModule.class).getLog();
 
         //This is the adventure loop. 
         if (!job.getCraftedResults().isEmpty())
         {
-            for (ItemStack currStack : job.getCraftedResults())
+            ItemStack currStack = job.getCraftedResults().poll();
+            if (currStack.getItem() instanceof ItemAdventureToken)
             {
-                if (currStack.getItem() instanceof ItemAdventureToken)
+                final @Nullable AdventureData component = AdventureData.readFromItemStack(currStack);
+                if (component != null)
                 {
-                    final @Nullable AdventureData component = AdventureData.readFromItemStack(currStack);
-                    if (component != null)
                     {
+                        equipArmor(true);
+                        worker.setItemSlot(EquipmentSlot.MAINHAND, findTool(ModEquipmentTypes.sword.get()));
+
+                        DamageSource source = world.damageSources().source(DamageSourceKeys.NETHER);
+
+                        //Set up the mob to do battle with
+                        EntityType<?> mobType = component.entityType();
+                        LivingEntity mob = (LivingEntity) mobType.create(world);
+                        float mobHealth = mob.getHealth();
+
+                        // Calculate how much damage the mob will do if it lands a hit (Before armor)
+                        float incomingDamage = component.damage();
+                        incomingDamage -= incomingDamage * (getSecondarySkillLevel() * SECONDARY_DAMAGE_REDUCTION);
+
+                        for (int hit = 0; mobHealth > 0 && !worker.isDeadOrDying(); hit++)
                         {
-                            equipArmor(true);
-                            worker.setItemSlot(EquipmentSlot.MAINHAND, findTool(ModEquipmentTypes.sword.get()));
+                            // Clear anti-hurt timers.
+                            worker.hurtTime = 0;
+                            worker.invulnerableTime = 0;
+                            float damageToDo = BASE_PHYSICAL_DAMAGE;
 
-                            DamageSource source = world.damageSources().source(DamageSourceKeys.NETHER);
+                            // Figure out who gets to hit who this round
+                            boolean doDamage = worker.getRandom().nextBoolean();
+                            boolean takeDamage = worker.getRandom().nextBoolean();
 
-                            //Set up the mob to do battle with
-                            EntityType<?> mobType = component.entityType();
-                            LivingEntity mob = (LivingEntity) mobType.create(world);
-                            float mobHealth = mob.getHealth();
-
-                            // Calculate how much damage the mob will do if it lands a hit (Before armor)
-                            float incomingDamage = component.damage();
-                            incomingDamage -= incomingDamage * (getSecondarySkillLevel() * SECONDARY_DAMAGE_REDUCTION);
-
-                            for (int hit = 0; mobHealth > 0 && !worker.isDeadOrDying(); hit++)
+                            // Calculate if the sword still exists, how much damage will be done to the mob
+                            final ItemStack sword = worker.getItemBySlot(EquipmentSlot.MAINHAND);
+                            if (!sword.isEmpty())
                             {
-                                // Clear anti-hurt timers.
-                                worker.hurtTime = 0;
-                                worker.invulnerableTime = 0;
-                                float damageToDo = BASE_PHYSICAL_DAMAGE;
-
-                                // Figure out who gets to hit who this round
-                                boolean doDamage = worker.getRandom().nextBoolean();
-                                boolean takeDamage = worker.getRandom().nextBoolean();
-
-                                // Calculate if the sword still exists, how much damage will be done to the mob
-                                final ItemStack sword = worker.getItemBySlot(EquipmentSlot.MAINHAND);
-                                if (!sword.isEmpty())
+                                if (sword.getItem() instanceof SwordItem swordItem)
                                 {
-                                    if (sword.getItem() instanceof SwordItem swordItem)
-                                    {
-                                        damageToDo += swordItem.getDamage(sword);
-                                    }
-                                    else
-                                    {
-                                        damageToDo += TinkersToolHelper.getDamage(sword);
-                                    }
-
-                                    damageToDo += EnchantmentHelper.modifyDamage((ServerLevel) worker.level(), sword, mob, worker.level().damageSources().source(DamageSourceKeys.DEFAULT, worker), 1f) / 2.5f;
-                                    if (doDamage)
-                                    {
-                                        sword.hurtAndBreak(1, (ServerLevel) worker.level(), worker, item -> {
-                                            // the sword broke; try to find another sword
-                                            worker.setItemSlot(EquipmentSlot.MAINHAND, findTool(ModEquipmentTypes.sword.get()));
-                                        });
-                                    }
-                                }
-
-                                // Hit the mob
-                                if (doDamage)
-                                {
-                                    mobHealth -= damageToDo;
-                                }
-
-                                // Get hit by the mob
-                                if (takeDamage && !worker.hurt(source, incomingDamage))
-                                {
-                                    //Shouldn't get here, but if we do we can force the damage.
-                                    incomingDamage = worker.calculateDamageAfterAbsorbs(source, incomingDamage);
-                                    worker.setHealth(worker.getHealth() - incomingDamage);
-                                }
-
-                                // Every other round, heal up if possible, to compensate for all of this happening in a single tick.
-                                if (hit % 2 == 0)
-                                {
-                                    float healAmount = checkHeal(worker);
-                                    final float saturationFactor = 0.25f;
-                                    if (healAmount > 0)
-                                    {
-                                        worker.heal(healAmount);
-                                        worker.getCitizenData().decreaseSaturation(healAmount * saturationFactor);
-                                    }
+                                    damageToDo += swordItem.getDamage(sword);
                                 }
                                 else
                                 {
-                                    if (worker.getCitizenData().getSaturation() < AVERAGE_SATURATION)
-                                    {
-                                        attemptToEat();
-                                    }
+                                    damageToDo += TinkersToolHelper.getDamage(sword);
+                                }
+
+                                damageToDo += EnchantmentHelper.modifyDamage((ServerLevel) worker.level(),
+                                    sword,
+                                    mob,
+                                    worker.level().damageSources().source(DamageSourceKeys.DEFAULT, worker),
+                                    1f) / 2.5f;
+                                if (doDamage)
+                                {
+                                    sword.hurtAndBreak(1, (ServerLevel) worker.level(), worker, item -> {
+                                        // the sword broke; try to find another sword
+                                        worker.setItemSlot(EquipmentSlot.MAINHAND, findTool(ModEquipmentTypes.sword.get()));
+                                    });
                                 }
                             }
 
-                            expeditionLog.setCitizen(worker);
-                            logAllEquipment(expeditionLog, true);
-
-                            if (worker.isDeadOrDying())
+                            // Hit the mob
+                            if (doDamage)
                             {
-                                expeditionLog.setKilled();
-                                
-                                StatsUtil.trackStat(building, MINER_DEATHS, 1);
+                                mobHealth -= damageToDo;
+                            }
 
-                                // Stop processing loot table data, as the worker died before finishing the trip.
-                                InventoryUtils.clearItemHandler(worker.getItemHandlerCitizen());
-                                job.getCraftedResults().clear();
-                                job.getProcessedResults().clear();
-                                return IDLE;
+                            // Get hit by the mob
+                            if (takeDamage && !worker.hurt(source, incomingDamage))
+                            {
+                                //Shouldn't get here, but if we do we can force the damage.
+                                incomingDamage = worker.calculateDamageAfterAbsorbs(source, incomingDamage);
+                                worker.setHealth(worker.getHealth() - incomingDamage);
+                            }
+
+                            // Every other round, heal up if possible, to compensate for all of this happening in a single tick.
+                            if (hit % 2 == 0)
+                            {
+                                float healAmount = checkHeal(worker);
+                                final float saturationFactor = 0.25f;
+                                if (healAmount > 0)
+                                {
+                                    worker.heal(healAmount);
+                                    worker.getCitizenData().decreaseSaturation(healAmount * saturationFactor);
+                                }
                             }
                             else
                             {
-                                // Generate loot for this mob, with all the right modifiers
-                                LootParams context = this.getLootContext();
-                                LootTable loot = world.getServer().reloadableRegistries().getLootTable(mob.getLootTable());
-                                List<ItemStack> mobLoot = loot.getRandomItems(context);
-                                job.addProcessedResultsList(mobLoot);
-
-                                expeditionLog.addMob(mobType);
-                                expeditionLog.addLoot(mobLoot);
+                                if (worker.getCitizenData().getSaturation() < AVERAGE_SATURATION)
+                                {
+                                    attemptToEat();
+                                }
                             }
-
-                            worker.setItemSlot(EquipmentSlot.MAINHAND, ItemStack.EMPTY);
-                            equipArmor(false);
                         }
 
-                        worker.getCitizenExperienceHandler().addExperience(CitizenItemUtils.applyMending(worker, component.xp()));
-                    }
-                }
-                else if (!currStack.isEmpty())
-                {
-                    int itemDelay = 0;
-                    if (currStack.getItem() instanceof BlockItem bi)
-                    {
-                        final Block block = bi.getBlock();
+                        expeditionLog.setCitizen(worker);
+                        logAllEquipment(expeditionLog, true);
 
-                        ItemStack tool = findTool(block.defaultBlockState(), worker.blockPosition());
-                        if (tool.getItem() instanceof TieredItem)
+                        if (worker.isDeadOrDying())
                         {
-                            worker.setItemSlot(EquipmentSlot.MAINHAND, tool);
+                            expeditionLog.setKilled();
 
-                            for (int i = 0; i < currStack.getCount() && !tool.isEmpty(); i++)
-                            {
-                                LootParams context = this.getLootContext();
-                                LootTable loot = world.getServer().reloadableRegistries().getLootTable(block.getLootTable());
-                                List<ItemStack> mobLoot = loot.getRandomItems(context);
+                            StatsUtil.trackStat(building, MINER_DEATHS, 1);
 
-                                job.addProcessedResultsList(mobLoot);
-                                expeditionLog.addLoot(mobLoot);
-                                tool.hurtAndBreak(1, (ServerLevel) worker.level(), worker, item -> {});
-                                if (tool.isEmpty())
-                                {
-                                    // it's unlikely the worker will have a spare tool (mobs probably don't drop any), but
-                                    // just in case, let's not be silly and ignore it if we do have one
-                                    tool = findTool(block.defaultBlockState(), worker.blockPosition());
-                                    worker.setItemSlot(EquipmentSlot.MAINHAND, tool);
-                                }
-                                worker.getCitizenExperienceHandler().addExperience(CitizenItemUtils.applyMending(worker, xpOnDrop(block)));
-
-                                itemDelay += TICK_DELAY;
-                            }
-
-                            worker.setItemSlot(EquipmentSlot.MAINHAND, ItemStack.EMPTY);
-                            logAllEquipment(expeditionLog, false);
+                            // Stop processing loot table data, as the worker died before finishing the trip.
+                            InventoryUtils.clearItemHandler(worker.getItemHandlerCitizen());
+                            job.getCraftedResults().clear();
+                            job.getProcessedResults().clear();
+                            return IDLE;
                         }
                         else
                         {
-                            //we didn't have a tool to use.
-                            itemDelay = TICK_DELAY;
+                            // Generate loot for this mob, with all the right modifiers
+                            LootParams context = this.getLootContext();
+                            LootTable loot = world.getServer().reloadableRegistries().getLootTable(mob.getLootTable());
+                            List<ItemStack> mobLoot = loot.getRandomItems(context);
+                            job.addProcessedResultsList(mobLoot);
+
+                            expeditionLog.addMob(mobType);
+                            expeditionLog.addLoot(mobLoot);
                         }
+
+                        worker.setItemSlot(EquipmentSlot.MAINHAND, ItemStack.EMPTY);
+                        equipArmor(false);
+                    }
+
+                    worker.getCitizenExperienceHandler().addExperience(CitizenItemUtils.applyMending(worker, component.xp()));
+                }
+            }
+            else if (!currStack.isEmpty())
+            {
+                int itemDelay = 0;
+                if (currStack.getItem() instanceof BlockItem bi)
+                {
+                    final Block block = bi.getBlock();
+
+                    ItemStack tool = findTool(block.defaultBlockState(), worker.blockPosition());
+                    if (tool.getItem() instanceof TieredItem)
+                    {
+                        worker.setItemSlot(EquipmentSlot.MAINHAND, tool);
+
+                        for (int i = 0; i < currStack.getCount() && !tool.isEmpty(); i++)
+                        {
+                            LootParams context = this.getLootContext();
+                            LootTable loot = world.getServer().reloadableRegistries().getLootTable(block.getLootTable());
+                            List<ItemStack> mobLoot = loot.getRandomItems(context);
+
+                            job.addProcessedResultsList(mobLoot);
+                            expeditionLog.addLoot(mobLoot);
+                            tool.hurtAndBreak(1, (ServerLevel) worker.level(), worker, item -> {});
+                            if (tool.isEmpty())
+                            {
+                                // it's unlikely the worker will have a spare tool (mobs probably don't drop any), but
+                                // just in case, let's not be silly and ignore it if we do have one
+                                tool = findTool(block.defaultBlockState(), worker.blockPosition());
+                                worker.setItemSlot(EquipmentSlot.MAINHAND, tool);
+                            }
+                            worker.getCitizenExperienceHandler().addExperience(CitizenItemUtils.applyMending(worker, xpOnDrop(block)));
+
+                            itemDelay += TICK_DELAY;
+                        }
+
+                        worker.setItemSlot(EquipmentSlot.MAINHAND, ItemStack.EMPTY);
+                        logAllEquipment(expeditionLog, false);
                     }
                     else
                     {
-                        job.addProcessedResultsList(ImmutableList.of(currStack));
-                        expeditionLog.addLoot(Collections.singletonList(currStack));
-                        itemDelay = TICK_DELAY * currStack.getCount();
+                        //we didn't have a tool to use.
+                        itemDelay = TICK_DELAY;
                     }
-                    setDelay(itemDelay);
                 }
+                else
+                {
+                    job.addProcessedResultsList(ImmutableList.of(currStack));
+                    expeditionLog.addLoot(Collections.singletonList(currStack));
+                    itemDelay = TICK_DELAY * currStack.getCount();
+                }
+                setDelay(itemDelay);
             }
-            job.getCraftedResults().clear();
             return getState();
         }
 
@@ -564,17 +629,15 @@ public class EntityAIWorkNether extends AbstractEntityAICrafting<JobNetherWorker
             if (!worker.isDeadOrDying())
             {
                 expeditionLog.setStatus(ExpeditionLog.Status.RETURNING_HOME);
-                for (ItemStack item : job.getProcessedResults())
+                ItemStack item = job.getProcessedResults().poll();
+                if (InventoryUtils.addItemStackToItemHandler(worker.getItemHandlerCitizen(), item))
+
                 {
-                    if (InventoryUtils.addItemStackToItemHandler(worker.getItemHandlerCitizen(), item))
-                    {
-                        worker.decreaseSaturationForContinuousAction();
-                        worker.getCitizenExperienceHandler().addExperience(0.2);
-                        StatsUtil.trackStatByName(building, ITEMS_DISCOVERED, item.getHoverName(), item.getCount());
-                    }
+                    worker.decreaseSaturationForContinuousAction();
+                    worker.getCitizenExperienceHandler().addExperience(0.2);
+                    StatsUtil.trackStatByName(building, ITEMS_DISCOVERED, item.getHoverName(), item.getCount());
                 }
 
-                job.getProcessedResults().clear();
                 return getState();
             }
             else
@@ -624,6 +687,13 @@ public class EntityAIWorkNether extends AbstractEntityAICrafting<JobNetherWorker
      */
     protected IAIState returnFromNether()
     {
+        if (worker.isInvisible())
+        {
+            // we deliberately let this loop twice to give the worker time to teleport before becoming visible again
+            returnFromVault(false);
+            return getState();
+        }
+
         //Shutdown Portal
         if (building.shallClosePortalOnReturn() && world.getBlockState(building.getPortalLocation()).is(Blocks.NETHER_PORTAL))
         {

--- a/src/main/java/com/minecolonies/core/entity/ai/workers/production/EntityAIWorkNether.java
+++ b/src/main/java/com/minecolonies/core/entity/ai/workers/production/EntityAIWorkNether.java
@@ -19,21 +19,23 @@ import com.minecolonies.api.equipment.ModEquipmentTypes;
 import com.minecolonies.api.equipment.registry.EquipmentTypeEntry;
 import com.minecolonies.api.items.component.AdventureData;
 import com.minecolonies.api.util.*;
+import com.minecolonies.core.MineColonies;
 import com.minecolonies.core.colony.buildings.modules.ExpeditionLogModule;
 import com.minecolonies.core.colony.buildings.modules.expedition.ExpeditionLog;
 import com.minecolonies.core.colony.buildings.workerbuildings.BuildingNetherWorker;
 import com.minecolonies.core.colony.jobs.JobNetherWorker;
 import com.minecolonies.core.entity.ai.workers.crafting.AbstractEntityAICrafting;
 import com.minecolonies.core.items.ItemAdventureToken;
-import com.minecolonies.core.util.TeleportHelper;
 import com.minecolonies.core.util.citizenutils.CitizenItemUtils;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
 import net.minecraft.network.chat.Component;
 import net.minecraft.server.level.ServerLevel;
+import net.minecraft.nbt.CompoundTag;
 import net.minecraft.sounds.SoundEvents;
 import net.minecraft.util.RandomSource;
 import net.minecraft.world.damagesource.DamageSource;
+import net.minecraft.world.entity.Entity;
 import net.minecraft.world.entity.EntityType;
 import net.minecraft.world.entity.EquipmentSlot;
 import net.minecraft.world.entity.LivingEntity;
@@ -45,8 +47,6 @@ import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.portal.PortalShape;
 import net.minecraft.world.level.storage.loot.LootParams;
 import net.minecraft.world.level.storage.loot.LootTable;
-import net.minecraft.world.scores.Objective;
-import net.minecraft.world.scores.criteria.ObjectiveCriteria;
 import net.neoforged.neoforge.common.ItemAbilities;
 import net.neoforged.neoforge.items.IItemHandler;
 import org.jetbrains.annotations.NotNull;
@@ -62,6 +62,7 @@ import static com.minecolonies.api.research.util.ResearchConstants.SATLIMIT;
 import static com.minecolonies.api.util.constant.CitizenConstants.*;
 import static com.minecolonies.api.util.constant.EquipmentLevelConstants.*;
 import static com.minecolonies.api.util.constant.GuardConstants.*;
+import static com.minecolonies.api.util.constant.NbtTagConstants.*;
 import static com.minecolonies.api.util.constant.StatisticsConstants.ITEMS_DISCOVERED;
 import static com.minecolonies.api.util.constant.StatisticsConstants.TRIPS_COMPLETED;
 import static com.minecolonies.api.util.constant.StatisticsConstants.MINER_DEATHS;
@@ -75,16 +76,6 @@ public class EntityAIWorkNether extends AbstractEntityAICrafting<JobNetherWorker
      * Delay for each of the crafting operations.
      */
     private static final int TICK_DELAY = 40;
-
-    /**
-     * Objective to use to pass the hut level to the loottable
-     */
-    private static final String OBJECTIVE_HUT_LEVEL = "HutLevel";
-
-    /**
-     * Objective to use to pass the worker's secondary skill level to the loottable
-     */
-    private static final String OBJECTIVE_SECONDARY_SKILL = "SecSkillLevel";
 
     /**
      * Multiplier for damage reduction.
@@ -186,50 +177,33 @@ public class EntityAIWorkNether extends AbstractEntityAICrafting<JobNetherWorker
     private void goToVault()
     {
         worker.playSound(SoundEvents.PORTAL_TRIGGER, worker.getRandom().nextFloat() * 0.5F + 0.25F, 0.25F);
-        worker.setInvisible(true);
-        worker.setSilent(true);
-        BlockPos vaultPos = building.getVaultLocation();
-        if (vaultPos != null)
-        {
-            TeleportHelper.teleportCitizen(worker, world, vaultPos);
-        }
-    }
+        worker.getCitizenData().getColony().getTravellingManager().startTravellingTo(
+            worker.getCitizenData(),
+            building.getPortalLocation(),
+            job.getCraftedResults().size() * 400 //Twenty seconds of travelling time per item, task or adventure that we complete, maybe parameterize in the config.
+        );
 
-    private void returnFromVault(final boolean force)
-    {
-        BlockPos vaultPos = building.getVaultLocation();
-        BlockPos portalPos = building.getPortalLocation();
-        if (portalPos != null && vaultPos != null && EntityUtils.isLivingAtSite(worker, vaultPos.getX(), vaultPos.getY(), vaultPos.getZ(), 2))
-        {
-            TeleportHelper.teleportCitizen(worker, world, portalPos);
-            worker.setSilent(false);
-            worker.playSound(SoundEvents.PORTAL_TRIGGER, worker.getRandom().nextFloat() * 0.5F + 0.25F, 0.25F);
-
-            if (!force)
-            {
-                return;
-            }
-        }
-        worker.setInvisible(false);
-        worker.setSilent(false);
+        worker.remove(Entity.RemovalReason.DISCARDED);
     }
 
     @Override
     protected IAIState decide()
     {
-        if (job.isInNether())
+        //Check if we are traveling, we don't spawn an entity if we are traveling.
+        if (worker.getCitizenData().getColony().getTravellingManager().isTravelling(worker.getCitizenData()) || job.isInNether())
         {
-            if (!worker.isInvisible())
-            {
-                goToVault();
-            }
             return NETHER_AWAY;
         }
 
-        if (worker.isInvisible())
+        //Now check if travelling finished.
+        final Optional<BlockPos> travelingTarget = worker.getCitizenData().getColony().getTravellingManager().getTravellingTargetFor(worker.getCitizenData());
+        if (travelingTarget.isPresent())
         {
-            returnFromVault(true);
+            worker.getCitizenData().setNextRespawnPosition(EntityUtils.getSpawnPoint(job.getColony().getWorld(), travelingTarget.get()));
+            worker.getCitizenData().updateEntityIfNecessary();
         }
+
+        job.setInNether(false);
 
         IAIState crafterState = super.decide();
 
@@ -361,23 +335,6 @@ public class EntityAIWorkNether extends AbstractEntityAICrafting<JobNetherWorker
             return IDLE;
         }
 
-        // Set up Objectives and scores.
-        if (world.getScoreboard().getObjective(OBJECTIVE_HUT_LEVEL) == null)
-        {
-            world.getScoreboard().addObjective(OBJECTIVE_HUT_LEVEL, ObjectiveCriteria.DUMMY, Component.literal("Worker Building Level"), ObjectiveCriteria.RenderType.INTEGER, false, null);
-        }
-        if (world.getScoreboard().getObjective(OBJECTIVE_SECONDARY_SKILL) == null)
-        {
-            world.getScoreboard()
-              .addObjective(OBJECTIVE_SECONDARY_SKILL, ObjectiveCriteria.DUMMY, Component.literal("Worker Secondary Skill Level"), ObjectiveCriteria.RenderType.INTEGER, false, null);
-        }
-        final Objective hutLevelObjective = world.getScoreboard().getObjective(OBJECTIVE_HUT_LEVEL);
-        final Objective secondarySkillLevelObjective = world.getScoreboard().getObjective(OBJECTIVE_SECONDARY_SKILL);
-
-        world.getScoreboard().getOrCreatePlayerScore(worker, hutLevelObjective).set(building.getBuildingLevel());
-        world.getScoreboard().getOrCreatePlayerScore(worker, secondarySkillLevelObjective).set(getSecondarySkillLevel());
-
-
         final ExpeditionLog expeditionLog = building.getFirstModuleOccurance(ExpeditionLogModule.class).getLog();
         expeditionLog.reset();
         expeditionLog.setStatus(ExpeditionLog.Status.STARTING);
@@ -394,7 +351,6 @@ public class EntityAIWorkNether extends AbstractEntityAICrafting<JobNetherWorker
                 {
                     return getState();
                 }
-                goToVault();
                 building.recordTrip();
                 job.setInNether(true);
 
@@ -410,6 +366,7 @@ public class EntityAIWorkNether extends AbstractEntityAICrafting<JobNetherWorker
                     job.addCraftedResultsList(result);
                 }
 
+                goToVault();
                 worker.getCitizenData().setJobStatus(JobStatus.WORKING);
                 return NETHER_AWAY;
             }
@@ -424,202 +381,187 @@ public class EntityAIWorkNether extends AbstractEntityAICrafting<JobNetherWorker
      */
     protected IAIState stayInNether()
     {
-        if (building.getVaultLocation() == null)
-        {
-            //Ensure we stay put in the portal
-            final BlockPos portal = building.getPortalLocation();
-            if (portal != null && !walkToWorkPos(portal))
-            {
-                return getState();
-            }
-            if (!worker.isInvisible())
-            {
-                worker.setInvisible(true);
-            }
-        }
-
         final ExpeditionLog expeditionLog = building.getFirstModuleOccurance(ExpeditionLogModule.class).getLog();
 
         //This is the adventure loop. 
         if (!job.getCraftedResults().isEmpty())
         {
-            ItemStack currStack = job.getCraftedResults().poll();
-            if (currStack.getItem() instanceof ItemAdventureToken)
+            for (ItemStack currStack : job.getCraftedResults())
             {
-                final @Nullable AdventureData component = AdventureData.readFromItemStack(currStack);
-                if (component != null)
+                if (currStack.getItem() instanceof ItemAdventureToken)
                 {
+                    final @Nullable AdventureData component = AdventureData.readFromItemStack(currStack);
+                    if (component != null)
                     {
-                        equipArmor(true);
-                        worker.setItemSlot(EquipmentSlot.MAINHAND, findTool(ModEquipmentTypes.sword.get()));
-
-                        DamageSource source = world.damageSources().source(DamageSourceKeys.NETHER);
-
-                        //Set up the mob to do battle with
-                        EntityType<?> mobType = component.entityType();
-                        LivingEntity mob = (LivingEntity) mobType.create(world);
-                        float mobHealth = mob.getHealth();
-
-                        // Calculate how much damage the mob will do if it lands a hit (Before armor)
-                        float incomingDamage = component.damage();
-                        incomingDamage -= incomingDamage * (getSecondarySkillLevel() * SECONDARY_DAMAGE_REDUCTION);
-
-                        for (int hit = 0; mobHealth > 0 && !worker.isDeadOrDying(); hit++)
                         {
-                            // Clear anti-hurt timers.
-                            worker.hurtTime = 0;
-                            worker.invulnerableTime = 0;
-                            float damageToDo = BASE_PHYSICAL_DAMAGE;
+                            equipArmor(true);
+                            worker.setItemSlot(EquipmentSlot.MAINHAND, findTool(ModEquipmentTypes.sword.get()));
 
-                            // Figure out who gets to hit who this round
-                            boolean doDamage = worker.getRandom().nextBoolean();
-                            boolean takeDamage = worker.getRandom().nextBoolean();
+                            DamageSource source = world.damageSources().source(DamageSourceKeys.NETHER);
 
-                            // Calculate if the sword still exists, how much damage will be done to the mob
-                            final ItemStack sword = worker.getItemBySlot(EquipmentSlot.MAINHAND);
-                            if (!sword.isEmpty())
+                            //Set up the mob to do battle with
+                            EntityType<?> mobType = component.entityType();
+                            LivingEntity mob = (LivingEntity) mobType.create(world);
+                            float mobHealth = mob.getHealth();
+
+                            // Calculate how much damage the mob will do if it lands a hit (Before armor)
+                            float incomingDamage = component.damage();
+                            incomingDamage -= incomingDamage * (getSecondarySkillLevel() * SECONDARY_DAMAGE_REDUCTION);
+
+                            for (int hit = 0; mobHealth > 0 && !worker.isDeadOrDying(); hit++)
                             {
-                                if (sword.getItem() instanceof SwordItem swordItem)
+                                // Clear anti-hurt timers.
+                                worker.hurtTime = 0;
+                                worker.invulnerableTime = 0;
+                                float damageToDo = BASE_PHYSICAL_DAMAGE;
+
+                                // Figure out who gets to hit who this round
+                                boolean doDamage = worker.getRandom().nextBoolean();
+                                boolean takeDamage = worker.getRandom().nextBoolean();
+
+                                // Calculate if the sword still exists, how much damage will be done to the mob
+                                final ItemStack sword = worker.getItemBySlot(EquipmentSlot.MAINHAND);
+                                if (!sword.isEmpty())
                                 {
-                                    damageToDo += swordItem.getDamage(sword);
+                                    if (sword.getItem() instanceof SwordItem swordItem)
+                                    {
+                                        damageToDo += swordItem.getDamage(sword);
+                                    }
+                                    else
+                                    {
+                                        damageToDo += TinkersToolHelper.getDamage(sword);
+                                    }
+
+                                    damageToDo += EnchantmentHelper.modifyDamage((ServerLevel) worker.level(), sword, mob, worker.level().damageSources().source(DamageSourceKeys.DEFAULT, worker), 1f) / 2.5f;
+                                    if (doDamage)
+                                    {
+                                        sword.hurtAndBreak(1, (ServerLevel) worker.level(), worker, item -> {
+                                            // the sword broke; try to find another sword
+                                            worker.setItemSlot(EquipmentSlot.MAINHAND, findTool(ModEquipmentTypes.sword.get()));
+                                        });
+                                    }
+                                }
+
+                                // Hit the mob
+                                if (doDamage)
+                                {
+                                    mobHealth -= damageToDo;
+                                }
+
+                                // Get hit by the mob
+                                if (takeDamage && !worker.hurt(source, incomingDamage))
+                                {
+                                    //Shouldn't get here, but if we do we can force the damage.
+                                    incomingDamage = worker.calculateDamageAfterAbsorbs(source, incomingDamage);
+                                    worker.setHealth(worker.getHealth() - incomingDamage);
+                                }
+
+                                // Every other round, heal up if possible, to compensate for all of this happening in a single tick.
+                                if (hit % 2 == 0)
+                                {
+                                    float healAmount = checkHeal(worker);
+                                    final float saturationFactor = 0.25f;
+                                    if (healAmount > 0)
+                                    {
+                                        worker.heal(healAmount);
+                                        worker.getCitizenData().decreaseSaturation(healAmount * saturationFactor);
+                                    }
                                 }
                                 else
                                 {
-                                    damageToDo += TinkersToolHelper.getDamage(sword);
-                                }
-
-                                damageToDo += EnchantmentHelper.modifyDamage((ServerLevel) worker.level(),
-                                    sword,
-                                    mob,
-                                    worker.level().damageSources().source(DamageSourceKeys.DEFAULT, worker),
-                                    1f) / 2.5f;
-                                if (doDamage)
-                                {
-                                    sword.hurtAndBreak(1, (ServerLevel) worker.level(), worker, item -> {
-                                        // the sword broke; try to find another sword
-                                        worker.setItemSlot(EquipmentSlot.MAINHAND, findTool(ModEquipmentTypes.sword.get()));
-                                    });
+                                    if (worker.getCitizenData().getSaturation() < AVERAGE_SATURATION)
+                                    {
+                                        attemptToEat();
+                                    }
                                 }
                             }
 
-                            // Hit the mob
-                            if (doDamage)
-                            {
-                                mobHealth -= damageToDo;
-                            }
+                            expeditionLog.setCitizen(worker);
+                            logAllEquipment(expeditionLog, true);
 
-                            // Get hit by the mob
-                            if (takeDamage && !worker.hurt(source, incomingDamage))
+                            if (worker.isDeadOrDying())
                             {
-                                //Shouldn't get here, but if we do we can force the damage.
-                                incomingDamage = worker.calculateDamageAfterAbsorbs(source, incomingDamage);
-                                worker.setHealth(worker.getHealth() - incomingDamage);
-                            }
+                                expeditionLog.setKilled();
+                                
+                                StatsUtil.trackStat(building, MINER_DEATHS, 1);
 
-                            // Every other round, heal up if possible, to compensate for all of this happening in a single tick.
-                            if (hit % 2 == 0)
-                            {
-                                float healAmount = checkHeal(worker);
-                                final float saturationFactor = 0.25f;
-                                if (healAmount > 0)
-                                {
-                                    worker.heal(healAmount);
-                                    worker.getCitizenData().decreaseSaturation(healAmount * saturationFactor);
-                                }
+                                // Stop processing loot table data, as the worker died before finishing the trip.
+                                InventoryUtils.clearItemHandler(worker.getItemHandlerCitizen());
+                                job.getCraftedResults().clear();
+                                job.getProcessedResults().clear();
+                                return IDLE;
                             }
                             else
                             {
-                                if (worker.getCitizenData().getSaturation() < AVERAGE_SATURATION)
-                                {
-                                    attemptToEat();
-                                }
+                                // Generate loot for this mob, with all the right modifiers
+                                LootParams context = this.getLootContext();
+                                LootTable loot = world.getServer().reloadableRegistries().getLootTable(mob.getLootTable());
+                                List<ItemStack> mobLoot = loot.getRandomItems(context);
+                                job.addProcessedResultsList(mobLoot);
+
+                                expeditionLog.addMob(mobType);
+                                expeditionLog.addLoot(mobLoot);
                             }
+
+                            worker.setItemSlot(EquipmentSlot.MAINHAND, ItemStack.EMPTY);
+                            equipArmor(false);
                         }
 
-                        expeditionLog.setCitizen(worker);
-                        logAllEquipment(expeditionLog, true);
+                        worker.getCitizenExperienceHandler().addExperience(CitizenItemUtils.applyMending(worker, component.xp()));
+                    }
+                }
+                else if (!currStack.isEmpty())
+                {
+                    int itemDelay = 0;
+                    if (currStack.getItem() instanceof BlockItem bi)
+                    {
+                        final Block block = bi.getBlock();
 
-                        if (worker.isDeadOrDying())
+                        ItemStack tool = findTool(block.defaultBlockState(), worker.blockPosition());
+                        if (tool.getItem() instanceof TieredItem)
                         {
-                            expeditionLog.setKilled();
+                            worker.setItemSlot(EquipmentSlot.MAINHAND, tool);
 
-                            StatsUtil.trackStat(building, MINER_DEATHS, 1);
+                            for (int i = 0; i < currStack.getCount() && !tool.isEmpty(); i++)
+                            {
+                                LootParams context = this.getLootContext();
+                                LootTable loot = world.getServer().reloadableRegistries().getLootTable(block.getLootTable());
+                                List<ItemStack> mobLoot = loot.getRandomItems(context);
 
-                            // Stop processing loot table data, as the worker died before finishing the trip.
-                            InventoryUtils.clearItemHandler(worker.getItemHandlerCitizen());
-                            job.getCraftedResults().clear();
-                            job.getProcessedResults().clear();
-                            return IDLE;
+                                job.addProcessedResultsList(mobLoot);
+                                expeditionLog.addLoot(mobLoot);
+                                tool.hurtAndBreak(1, (ServerLevel) worker.level(), worker, item -> {});
+                                if (tool.isEmpty())
+                                {
+                                    // it's unlikely the worker will have a spare tool (mobs probably don't drop any), but
+                                    // just in case, let's not be silly and ignore it if we do have one
+                                    tool = findTool(block.defaultBlockState(), worker.blockPosition());
+                                    worker.setItemSlot(EquipmentSlot.MAINHAND, tool);
+                                }
+                                worker.getCitizenExperienceHandler().addExperience(CitizenItemUtils.applyMending(worker, xpOnDrop(block)));
+
+                                itemDelay += TICK_DELAY;
+                            }
+
+                            worker.setItemSlot(EquipmentSlot.MAINHAND, ItemStack.EMPTY);
+                            logAllEquipment(expeditionLog, false);
                         }
                         else
                         {
-                            // Generate loot for this mob, with all the right modifiers
-                            LootParams context = this.getLootContext();
-                            LootTable loot = world.getServer().reloadableRegistries().getLootTable(mob.getLootTable());
-                            List<ItemStack> mobLoot = loot.getRandomItems(context);
-                            job.addProcessedResultsList(mobLoot);
-
-                            expeditionLog.addMob(mobType);
-                            expeditionLog.addLoot(mobLoot);
+                            //we didn't have a tool to use.
+                            itemDelay = TICK_DELAY;
                         }
-
-                        worker.setItemSlot(EquipmentSlot.MAINHAND, ItemStack.EMPTY);
-                        equipArmor(false);
-                    }
-
-                    worker.getCitizenExperienceHandler().addExperience(CitizenItemUtils.applyMending(worker, component.xp()));
-                }
-            }
-            else if (!currStack.isEmpty())
-            {
-                int itemDelay = 0;
-                if (currStack.getItem() instanceof BlockItem bi)
-                {
-                    final Block block = bi.getBlock();
-
-                    ItemStack tool = findTool(block.defaultBlockState(), worker.blockPosition());
-                    if (tool.getItem() instanceof TieredItem)
-                    {
-                        worker.setItemSlot(EquipmentSlot.MAINHAND, tool);
-
-                        for (int i = 0; i < currStack.getCount() && !tool.isEmpty(); i++)
-                        {
-                            LootParams context = this.getLootContext();
-                            LootTable loot = world.getServer().reloadableRegistries().getLootTable(block.getLootTable());
-                            List<ItemStack> mobLoot = loot.getRandomItems(context);
-
-                            job.addProcessedResultsList(mobLoot);
-                            expeditionLog.addLoot(mobLoot);
-                            tool.hurtAndBreak(1, (ServerLevel) worker.level(), worker, item -> {});
-                            if (tool.isEmpty())
-                            {
-                                // it's unlikely the worker will have a spare tool (mobs probably don't drop any), but
-                                // just in case, let's not be silly and ignore it if we do have one
-                                tool = findTool(block.defaultBlockState(), worker.blockPosition());
-                                worker.setItemSlot(EquipmentSlot.MAINHAND, tool);
-                            }
-                            worker.getCitizenExperienceHandler().addExperience(CitizenItemUtils.applyMending(worker, xpOnDrop(block)));
-
-                            itemDelay += TICK_DELAY;
-                        }
-
-                        worker.setItemSlot(EquipmentSlot.MAINHAND, ItemStack.EMPTY);
-                        logAllEquipment(expeditionLog, false);
                     }
                     else
                     {
-                        //we didn't have a tool to use.
-                        itemDelay = TICK_DELAY;
+                        job.addProcessedResultsList(ImmutableList.of(currStack));
+                        expeditionLog.addLoot(Collections.singletonList(currStack));
+                        itemDelay = TICK_DELAY * currStack.getCount();
                     }
+                    setDelay(itemDelay);
                 }
-                else
-                {
-                    job.addProcessedResultsList(ImmutableList.of(currStack));
-                    expeditionLog.addLoot(Collections.singletonList(currStack));
-                    itemDelay = TICK_DELAY * currStack.getCount();
-                }
-                setDelay(itemDelay);
             }
+            job.getCraftedResults().clear();
             return getState();
         }
 
@@ -628,15 +570,17 @@ public class EntityAIWorkNether extends AbstractEntityAICrafting<JobNetherWorker
             if (!worker.isDeadOrDying())
             {
                 expeditionLog.setStatus(ExpeditionLog.Status.RETURNING_HOME);
-                ItemStack item = job.getProcessedResults().poll();
-                if (InventoryUtils.addItemStackToItemHandler(worker.getItemHandlerCitizen(), item))
-
+                for (ItemStack item : job.getProcessedResults())
                 {
-                    worker.decreaseSaturationForContinuousAction();
-                    worker.getCitizenExperienceHandler().addExperience(0.2);
-                    StatsUtil.trackStatByName(building, ITEMS_DISCOVERED, item.getHoverName(), item.getCount());
+                    if (InventoryUtils.addItemStackToItemHandler(worker.getItemHandlerCitizen(), item))
+                    {
+                        worker.decreaseSaturationForContinuousAction();
+                        worker.getCitizenExperienceHandler().addExperience(0.2);
+                        StatsUtil.trackStatByName(building, ITEMS_DISCOVERED, item.getHoverName(), item.getCount());
+                    }
                 }
 
+                job.getProcessedResults().clear();
                 return getState();
             }
             else
@@ -686,13 +630,6 @@ public class EntityAIWorkNether extends AbstractEntityAICrafting<JobNetherWorker
      */
     protected IAIState returnFromNether()
     {
-        if (worker.isInvisible())
-        {
-            // we deliberately let this loop twice to give the worker time to teleport before becoming visible again
-            returnFromVault(false);
-            return getState();
-        }
-
         //Shutdown Portal
         if (building.shallClosePortalOnReturn() && world.getBlockState(building.getPortalLocation()).is(Blocks.NETHER_PORTAL))
         {

--- a/src/main/java/com/minecolonies/core/entity/ai/workers/production/EntityAIWorkNether.java
+++ b/src/main/java/com/minecolonies/core/entity/ai/workers/production/EntityAIWorkNether.java
@@ -410,7 +410,6 @@ public class EntityAIWorkNether extends AbstractEntityAICrafting<JobNetherWorker
                     job.addCraftedResultsList(result);
                 }
 
-                goToVault();
                 worker.getCitizenData().setJobStatus(JobStatus.WORKING);
                 return NETHER_AWAY;
             }


### PR DESCRIPTION
Closes #11111

# Changes proposed in this pull request
- Leisure system updates caused nether miner not to go on expeditions anymore
- ~~Nether miner was completely broken after the traveling manager changes, reverted for now until we can properly implement an event based system similar to colony expeditions~~
- Increased the traveling time to twenty seconds per item to make sure that the expeditions still take plenty of time, as before

## Testing
- [X] Yes I tested this before submitting it.
- [ ] I also did a multiplayer test.

Review please