### PR TITLE
Add Biome matching tooltip to crops

### DIFF
--- a/src/main/java/com/minecolonies/core/items/ItemCrop.java
+++ b/src/main/java/com/minecolonies/core/items/ItemCrop.java
@@ -6,6 +6,7 @@ import com.minecolonies.api.util.constant.TranslationConstants;
 import com.minecolonies.core.blocks.MinecoloniesCropBlock;
 import com.minecolonies.core.blocks.MinecoloniesFarmland;
 import net.minecraft.ChatFormatting;
+import net.minecraft.client.Minecraft;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Holder;
 import net.minecraft.network.chat.Component;
@@ -71,9 +72,17 @@ public class ItemCrop extends BlockItem
     public void appendHoverText(@NotNull final ItemStack stack, @Nullable final Level worldIn, @NotNull final List<Component> tooltip, @NotNull final TooltipFlag flagIn)
     {
         tooltip.add(Component.translatable(TranslationConstants.CROP_TOOLTIP).withStyle(ChatFormatting.GRAY));
-        if (preferredBiome != null)
+        if (preferredBiome != null && worldIn != null)
         {
             tooltip.add(Component.translatable(TranslationConstants.BIOME_TOOLTIP + "." + preferredBiome.location().getPath()));
+            if (worldIn.getBiome(Minecraft.getInstance().player.blockPosition()).is(preferredBiome))
+            {
+                tooltip.add(Component.translatable("com.minecolonies.core.item.crop.tooltip.biome.match").withStyle(ChatFormatting.GREEN));
+            }
+            else
+            {
+                tooltip.add(Component.translatable("com.minecolonies.core.item.crop.tooltip.biome.nomatch").withStyle(ChatFormatting.RED));
+            }
         }
         tooltip.add(Component.translatable(TranslationConstants.CROP_TOOLTIP_HOE).withStyle(ChatFormatting.DARK_AQUA).withStyle(ChatFormatting.ITALIC));
     }

--- a/src/main/resources/assets/minecolonies/lang/manual_en_us.json
+++ b/src/main/resources/assets/minecolonies/lang/manual_en_us.json
@@ -2715,6 +2715,8 @@
   "com.minecolonies.core.crop.cantplant": "You do not possess the necessary knowledge to plant this crop. You should ask a Colony's Farmer to plant this for you!",
   "com.minecolonies.core.item.crop.tooltip": "Ask a Farmer to plant this for you",
   "com.minecolonies.core.item.crop.tooltip.hoe": "Easier to find with a quality hoe",
+  "com.minecolonies.core.item.crop.tooltip.biome.match": "You can plant this here",
+  "com.minecolonies.core.item.crop.tooltip.biome.nomatch": "You cannot plant this here",
   "com.minecolonies.core.item.crop.tooltip.biome.coldbiomes": "Only suitable for Cold Biomes",
   "com.minecolonies.core.item.crop.tooltip.biome.temperatebiomes": "Only suitable for Temperate Biomes",
   "com.minecolonies.core.item.crop.tooltip.biome.humidbiomes": "Only suitable for Hot and Humid Biomes",


### PR DESCRIPTION
Closes #
Closes #

# Changes proposed in this pull request
-Add Biome matching tooltip to crops
<img width="600" height="232" alt="image" src="https://github.com/user-attachments/assets/ead8f36b-8e49-4b09-986e-9b57d135250a" />

## Testing
- [x ] Yes I tested this before submitting it.
- [ ] I also did a multiplayer test.

Review please