### PR TITLE
Show tooltip for pickup huts

### DIFF
--- a/src/main/java/com/minecolonies/api/items/ItemBlockHut.java
+++ b/src/main/java/com/minecolonies/api/items/ItemBlockHut.java
@@ -1,8 +1,22 @@
 package com.minecolonies.api.items;
 
-import com.minecolonies.api.blocks.AbstractColonyBlock;
+import com.minecolonies.api.IMinecoloniesAPI;
 import com.minecolonies.api.blocks.AbstractBlockHut;
+import com.minecolonies.api.blocks.AbstractColonyBlock;
+import com.minecolonies.api.colony.IColonyView;
+import net.minecraft.ChatFormatting;
+import net.minecraft.network.chat.Component;
 import net.minecraft.world.item.BlockItem;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.TooltipFlag;
+import net.minecraft.world.level.Level;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.List;
+
+import static com.minecolonies.api.util.constant.NbtTagConstants.TAG_COLONY_ID;
+import static com.minecolonies.api.util.constant.NbtTagConstants.TAG_OTHER_LEVEL;
 
 /**
  * A custom item class for hut blocks.
@@ -24,5 +38,24 @@ public class ItemBlockHut extends BlockItem
     {
         super(block, builder);
         this.block = block;
+    }
+
+    @Override
+    public void appendHoverText(@NotNull final ItemStack stack, @Nullable final Level world, @NotNull final List<Component> tooltip, @NotNull final TooltipFlag flags)
+    {
+        super.appendHoverText(stack, world, tooltip, flags);
+
+        if (stack.hasTag() && stack.getTag().contains(TAG_OTHER_LEVEL))
+        {
+            final Component level = Component.literal(String.valueOf(stack.getTag().getInt(TAG_OTHER_LEVEL))).withStyle(ChatFormatting.GOLD);
+            tooltip.add(Component.translatable("item.minecolonies.hut.level", level).withStyle(ChatFormatting.GREEN));
+        }
+        if (stack.hasTag() && stack.getTag().contains(TAG_COLONY_ID) && world != null)
+        {
+            // todo: should we store a dimension id as well? because currently this can't tell, so it will sometimes be wrong
+            final IColonyView colony = IMinecoloniesAPI.getInstance().getColonyManager().getColonyView(stack.getTag().getInt(TAG_COLONY_ID), world.dimension());
+            final Component name = colony != null ? Component.literal(colony.getName()) : Component.translatable("item.minecolonies.hut.unknowncolony");
+            tooltip.add(Component.translatable("item.minecolonies.hut.colony", name).withStyle(ChatFormatting.ITALIC));
+        }
     }
 }

--- a/src/main/resources/assets/minecolonies/lang/manual_en_us.json
+++ b/src/main/resources/assets/minecolonies/lang/manual_en_us.json
@@ -760,6 +760,9 @@
   "item.minecolonies.supplychestdeployer": "Supply Ship",
   "item.minecolonies.supplycampdeployer": "Supply Camp",
   "item.minecolonies.supply.free": "%s - free",
+  "item.minecolonies.hut.level": "Places at level %s",
+  "item.minecolonies.hut.colony": "Can only be placed in %s",
+  "item.minecolonies.hut.unknowncolony": "unknown colony",
   "com.minecolonies.coremod.job.guard.toolclickguardtoofar": "Too far away from Guard Tower, please upgrade your Guard Tower to set this spot!",
 
   "item.minecolonies.scepterbeekeeper": "Hive Tool",


### PR DESCRIPTION
Closes [discord request](https://discord.com/channels/472875599422291968/1413087126148350006)

# Changes proposed in this pull request
- Shows a tooltip on hut blocks resulting from picking up a deconstructed hut
    <img width="360" height="68" alt="image" src="https://github.com/user-attachments/assets/55187da8-7bd8-4edd-953e-afa008ab6209" />

## Testing
- [x] Yes I tested this before submitting it.
- [ ] I also did a multiplayer test.

Review please (do not port)