### PR TITLE
Smart colony id command arguments

### DIFF
--- a/src/main/java/com/minecolonies/api/colony/IColonyManager.java
+++ b/src/main/java/com/minecolonies/api/colony/IColonyManager.java
@@ -158,6 +158,15 @@ public interface IColonyManager
     IBuildingView getBuildingView(final ResourceKey<Level> dimension, BlockPos pos);
 
     /**
+     * Get all colonies in this world.  (Side neutral; on clients it returns the subset of views known to the player.)
+     *
+     * @param w World.
+     * @return a list of colonies.
+     */
+    @NotNull
+    List<IColony> getIColonies(@NotNull Level w);
+
+    /**
      * Side neutral method to get colony. On clients it returns the view. On servers it returns the colony itself.
      *
      * @param w   World.
@@ -166,6 +175,15 @@ public interface IColonyManager
      */
     @Nullable
     IColony getIColony(@NotNull Level w, @NotNull BlockPos pos);
+
+    /**
+     * Get all colony views in this world known to the current player.
+     *
+     * @param w World.
+     * @return a list of colony views.
+     */
+    @NotNull
+    List<IColonyView> getColonyViews(@NotNull Level w);
 
     /**
      * Gets the colony view aat the given position

--- a/src/main/java/com/minecolonies/core/MineColonies.java
+++ b/src/main/java/com/minecolonies/core/MineColonies.java
@@ -31,6 +31,7 @@ import com.minecolonies.core.blocks.huts.BlockHutGateHouse;
 import com.minecolonies.core.colony.IColonyManagerCapability;
 import com.minecolonies.core.colony.requestsystem.init.RequestSystemInitializer;
 import com.minecolonies.core.colony.requestsystem.init.StandardFactoryControllerInitializer;
+import com.minecolonies.core.commands.arguments.ModArgumentTypes;
 import com.minecolonies.core.entity.mobs.EntityMercenary;
 import com.minecolonies.core.event.*;
 import com.minecolonies.core.loot.SupplyLoot;
@@ -103,6 +104,7 @@ public class MineColonies
         ModLootConditions.DEFERRED_REGISTER.register(FMLJavaModLoadingContext.get().getModEventBus());
         SupplyLoot.GLM.register(FMLJavaModLoadingContext.get().getModEventBus());
         ModBannerPatterns.BANNER_PATTERNS.register(FMLJavaModLoadingContext.get().getModEventBus());
+        ModArgumentTypes.ARGUMENT_TYPES.register(FMLJavaModLoadingContext.get().getModEventBus());
 
         ModQuestInitializer.DEFERRED_REGISTER_OBJECTIVE.register(FMLJavaModLoadingContext.get().getModEventBus());
         ModQuestInitializer.DEFERRED_REGISTER_TRIGGER.register(FMLJavaModLoadingContext.get().getModEventBus());

--- a/src/main/java/com/minecolonies/core/colony/ColonyManager.java
+++ b/src/main/java/com/minecolonies/core/colony/ColonyManager.java
@@ -327,22 +327,13 @@ public final class ColonyManager implements IColonyManager
     @NotNull
     public List<IColony> getColonies(@NotNull final Level w)
     {
-        if (w.isClientSide())
+        final IColonyManagerCapability cap = w.getCapability(COLONY_MANAGER_CAP, null).resolve().orElse(null);
+        if (cap == null)
         {
-            // this might be a subset of colonies since it's only those known to the player right now
-            final ColonyList<IColonyView> colonies = colonyViews.get(w.dimension());
-            return colonies == null ? List.of() : new ArrayList<>(colonies.getCopyAsList());
+            Log.getLogger().warn(MISSING_WORLD_CAP_MESSAGE);
+            return Collections.emptyList();
         }
-        else
-        {
-            final IColonyManagerCapability cap = w.getCapability(COLONY_MANAGER_CAP, null).resolve().orElse(null);
-            if (cap == null)
-            {
-                Log.getLogger().warn(MISSING_WORLD_CAP_MESSAGE);
-                return Collections.emptyList();
-            }
-            return cap.getColonies();
-        }
+        return cap.getColonies();
     }
 
     @Override
@@ -393,6 +384,13 @@ public final class ColonyManager implements IColonyManager
     }
 
     @Override
+    @NotNull
+    public List<IColony> getIColonies(@NotNull final Level w)
+    {
+        return w.isClientSide() ? new ArrayList<>(getColonyViews(w)) : getColonies(w);
+    }
+
+    @Override
     @Nullable
     public IColony getIColony(@NotNull final Level w, @NotNull final BlockPos pos)
     {
@@ -403,6 +401,15 @@ public final class ColonyManager implements IColonyManager
     public void openReactivationWindow(final BlockPos pos)
     {
         new WindowReactivateBuilding(pos).open();
+    }
+
+    @Override
+    @NotNull
+    public List<IColonyView> getColonyViews(@NotNull final Level w)
+    {
+        // this might be a subset of colonies since it's only those known to the player right now
+        final ColonyList<IColonyView> colonies = colonyViews.get(w.dimension());
+        return colonies == null ? List.of() : new ArrayList<>(colonies.getCopyAsList());
     }
 
     /**

--- a/src/main/java/com/minecolonies/core/colony/ColonyManager.java
+++ b/src/main/java/com/minecolonies/core/colony/ColonyManager.java
@@ -327,13 +327,22 @@ public final class ColonyManager implements IColonyManager
     @NotNull
     public List<IColony> getColonies(@NotNull final Level w)
     {
-        final IColonyManagerCapability cap = w.getCapability(COLONY_MANAGER_CAP, null).resolve().orElse(null);
-        if (cap == null)
+        if (w.isClientSide())
         {
-            Log.getLogger().warn(MISSING_WORLD_CAP_MESSAGE);
-            return Collections.emptyList();
+            // this might be a subset of colonies since it's only those known to the player right now
+            final ColonyList<IColonyView> colonies = colonyViews.get(w.dimension());
+            return colonies == null ? List.of() : new ArrayList<>(colonies.getCopyAsList());
         }
-        return cap.getColonies();
+        else
+        {
+            final IColonyManagerCapability cap = w.getCapability(COLONY_MANAGER_CAP, null).resolve().orElse(null);
+            if (cap == null)
+            {
+                Log.getLogger().warn(MISSING_WORLD_CAP_MESSAGE);
+                return Collections.emptyList();
+            }
+            return cap.getColonies();
+        }
     }
 
     @Override

--- a/src/main/java/com/minecolonies/core/commands/arguments/ColonyIdArgument.java
+++ b/src/main/java/com/minecolonies/core/commands/arguments/ColonyIdArgument.java
@@ -186,7 +186,7 @@ public class ColonyIdArgument implements ArgumentType<ColonyIdArgument.Result>
     {
         if (context.getSource() instanceof final CommandSourceStack source)
         {
-            for (final IColony colony : IColonyManager.getInstance().getColonies(source.getLevel()))
+            for (final IColony colony : IColonyManager.getInstance().getIColonies(source.getLevel()))
             {
                 suggestions.add(String.valueOf(colony.getID()));
             }
@@ -204,7 +204,7 @@ public class ColonyIdArgument implements ArgumentType<ColonyIdArgument.Result>
         {
             if (source instanceof ClientSuggestionProvider)
             {
-                for (final IColony colony : IColonyManager.getInstance().getColonies(Minecraft.getInstance().level))
+                for (final IColony colony : IColonyManager.getInstance().getIColonies(Minecraft.getInstance().level))
                 {
                     suggestions.add(String.valueOf(colony.getID()));
                 }

--- a/src/main/java/com/minecolonies/core/commands/arguments/ColonyIdArgument.java
+++ b/src/main/java/com/minecolonies/core/commands/arguments/ColonyIdArgument.java
@@ -1,0 +1,231 @@
+package com.minecolonies.core.commands.arguments;
+
+import com.minecolonies.api.colony.IColony;
+import com.minecolonies.api.colony.IColonyManager;
+import com.mojang.authlib.GameProfile;
+import com.mojang.brigadier.Message;
+import com.mojang.brigadier.StringReader;
+import com.mojang.brigadier.arguments.ArgumentType;
+import com.mojang.brigadier.context.CommandContext;
+import com.mojang.brigadier.exceptions.CommandSyntaxException;
+import com.mojang.brigadier.exceptions.SimpleCommandExceptionType;
+import com.mojang.brigadier.suggestion.Suggestions;
+import com.mojang.brigadier.suggestion.SuggestionsBuilder;
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.multiplayer.ClientSuggestionProvider;
+import net.minecraft.commands.CommandRuntimeException;
+import net.minecraft.commands.CommandSourceStack;
+import net.minecraft.commands.SharedSuggestionProvider;
+import net.minecraft.commands.arguments.selector.EntitySelectorParser;
+import net.minecraft.core.BlockPos;
+import net.minecraft.network.chat.Component;
+import net.minecraft.network.chat.ComponentUtils;
+import net.minecraftforge.api.distmarker.Dist;
+import net.minecraftforge.fml.DistExecutor;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.*;
+import java.util.concurrent.CompletableFuture;
+import java.util.function.Function;
+
+/**
+ * A command argument that can dynamically resolve to a colony id.
+ */
+public class ColonyIdArgument implements ArgumentType<ColonyIdArgument.Result>
+{
+    private static final String                     HERE                 = "@here";
+    private static final String                     MINE                 = "@mine";
+    private static final Collection<String>         EXAMPLES             = List.of("1", HERE, MINE, "Player", "dd12be42-52a9-4a91-a8a1-11c01849e498");
+    private static final SimpleCommandExceptionType ERROR_UNKNOWN_PLAYER = new SimpleCommandExceptionType(Component.translatable("argument.player.unknown"));
+    private static final SimpleCommandExceptionType ERROR_UNKNOWN_COLONY = new SimpleCommandExceptionType(Component.translatable("com.minecolonies.command.argument.colony.unknown"));
+
+    private static final Map<String, Message>       TOOLTIPS             = Map.of(
+        HERE, Component.translatable("com.minecolonies.command.argument.colony.here"),
+        MINE, Component.translatable("com.minecolonies.command.argument.colony.mine")
+    );
+
+    /**
+     * Create a placeholder for a {@link ColonyIdArgument} when defining a command.
+     */
+    public static ColonyIdArgument id()
+    {
+        return new ColonyIdArgument();
+    }
+
+    /**
+     * Resolve the actual argument value into a colony id.
+     * @param context the command context.
+     * @param name    the argument name.
+     * @return the colony id.
+     * @throws CommandRuntimeException if a colony id cannot be parsed from the given argument (this is already reported back).
+     */
+    public static int getColonyId(@NotNull final CommandContext<CommandSourceStack> context, @NotNull final String name)
+    {
+        try
+        {
+            return context.getArgument(name, ColonyIdArgument.Result.class).resolve(context.getSource());
+        }
+        catch (CommandSyntaxException e)
+        {
+            final Component message = ComponentUtils.fromMessage(e.getRawMessage());
+            context.getSource().sendFailure(message);
+            throw new CommandRuntimeException(message);
+        }
+    }
+
+    @Override
+    public ColonyIdArgument.Result parse(final StringReader reader) throws CommandSyntaxException
+    {
+        int i = reader.getCursor();
+
+        if (reader.canRead() && reader.peek() == '@')
+        {
+            reader.skip();
+            final String selector = "@" + reader.readUnquotedString();
+
+            if (selector.equals(HERE))
+            {
+                return ColonyIdArgument::resolveHere;
+            }
+            else if (selector.equals(MINE))
+            {
+                return ColonyIdArgument::resolveMine;
+            }
+
+            reader.setCursor(i + 1);
+            throw EntitySelectorParser.ERROR_UNKNOWN_SELECTOR_TYPE.createWithContext(reader, selector);
+        }
+        else if (reader.canRead())
+        {
+            try
+            {
+                final int id = reader.readInt();
+                if (id < 1)
+                {
+                    throw CommandSyntaxException.BUILT_IN_EXCEPTIONS.integerTooLow().createWithContext(reader, id, 1);
+                }
+                return source -> id;
+            }
+            catch (CommandSyntaxException e)
+            {
+                reader.setCursor(i);
+            }
+
+            final String name = reader.readString();
+            try
+            {
+                final UUID id = UUID.fromString(name);
+                return source -> resolveTheirs(source, id);
+            }
+            catch (IllegalArgumentException e)
+            {
+                if (name.isEmpty() || name.length() > 16)
+                {
+                    reader.setCursor(i);
+                    throw EntitySelectorParser.ERROR_INVALID_NAME_OR_UUID.createWithContext(reader);
+                }
+
+                return source -> resolveTheirs(source, name);
+            }
+        }
+
+        throw EntitySelectorParser.ERROR_INVALID_NAME_OR_UUID.createWithContext(reader);
+    }
+
+    @Override
+    public Collection<String> getExamples()
+    {
+        return EXAMPLES;
+    }
+
+    @Override
+    public <S> CompletableFuture<Suggestions> listSuggestions(final CommandContext<S> context, final SuggestionsBuilder builder)
+    {
+        if (context.getSource() instanceof final SharedSuggestionProvider provider)
+        {
+            final List<String> suggestions = new ArrayList<>();
+            suggestions.add(HERE);
+            suggestions.add(MINE);
+
+            suggestColonyIds(context, suggestions);
+            suggestions.addAll(provider.getOnlinePlayerNames());
+
+            return SharedSuggestionProvider.suggest(suggestions, builder, Function.identity(), TOOLTIPS::get);
+        }
+        else
+        {
+            return Suggestions.empty();
+        }
+    }
+
+    private static <S> void suggestColonyIds(final CommandContext<S> context, final List<String> suggestions)
+    {
+        if (context.getSource() instanceof final CommandSourceStack source)
+        {
+            for (final IColony colony : IColonyManager.getInstance().getColonies(source.getLevel()))
+            {
+                suggestions.add(String.valueOf(colony.getID()));
+            }
+        }
+        else
+        {
+            // this is safe but Forge still gets upset with safeRun
+            DistExecutor.unsafeRunWhenOn(Dist.CLIENT, () -> () -> ClientOnly.suggestColonyIds(context.getSource(), suggestions));
+        }
+    }
+
+    private static class ClientOnly
+    {
+        public static <S> void suggestColonyIds(final S source, final List<String> suggestions)
+        {
+            if (source instanceof ClientSuggestionProvider)
+            {
+                for (final IColony colony : IColonyManager.getInstance().getColonies(Minecraft.getInstance().level))
+                {
+                    suggestions.add(String.valueOf(colony.getID()));
+                }
+            }
+        }
+    }
+
+    private static int resolveHere(@NotNull final CommandSourceStack source) throws CommandSyntaxException
+    {
+        final IColony colony = IColonyManager.getInstance().getIColony(source.getLevel(), BlockPos.containing(source.getPosition()));
+        if (colony == null)
+        {
+            throw ERROR_UNKNOWN_COLONY.create();
+        }
+        return colony.getID();
+    }
+
+    private static int resolveMine(@NotNull final CommandSourceStack source) throws CommandSyntaxException
+    {
+        return resolveTheirs(source, source.getPlayerOrException().getGameProfile().getId());
+    }
+
+    private static int resolveTheirs(@NotNull final CommandSourceStack source, @NotNull final String name) throws CommandSyntaxException
+    {
+        final Optional<GameProfile> profile = source.getServer().getProfileCache().get(name);
+        if (profile.isPresent())
+        {
+            return resolveTheirs(source, profile.get().getId());
+        }
+        throw ERROR_UNKNOWN_PLAYER.create();
+    }
+
+    private static int resolveTheirs(@NotNull final CommandSourceStack source, @NotNull final UUID id) throws CommandSyntaxException
+    {
+        final IColony colony = IColonyManager.getInstance().getIColonyByOwner(source.getLevel(), id);
+        if (colony == null)
+        {
+            throw ERROR_UNKNOWN_COLONY.create();
+        }
+        return colony.getID();
+    }
+
+    @FunctionalInterface
+    public interface Result
+    {
+        int resolve(CommandSourceStack source) throws CommandSyntaxException;
+    }
+}

--- a/src/main/java/com/minecolonies/core/commands/arguments/ColonyIdArgument.java
+++ b/src/main/java/com/minecolonies/core/commands/arguments/ColonyIdArgument.java
@@ -2,6 +2,7 @@ package com.minecolonies.core.commands.arguments;
 
 import com.minecolonies.api.colony.IColony;
 import com.minecolonies.api.colony.IColonyManager;
+import com.minecolonies.api.util.constant.translation.CommandTranslationConstants;
 import com.mojang.authlib.GameProfile;
 import com.mojang.brigadier.Message;
 import com.mojang.brigadier.StringReader;
@@ -71,6 +72,29 @@ public class ColonyIdArgument implements ArgumentType<ColonyIdArgument.Result>
             context.getSource().sendFailure(message);
             throw new CommandRuntimeException(message);
         }
+    }
+
+    /**
+     * Resolve the actual argument value into a colony.
+     * @param context the command context.
+     * @param name    the argument name.
+     * @return the colony.
+     * @throws CommandRuntimeException if a colony id cannot be parsed from the given argument (this is already reported back).
+     */
+    @NotNull
+    public static IColony getColony(@NotNull final CommandContext<CommandSourceStack> context, @NotNull final String name)
+    {
+        final int colonyId = getColonyId(context, name);
+
+        final IColony colony = IColonyManager.getInstance().getColonyByWorld(colonyId, context.getSource().getLevel());
+        if (colony == null)
+        {
+            final Component message = Component.translatable(CommandTranslationConstants.COMMAND_COLONY_ID_NOT_FOUND, colonyId);
+            context.getSource().sendFailure(message);
+            throw new CommandRuntimeException(message);
+        }
+
+        return colony;
     }
 
     @Override

--- a/src/main/java/com/minecolonies/core/commands/arguments/ModArgumentTypes.java
+++ b/src/main/java/com/minecolonies/core/commands/arguments/ModArgumentTypes.java
@@ -1,0 +1,22 @@
+package com.minecolonies.core.commands.arguments;
+
+import net.minecraft.commands.synchronization.ArgumentTypeInfo;
+import net.minecraft.commands.synchronization.ArgumentTypeInfos;
+import net.minecraft.commands.synchronization.SingletonArgumentInfo;
+import net.minecraft.core.registries.Registries;
+import net.minecraftforge.registries.DeferredRegister;
+import net.minecraftforge.registries.RegistryObject;
+
+import static com.minecolonies.api.util.constant.Constants.MOD_ID;
+
+/**
+ * This class handles registration for custom argument types.
+ */
+public class ModArgumentTypes
+{
+    public static final DeferredRegister<ArgumentTypeInfo<?, ?>> ARGUMENT_TYPES = DeferredRegister.create(Registries.COMMAND_ARGUMENT_TYPE, MOD_ID);
+
+    public static final RegistryObject<SingletonArgumentInfo<ColonyIdArgument>> COLONY_ID =
+            ARGUMENT_TYPES.register("colony_id", () -> ArgumentTypeInfos.registerByClass(ColonyIdArgument.class,
+                    SingletonArgumentInfo.contextFree(ColonyIdArgument::id)));
+}

--- a/src/main/java/com/minecolonies/core/commands/citizencommands/CommandCitizenInfo.java
+++ b/src/main/java/com/minecolonies/core/commands/citizencommands/CommandCitizenInfo.java
@@ -7,6 +7,7 @@ import com.minecolonies.api.entity.citizen.AbstractEntityCitizen;
 import com.minecolonies.api.entity.pathfinding.IMinecoloniesNavigator;
 import com.minecolonies.api.util.constant.translation.CommandTranslationConstants;
 import com.minecolonies.core.colony.buildings.modules.WorkerBuildingModule;
+import com.minecolonies.core.commands.arguments.ColonyIdArgument;
 import com.minecolonies.core.commands.commandTypes.IMCColonyOfficerCommand;
 import com.minecolonies.core.commands.commandTypes.IMCCommand;
 import com.minecolonies.core.entity.citizen.EntityCitizen;
@@ -44,7 +45,7 @@ public class CommandCitizenInfo implements IMCColonyOfficerCommand
 
         final Entity sender = context.getSource().getEntity();
         // Colony
-        final int colonyID = IntegerArgumentType.getInteger(context, COLONYID_ARG);
+        final int colonyID = ColonyIdArgument.getColonyId(context, COLONYID_ARG);
         final IColony colony = IColonyManager.getInstance().getColonyByDimension(colonyID, sender == null ? Level.OVERWORLD : context.getSource().getLevel().dimension());
         if (colony == null)
         {
@@ -184,7 +185,7 @@ public class CommandCitizenInfo implements IMCColonyOfficerCommand
     public LiteralArgumentBuilder<CommandSourceStack> build()
     {
         return IMCCommand.newLiteral(getName())
-                 .then(IMCCommand.newArgument(COLONYID_ARG, IntegerArgumentType.integer(1))
+                 .then(IMCCommand.newArgument(COLONYID_ARG, ColonyIdArgument.id())
                          .then(IMCCommand.newArgument(CITIZENID_ARG, IntegerArgumentType.integer(1)).executes(this::checkPreConditionAndExecute)));
     }
 }

--- a/src/main/java/com/minecolonies/core/commands/citizencommands/CommandCitizenInfo.java
+++ b/src/main/java/com/minecolonies/core/commands/citizencommands/CommandCitizenInfo.java
@@ -2,7 +2,6 @@ package com.minecolonies.core.commands.citizencommands;
 
 import com.minecolonies.api.colony.ICitizenData;
 import com.minecolonies.api.colony.IColony;
-import com.minecolonies.api.colony.IColonyManager;
 import com.minecolonies.api.entity.citizen.AbstractEntityCitizen;
 import com.minecolonies.api.entity.pathfinding.IMinecoloniesNavigator;
 import com.minecolonies.api.util.constant.translation.CommandTranslationConstants;
@@ -19,10 +18,8 @@ import net.minecraft.core.BlockPos;
 import net.minecraft.network.chat.ClickEvent;
 import net.minecraft.network.chat.Component;
 import net.minecraft.network.chat.Style;
-import net.minecraft.world.entity.Entity;
 import net.minecraft.world.item.Item;
 import net.minecraft.world.item.ItemStack;
-import net.minecraft.world.level.Level;
 
 import java.util.Optional;
 
@@ -42,17 +39,7 @@ public class CommandCitizenInfo implements IMCColonyOfficerCommand
     @Override
     public int onExecute(final CommandContext<CommandSourceStack> context)
     {
-
-        final Entity sender = context.getSource().getEntity();
-        // Colony
-        final int colonyID = ColonyIdArgument.getColonyId(context, COLONYID_ARG);
-        final IColony colony = IColonyManager.getInstance().getColonyByDimension(colonyID, sender == null ? Level.OVERWORLD : context.getSource().getLevel().dimension());
-        if (colony == null)
-        {
-            context.getSource().sendSuccess(() -> Component.translatable(CommandTranslationConstants.COMMAND_COLONY_ID_NOT_FOUND, colonyID), false);
-            return 0;
-        }
-
+        final IColony colony = ColonyIdArgument.getColony(context, COLONYID_ARG);
         final ICitizenData citizenData = colony.getCitizenManager().getCivilian(IntegerArgumentType.getInteger(context, CITIZENID_ARG));
 
         if (citizenData == null)

--- a/src/main/java/com/minecolonies/core/commands/citizencommands/CommandCitizenKill.java
+++ b/src/main/java/com/minecolonies/core/commands/citizencommands/CommandCitizenKill.java
@@ -2,7 +2,6 @@ package com.minecolonies.core.commands.citizencommands;
 
 import com.minecolonies.api.colony.ICitizenData;
 import com.minecolonies.api.colony.IColony;
-import com.minecolonies.api.colony.IColonyManager;
 import com.minecolonies.api.entity.citizen.AbstractEntityCitizen;
 import com.minecolonies.api.util.DamageSourceKeys;
 import com.minecolonies.api.util.constant.translation.CommandTranslationConstants;
@@ -14,8 +13,8 @@ import com.mojang.brigadier.arguments.IntegerArgumentType;
 import com.mojang.brigadier.builder.LiteralArgumentBuilder;
 import com.mojang.brigadier.context.CommandContext;
 import net.minecraft.commands.CommandSourceStack;
-import net.minecraft.network.chat.Component;
 import net.minecraft.core.BlockPos;
+import net.minecraft.network.chat.Component;
 
 import java.util.Optional;
 
@@ -35,14 +34,7 @@ public class CommandCitizenKill implements IMCColonyOfficerCommand
     @Override
     public int onExecute(final CommandContext<CommandSourceStack> context)
     {
-        // Colony
-        final int colonyID = ColonyIdArgument.getColonyId(context, COLONYID_ARG);
-        final IColony colony = IColonyManager.getInstance().getColonyByDimension(colonyID, context.getSource().getLevel().dimension());
-        if (colony == null)
-        {
-            context.getSource().sendSuccess(() -> Component.translatable(CommandTranslationConstants.COMMAND_COLONY_ID_NOT_FOUND, colonyID), true);
-            return 0;
-        }
+        final IColony colony = ColonyIdArgument.getColony(context, COLONYID_ARG);
 
         if (!context.getSource().hasPermission(OP_PERM_LEVEL) && !MineColonies.getConfig().getServer().canPlayerUseKillCitizensCommand.get())
         {

--- a/src/main/java/com/minecolonies/core/commands/citizencommands/CommandCitizenKill.java
+++ b/src/main/java/com/minecolonies/core/commands/citizencommands/CommandCitizenKill.java
@@ -7,6 +7,7 @@ import com.minecolonies.api.entity.citizen.AbstractEntityCitizen;
 import com.minecolonies.api.util.DamageSourceKeys;
 import com.minecolonies.api.util.constant.translation.CommandTranslationConstants;
 import com.minecolonies.core.MineColonies;
+import com.minecolonies.core.commands.arguments.ColonyIdArgument;
 import com.minecolonies.core.commands.commandTypes.IMCColonyOfficerCommand;
 import com.minecolonies.core.commands.commandTypes.IMCCommand;
 import com.mojang.brigadier.arguments.IntegerArgumentType;
@@ -35,7 +36,7 @@ public class CommandCitizenKill implements IMCColonyOfficerCommand
     public int onExecute(final CommandContext<CommandSourceStack> context)
     {
         // Colony
-        final int colonyID = IntegerArgumentType.getInteger(context, COLONYID_ARG);
+        final int colonyID = ColonyIdArgument.getColonyId(context, COLONYID_ARG);
         final IColony colony = IColonyManager.getInstance().getColonyByDimension(colonyID, context.getSource().getLevel().dimension());
         if (colony == null)
         {
@@ -89,7 +90,7 @@ public class CommandCitizenKill implements IMCColonyOfficerCommand
     public LiteralArgumentBuilder<CommandSourceStack> build()
     {
         return IMCCommand.newLiteral(getName())
-                 .then(IMCCommand.newArgument(COLONYID_ARG, IntegerArgumentType.integer(1))
+                 .then(IMCCommand.newArgument(COLONYID_ARG, ColonyIdArgument.id())
                          .then(IMCCommand.newArgument(CITIZENID_ARG, IntegerArgumentType.integer(1)).executes(this::checkPreConditionAndExecute)));
     }
 }

--- a/src/main/java/com/minecolonies/core/commands/citizencommands/CommandCitizenList.java
+++ b/src/main/java/com/minecolonies/core/commands/citizencommands/CommandCitizenList.java
@@ -4,15 +4,19 @@ import com.minecolonies.api.colony.ICitizenData;
 import com.minecolonies.api.colony.IColony;
 import com.minecolonies.api.colony.IColonyManager;
 import com.minecolonies.api.util.constant.translation.CommandTranslationConstants;
+import com.minecolonies.core.commands.arguments.ColonyIdArgument;
 import com.minecolonies.core.commands.commandTypes.IMCColonyOfficerCommand;
 import com.minecolonies.core.commands.commandTypes.IMCCommand;
 import com.mojang.brigadier.arguments.IntegerArgumentType;
 import com.mojang.brigadier.builder.LiteralArgumentBuilder;
 import com.mojang.brigadier.context.CommandContext;
+import net.minecraft.ChatFormatting;
 import net.minecraft.commands.CommandSourceStack;
 import net.minecraft.core.BlockPos;
-
-import net.minecraft.network.chat.*;
+import net.minecraft.network.chat.ClickEvent;
+import net.minecraft.network.chat.Component;
+import net.minecraft.network.chat.MutableComponent;
+import net.minecraft.network.chat.Style;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.ArrayList;
@@ -21,8 +25,6 @@ import java.util.List;
 import static com.minecolonies.api.util.constant.translation.CommandTranslationConstants.COMMAND_CITIZEN_INFO;
 import static com.minecolonies.core.commands.CommandArgumentNames.COLONYID_ARG;
 import static com.minecolonies.core.commands.colonycommands.CommandListColonies.START_PAGE_ARG;
-
-import net.minecraft.ChatFormatting;
 
 /**
  * Lists all citizen of a given colony.
@@ -58,7 +60,7 @@ public class CommandCitizenList implements IMCColonyOfficerCommand
     private int displayListFor(final CommandContext<CommandSourceStack> context, int page)
     {
         // Colony
-        final int colonyID = IntegerArgumentType.getInteger(context, COLONYID_ARG);
+        final int colonyID = ColonyIdArgument.getColonyId(context, COLONYID_ARG);
         final IColony colony = IColonyManager.getInstance().getColonyByDimension(colonyID, context.getSource().getLevel().dimension());
         if (colony == null)
         {
@@ -168,7 +170,7 @@ public class CommandCitizenList implements IMCColonyOfficerCommand
     public LiteralArgumentBuilder<CommandSourceStack> build()
     {
         return IMCCommand.newLiteral(getName())
-                 .then(IMCCommand.newArgument(COLONYID_ARG, IntegerArgumentType.integer(1))
+                 .then(IMCCommand.newArgument(COLONYID_ARG, ColonyIdArgument.id())
                          .executes(this::checkPreConditionAndExecute)
                          .then(IMCCommand.newArgument(START_PAGE_ARG, IntegerArgumentType.integer(1)).executes(this::executeWithPage)));
     }

--- a/src/main/java/com/minecolonies/core/commands/citizencommands/CommandCitizenList.java
+++ b/src/main/java/com/minecolonies/core/commands/citizencommands/CommandCitizenList.java
@@ -2,7 +2,6 @@ package com.minecolonies.core.commands.citizencommands;
 
 import com.minecolonies.api.colony.ICitizenData;
 import com.minecolonies.api.colony.IColony;
-import com.minecolonies.api.colony.IColonyManager;
 import com.minecolonies.api.util.constant.translation.CommandTranslationConstants;
 import com.minecolonies.core.commands.arguments.ColonyIdArgument;
 import com.minecolonies.core.commands.commandTypes.IMCColonyOfficerCommand;
@@ -59,15 +58,7 @@ public class CommandCitizenList implements IMCColonyOfficerCommand
 
     private int displayListFor(final CommandContext<CommandSourceStack> context, int page)
     {
-        // Colony
-        final int colonyID = ColonyIdArgument.getColonyId(context, COLONYID_ARG);
-        final IColony colony = IColonyManager.getInstance().getColonyByDimension(colonyID, context.getSource().getLevel().dimension());
-        if (colony == null)
-        {
-            context.getSource().sendSuccess(() -> Component.translatable(CommandTranslationConstants.COMMAND_COLONY_ID_NOT_FOUND, colonyID), true);
-            return 0;
-        }
-
+        final IColony colony = ColonyIdArgument.getColony(context, COLONYID_ARG);
         final List<ICitizenData> citizens = colony.getCitizenManager().getCitizens();
         final int citizenCount = citizens.size();
 

--- a/src/main/java/com/minecolonies/core/commands/citizencommands/CommandCitizenModify.java
+++ b/src/main/java/com/minecolonies/core/commands/citizencommands/CommandCitizenModify.java
@@ -119,14 +119,7 @@ public class CommandCitizenModify implements IMCColonyOfficerCommand
                 return 0;
             }
 
-            final int colonyID = ColonyIdArgument.getColonyId(context, COLONYID_ARG);
-            final IColony colony = IColonyManager.getInstance().getColonyByDimension(colonyID, context.getSource().getLevel().dimension());
-            if (colony == null)
-            {
-                context.getSource().sendSuccess(() -> Component.translatable(CommandTranslationConstants.COMMAND_COLONY_ID_NOT_FOUND, colonyID), true);
-                return 0;
-            }
-
+            final IColony colony = ColonyIdArgument.getColony(context, COLONYID_ARG);
             final ICitizenData citizenData = colony.getCitizenManager().getCivilian(IntegerArgumentType.getInteger(context, CITIZENID_ARG));
             if (citizenData == null)
             {

--- a/src/main/java/com/minecolonies/core/commands/citizencommands/CommandCitizenModify.java
+++ b/src/main/java/com/minecolonies/core/commands/citizencommands/CommandCitizenModify.java
@@ -6,6 +6,7 @@ import com.minecolonies.api.colony.IColonyManager;
 import com.minecolonies.api.util.Log;
 import com.minecolonies.api.util.constant.translation.CommandTranslationConstants;
 import com.minecolonies.core.MineColonies;
+import com.minecolonies.core.commands.arguments.ColonyIdArgument;
 import com.minecolonies.core.commands.commandTypes.IMCColonyOfficerCommand;
 import com.minecolonies.core.commands.commandTypes.IMCCommand;
 import com.mojang.brigadier.arguments.DoubleArgumentType;
@@ -52,7 +53,7 @@ public class CommandCitizenModify implements IMCColonyOfficerCommand
     public LiteralArgumentBuilder<CommandSourceStack> build()
     {
         return IMCCommand.newLiteral(getName())
-                .then(IMCCommand.newArgument(COLONYID_ARG, IntegerArgumentType.integer(1))
+                .then(IMCCommand.newArgument(COLONYID_ARG, ColonyIdArgument.id())
                         .then(IMCCommand.newArgument(CITIZENID_ARG, IntegerArgumentType.integer(1))
                                 .then(IMCCommand.newLiteral("saturation")
                                         .then(IMCCommand.newLiteral("=")
@@ -118,7 +119,7 @@ public class CommandCitizenModify implements IMCColonyOfficerCommand
                 return 0;
             }
 
-            final int colonyID = IntegerArgumentType.getInteger(context, COLONYID_ARG);
+            final int colonyID = ColonyIdArgument.getColonyId(context, COLONYID_ARG);
             final IColony colony = IColonyManager.getInstance().getColonyByDimension(colonyID, context.getSource().getLevel().dimension());
             if (colony == null)
             {

--- a/src/main/java/com/minecolonies/core/commands/citizencommands/CommandCitizenReload.java
+++ b/src/main/java/com/minecolonies/core/commands/citizencommands/CommandCitizenReload.java
@@ -4,6 +4,7 @@ import com.minecolonies.api.colony.ICitizenData;
 import com.minecolonies.api.colony.IColony;
 import com.minecolonies.api.colony.IColonyManager;
 import com.minecolonies.api.util.constant.translation.CommandTranslationConstants;
+import com.minecolonies.core.commands.arguments.ColonyIdArgument;
 import com.minecolonies.core.commands.commandTypes.IMCColonyOfficerCommand;
 import com.minecolonies.core.commands.commandTypes.IMCCommand;
 import com.mojang.brigadier.arguments.IntegerArgumentType;
@@ -29,7 +30,7 @@ public class CommandCitizenReload implements IMCColonyOfficerCommand
     public int onExecute(final CommandContext<CommandSourceStack> context)
     {
         // Colony
-        final int colonyID = IntegerArgumentType.getInteger(context, COLONYID_ARG);
+        final int colonyID = ColonyIdArgument.getColonyId(context, COLONYID_ARG);
         final IColony colony = IColonyManager.getInstance().getColonyByDimension(colonyID, context.getSource().getLevel().dimension());
         if (colony == null)
         {
@@ -63,7 +64,7 @@ public class CommandCitizenReload implements IMCColonyOfficerCommand
     public LiteralArgumentBuilder<CommandSourceStack> build()
     {
         return IMCCommand.newLiteral(getName())
-                 .then(IMCCommand.newArgument(COLONYID_ARG, IntegerArgumentType.integer(1))
+                 .then(IMCCommand.newArgument(COLONYID_ARG, ColonyIdArgument.id())
                          .then(IMCCommand.newArgument(CITIZENID_ARG, IntegerArgumentType.integer(1)).executes(this::checkPreConditionAndExecute)));
     }
 }

--- a/src/main/java/com/minecolonies/core/commands/citizencommands/CommandCitizenReload.java
+++ b/src/main/java/com/minecolonies/core/commands/citizencommands/CommandCitizenReload.java
@@ -2,7 +2,6 @@ package com.minecolonies.core.commands.citizencommands;
 
 import com.minecolonies.api.colony.ICitizenData;
 import com.minecolonies.api.colony.IColony;
-import com.minecolonies.api.colony.IColonyManager;
 import com.minecolonies.api.util.constant.translation.CommandTranslationConstants;
 import com.minecolonies.core.commands.arguments.ColonyIdArgument;
 import com.minecolonies.core.commands.commandTypes.IMCColonyOfficerCommand;
@@ -29,15 +28,7 @@ public class CommandCitizenReload implements IMCColonyOfficerCommand
     @Override
     public int onExecute(final CommandContext<CommandSourceStack> context)
     {
-        // Colony
-        final int colonyID = ColonyIdArgument.getColonyId(context, COLONYID_ARG);
-        final IColony colony = IColonyManager.getInstance().getColonyByDimension(colonyID, context.getSource().getLevel().dimension());
-        if (colony == null)
-        {
-            context.getSource().sendSuccess(() -> Component.translatable(CommandTranslationConstants.COMMAND_COLONY_ID_NOT_FOUND, colonyID), true);
-            return 0;
-        }
-
+        final IColony colony = ColonyIdArgument.getColony(context, COLONYID_ARG);
         final ICitizenData citizenData = colony.getCitizenManager().getCivilian(IntegerArgumentType.getInteger(context, CITIZENID_ARG));
 
         if (citizenData == null)

--- a/src/main/java/com/minecolonies/core/commands/citizencommands/CommandCitizenSpawnNew.java
+++ b/src/main/java/com/minecolonies/core/commands/citizencommands/CommandCitizenSpawnNew.java
@@ -3,7 +3,6 @@ package com.minecolonies.core.commands.citizencommands;
 import com.minecolonies.api.IMinecoloniesAPI;
 import com.minecolonies.api.colony.ICitizenData;
 import com.minecolonies.api.colony.IColony;
-import com.minecolonies.api.colony.IColonyManager;
 import com.minecolonies.api.eventbus.events.colony.citizens.CitizenAddedModEvent;
 import com.minecolonies.core.commands.arguments.ColonyIdArgument;
 import com.minecolonies.core.commands.commandTypes.IMCCommand;
@@ -14,7 +13,6 @@ import net.minecraft.commands.CommandSourceStack;
 import net.minecraft.network.chat.Component;
 
 import static com.minecolonies.api.util.constant.translation.CommandTranslationConstants.COMMAND_CITIZEN_SPAWN_SUCCESS;
-import static com.minecolonies.api.util.constant.translation.CommandTranslationConstants.COMMAND_COLONY_ID_NOT_FOUND;
 import static com.minecolonies.core.commands.CommandArgumentNames.COLONYID_ARG;
 
 /**
@@ -30,15 +28,7 @@ public class CommandCitizenSpawnNew implements IMCOPCommand
     @Override
     public int onExecute(final CommandContext<CommandSourceStack> context)
     {
-        // Colony
-        final int colonyID = ColonyIdArgument.getColonyId(context, COLONYID_ARG);
-        final IColony colony = IColonyManager.getInstance().getColonyByDimension(colonyID, context.getSource().getLevel().dimension());
-        if (colony == null)
-        {
-            context.getSource().sendSuccess(() -> Component.translatable(COMMAND_COLONY_ID_NOT_FOUND, colonyID), true);
-            return 0;
-        }
-
+        final IColony colony = ColonyIdArgument.getColony(context, COLONYID_ARG);
         final ICitizenData newCitizen = colony.getCitizenManager().spawnOrCreateCivilian(null, colony.getWorld(), null, true);
         context.getSource().sendSuccess(() -> Component.translatable(COMMAND_CITIZEN_SPAWN_SUCCESS, newCitizen.getName()), true);
 

--- a/src/main/java/com/minecolonies/core/commands/citizencommands/CommandCitizenSpawnNew.java
+++ b/src/main/java/com/minecolonies/core/commands/citizencommands/CommandCitizenSpawnNew.java
@@ -5,9 +5,9 @@ import com.minecolonies.api.colony.ICitizenData;
 import com.minecolonies.api.colony.IColony;
 import com.minecolonies.api.colony.IColonyManager;
 import com.minecolonies.api.eventbus.events.colony.citizens.CitizenAddedModEvent;
+import com.minecolonies.core.commands.arguments.ColonyIdArgument;
 import com.minecolonies.core.commands.commandTypes.IMCCommand;
 import com.minecolonies.core.commands.commandTypes.IMCOPCommand;
-import com.mojang.brigadier.arguments.IntegerArgumentType;
 import com.mojang.brigadier.builder.LiteralArgumentBuilder;
 import com.mojang.brigadier.context.CommandContext;
 import net.minecraft.commands.CommandSourceStack;
@@ -31,7 +31,7 @@ public class CommandCitizenSpawnNew implements IMCOPCommand
     public int onExecute(final CommandContext<CommandSourceStack> context)
     {
         // Colony
-        final int colonyID = IntegerArgumentType.getInteger(context, COLONYID_ARG);
+        final int colonyID = ColonyIdArgument.getColonyId(context, COLONYID_ARG);
         final IColony colony = IColonyManager.getInstance().getColonyByDimension(colonyID, context.getSource().getLevel().dimension());
         if (colony == null)
         {
@@ -59,6 +59,6 @@ public class CommandCitizenSpawnNew implements IMCOPCommand
     public LiteralArgumentBuilder<CommandSourceStack> build()
     {
         return IMCCommand.newLiteral(getName())
-                 .then(IMCCommand.newArgument(COLONYID_ARG, IntegerArgumentType.integer(1)).executes(this::checkPreConditionAndExecute));
+                 .then(IMCCommand.newArgument(COLONYID_ARG, ColonyIdArgument.id()).executes(this::checkPreConditionAndExecute));
     }
 }

--- a/src/main/java/com/minecolonies/core/commands/citizencommands/CommandCitizenTeleport.java
+++ b/src/main/java/com/minecolonies/core/commands/citizencommands/CommandCitizenTeleport.java
@@ -2,7 +2,6 @@ package com.minecolonies.core.commands.citizencommands;
 
 import com.minecolonies.api.colony.ICitizenData;
 import com.minecolonies.api.colony.IColony;
-import com.minecolonies.api.colony.IColonyManager;
 import com.minecolonies.api.entity.citizen.AbstractEntityCitizen;
 import com.minecolonies.api.util.constant.translation.CommandTranslationConstants;
 import com.minecolonies.core.commands.arguments.ColonyIdArgument;
@@ -14,10 +13,8 @@ import com.mojang.brigadier.context.CommandContext;
 import net.minecraft.commands.CommandSourceStack;
 import net.minecraft.commands.arguments.coordinates.Coordinates;
 import net.minecraft.commands.arguments.coordinates.Vec3Argument;
-import net.minecraft.network.chat.Component;
-import net.minecraft.world.entity.Entity;
 import net.minecraft.core.BlockPos;
-import net.minecraft.world.level.Level;
+import net.minecraft.network.chat.Component;
 
 import java.util.Optional;
 
@@ -37,17 +34,7 @@ public class CommandCitizenTeleport implements IMCColonyOfficerCommand
     @Override
     public int onExecute(final CommandContext<CommandSourceStack> context)
     {
-
-        final Entity sender = context.getSource().getEntity();
-        // Colony
-        final int colonyID = ColonyIdArgument.getColonyId(context, COLONYID_ARG);
-        final IColony colony = IColonyManager.getInstance().getColonyByDimension(colonyID, sender == null ? Level.OVERWORLD : context.getSource().getLevel().dimension());
-        if (colony == null)
-        {
-            context.getSource().sendSuccess(() -> Component.translatable(CommandTranslationConstants.COMMAND_COLONY_ID_NOT_FOUND, colonyID), true);
-            return 0;
-        }
-
+        final IColony colony = ColonyIdArgument.getColony(context, COLONYID_ARG);
         final ICitizenData citizenData = colony.getCitizenManager().getCivilian(IntegerArgumentType.getInteger(context, CITIZENID_ARG));
 
         if (citizenData == null)

--- a/src/main/java/com/minecolonies/core/commands/citizencommands/CommandCitizenTeleport.java
+++ b/src/main/java/com/minecolonies/core/commands/citizencommands/CommandCitizenTeleport.java
@@ -5,6 +5,7 @@ import com.minecolonies.api.colony.IColony;
 import com.minecolonies.api.colony.IColonyManager;
 import com.minecolonies.api.entity.citizen.AbstractEntityCitizen;
 import com.minecolonies.api.util.constant.translation.CommandTranslationConstants;
+import com.minecolonies.core.commands.arguments.ColonyIdArgument;
 import com.minecolonies.core.commands.commandTypes.IMCColonyOfficerCommand;
 import com.minecolonies.core.commands.commandTypes.IMCCommand;
 import com.mojang.brigadier.arguments.IntegerArgumentType;
@@ -39,7 +40,7 @@ public class CommandCitizenTeleport implements IMCColonyOfficerCommand
 
         final Entity sender = context.getSource().getEntity();
         // Colony
-        final int colonyID = IntegerArgumentType.getInteger(context, COLONYID_ARG);
+        final int colonyID = ColonyIdArgument.getColonyId(context, COLONYID_ARG);
         final IColony colony = IColonyManager.getInstance().getColonyByDimension(colonyID, sender == null ? Level.OVERWORLD : context.getSource().getLevel().dimension());
         if (colony == null)
         {
@@ -89,7 +90,7 @@ public class CommandCitizenTeleport implements IMCColonyOfficerCommand
     public LiteralArgumentBuilder<CommandSourceStack> build()
     {
         return IMCCommand.newLiteral(getName())
-                 .then(IMCCommand.newArgument(COLONYID_ARG, IntegerArgumentType.integer(1))
+                 .then(IMCCommand.newArgument(COLONYID_ARG, ColonyIdArgument.id())
                          .then(IMCCommand.newArgument(CITIZENID_ARG, IntegerArgumentType.integer(1))
                                  .then(IMCCommand.newArgument(POS_ARG, Vec3Argument.vec3())
                                          .executes(this::checkPreConditionAndExecute))));

--- a/src/main/java/com/minecolonies/core/commands/citizencommands/CommandCitizenTrack.java
+++ b/src/main/java/com/minecolonies/core/commands/citizencommands/CommandCitizenTrack.java
@@ -2,7 +2,6 @@ package com.minecolonies.core.commands.citizencommands;
 
 import com.minecolonies.api.colony.ICitizenData;
 import com.minecolonies.api.colony.IColony;
-import com.minecolonies.api.colony.IColonyManager;
 import com.minecolonies.api.entity.citizen.AbstractEntityCitizen;
 import com.minecolonies.api.util.constant.translation.CommandTranslationConstants;
 import com.minecolonies.core.Network;
@@ -19,7 +18,6 @@ import net.minecraft.network.chat.Component;
 import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.world.entity.Entity;
 import net.minecraft.world.entity.player.Player;
-import net.minecraft.world.level.Level;
 
 import java.util.HashSet;
 import java.util.Optional;
@@ -47,15 +45,7 @@ public class CommandCitizenTrack implements IMCColonyOfficerCommand
             return 1;
         }
 
-        // Colony
-        final int colonyID = ColonyIdArgument.getColonyId(context, COLONYID_ARG);
-        final IColony colony = IColonyManager.getInstance().getColonyByDimension(colonyID, sender == null ? Level.OVERWORLD : context.getSource().getLevel().dimension());
-        if (colony == null)
-        {
-            context.getSource().sendSuccess(() -> Component.translatable(CommandTranslationConstants.COMMAND_COLONY_ID_NOT_FOUND, colonyID), true);
-            return 0;
-        }
-
+        final IColony colony = ColonyIdArgument.getColony(context, COLONYID_ARG);
         final ICitizenData citizenData = colony.getCitizenManager().getCivilian(IntegerArgumentType.getInteger(context, CITIZENID_ARG));
 
         if (citizenData == null)

--- a/src/main/java/com/minecolonies/core/commands/citizencommands/CommandCitizenTrack.java
+++ b/src/main/java/com/minecolonies/core/commands/citizencommands/CommandCitizenTrack.java
@@ -6,6 +6,7 @@ import com.minecolonies.api.colony.IColonyManager;
 import com.minecolonies.api.entity.citizen.AbstractEntityCitizen;
 import com.minecolonies.api.util.constant.translation.CommandTranslationConstants;
 import com.minecolonies.core.Network;
+import com.minecolonies.core.commands.arguments.ColonyIdArgument;
 import com.minecolonies.core.commands.commandTypes.IMCColonyOfficerCommand;
 import com.minecolonies.core.commands.commandTypes.IMCCommand;
 import com.minecolonies.core.entity.pathfinding.PathfindingUtils;
@@ -47,7 +48,7 @@ public class CommandCitizenTrack implements IMCColonyOfficerCommand
         }
 
         // Colony
-        final int colonyID = IntegerArgumentType.getInteger(context, COLONYID_ARG);
+        final int colonyID = ColonyIdArgument.getColonyId(context, COLONYID_ARG);
         final IColony colony = IColonyManager.getInstance().getColonyByDimension(colonyID, sender == null ? Level.OVERWORLD : context.getSource().getLevel().dimension());
         if (colony == null)
         {
@@ -102,7 +103,7 @@ public class CommandCitizenTrack implements IMCColonyOfficerCommand
     public LiteralArgumentBuilder<CommandSourceStack> build()
     {
         return IMCCommand.newLiteral(getName())
-                 .then(IMCCommand.newArgument(COLONYID_ARG, IntegerArgumentType.integer(1))
+                 .then(IMCCommand.newArgument(COLONYID_ARG, ColonyIdArgument.id())
                          .then(IMCCommand.newArgument(CITIZENID_ARG, IntegerArgumentType.integer(1)).executes(this::checkPreConditionAndExecute)));
     }
 }

--- a/src/main/java/com/minecolonies/core/commands/citizencommands/CommandCitizenTriggerWalkTo.java
+++ b/src/main/java/com/minecolonies/core/commands/citizencommands/CommandCitizenTriggerWalkTo.java
@@ -7,6 +7,7 @@ import com.minecolonies.api.entity.ai.statemachine.AIOneTimeEventTarget;
 import com.minecolonies.api.entity.ai.statemachine.states.IState;
 import com.minecolonies.api.entity.citizen.AbstractEntityCitizen;
 import com.minecolonies.api.util.constant.translation.CommandTranslationConstants;
+import com.minecolonies.core.commands.arguments.ColonyIdArgument;
 import com.minecolonies.core.commands.commandTypes.IMCColonyOfficerCommand;
 import com.minecolonies.core.commands.commandTypes.IMCCommand;
 import com.minecolonies.core.entity.citizen.EntityCitizen;
@@ -51,7 +52,7 @@ public class CommandCitizenTriggerWalkTo implements IMCColonyOfficerCommand
 
         final Entity sender = context.getSource().getEntity();
         // Colony
-        final int colonyID = IntegerArgumentType.getInteger(context, COLONYID_ARG);
+        final int colonyID = ColonyIdArgument.getColonyId(context, COLONYID_ARG);
         final IColony colony = IColonyManager.getInstance().getColonyByDimension(colonyID, sender == null ? Level.OVERWORLD : context.getSource().getLevel().dimension());
         if (colony == null)
         {
@@ -134,7 +135,7 @@ public class CommandCitizenTriggerWalkTo implements IMCColonyOfficerCommand
     {
         return IMCCommand.newLiteral(getName())
             .then(IMCCommand.newLiteral("stop").executes(this::stop))
-            .then(IMCCommand.newArgument(COLONYID_ARG, IntegerArgumentType.integer(1))
+            .then(IMCCommand.newArgument(COLONYID_ARG, ColonyIdArgument.id())
                 .then(IMCCommand.newArgument(CITIZENID_ARG, IntegerArgumentType.integer(1))
                     .then(IMCCommand.newArgument(POS_ARG, Vec3Argument.vec3())
                         .executes(this::checkPreConditionAndExecute))));

--- a/src/main/java/com/minecolonies/core/commands/citizencommands/CommandCitizenTriggerWalkTo.java
+++ b/src/main/java/com/minecolonies/core/commands/citizencommands/CommandCitizenTriggerWalkTo.java
@@ -2,7 +2,6 @@ package com.minecolonies.core.commands.citizencommands;
 
 import com.minecolonies.api.colony.ICitizenData;
 import com.minecolonies.api.colony.IColony;
-import com.minecolonies.api.colony.IColonyManager;
 import com.minecolonies.api.entity.ai.statemachine.AIOneTimeEventTarget;
 import com.minecolonies.api.entity.ai.statemachine.states.IState;
 import com.minecolonies.api.entity.citizen.AbstractEntityCitizen;
@@ -22,7 +21,6 @@ import net.minecraft.commands.arguments.coordinates.Vec3Argument;
 import net.minecraft.core.BlockPos;
 import net.minecraft.network.chat.Component;
 import net.minecraft.world.entity.Entity;
-import net.minecraft.world.level.Level;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -49,17 +47,8 @@ public class CommandCitizenTriggerWalkTo implements IMCColonyOfficerCommand
     @Override
     public int onExecute(final CommandContext<CommandSourceStack> context)
     {
-
         final Entity sender = context.getSource().getEntity();
-        // Colony
-        final int colonyID = ColonyIdArgument.getColonyId(context, COLONYID_ARG);
-        final IColony colony = IColonyManager.getInstance().getColonyByDimension(colonyID, sender == null ? Level.OVERWORLD : context.getSource().getLevel().dimension());
-        if (colony == null)
-        {
-            context.getSource().sendSuccess(() -> Component.translatable(CommandTranslationConstants.COMMAND_COLONY_ID_NOT_FOUND, colonyID), true);
-            return 0;
-        }
-
+        final IColony colony = ColonyIdArgument.getColony(context, COLONYID_ARG);
         final ICitizenData citizenData = colony.getCitizenManager().getCivilian(IntegerArgumentType.getInteger(context, CITIZENID_ARG));
 
         if (citizenData == null)

--- a/src/main/java/com/minecolonies/core/commands/colonycommands/CommandAddOfficer.java
+++ b/src/main/java/com/minecolonies/core/commands/colonycommands/CommandAddOfficer.java
@@ -4,10 +4,10 @@ import com.minecolonies.api.colony.IColony;
 import com.minecolonies.api.colony.IColonyManager;
 import com.minecolonies.api.util.constant.translation.CommandTranslationConstants;
 import com.minecolonies.core.MineColonies;
+import com.minecolonies.core.commands.arguments.ColonyIdArgument;
 import com.minecolonies.core.commands.commandTypes.IMCColonyOfficerCommand;
 import com.minecolonies.core.commands.commandTypes.IMCCommand;
 import com.mojang.authlib.GameProfile;
-import com.mojang.brigadier.arguments.IntegerArgumentType;
 import com.mojang.brigadier.builder.LiteralArgumentBuilder;
 import com.mojang.brigadier.context.CommandContext;
 import com.mojang.brigadier.exceptions.CommandSyntaxException;
@@ -35,7 +35,7 @@ public class CommandAddOfficer implements IMCColonyOfficerCommand
         }
 
 
-        final int colonyID = IntegerArgumentType.getInteger(context, COLONYID_ARG);
+        final int colonyID = ColonyIdArgument.getColonyId(context, COLONYID_ARG);
         final IColony colony = IColonyManager.getInstance().getColonyByDimension(colonyID, context.getSource().getLevel().dimension());
         if (colony == null)
         {
@@ -79,7 +79,7 @@ public class CommandAddOfficer implements IMCColonyOfficerCommand
     public LiteralArgumentBuilder<CommandSourceStack> build()
     {
         return IMCCommand.newLiteral(getName())
-                 .then(IMCCommand.newArgument(COLONYID_ARG, IntegerArgumentType.integer(1))
+                 .then(IMCCommand.newArgument(COLONYID_ARG, ColonyIdArgument.id())
                          .then(IMCCommand.newArgument(PLAYERNAME_ARG, GameProfileArgument.gameProfile()).executes(this::checkPreConditionAndExecute)));
     }
 }

--- a/src/main/java/com/minecolonies/core/commands/colonycommands/CommandAddOfficer.java
+++ b/src/main/java/com/minecolonies/core/commands/colonycommands/CommandAddOfficer.java
@@ -1,7 +1,6 @@
 package com.minecolonies.core.commands.colonycommands;
 
 import com.minecolonies.api.colony.IColony;
-import com.minecolonies.api.colony.IColonyManager;
 import com.minecolonies.api.util.constant.translation.CommandTranslationConstants;
 import com.minecolonies.core.MineColonies;
 import com.minecolonies.core.commands.arguments.ColonyIdArgument;
@@ -34,14 +33,7 @@ public class CommandAddOfficer implements IMCColonyOfficerCommand
             return 0;
         }
 
-
-        final int colonyID = ColonyIdArgument.getColonyId(context, COLONYID_ARG);
-        final IColony colony = IColonyManager.getInstance().getColonyByDimension(colonyID, context.getSource().getLevel().dimension());
-        if (colony == null)
-        {
-            context.getSource().sendSuccess(() -> Component.translatable(CommandTranslationConstants.COMMAND_COLONY_ID_NOT_FOUND, colonyID), true);
-            return 0;
-        }
+        final IColony colony = ColonyIdArgument.getColony(context, COLONYID_ARG);
 
         GameProfile profile;
         try

--- a/src/main/java/com/minecolonies/core/commands/colonycommands/CommandCanRaiderSpawn.java
+++ b/src/main/java/com/minecolonies/core/commands/colonycommands/CommandCanRaiderSpawn.java
@@ -1,7 +1,6 @@
 package com.minecolonies.core.commands.colonycommands;
 
 import com.minecolonies.api.colony.IColony;
-import com.minecolonies.api.colony.IColonyManager;
 import com.minecolonies.core.commands.arguments.ColonyIdArgument;
 import com.minecolonies.core.commands.commandTypes.IMCCommand;
 import com.minecolonies.core.commands.commandTypes.IMCOPCommand;
@@ -12,7 +11,6 @@ import net.minecraft.commands.CommandSourceStack;
 import net.minecraft.network.chat.Component;
 
 import static com.minecolonies.api.util.constant.translation.CommandTranslationConstants.COMMAND_CAN_RAIDER_SPAWN_SUCCESS;
-import static com.minecolonies.api.util.constant.translation.CommandTranslationConstants.COMMAND_COLONY_ID_NOT_FOUND;
 import static com.minecolonies.core.commands.CommandArgumentNames.COLONYID_ARG;
 
 public class CommandCanRaiderSpawn implements IMCOPCommand
@@ -27,15 +25,7 @@ public class CommandCanRaiderSpawn implements IMCOPCommand
     @Override
     public int onExecute(final CommandContext<CommandSourceStack> context)
     {
-        // Colony
-        final int colonyID = ColonyIdArgument.getColonyId(context, COLONYID_ARG);
-        final IColony colony = IColonyManager.getInstance().getColonyByDimension(colonyID, context.getSource().getLevel().dimension());
-        if (colony == null)
-        {
-            context.getSource().sendSuccess(() -> Component.translatable(COMMAND_COLONY_ID_NOT_FOUND, colonyID), true);
-            return 0;
-        }
-
+        final IColony colony = ColonyIdArgument.getColony(context, COLONYID_ARG);
         final boolean canHaveBarbEvents = BoolArgumentType.getBool(context, CANSPAWN_ARG);
 
         colony.getRaiderManager().setCanHaveRaiderEvents(canHaveBarbEvents);

--- a/src/main/java/com/minecolonies/core/commands/colonycommands/CommandCanRaiderSpawn.java
+++ b/src/main/java/com/minecolonies/core/commands/colonycommands/CommandCanRaiderSpawn.java
@@ -2,10 +2,10 @@ package com.minecolonies.core.commands.colonycommands;
 
 import com.minecolonies.api.colony.IColony;
 import com.minecolonies.api.colony.IColonyManager;
+import com.minecolonies.core.commands.arguments.ColonyIdArgument;
 import com.minecolonies.core.commands.commandTypes.IMCCommand;
 import com.minecolonies.core.commands.commandTypes.IMCOPCommand;
 import com.mojang.brigadier.arguments.BoolArgumentType;
-import com.mojang.brigadier.arguments.IntegerArgumentType;
 import com.mojang.brigadier.builder.LiteralArgumentBuilder;
 import com.mojang.brigadier.context.CommandContext;
 import net.minecraft.commands.CommandSourceStack;
@@ -28,7 +28,7 @@ public class CommandCanRaiderSpawn implements IMCOPCommand
     public int onExecute(final CommandContext<CommandSourceStack> context)
     {
         // Colony
-        final int colonyID = IntegerArgumentType.getInteger(context, COLONYID_ARG);
+        final int colonyID = ColonyIdArgument.getColonyId(context, COLONYID_ARG);
         final IColony colony = IColonyManager.getInstance().getColonyByDimension(colonyID, context.getSource().getLevel().dimension());
         if (colony == null)
         {
@@ -57,7 +57,7 @@ public class CommandCanRaiderSpawn implements IMCOPCommand
     public LiteralArgumentBuilder<CommandSourceStack> build()
     {
         return IMCCommand.newLiteral(getName())
-                 .then(IMCCommand.newArgument(COLONYID_ARG, IntegerArgumentType.integer(1))
+                 .then(IMCCommand.newArgument(COLONYID_ARG, ColonyIdArgument.id())
                          .then(IMCCommand.newArgument(CANSPAWN_ARG, BoolArgumentType.bool()).executes(this::checkPreConditionAndExecute)));
     }
 }

--- a/src/main/java/com/minecolonies/core/commands/colonycommands/CommandChangeOwner.java
+++ b/src/main/java/com/minecolonies/core/commands/colonycommands/CommandChangeOwner.java
@@ -1,7 +1,6 @@
 package com.minecolonies.core.commands.colonycommands;
 
 import com.minecolonies.api.colony.IColony;
-import com.minecolonies.api.colony.IColonyManager;
 import com.minecolonies.api.util.constant.translation.CommandTranslationConstants;
 import com.minecolonies.core.commands.arguments.ColonyIdArgument;
 import com.minecolonies.core.commands.commandTypes.IMCColonyOfficerCommand;
@@ -29,13 +28,7 @@ public class CommandChangeOwner implements IMCColonyOfficerCommand
     @Override
     public int onExecute(final CommandContext<CommandSourceStack> context)
     {
-        final int colonyID = ColonyIdArgument.getColonyId(context, COLONYID_ARG);
-        final IColony colony = IColonyManager.getInstance().getColonyByDimension(colonyID, context.getSource().getLevel().dimension());
-        if (colony == null)
-        {
-            context.getSource().sendSuccess(() -> Component.translatable(CommandTranslationConstants.COMMAND_COLONY_ID_NOT_FOUND, colonyID), true);
-            return 0;
-        }
+        final IColony colony = ColonyIdArgument.getColony(context, COLONYID_ARG);
 
         GameProfile profile;
         try

--- a/src/main/java/com/minecolonies/core/commands/colonycommands/CommandChangeOwner.java
+++ b/src/main/java/com/minecolonies/core/commands/colonycommands/CommandChangeOwner.java
@@ -3,10 +3,10 @@ package com.minecolonies.core.commands.colonycommands;
 import com.minecolonies.api.colony.IColony;
 import com.minecolonies.api.colony.IColonyManager;
 import com.minecolonies.api.util.constant.translation.CommandTranslationConstants;
+import com.minecolonies.core.commands.arguments.ColonyIdArgument;
 import com.minecolonies.core.commands.commandTypes.IMCColonyOfficerCommand;
 import com.minecolonies.core.commands.commandTypes.IMCCommand;
 import com.mojang.authlib.GameProfile;
-import com.mojang.brigadier.arguments.IntegerArgumentType;
 import com.mojang.brigadier.builder.LiteralArgumentBuilder;
 import com.mojang.brigadier.context.CommandContext;
 import com.mojang.brigadier.exceptions.CommandSyntaxException;
@@ -29,7 +29,7 @@ public class CommandChangeOwner implements IMCColonyOfficerCommand
     @Override
     public int onExecute(final CommandContext<CommandSourceStack> context)
     {
-        final int colonyID = IntegerArgumentType.getInteger(context, COLONYID_ARG);
+        final int colonyID = ColonyIdArgument.getColonyId(context, COLONYID_ARG);
         final IColony colony = IColonyManager.getInstance().getColonyByDimension(colonyID, context.getSource().getLevel().dimension());
         if (colony == null)
         {
@@ -74,7 +74,7 @@ public class CommandChangeOwner implements IMCColonyOfficerCommand
     public LiteralArgumentBuilder<CommandSourceStack> build()
     {
         return IMCCommand.newLiteral(getName())
-                 .then(IMCCommand.newArgument(COLONYID_ARG, IntegerArgumentType.integer(1))
+                 .then(IMCCommand.newArgument(COLONYID_ARG, ColonyIdArgument.id())
                          .then(IMCCommand.newArgument(PLAYERNAME_ARG, GameProfileArgument.gameProfile()).executes(this::checkPreConditionAndExecute)));
     }
 }

--- a/src/main/java/com/minecolonies/core/commands/colonycommands/CommandClaimChunks.java
+++ b/src/main/java/com/minecolonies/core/commands/colonycommands/CommandClaimChunks.java
@@ -5,6 +5,7 @@ import com.minecolonies.api.util.Log;
 import com.minecolonies.api.util.MessageUtils;
 import com.minecolonies.api.util.constant.translation.CommandTranslationConstants;
 import com.minecolonies.core.MineColonies;
+import com.minecolonies.core.commands.arguments.ColonyIdArgument;
 import com.minecolonies.core.commands.commandTypes.IMCCommand;
 import com.minecolonies.core.commands.commandTypes.IMCOPCommand;
 import com.minecolonies.core.util.ChunkDataHelper;
@@ -39,7 +40,7 @@ public class CommandClaimChunks implements IMCOPCommand
         }
 
         // Colony
-        final int colonyID = IntegerArgumentType.getInteger(context, COLONYID_ARG);
+        final int colonyID = ColonyIdArgument.getColonyId(context, COLONYID_ARG);
 
         // Range
         final int range = IntegerArgumentType.getInteger(context, RANGE_ARG);
@@ -89,7 +90,7 @@ public class CommandClaimChunks implements IMCOPCommand
     public LiteralArgumentBuilder<CommandSourceStack> build()
     {
         return IMCCommand.newLiteral(getName())
-                 .then(IMCCommand.newArgument(COLONYID_ARG, IntegerArgumentType.integer(1))
+                 .then(IMCCommand.newArgument(COLONYID_ARG, ColonyIdArgument.id())
                          .then(IMCCommand.newArgument(RANGE_ARG, IntegerArgumentType.integer(0, 10))
                                  .then(IMCCommand.newArgument(ADD_ARG, BoolArgumentType.bool()).executes(this::checkPreConditionAndExecute))));
     }

--- a/src/main/java/com/minecolonies/core/commands/colonycommands/CommandColonyChunks.java
+++ b/src/main/java/com/minecolonies/core/commands/colonycommands/CommandColonyChunks.java
@@ -1,7 +1,6 @@
 package com.minecolonies.core.commands.colonycommands;
 
 import com.minecolonies.api.colony.IColony;
-import com.minecolonies.api.colony.IColonyManager;
 import com.minecolonies.core.commands.arguments.ColonyIdArgument;
 import com.minecolonies.core.commands.commandTypes.IMCColonyOfficerCommand;
 import com.minecolonies.core.commands.commandTypes.IMCCommand;
@@ -17,7 +16,6 @@ import net.minecraft.util.SortedArraySet;
 import java.util.HashSet;
 import java.util.Set;
 
-import static com.minecolonies.api.util.constant.translation.CommandTranslationConstants.COMMAND_COLONY_ID_NOT_FOUND;
 import static com.minecolonies.core.commands.CommandArgumentNames.COLONYID_ARG;
 import static com.minecolonies.core.commands.colonycommands.CommandColonyInfo.ID_TEXT;
 import static com.minecolonies.core.commands.colonycommands.CommandColonyInfo.NAME_TEXT;
@@ -32,15 +30,7 @@ public class CommandColonyChunks implements IMCColonyOfficerCommand
     @Override
     public int onExecute(final CommandContext<CommandSourceStack> context)
     {
-        // Colony
-        final int colonyID = ColonyIdArgument.getColonyId(context, COLONYID_ARG);
-        final IColony colony = IColonyManager.getInstance().getColonyByDimension(colonyID, context.getSource().getLevel().dimension());
-        if (colony == null)
-        {
-            context.getSource().sendSuccess(() -> Component.translatable(COMMAND_COLONY_ID_NOT_FOUND, colonyID), true);
-            return 0;
-        }
-
+        final IColony colony = ColonyIdArgument.getColony(context, COLONYID_ARG);
 
         Set<TicketType> types = new HashSet<>();
 

--- a/src/main/java/com/minecolonies/core/commands/colonycommands/CommandColonyChunks.java
+++ b/src/main/java/com/minecolonies/core/commands/colonycommands/CommandColonyChunks.java
@@ -2,9 +2,9 @@ package com.minecolonies.core.commands.colonycommands;
 
 import com.minecolonies.api.colony.IColony;
 import com.minecolonies.api.colony.IColonyManager;
+import com.minecolonies.core.commands.arguments.ColonyIdArgument;
 import com.minecolonies.core.commands.commandTypes.IMCColonyOfficerCommand;
 import com.minecolonies.core.commands.commandTypes.IMCCommand;
-import com.mojang.brigadier.arguments.IntegerArgumentType;
 import com.mojang.brigadier.builder.LiteralArgumentBuilder;
 import com.mojang.brigadier.context.CommandContext;
 import net.minecraft.ChatFormatting;
@@ -33,7 +33,7 @@ public class CommandColonyChunks implements IMCColonyOfficerCommand
     public int onExecute(final CommandContext<CommandSourceStack> context)
     {
         // Colony
-        final int colonyID = IntegerArgumentType.getInteger(context, COLONYID_ARG);
+        final int colonyID = ColonyIdArgument.getColonyId(context, COLONYID_ARG);
         final IColony colony = IColonyManager.getInstance().getColonyByDimension(colonyID, context.getSource().getLevel().dimension());
         if (colony == null)
         {
@@ -86,6 +86,6 @@ public class CommandColonyChunks implements IMCColonyOfficerCommand
     public LiteralArgumentBuilder<CommandSourceStack> build()
     {
         return IMCCommand.newLiteral(getName())
-          .then(IMCCommand.newArgument(COLONYID_ARG, IntegerArgumentType.integer(1)).executes(this::checkPreConditionAndExecute));
+          .then(IMCCommand.newArgument(COLONYID_ARG, ColonyIdArgument.id()).executes(this::checkPreConditionAndExecute));
     }
 }

--- a/src/main/java/com/minecolonies/core/commands/colonycommands/CommandColonyInfo.java
+++ b/src/main/java/com/minecolonies/core/commands/colonycommands/CommandColonyInfo.java
@@ -3,9 +3,9 @@ package com.minecolonies.core.commands.colonycommands;
 import com.minecolonies.api.colony.IColony;
 import com.minecolonies.api.colony.IColonyManager;
 import com.minecolonies.core.MineColonies;
+import com.minecolonies.core.commands.arguments.ColonyIdArgument;
 import com.minecolonies.core.commands.commandTypes.IMCColonyOfficerCommand;
 import com.minecolonies.core.commands.commandTypes.IMCCommand;
-import com.mojang.brigadier.arguments.IntegerArgumentType;
 import com.mojang.brigadier.builder.LiteralArgumentBuilder;
 import com.mojang.brigadier.context.CommandContext;
 import net.minecraft.ChatFormatting;
@@ -39,7 +39,8 @@ public class CommandColonyInfo implements IMCColonyOfficerCommand
     public int onExecute(final CommandContext<CommandSourceStack> context)
     {
         // Colony
-        final int colonyID = IntegerArgumentType.getInteger(context, COLONYID_ARG);
+        final int colonyID = ColonyIdArgument.getColonyId(context, COLONYID_ARG);
+
         final IColony colony = IColonyManager.getInstance().getColonyByDimension(colonyID, context.getSource().getLevel().dimension());
         if (colony == null)
         {
@@ -85,6 +86,6 @@ public class CommandColonyInfo implements IMCColonyOfficerCommand
     public LiteralArgumentBuilder<CommandSourceStack> build()
     {
         return IMCCommand.newLiteral(getName())
-                 .then(IMCCommand.newArgument(COLONYID_ARG, IntegerArgumentType.integer(1)).executes(this::checkPreConditionAndExecute));
+                 .then(IMCCommand.newArgument(COLONYID_ARG, ColonyIdArgument.id()).executes(this::checkPreConditionAndExecute));
     }
 }

--- a/src/main/java/com/minecolonies/core/commands/colonycommands/CommandColonyInfo.java
+++ b/src/main/java/com/minecolonies/core/commands/colonycommands/CommandColonyInfo.java
@@ -1,7 +1,6 @@
 package com.minecolonies.core.commands.colonycommands;
 
 import com.minecolonies.api.colony.IColony;
-import com.minecolonies.api.colony.IColonyManager;
 import com.minecolonies.core.MineColonies;
 import com.minecolonies.core.commands.arguments.ColonyIdArgument;
 import com.minecolonies.core.commands.commandTypes.IMCColonyOfficerCommand;
@@ -14,7 +13,6 @@ import net.minecraft.core.BlockPos;
 import net.minecraft.network.chat.Component;
 import net.minecraft.network.chat.Style;
 
-import static com.minecolonies.api.util.constant.translation.CommandTranslationConstants.COMMAND_COLONY_ID_NOT_FOUND;
 import static com.minecolonies.api.util.constant.translation.CommandTranslationConstants.COMMAND_DISABLED_IN_CONFIG;
 import static com.minecolonies.core.commands.CommandArgumentNames.COLONYID_ARG;
 
@@ -38,15 +36,7 @@ public class CommandColonyInfo implements IMCColonyOfficerCommand
     @Override
     public int onExecute(final CommandContext<CommandSourceStack> context)
     {
-        // Colony
-        final int colonyID = ColonyIdArgument.getColonyId(context, COLONYID_ARG);
-
-        final IColony colony = IColonyManager.getInstance().getColonyByDimension(colonyID, context.getSource().getLevel().dimension());
-        if (colony == null)
-        {
-            context.getSource().sendSuccess(() -> Component.translatable(COMMAND_COLONY_ID_NOT_FOUND, colonyID), true);
-            return 0;
-        }
+        final IColony colony = ColonyIdArgument.getColony(context, COLONYID_ARG);
 
         if (!context.getSource().hasPermission(OP_PERM_LEVEL) && !MineColonies.getConfig().getServer().canPlayerUseShowColonyInfoCommand.get())
         {

--- a/src/main/java/com/minecolonies/core/commands/colonycommands/CommandColonyPrintStats.java
+++ b/src/main/java/com/minecolonies/core/commands/colonycommands/CommandColonyPrintStats.java
@@ -1,7 +1,6 @@
 package com.minecolonies.core.commands.colonycommands;
 
 import com.minecolonies.api.colony.IColony;
-import com.minecolonies.api.colony.IColonyManager;
 import com.minecolonies.api.colony.buildings.IBuilding;
 import com.minecolonies.api.util.Log;
 import com.minecolonies.core.colony.events.raid.RaidManager;
@@ -14,7 +13,6 @@ import com.mojang.brigadier.context.CommandContext;
 import net.minecraft.ChatFormatting;
 import net.minecraft.commands.CommandSourceStack;
 import net.minecraft.core.BlockPos;
-import net.minecraft.network.chat.Component;
 import net.minecraft.network.chat.MutableComponent;
 import net.minecraft.network.chat.Style;
 import net.minecraft.network.chat.contents.LiteralContents;
@@ -23,7 +21,6 @@ import net.minecraft.resources.ResourceLocation;
 import java.util.List;
 import java.util.stream.Collectors;
 
-import static com.minecolonies.api.util.constant.translation.CommandTranslationConstants.COMMAND_COLONY_ID_NOT_FOUND;
 import static com.minecolonies.core.commands.CommandArgumentNames.COLONYID_ARG;
 
 /**
@@ -51,15 +48,7 @@ public class CommandColonyPrintStats implements IMCOPCommand
     public int onExecute(final CommandContext<CommandSourceStack> context)
     {
         fullLog = "\n";
-        // Colony
-        final int colonyID = ColonyIdArgument.getColonyId(context, COLONYID_ARG);
-        final IColony colony = IColonyManager.getInstance().getColonyByDimension(colonyID, context.getSource().getLevel().dimension());
-        if (colony == null)
-        {
-            context.getSource().sendSuccess(() -> Component.translatable(COMMAND_COLONY_ID_NOT_FOUND, colonyID), false);
-            return 0;
-        }
-
+        final IColony colony = ColonyIdArgument.getColony(context, COLONYID_ARG);
         final BlockPos position = colony.getCenter();
         context.getSource().sendSuccess(() -> literalAndRemember(ID_TEXT + colony.getID() + NAME_TEXT + colony.getName()), false);
         final String mayor = colony.getPermissions().getOwnerName();

--- a/src/main/java/com/minecolonies/core/commands/colonycommands/CommandColonyPrintStats.java
+++ b/src/main/java/com/minecolonies/core/commands/colonycommands/CommandColonyPrintStats.java
@@ -5,10 +5,10 @@ import com.minecolonies.api.colony.IColonyManager;
 import com.minecolonies.api.colony.buildings.IBuilding;
 import com.minecolonies.api.util.Log;
 import com.minecolonies.core.colony.events.raid.RaidManager;
+import com.minecolonies.core.commands.arguments.ColonyIdArgument;
 import com.minecolonies.core.commands.commandTypes.IMCCommand;
 import com.minecolonies.core.commands.commandTypes.IMCOPCommand;
 import com.minecolonies.core.research.LocalResearchTree;
-import com.mojang.brigadier.arguments.IntegerArgumentType;
 import com.mojang.brigadier.builder.LiteralArgumentBuilder;
 import com.mojang.brigadier.context.CommandContext;
 import net.minecraft.ChatFormatting;
@@ -52,7 +52,7 @@ public class CommandColonyPrintStats implements IMCOPCommand
     {
         fullLog = "\n";
         // Colony
-        final int colonyID = IntegerArgumentType.getInteger(context, COLONYID_ARG);
+        final int colonyID = ColonyIdArgument.getColonyId(context, COLONYID_ARG);
         final IColony colony = IColonyManager.getInstance().getColonyByDimension(colonyID, context.getSource().getLevel().dimension());
         if (colony == null)
         {
@@ -146,6 +146,6 @@ public class CommandColonyPrintStats implements IMCOPCommand
     public LiteralArgumentBuilder<CommandSourceStack> build()
     {
         return IMCCommand.newLiteral(getName())
-          .then(IMCCommand.newArgument(COLONYID_ARG, IntegerArgumentType.integer(1)).executes(this::checkPreConditionAndExecute));
+          .then(IMCCommand.newArgument(COLONYID_ARG, ColonyIdArgument.id()).executes(this::checkPreConditionAndExecute));
     }
 }

--- a/src/main/java/com/minecolonies/core/commands/colonycommands/CommandColonyRaidsInfo.java
+++ b/src/main/java/com/minecolonies/core/commands/colonycommands/CommandColonyRaidsInfo.java
@@ -1,7 +1,6 @@
 package com.minecolonies.core.commands.colonycommands;
 
 import com.minecolonies.api.colony.IColony;
-import com.minecolonies.api.colony.IColonyManager;
 import com.minecolonies.core.MineColonies;
 import com.minecolonies.core.colony.events.raid.RaidManager;
 import com.minecolonies.core.commands.arguments.ColonyIdArgument;
@@ -14,7 +13,6 @@ import net.minecraft.network.chat.Component;
 
 import java.util.List;
 
-import static com.minecolonies.api.util.constant.translation.CommandTranslationConstants.COMMAND_COLONY_ID_NOT_FOUND;
 import static com.minecolonies.api.util.constant.translation.CommandTranslationConstants.COMMAND_DISABLED_IN_CONFIG;
 import static com.minecolonies.core.commands.CommandArgumentNames.COLONYID_ARG;
 
@@ -28,14 +26,7 @@ public class CommandColonyRaidsInfo implements IMCOPCommand
     @Override
     public int onExecute(final CommandContext<CommandSourceStack> context)
     {
-        // Colony
-        final int colonyID = ColonyIdArgument.getColonyId(context, COLONYID_ARG);
-        final IColony colony = IColonyManager.getInstance().getColonyByDimension(colonyID, context.getSource().getLevel().dimension());
-        if (colony == null)
-        {
-            context.getSource().sendSuccess(() -> Component.translatable(COMMAND_COLONY_ID_NOT_FOUND, colonyID), true);
-            return 0;
-        }
+        final IColony colony = ColonyIdArgument.getColony(context, COLONYID_ARG);
 
         if (!context.getSource().hasPermission(OP_PERM_LEVEL) && !MineColonies.getConfig().getServer().canPlayerUseShowColonyInfoCommand.get())
         {

--- a/src/main/java/com/minecolonies/core/commands/colonycommands/CommandColonyRaidsInfo.java
+++ b/src/main/java/com/minecolonies/core/commands/colonycommands/CommandColonyRaidsInfo.java
@@ -4,9 +4,9 @@ import com.minecolonies.api.colony.IColony;
 import com.minecolonies.api.colony.IColonyManager;
 import com.minecolonies.core.MineColonies;
 import com.minecolonies.core.colony.events.raid.RaidManager;
+import com.minecolonies.core.commands.arguments.ColonyIdArgument;
 import com.minecolonies.core.commands.commandTypes.IMCCommand;
 import com.minecolonies.core.commands.commandTypes.IMCOPCommand;
-import com.mojang.brigadier.arguments.IntegerArgumentType;
 import com.mojang.brigadier.builder.LiteralArgumentBuilder;
 import com.mojang.brigadier.context.CommandContext;
 import net.minecraft.commands.CommandSourceStack;
@@ -29,7 +29,7 @@ public class CommandColonyRaidsInfo implements IMCOPCommand
     public int onExecute(final CommandContext<CommandSourceStack> context)
     {
         // Colony
-        final int colonyID = IntegerArgumentType.getInteger(context, COLONYID_ARG);
+        final int colonyID = ColonyIdArgument.getColonyId(context, COLONYID_ARG);
         final IColony colony = IColonyManager.getInstance().getColonyByDimension(colonyID, context.getSource().getLevel().dimension());
         if (colony == null)
         {
@@ -67,6 +67,6 @@ public class CommandColonyRaidsInfo implements IMCOPCommand
     public LiteralArgumentBuilder<CommandSourceStack> build()
     {
         return IMCCommand.newLiteral(getName())
-          .then(IMCCommand.newArgument(COLONYID_ARG, IntegerArgumentType.integer(1)).executes(this::checkPreConditionAndExecute));
+          .then(IMCCommand.newArgument(COLONYID_ARG, ColonyIdArgument.id()).executes(this::checkPreConditionAndExecute));
     }
 }

--- a/src/main/java/com/minecolonies/core/commands/colonycommands/CommandDeleteColony.java
+++ b/src/main/java/com/minecolonies/core/commands/colonycommands/CommandDeleteColony.java
@@ -159,14 +159,7 @@ public class CommandDeleteColony implements IMCColonyOfficerCommand
     @Override
     public int onExecute(final CommandContext<CommandSourceStack> context)
     {
-        // Colony
-        final int colonyID = ColonyIdArgument.getColonyId(context, COLONYID_ARG);
-        final IColony colony = IColonyManager.getInstance().getColonyByDimension(colonyID, context.getSource().getLevel().dimension());
-        if (colony == null)
-        {
-            context.getSource().sendSuccess(() -> Component.translatable(CommandTranslationConstants.COMMAND_COLONY_ID_NOT_FOUND, colonyID), true);
-            return 0;
-        }
+        final IColony colony = ColonyIdArgument.getColony(context, COLONYID_ARG);
 
         final boolean deleteBuildings = BoolArgumentType.getBool(context, DELETE_BUILDINGS_ARG);
         final boolean confirmation = BoolArgumentType.getBool(context, CONFIRM_ARG);
@@ -177,7 +170,7 @@ public class CommandDeleteColony implements IMCColonyOfficerCommand
         }
 
         BackUpHelper.backupColonyData();
-        IColonyManager.getInstance().deleteColonyByDimension(colonyID, deleteBuildings, context.getSource().getLevel().dimension());
+        IColonyManager.getInstance().deleteColonyByDimension(colony.getID(), deleteBuildings, context.getSource().getLevel().dimension());
         context.getSource().sendSuccess(() -> Component.translatable(CommandTranslationConstants.COMMAND_COLONY_DELETE_SUCCESS, colony.getName()), true);
         return 1;
     }

--- a/src/main/java/com/minecolonies/core/commands/colonycommands/CommandDeleteColony.java
+++ b/src/main/java/com/minecolonies/core/commands/colonycommands/CommandDeleteColony.java
@@ -4,13 +4,13 @@ import com.minecolonies.api.colony.IColony;
 import com.minecolonies.api.colony.IColonyManager;
 import com.minecolonies.api.util.constant.translation.CommandTranslationConstants;
 import com.minecolonies.core.MineColonies;
+import com.minecolonies.core.commands.arguments.ColonyIdArgument;
 import com.minecolonies.core.commands.commandTypes.IMCColonyOfficerCommand;
 import com.minecolonies.core.commands.commandTypes.IMCCommand;
 import com.minecolonies.core.util.BackUpHelper;
 import com.mojang.brigadier.StringReader;
 import com.mojang.brigadier.arguments.ArgumentType;
 import com.mojang.brigadier.arguments.BoolArgumentType;
-import com.mojang.brigadier.arguments.IntegerArgumentType;
 import com.mojang.brigadier.builder.LiteralArgumentBuilder;
 import com.mojang.brigadier.context.CommandContext;
 import com.mojang.brigadier.exceptions.CommandSyntaxException;
@@ -52,7 +52,7 @@ public class CommandDeleteColony implements IMCColonyOfficerCommand
     public LiteralArgumentBuilder<CommandSourceStack> build()
     {
         return IMCCommand.newLiteral(getName())
-                 .then(IMCCommand.newArgument(COLONYID_ARG, IntegerArgumentType.integer(1))
+                 .then(IMCCommand.newArgument(COLONYID_ARG, ColonyIdArgument.id())
                          .executes(this::executeGuidedBuildingAsk)
                          .then(IMCCommand.newArgument(DELETE_BUILDINGS_ARG, DeleteBuildingsArgumentType.argument())
                                  .executes(this::executeGuidedConfirm)
@@ -160,7 +160,7 @@ public class CommandDeleteColony implements IMCColonyOfficerCommand
     public int onExecute(final CommandContext<CommandSourceStack> context)
     {
         // Colony
-        final int colonyID = IntegerArgumentType.getInteger(context, COLONYID_ARG);
+        final int colonyID = ColonyIdArgument.getColonyId(context, COLONYID_ARG);
         final IColony colony = IColonyManager.getInstance().getColonyByDimension(colonyID, context.getSource().getLevel().dimension());
         if (colony == null)
         {

--- a/src/main/java/com/minecolonies/core/commands/colonycommands/CommandExportColony.java
+++ b/src/main/java/com/minecolonies/core/commands/colonycommands/CommandExportColony.java
@@ -2,10 +2,10 @@ package com.minecolonies.core.commands.colonycommands;
 
 import com.minecolonies.api.colony.IColony;
 import com.minecolonies.api.colony.IColonyManager;
+import com.minecolonies.core.commands.arguments.ColonyIdArgument;
 import com.minecolonies.core.commands.commandTypes.IMCCommand;
 import com.minecolonies.core.commands.commandTypes.IMCOPCommand;
 import com.minecolonies.core.util.BackUpHelper;
-import com.mojang.brigadier.arguments.IntegerArgumentType;
 import com.mojang.brigadier.builder.LiteralArgumentBuilder;
 import com.mojang.brigadier.context.CommandContext;
 import net.minecraft.commands.CommandSourceStack;
@@ -23,7 +23,7 @@ public class CommandExportColony implements IMCOPCommand
     @Override
     public int onExecute(final CommandContext<CommandSourceStack> context)
     {
-        final int colonyId = IntegerArgumentType.getInteger(context, COLONYID_ARG);
+        final int colonyId = ColonyIdArgument.getColonyId(context, COLONYID_ARG);
         BackUpHelper.backupColonyData();
         final IColony colony = IColonyManager.getInstance().getColonyByDimension(colonyId, context.getSource().getLevel().dimension());
         if (colony == null)
@@ -49,6 +49,6 @@ public class CommandExportColony implements IMCOPCommand
     public LiteralArgumentBuilder<CommandSourceStack> build()
     {
         return IMCCommand.newLiteral(getName())
-                 .then(IMCCommand.newArgument(COLONYID_ARG, IntegerArgumentType.integer(1)).executes(this::checkPreConditionAndExecute));
+                 .then(IMCCommand.newArgument(COLONYID_ARG, ColonyIdArgument.id()).executes(this::checkPreConditionAndExecute));
     }
 }

--- a/src/main/java/com/minecolonies/core/commands/colonycommands/CommandExportColony.java
+++ b/src/main/java/com/minecolonies/core/commands/colonycommands/CommandExportColony.java
@@ -1,7 +1,6 @@
 package com.minecolonies.core.commands.colonycommands;
 
 import com.minecolonies.api.colony.IColony;
-import com.minecolonies.api.colony.IColonyManager;
 import com.minecolonies.core.commands.arguments.ColonyIdArgument;
 import com.minecolonies.core.commands.commandTypes.IMCCommand;
 import com.minecolonies.core.commands.commandTypes.IMCOPCommand;
@@ -12,7 +11,6 @@ import net.minecraft.commands.CommandSourceStack;
 import net.minecraft.network.chat.Component;
 
 import static com.minecolonies.api.util.constant.translation.CommandTranslationConstants.COMMAND_COLONY_EXPORT_SUCCESS;
-import static com.minecolonies.api.util.constant.translation.CommandTranslationConstants.COMMAND_COLONY_ID_NOT_FOUND;
 import static com.minecolonies.core.commands.CommandArgumentNames.COLONYID_ARG;
 
 /**
@@ -23,16 +21,11 @@ public class CommandExportColony implements IMCOPCommand
     @Override
     public int onExecute(final CommandContext<CommandSourceStack> context)
     {
-        final int colonyId = ColonyIdArgument.getColonyId(context, COLONYID_ARG);
+        final IColony colony = ColonyIdArgument.getColony(context, COLONYID_ARG);
         BackUpHelper.backupColonyData();
-        final IColony colony = IColonyManager.getInstance().getColonyByDimension(colonyId, context.getSource().getLevel().dimension());
-        if (colony == null)
-        {
-            context.getSource().sendSuccess(() -> Component.translatable(COMMAND_COLONY_ID_NOT_FOUND, colonyId), true);
-            return 0;
-        }
 
-        context.getSource().sendSuccess(() -> Component.translatable(COMMAND_COLONY_EXPORT_SUCCESS, BackUpHelper.exportColony(colony)), true);
+        final String filename = BackUpHelper.exportColony(colony);
+        context.getSource().sendSuccess(() -> Component.translatable(COMMAND_COLONY_EXPORT_SUCCESS, filename), true);
         return 1;
     }
 

--- a/src/main/java/com/minecolonies/core/commands/colonycommands/CommandLoadBackup.java
+++ b/src/main/java/com/minecolonies/core/commands/colonycommands/CommandLoadBackup.java
@@ -1,9 +1,9 @@
 package com.minecolonies.core.commands.colonycommands;
 
+import com.minecolonies.core.commands.arguments.ColonyIdArgument;
 import com.minecolonies.core.commands.commandTypes.IMCCommand;
 import com.minecolonies.core.commands.commandTypes.IMCOPCommand;
 import com.minecolonies.core.util.BackUpHelper;
-import com.mojang.brigadier.arguments.IntegerArgumentType;
 import com.mojang.brigadier.builder.LiteralArgumentBuilder;
 import com.mojang.brigadier.context.CommandContext;
 import net.minecraft.commands.CommandSourceStack;
@@ -25,7 +25,7 @@ public class CommandLoadBackup implements IMCOPCommand
     @Override
     public int onExecute(final CommandContext<CommandSourceStack> context)
     {
-        final int colonyId = IntegerArgumentType.getInteger(context, COLONYID_ARG);
+        final int colonyId = ColonyIdArgument.getColonyId(context, COLONYID_ARG);
         BackUpHelper.loadColonyBackup(colonyId, context.getSource().getLevel().dimension(), true, true);
         context.getSource().sendSuccess(() -> Component.translatable(COMMAND_COLONY_LOAD_BACKUP_SUCCESS), true);
         return 1;
@@ -44,6 +44,6 @@ public class CommandLoadBackup implements IMCOPCommand
     public LiteralArgumentBuilder<CommandSourceStack> build()
     {
         return IMCCommand.newLiteral(getName())
-                 .then(IMCCommand.newArgument(COLONYID_ARG, IntegerArgumentType.integer(1)).executes(this::checkPreConditionAndExecute));
+                 .then(IMCCommand.newArgument(COLONYID_ARG, ColonyIdArgument.id()).executes(this::checkPreConditionAndExecute));
     }
 }

--- a/src/main/java/com/minecolonies/core/commands/colonycommands/CommandRaid.java
+++ b/src/main/java/com/minecolonies/core/commands/colonycommands/CommandRaid.java
@@ -9,10 +9,10 @@ import com.minecolonies.api.util.Log;
 import com.minecolonies.api.util.constant.translation.CommandTranslationConstants;
 import com.minecolonies.core.colony.events.raid.norsemenevent.NorsemenShipRaidEvent;
 import com.minecolonies.core.colony.events.raid.pirateEvent.PirateGroundRaidEvent;
+import com.minecolonies.core.commands.arguments.ColonyIdArgument;
 import com.minecolonies.core.commands.commandTypes.IMCCommand;
 import com.minecolonies.core.commands.commandTypes.IMCOPCommand;
 import com.mojang.brigadier.arguments.BoolArgumentType;
-import com.mojang.brigadier.arguments.IntegerArgumentType;
 import com.mojang.brigadier.arguments.StringArgumentType;
 import com.mojang.brigadier.builder.LiteralArgumentBuilder;
 import com.mojang.brigadier.context.CommandContext;
@@ -66,7 +66,7 @@ public class CommandRaid implements IMCOPCommand
     public int raidExecute(final CommandContext<CommandSourceStack> context, final String raidType)
     {
         // Colony
-        final int colonyID = IntegerArgumentType.getInteger(context, COLONYID_ARG);
+        final int colonyID = ColonyIdArgument.getColonyId(context, COLONYID_ARG);
         final IColony colony = IColonyManager.getInstance().getColonyByDimension(colonyID, context.getSource().getLevel().dimension());
         if (colony == null)
         {
@@ -129,7 +129,7 @@ public class CommandRaid implements IMCOPCommand
         return IMCCommand.newLiteral(getName())
                  .then(IMCCommand.newArgument(RAID_TIME_ARG, StringArgumentType.string())
                          .suggests((ctx, builder) -> SharedSuggestionProvider.suggest(opt, builder))
-                         .then(IMCCommand.newArgument(COLONYID_ARG, IntegerArgumentType.integer(1))
+                         .then(IMCCommand.newArgument(COLONYID_ARG, ColonyIdArgument.id())
                                  .then(IMCCommand.newArgument(RAID_TYPE_ARG, StringArgumentType.string())
                                          .suggests((ctx, builder) -> SharedSuggestionProvider.suggest(raidTypes, builder))
                                          .then(IMCCommand.newArgument(SHIP_ARG, BoolArgumentType.bool())

--- a/src/main/java/com/minecolonies/core/commands/colonycommands/CommandRaid.java
+++ b/src/main/java/com/minecolonies/core/commands/colonycommands/CommandRaid.java
@@ -2,7 +2,6 @@ package com.minecolonies.core.commands.colonycommands;
 
 import com.minecolonies.api.IMinecoloniesAPI;
 import com.minecolonies.api.colony.IColony;
-import com.minecolonies.api.colony.IColonyManager;
 import com.minecolonies.api.colony.colonyEvents.registry.ColonyEventTypeRegistryEntry;
 import com.minecolonies.api.colony.managers.interfaces.IRaiderManager;
 import com.minecolonies.api.util.Log;
@@ -65,14 +64,7 @@ public class CommandRaid implements IMCOPCommand
      */
     public int raidExecute(final CommandContext<CommandSourceStack> context, final String raidType)
     {
-        // Colony
-        final int colonyID = ColonyIdArgument.getColonyId(context, COLONYID_ARG);
-        final IColony colony = IColonyManager.getInstance().getColonyByDimension(colonyID, context.getSource().getLevel().dimension());
-        if (colony == null)
-        {
-            context.getSource().sendSuccess(() -> Component.translatable(CommandTranslationConstants.COMMAND_COLONY_ID_NOT_FOUND, colonyID), true);
-            return 0;
-        }
+        final IColony colony = ColonyIdArgument.getColony(context, COLONYID_ARG);
 
         final boolean allowShips = BoolArgumentType.getBool(context, SHIP_ARG);
         if (StringArgumentType.getString(context, RAID_TIME_ARG).equals(RAID_NOW))

--- a/src/main/java/com/minecolonies/core/commands/colonycommands/CommandReclaimChunks.java
+++ b/src/main/java/com/minecolonies/core/commands/colonycommands/CommandReclaimChunks.java
@@ -6,10 +6,10 @@ import com.minecolonies.api.colony.IColonyManager;
 import com.minecolonies.api.util.Log;
 import com.minecolonies.api.util.MessageUtils;
 import com.minecolonies.api.util.constant.translation.CommandTranslationConstants;
+import com.minecolonies.core.commands.arguments.ColonyIdArgument;
 import com.minecolonies.core.commands.commandTypes.IMCCommand;
 import com.minecolonies.core.commands.commandTypes.IMCOPCommand;
 import com.minecolonies.core.util.BackUpHelper;
-import com.mojang.brigadier.arguments.IntegerArgumentType;
 import com.mojang.brigadier.builder.LiteralArgumentBuilder;
 import com.mojang.brigadier.context.CommandContext;
 import net.minecraft.commands.CommandSourceStack;
@@ -39,7 +39,7 @@ public class CommandReclaimChunks implements IMCOPCommand
         }
 
         // Colony
-        final int colonyID = IntegerArgumentType.getInteger(context, COLONYID_ARG);
+        final int colonyID = ColonyIdArgument.getColonyId(context, COLONYID_ARG);
 
         final IChunkmanagerCapability chunkManager = sender.level.getCapability(CHUNK_STORAGE_UPDATE_CAP, null).resolve().orElse(null);
         if (chunkManager == null)
@@ -72,6 +72,6 @@ public class CommandReclaimChunks implements IMCOPCommand
     public LiteralArgumentBuilder<CommandSourceStack> build()
     {
         return IMCCommand.newLiteral(getName())
-          .then(IMCCommand.newArgument(COLONYID_ARG, IntegerArgumentType.integer(1)).executes(this::checkPreConditionAndExecute));
+          .then(IMCCommand.newArgument(COLONYID_ARG, ColonyIdArgument.id()).executes(this::checkPreConditionAndExecute));
     }
 }

--- a/src/main/java/com/minecolonies/core/commands/colonycommands/CommandReclaimChunks.java
+++ b/src/main/java/com/minecolonies/core/commands/colonycommands/CommandReclaimChunks.java
@@ -2,7 +2,6 @@ package com.minecolonies.core.commands.colonycommands;
 
 import com.minecolonies.api.colony.IChunkmanagerCapability;
 import com.minecolonies.api.colony.IColony;
-import com.minecolonies.api.colony.IColonyManager;
 import com.minecolonies.api.util.Log;
 import com.minecolonies.api.util.MessageUtils;
 import com.minecolonies.api.util.constant.translation.CommandTranslationConstants;
@@ -38,8 +37,7 @@ public class CommandReclaimChunks implements IMCOPCommand
             return 0;
         }
 
-        // Colony
-        final int colonyID = ColonyIdArgument.getColonyId(context, COLONYID_ARG);
+        final IColony colony = ColonyIdArgument.getColony(context, COLONYID_ARG);
 
         final IChunkmanagerCapability chunkManager = sender.level.getCapability(CHUNK_STORAGE_UPDATE_CAP, null).resolve().orElse(null);
         if (chunkManager == null)
@@ -54,7 +52,6 @@ public class CommandReclaimChunks implements IMCOPCommand
             return 0;
         }
 
-        final IColony colony = IColonyManager.getInstance().getColonyByWorld(colonyID, sender.level);
         BackUpHelper.reclaimChunks(colony);
         MessageUtils.format(CommandTranslationConstants.COMMAND_CLAIM_SUCCESS).sendTo((Player) sender);
         return 1;

--- a/src/main/java/com/minecolonies/core/commands/colonycommands/CommandSetAbandoned.java
+++ b/src/main/java/com/minecolonies/core/commands/colonycommands/CommandSetAbandoned.java
@@ -1,7 +1,6 @@
 package com.minecolonies.core.commands.colonycommands;
 
 import com.minecolonies.api.colony.IColony;
-import com.minecolonies.api.colony.IColonyManager;
 import com.minecolonies.core.commands.arguments.ColonyIdArgument;
 import com.minecolonies.core.commands.commandTypes.IMCColonyOfficerCommand;
 import com.minecolonies.core.commands.commandTypes.IMCCommand;
@@ -12,7 +11,6 @@ import net.minecraft.network.chat.Component;
 import net.minecraft.world.entity.Entity;
 import net.minecraft.world.entity.player.Player;
 
-import static com.minecolonies.api.util.constant.translation.CommandTranslationConstants.COMMAND_COLONY_ID_NOT_FOUND;
 import static com.minecolonies.api.util.constant.translation.CommandTranslationConstants.COMMAND_OWNER_CHANGE_SUCCESS;
 import static com.minecolonies.core.commands.CommandArgumentNames.COLONYID_ARG;
 
@@ -27,14 +25,7 @@ public class CommandSetAbandoned implements IMCColonyOfficerCommand
     public int onExecute(final CommandContext<CommandSourceStack> context)
     {
         final Entity sender = context.getSource().getEntity();
-
-        final int colonyID = ColonyIdArgument.getColonyId(context, COLONYID_ARG);
-        final IColony colony = IColonyManager.getInstance().getColonyByDimension(colonyID, context.getSource().getLevel().dimension());
-        if (colony == null)
-        {
-            context.getSource().sendSuccess(() -> Component.translatable(COMMAND_COLONY_ID_NOT_FOUND, colonyID), true);
-            return 0;
-        }
+        final IColony colony = ColonyIdArgument.getColony(context, COLONYID_ARG);
 
         boolean addOfficer = false;
         if (sender != null && (colony.getPermissions().getRank((Player) sender).isColonyManager()))

--- a/src/main/java/com/minecolonies/core/commands/colonycommands/CommandSetAbandoned.java
+++ b/src/main/java/com/minecolonies/core/commands/colonycommands/CommandSetAbandoned.java
@@ -2,9 +2,9 @@ package com.minecolonies.core.commands.colonycommands;
 
 import com.minecolonies.api.colony.IColony;
 import com.minecolonies.api.colony.IColonyManager;
+import com.minecolonies.core.commands.arguments.ColonyIdArgument;
 import com.minecolonies.core.commands.commandTypes.IMCColonyOfficerCommand;
 import com.minecolonies.core.commands.commandTypes.IMCCommand;
-import com.mojang.brigadier.arguments.IntegerArgumentType;
 import com.mojang.brigadier.builder.LiteralArgumentBuilder;
 import com.mojang.brigadier.context.CommandContext;
 import net.minecraft.commands.CommandSourceStack;
@@ -28,7 +28,7 @@ public class CommandSetAbandoned implements IMCColonyOfficerCommand
     {
         final Entity sender = context.getSource().getEntity();
 
-        final int colonyID = IntegerArgumentType.getInteger(context, COLONYID_ARG);
+        final int colonyID = ColonyIdArgument.getColonyId(context, COLONYID_ARG);
         final IColony colony = IColonyManager.getInstance().getColonyByDimension(colonyID, context.getSource().getLevel().dimension());
         if (colony == null)
         {
@@ -66,6 +66,6 @@ public class CommandSetAbandoned implements IMCColonyOfficerCommand
     public LiteralArgumentBuilder<CommandSourceStack> build()
     {
         return IMCCommand.newLiteral(getName())
-                 .then(IMCCommand.newArgument(COLONYID_ARG, IntegerArgumentType.integer(1)).executes(this::checkPreConditionAndExecute));
+                 .then(IMCCommand.newArgument(COLONYID_ARG, ColonyIdArgument.id()).executes(this::checkPreConditionAndExecute));
     }
 }

--- a/src/main/java/com/minecolonies/core/commands/colonycommands/CommandSetDeletable.java
+++ b/src/main/java/com/minecolonies/core/commands/colonycommands/CommandSetDeletable.java
@@ -2,10 +2,10 @@ package com.minecolonies.core.commands.colonycommands;
 
 import com.minecolonies.api.colony.IColony;
 import com.minecolonies.api.colony.IColonyManager;
+import com.minecolonies.core.commands.arguments.ColonyIdArgument;
 import com.minecolonies.core.commands.commandTypes.IMCCommand;
 import com.minecolonies.core.commands.commandTypes.IMCOPCommand;
 import com.mojang.brigadier.arguments.BoolArgumentType;
-import com.mojang.brigadier.arguments.IntegerArgumentType;
 import com.mojang.brigadier.builder.LiteralArgumentBuilder;
 import com.mojang.brigadier.context.CommandContext;
 import net.minecraft.commands.CommandSourceStack;
@@ -29,7 +29,7 @@ public class CommandSetDeletable implements IMCOPCommand
     @Override
     public int onExecute(final CommandContext<CommandSourceStack> context)
     {
-        final int colonyID = IntegerArgumentType.getInteger(context, COLONYID_ARG);
+        final int colonyID = ColonyIdArgument.getColonyId(context, COLONYID_ARG);
         final IColony colony = IColonyManager.getInstance().getColonyByDimension(colonyID, context.getSource().getLevel().dimension());
         if (colony == null)
         {
@@ -56,7 +56,7 @@ public class CommandSetDeletable implements IMCOPCommand
     public LiteralArgumentBuilder<CommandSourceStack> build()
     {
         return IMCCommand.newLiteral(getName())
-                 .then(IMCCommand.newArgument(COLONYID_ARG, IntegerArgumentType.integer(1))
+                 .then(IMCCommand.newArgument(COLONYID_ARG, ColonyIdArgument.id())
                          .then(IMCCommand.newArgument(DELETEABLE_ARG, BoolArgumentType.bool()).executes(this::checkPreConditionAndExecute)));
     }
 }

--- a/src/main/java/com/minecolonies/core/commands/colonycommands/CommandSetDeletable.java
+++ b/src/main/java/com/minecolonies/core/commands/colonycommands/CommandSetDeletable.java
@@ -1,7 +1,6 @@
 package com.minecolonies.core.commands.colonycommands;
 
 import com.minecolonies.api.colony.IColony;
-import com.minecolonies.api.colony.IColonyManager;
 import com.minecolonies.core.commands.arguments.ColonyIdArgument;
 import com.minecolonies.core.commands.commandTypes.IMCCommand;
 import com.minecolonies.core.commands.commandTypes.IMCOPCommand;
@@ -12,7 +11,6 @@ import net.minecraft.commands.CommandSourceStack;
 import net.minecraft.network.chat.Component;
 
 import static com.minecolonies.api.util.constant.translation.CommandTranslationConstants.COMMAND_COLONY_DELETABLE_SUCCESS;
-import static com.minecolonies.api.util.constant.translation.CommandTranslationConstants.COMMAND_COLONY_ID_NOT_FOUND;
 import static com.minecolonies.core.commands.CommandArgumentNames.COLONYID_ARG;
 
 // TODO: Unused, maybe drop or add an auto delete feature
@@ -29,17 +27,11 @@ public class CommandSetDeletable implements IMCOPCommand
     @Override
     public int onExecute(final CommandContext<CommandSourceStack> context)
     {
-        final int colonyID = ColonyIdArgument.getColonyId(context, COLONYID_ARG);
-        final IColony colony = IColonyManager.getInstance().getColonyByDimension(colonyID, context.getSource().getLevel().dimension());
-        if (colony == null)
-        {
-            context.getSource().sendSuccess(() -> Component.translatable(COMMAND_COLONY_ID_NOT_FOUND, colonyID), true);
-            return 0;
-        }
+        final IColony colony = ColonyIdArgument.getColony(context, COLONYID_ARG);
 
         colony.setCanBeAutoDeleted(BoolArgumentType.getBool(context, DELETEABLE_ARG));
         context.getSource()
-          .sendSuccess(() -> Component.translatable(COMMAND_COLONY_DELETABLE_SUCCESS, colonyID, BoolArgumentType.getBool(context, DELETEABLE_ARG)), true);
+          .sendSuccess(() -> Component.translatable(COMMAND_COLONY_DELETABLE_SUCCESS, colony.getID(), BoolArgumentType.getBool(context, DELETEABLE_ARG)), true);
         return 1;
     }
 

--- a/src/main/java/com/minecolonies/core/commands/colonycommands/CommandSetRank.java
+++ b/src/main/java/com/minecolonies/core/commands/colonycommands/CommandSetRank.java
@@ -1,7 +1,6 @@
 package com.minecolonies.core.commands.colonycommands;
 
 import com.minecolonies.api.colony.IColony;
-import com.minecolonies.api.colony.IColonyManager;
 import com.minecolonies.api.colony.permissions.Rank;
 import com.minecolonies.api.util.constant.translation.CommandTranslationConstants;
 import com.minecolonies.core.commands.arguments.ColonyIdArgument;
@@ -31,13 +30,7 @@ public class CommandSetRank implements IMCOPCommand
     @Override
     public int onExecute(final CommandContext<CommandSourceStack> context)
     {
-        final int colonyID = ColonyIdArgument.getColonyId(context, COLONYID_ARG);
-        final IColony colony = IColonyManager.getInstance().getColonyByDimension(colonyID, context.getSource().getLevel().dimension());
-        if (colony == null)
-        {
-            context.getSource().sendSuccess(() -> Component.translatable(CommandTranslationConstants.COMMAND_COLONY_ID_NOT_FOUND, colonyID), true);
-            return 0;
-        }
+        final IColony colony = ColonyIdArgument.getColony(context, COLONYID_ARG);
 
         GameProfile profile;
         try
@@ -101,13 +94,7 @@ public class CommandSetRank implements IMCOPCommand
             .then(IMCCommand.newArgument(PLAYERNAME_ARG, GameProfileArgument.gameProfile())
               .then(IMCCommand.newArgument("rank", StringArgumentType.greedyString())
                 .suggests((context, builder) -> {
-                    final int colonyID = ColonyIdArgument.getColonyId(context, COLONYID_ARG);
-                    final IColony colony = IColonyManager.getInstance().getColonyByDimension(colonyID, context.getSource().getLevel().dimension());
-                    if (colony == null)
-                    {
-                        context.getSource().sendSuccess(() -> Component.translatable(CommandTranslationConstants.COMMAND_COLONY_ID_NOT_FOUND, colonyID), true);
-                        return null;
-                    }
+                    final IColony colony = ColonyIdArgument.getColony(context, COLONYID_ARG);
 
                     for (final Rank rank : colony.getPermissions().getRanks().values())
                     {

--- a/src/main/java/com/minecolonies/core/commands/colonycommands/CommandSetRank.java
+++ b/src/main/java/com/minecolonies/core/commands/colonycommands/CommandSetRank.java
@@ -4,10 +4,10 @@ import com.minecolonies.api.colony.IColony;
 import com.minecolonies.api.colony.IColonyManager;
 import com.minecolonies.api.colony.permissions.Rank;
 import com.minecolonies.api.util.constant.translation.CommandTranslationConstants;
+import com.minecolonies.core.commands.arguments.ColonyIdArgument;
 import com.minecolonies.core.commands.commandTypes.IMCCommand;
 import com.minecolonies.core.commands.commandTypes.IMCOPCommand;
 import com.mojang.authlib.GameProfile;
-import com.mojang.brigadier.arguments.IntegerArgumentType;
 import com.mojang.brigadier.arguments.StringArgumentType;
 import com.mojang.brigadier.builder.LiteralArgumentBuilder;
 import com.mojang.brigadier.context.CommandContext;
@@ -31,7 +31,7 @@ public class CommandSetRank implements IMCOPCommand
     @Override
     public int onExecute(final CommandContext<CommandSourceStack> context)
     {
-        final int colonyID = IntegerArgumentType.getInteger(context, COLONYID_ARG);
+        final int colonyID = ColonyIdArgument.getColonyId(context, COLONYID_ARG);
         final IColony colony = IColonyManager.getInstance().getColonyByDimension(colonyID, context.getSource().getLevel().dimension());
         if (colony == null)
         {
@@ -97,11 +97,11 @@ public class CommandSetRank implements IMCOPCommand
     public LiteralArgumentBuilder<CommandSourceStack> build()
     {
         return IMCCommand.newLiteral(getName())
-          .then(IMCCommand.newArgument(COLONYID_ARG, IntegerArgumentType.integer(1))
+          .then(IMCCommand.newArgument(COLONYID_ARG, ColonyIdArgument.id())
             .then(IMCCommand.newArgument(PLAYERNAME_ARG, GameProfileArgument.gameProfile())
               .then(IMCCommand.newArgument("rank", StringArgumentType.greedyString())
                 .suggests((context, builder) -> {
-                    final int colonyID = IntegerArgumentType.getInteger(context, COLONYID_ARG);
+                    final int colonyID = ColonyIdArgument.getColonyId(context, COLONYID_ARG);
                     final IColony colony = IColonyManager.getInstance().getColonyByDimension(colonyID, context.getSource().getLevel().dimension());
                     if (colony == null)
                     {

--- a/src/main/java/com/minecolonies/core/commands/colonycommands/CommandTeleport.java
+++ b/src/main/java/com/minecolonies/core/commands/colonycommands/CommandTeleport.java
@@ -4,16 +4,16 @@ import com.minecolonies.api.colony.IColony;
 import com.minecolonies.api.colony.IColonyManager;
 import com.minecolonies.api.util.MessageUtils;
 import com.minecolonies.core.MineColonies;
+import com.minecolonies.core.commands.arguments.ColonyIdArgument;
 import com.minecolonies.core.commands.commandTypes.IMCColonyOfficerCommand;
 import com.minecolonies.core.commands.commandTypes.IMCCommand;
 import com.minecolonies.core.util.TeleportHelper;
-import com.mojang.brigadier.arguments.IntegerArgumentType;
 import com.mojang.brigadier.builder.LiteralArgumentBuilder;
 import com.mojang.brigadier.context.CommandContext;
 import net.minecraft.commands.CommandSourceStack;
+import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.world.entity.Entity;
 import net.minecraft.world.entity.player.Player;
-import net.minecraft.server.level.ServerPlayer;
 
 import static com.minecolonies.api.util.constant.translation.CommandTranslationConstants.COMMAND_COLONY_ID_NOT_FOUND;
 import static com.minecolonies.api.util.constant.translation.CommandTranslationConstants.COMMAND_DISABLED_IN_CONFIG;
@@ -41,7 +41,7 @@ public class CommandTeleport implements IMCColonyOfficerCommand
         }
 
         // Colony
-        final int colonyID = IntegerArgumentType.getInteger(context, COLONYID_ARG);
+        final int colonyID = ColonyIdArgument.getColonyId(context, COLONYID_ARG);
         final IColony colony = IColonyManager.getInstance().getColonyByDimension(colonyID, context.getSource().getLevel().dimension());
         if (colony == null)
         {
@@ -67,6 +67,6 @@ public class CommandTeleport implements IMCColonyOfficerCommand
     public LiteralArgumentBuilder<CommandSourceStack> build()
     {
         return IMCCommand.newLiteral(getName())
-                 .then(IMCCommand.newArgument(COLONYID_ARG, IntegerArgumentType.integer(1)).executes(this::checkPreConditionAndExecute));
+                 .then(IMCCommand.newArgument(COLONYID_ARG, ColonyIdArgument.id()).executes(this::checkPreConditionAndExecute));
     }
 }

--- a/src/main/java/com/minecolonies/core/commands/colonycommands/CommandTeleport.java
+++ b/src/main/java/com/minecolonies/core/commands/colonycommands/CommandTeleport.java
@@ -1,7 +1,6 @@
 package com.minecolonies.core.commands.colonycommands;
 
 import com.minecolonies.api.colony.IColony;
-import com.minecolonies.api.colony.IColonyManager;
 import com.minecolonies.api.util.MessageUtils;
 import com.minecolonies.core.MineColonies;
 import com.minecolonies.core.commands.arguments.ColonyIdArgument;
@@ -15,7 +14,6 @@ import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.world.entity.Entity;
 import net.minecraft.world.entity.player.Player;
 
-import static com.minecolonies.api.util.constant.translation.CommandTranslationConstants.COMMAND_COLONY_ID_NOT_FOUND;
 import static com.minecolonies.api.util.constant.translation.CommandTranslationConstants.COMMAND_DISABLED_IN_CONFIG;
 import static com.minecolonies.core.commands.CommandArgumentNames.COLONYID_ARG;
 
@@ -40,14 +38,7 @@ public class CommandTeleport implements IMCColonyOfficerCommand
             return 0;
         }
 
-        // Colony
-        final int colonyID = ColonyIdArgument.getColonyId(context, COLONYID_ARG);
-        final IColony colony = IColonyManager.getInstance().getColonyByDimension(colonyID, context.getSource().getLevel().dimension());
-        if (colony == null)
-        {
-            MessageUtils.format(COMMAND_COLONY_ID_NOT_FOUND, colonyID).sendTo((Player) sender);
-            return 0;
-        }
+        final IColony colony = ColonyIdArgument.getColony(context, COLONYID_ARG);
 
         final ServerPlayer player = (ServerPlayer) sender;
         TeleportHelper.colonyTeleport(player, colony);

--- a/src/main/java/com/minecolonies/core/commands/colonycommands/requestsystem/CommandRSReset.java
+++ b/src/main/java/com/minecolonies/core/commands/colonycommands/requestsystem/CommandRSReset.java
@@ -1,7 +1,6 @@
 package com.minecolonies.core.commands.colonycommands.requestsystem;
 
 import com.minecolonies.api.colony.IColony;
-import com.minecolonies.api.colony.IColonyManager;
 import com.minecolonies.api.util.constant.translation.CommandTranslationConstants;
 import com.minecolonies.core.MineColonies;
 import com.minecolonies.core.commands.arguments.ColonyIdArgument;
@@ -23,14 +22,7 @@ public class CommandRSReset implements IMCCommand
     @Override
     public int onExecute(final CommandContext<CommandSourceStack> context)
     {
-        // Colony
-        final int colonyID = ColonyIdArgument.getColonyId(context, COLONYID_ARG);
-        final IColony colony = IColonyManager.getInstance().getColonyByDimension(colonyID, context.getSource().getLevel().dimension());
-        if (colony == null)
-        {
-            context.getSource().sendSuccess(() -> Component.translatable(CommandTranslationConstants.COMMAND_COLONY_ID_NOT_FOUND, colonyID), true);
-            return 0;
-        }
+        final IColony colony = ColonyIdArgument.getColony(context, COLONYID_ARG);
 
         if (!context.getSource().hasPermission(OP_PERM_LEVEL) && !MineColonies.getConfig().getServer().canPlayerUseResetCommand.get())
         {

--- a/src/main/java/com/minecolonies/core/commands/colonycommands/requestsystem/CommandRSReset.java
+++ b/src/main/java/com/minecolonies/core/commands/colonycommands/requestsystem/CommandRSReset.java
@@ -4,8 +4,8 @@ import com.minecolonies.api.colony.IColony;
 import com.minecolonies.api.colony.IColonyManager;
 import com.minecolonies.api.util.constant.translation.CommandTranslationConstants;
 import com.minecolonies.core.MineColonies;
+import com.minecolonies.core.commands.arguments.ColonyIdArgument;
 import com.minecolonies.core.commands.commandTypes.IMCCommand;
-import com.mojang.brigadier.arguments.IntegerArgumentType;
 import com.mojang.brigadier.builder.LiteralArgumentBuilder;
 import com.mojang.brigadier.context.CommandContext;
 import net.minecraft.commands.CommandSourceStack;
@@ -24,7 +24,7 @@ public class CommandRSReset implements IMCCommand
     public int onExecute(final CommandContext<CommandSourceStack> context)
     {
         // Colony
-        final int colonyID = IntegerArgumentType.getInteger(context, COLONYID_ARG);
+        final int colonyID = ColonyIdArgument.getColonyId(context, COLONYID_ARG);
         final IColony colony = IColonyManager.getInstance().getColonyByDimension(colonyID, context.getSource().getLevel().dimension());
         if (colony == null)
         {
@@ -57,6 +57,6 @@ public class CommandRSReset implements IMCCommand
     public LiteralArgumentBuilder<CommandSourceStack> build()
     {
         return IMCCommand.newLiteral(getName())
-                 .then(IMCCommand.newArgument(COLONYID_ARG, IntegerArgumentType.integer(1)).executes(this::checkPreConditionAndExecute));
+                 .then(IMCCommand.newArgument(COLONYID_ARG, ColonyIdArgument.id()).executes(this::checkPreConditionAndExecute));
     }
 }

--- a/src/main/java/com/minecolonies/core/commands/commandTypes/IMCColonyOfficerCommand.java
+++ b/src/main/java/com/minecolonies/core/commands/commandTypes/IMCColonyOfficerCommand.java
@@ -3,7 +3,7 @@ package com.minecolonies.core.commands.commandTypes;
 import com.minecolonies.api.colony.IColony;
 import com.minecolonies.api.colony.IColonyManager;
 import com.minecolonies.api.util.MessageUtils;
-import com.mojang.brigadier.arguments.IntegerArgumentType;
+import com.minecolonies.core.commands.arguments.ColonyIdArgument;
 import com.mojang.brigadier.context.CommandContext;
 import net.minecraft.commands.CommandSourceStack;
 import net.minecraft.world.entity.Entity;
@@ -36,7 +36,7 @@ public interface IMCColonyOfficerCommand extends IMCCommand
         }
 
         // Colony
-        final int colonyID = IntegerArgumentType.getInteger(context, COLONYID_ARG);
+        final int colonyID = ColonyIdArgument.getColonyId(context, COLONYID_ARG);
         final IColony colony = IColonyManager.getInstance().getColonyByDimension(colonyID, context.getSource().getLevel().dimension());
         if (colony == null)
         {

--- a/src/main/java/com/minecolonies/core/commands/commandTypes/IMCColonyOfficerCommand.java
+++ b/src/main/java/com/minecolonies/core/commands/commandTypes/IMCColonyOfficerCommand.java
@@ -1,15 +1,13 @@
 package com.minecolonies.core.commands.commandTypes;
 
 import com.minecolonies.api.colony.IColony;
-import com.minecolonies.api.colony.IColonyManager;
-import com.minecolonies.api.util.MessageUtils;
 import com.minecolonies.core.commands.arguments.ColonyIdArgument;
 import com.mojang.brigadier.context.CommandContext;
+import net.minecraft.commands.CommandRuntimeException;
 import net.minecraft.commands.CommandSourceStack;
 import net.minecraft.world.entity.Entity;
 import net.minecraft.world.entity.player.Player;
 
-import static com.minecolonies.api.util.constant.translation.CommandTranslationConstants.COMMAND_COLONY_ID_NOT_FOUND;
 import static com.minecolonies.core.commands.CommandArgumentNames.COLONYID_ARG;
 
 /**
@@ -35,12 +33,13 @@ public interface IMCColonyOfficerCommand extends IMCCommand
             return false;
         }
 
-        // Colony
-        final int colonyID = ColonyIdArgument.getColonyId(context, COLONYID_ARG);
-        final IColony colony = IColonyManager.getInstance().getColonyByDimension(colonyID, context.getSource().getLevel().dimension());
-        if (colony == null)
+        final IColony colony;
+        try
         {
-            MessageUtils.format(COMMAND_COLONY_ID_NOT_FOUND, colonyID).sendTo((Player) sender);
+            colony = ColonyIdArgument.getColony(context, COLONYID_ARG);
+        }
+        catch (CommandRuntimeException e)
+        {
             return false;
         }
 

--- a/src/main/resources/assets/minecolonies/lang/manual_en_us.json
+++ b/src/main/resources/assets/minecolonies/lang/manual_en_us.json
@@ -388,6 +388,10 @@
   "entity.builder.messagenobuilder": "You need a Builder to build or upgrade this building.",
   "entity.farmer.needseed": "I need %s to plant.",
 
+  "com.minecolonies.command.argument.colony.unknown": "There is no colony here",
+  "com.minecolonies.command.argument.colony.here": "The colony at this location",
+  "com.minecolonies.command.argument.colony.mine": "The colony you own",
+
   "com.minecolonies.command.help.wiki": "Check out the wiki to learn more: ",
   "com.minecolonies.command.help.discord": "Join the community at  ",
   "com.minecolonies.command.notcreative": "Must be in Creative Mode to use this command.",


### PR DESCRIPTION
Closes [discord request](https://discord.com/channels/139070364159311872/1407552866096251004)

# Changes proposed in this pull request
- All commands that take a colony id now accept additional values in its place:
    - The colony id, as before (but now it suggests colony ids that you've been close to recently, i.e. are still in the client-side colony manager; you can still type other ids)
    - The name or id of a player, which resolves to their owned colony (and it suggests known player names, but not ids)
    - `@here`, which means the colony where you're running the command
    - `@mine`, which means your own colony
- `IColonyManager.getColonies()` now works on client side too.

## Testing
- [x] Yes I tested this before submitting it.
- [x] I also did a multiplayer test.

Review please (should port)

One caveat of note is that a lot of commands still require a player to execute them (used to check permissions), which in turn means that they still don't work in command blocks as desired in the linked thread.  But some now will.