### PR TITLE
Fix building UI button flickering on open

### DIFF
--- a/src/main/java/com/minecolonies/core/client/gui/AbstractWindowModuleBuilding.java
+++ b/src/main/java/com/minecolonies/core/client/gui/AbstractWindowModuleBuilding.java
@@ -190,5 +190,7 @@ public abstract class AbstractWindowModuleBuilding<B extends IBuildingView> exte
             final MutableComponent componentWithLevel = component.append(" ").append(String.valueOf(buildingView.getBuildingLevel()));
             title.setText(componentWithLevel);
         }
+
+        updateButtonBuild(building);
     }
 }


### PR DESCRIPTION
# Changes proposed in this pull request
- Fixed building UI button flickering when opening the window during an active build/upgrade
- Added explicit `updateButtonBuild()` call in `onOpened()` to ensure button displays correct state immediately instead of flickering from default state
  
When opening a building UI (e.g., builder hut during upgrade), the build/cancel button would briefly flicker from its default state before showing the correct state (e.g., "Cancel Build").

## Testing
- [x] Yes I tested this before submitting it.
- [ ] I also did a multiplayer test.

Review please