### PR TITLE
Chains for the chainmail

### DIFF
--- a/src/datagen/generated/minecolonies/data/minecolonies/loot_tables/blocks/blockhutgatehouse.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/loot_tables/blocks/blockhutgatehouse.json
@@ -1,0 +1,27 @@
+{
+  "type": "minecraft:block",
+  "pools": [
+    {
+      "bonus_rolls": 0.0,
+      "conditions": [
+        {
+          "condition": "minecraft:survives_explosion"
+        }
+      ],
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "functions": [
+            {
+              "function": "minecraft:copy_name",
+              "source": "block_entity"
+            }
+          ],
+          "name": "minecolonies:blockhutgatehouse"
+        }
+      ],
+      "rolls": 1.0
+    }
+  ],
+  "random_sequence": "minecolonies:blocks/blockhutgatehouse"
+}

--- a/src/datagen/generated/minecolonies/data/minecolonies/recipes/chainmailboots.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/recipes/chainmailboots.json
@@ -2,15 +2,15 @@
   "type": "minecraft:crafting_shaped",
   "category": "misc",
   "key": {
-    "I": {
-      "item": "minecraft:iron_ingot"
+    "C": {
+      "item": "minecraft:chain"
     },
     "N": {
       "item": "minecraft:iron_nugget"
     }
   },
   "pattern": [
-    "I I",
+    "C C",
     "N N"
   ],
   "result": {

--- a/src/datagen/generated/minecolonies/data/minecolonies/recipes/chainmailchestplate.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/recipes/chainmailchestplate.json
@@ -2,15 +2,15 @@
   "type": "minecraft:crafting_shaped",
   "category": "misc",
   "key": {
-    "I": {
-      "item": "minecraft:iron_ingot"
+    "C": {
+      "item": "minecraft:chain"
     },
     "N": {
       "item": "minecraft:iron_nugget"
     }
   },
   "pattern": [
-    "I I",
+    "C C",
     "NNN",
     "NNN"
   ],

--- a/src/datagen/generated/minecolonies/data/minecolonies/recipes/chainmailhelmet.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/recipes/chainmailhelmet.json
@@ -2,16 +2,16 @@
   "type": "minecraft:crafting_shaped",
   "category": "misc",
   "key": {
-    "I": {
-      "item": "minecraft:iron_ingot"
+    "C": {
+      "item": "minecraft:chain"
     },
     "N": {
       "item": "minecraft:iron_nugget"
     }
   },
   "pattern": [
-    "NNN",
-    "NIN"
+    "NCN",
+    "N N"
   ],
   "result": {
     "item": "minecraft:chainmail_helmet"

--- a/src/datagen/generated/minecolonies/data/minecolonies/recipes/chainmailleggings.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/recipes/chainmailleggings.json
@@ -2,15 +2,15 @@
   "type": "minecraft:crafting_shaped",
   "category": "misc",
   "key": {
-    "I": {
-      "item": "minecraft:iron_ingot"
+    "C": {
+      "item": "minecraft:chain"
     },
     "N": {
       "item": "minecraft:iron_nugget"
     }
   },
   "pattern": [
-    "III",
+    "CNC",
     "N N",
     "N N"
   ],

--- a/src/main/java/com/minecolonies/core/generation/defaults/DefaultRecipeProvider.java
+++ b/src/main/java/com/minecolonies/core/generation/defaults/DefaultRecipeProvider.java
@@ -547,35 +547,35 @@ public class DefaultRecipeProvider extends RecipeProvider
                 .save(consumer);
 
         ShapedRecipeBuilder.shaped(RecipeCategory.MISC,Items.CHAINMAIL_HELMET)
-                .pattern("NNN")
-                .pattern("NIN")
-                .define('I', Items.IRON_INGOT)
+                .pattern("NCN")
+                .pattern("N N")
+                .define('C', Items.CHAIN)
                 .define('N', Items.IRON_NUGGET)
                 .unlockedBy("has_iron", has(Items.IRON_INGOT))
                 .save(consumer, new ResourceLocation(MOD_ID, "chainmailhelmet"));
 
         ShapedRecipeBuilder.shaped(RecipeCategory.MISC,Items.CHAINMAIL_CHESTPLATE)
-                .pattern("I I")
+                .pattern("C C")
                 .pattern("NNN")
                 .pattern("NNN")
-                .define('I', Items.IRON_INGOT)
+                .define('C', Items.CHAIN)
                 .define('N', Items.IRON_NUGGET)
                 .unlockedBy("has_iron", has(Items.IRON_INGOT))
                 .save(consumer, new ResourceLocation(MOD_ID, "chainmailchestplate"));
 
         ShapedRecipeBuilder.shaped(RecipeCategory.MISC,Items.CHAINMAIL_LEGGINGS)
-                .pattern("III")
+                .pattern("CNC")
                 .pattern("N N")
                 .pattern("N N")
-                .define('I', Items.IRON_INGOT)
+                .define('C', Items.CHAIN)
                 .define('N', Items.IRON_NUGGET)
                 .unlockedBy("has_iron", has(Items.IRON_INGOT))
                 .save(consumer, new ResourceLocation(MOD_ID, "chainmailleggings"));
 
         ShapedRecipeBuilder.shaped(RecipeCategory.MISC,Items.CHAINMAIL_BOOTS)
-                .pattern("I I")
+                .pattern("C C")
                 .pattern("N N")
-                .define('I', Items.IRON_INGOT)
+                .define('C', Items.CHAIN)
                 .define('N', Items.IRON_NUGGET)
                 .unlockedBy("has_iron", has(Items.IRON_INGOT))
                 .save(consumer, new ResourceLocation(MOD_ID, "chainmailboots"));


### PR DESCRIPTION
Closes [discord request](https://discord.com/channels/139070364159311872/1125094832143077456/1409702896143958160)

# Changes proposed in this pull request
- Chainmail now uses chains in its crafting recipe, for thematic correctness.
    - Blacksmiths who already know it will continue to use the old recipe until re-taught.
    - This does make the recipes slightly more expensive, in general, to avoid disrupting the visual pattern.
        - Helmet went from 5 nuggets + 1 iron to 4 nuggets + 1 chain (net +1 nugget)
        - Chestplate went from 6 nuggets + 2 iron to 6 nuggets + 2 chain (net +4 nuggets)
        - Leggings went from 4 nuggets + 3 iron to 5 nuggets + 2 chain (net -4 nuggets)
        - Boots went from 2 nuggets + 2 iron to 2 nuggets + 2 chain (net +4 nuggets)
- Also randomly included a missing loot table for the gatehouse.

## Testing
- [x] Yes I tested this before submitting it.
- [ ] I also did a multiplayer test.

Review please (should port)

Alternative recipe suggestions welcome, if you don't like this balance.  I did have another idea for the boots in particular.