### PR TITLE
feat: Make name style changes apply instantly to all citizens

### DIFF
--- a/src/main/java/com/minecolonies/api/colony/ICivilianData.java
+++ b/src/main/java/com/minecolonies/api/colony/ICivilianData.java
@@ -213,4 +213,19 @@ public interface ICivilianData extends ICitizen, INBTSerializable<CompoundTag>
      * @return uuid
      */
     UUID getUUID();
+
+    /**
+     * Set the name with optional preserved flag.
+     *
+     * @param name the name to set.
+     * @param isPreserved true to mark this name as preserved (from nametag or special visitor) and prevent regeneration.
+     */
+    void setName(String name, boolean isPreserved);
+
+    /**
+     * Set whether this civilian has a preserved name.
+     *
+     * @param hasPreservedName true if the name should be preserved.
+     */
+    void setHasPreservedName(boolean hasPreservedName);
 }

--- a/src/main/java/com/minecolonies/api/colony/ICivilianData.java
+++ b/src/main/java/com/minecolonies/api/colony/ICivilianData.java
@@ -56,6 +56,11 @@ public interface ICivilianData extends ICitizen, INBTSerializable<CompoundTag>
     void setGenderAndGenerateName(boolean isFemale);
 
     /**
+     * Regenerates the name using the current gender and colony name pack.
+     */
+    void regenerateName();
+
+    /**
      * Sets the gender
      *
      * @param isFemale

--- a/src/main/java/com/minecolonies/api/eventbus/events/colony/ColonyNameStyleChangedModEvent.java
+++ b/src/main/java/com/minecolonies/api/eventbus/events/colony/ColonyNameStyleChangedModEvent.java
@@ -1,0 +1,20 @@
+package com.minecolonies.api.eventbus.events.colony;
+
+import com.minecolonies.api.colony.IColony;
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * Colony name style changed event.
+ */
+public final class ColonyNameStyleChangedModEvent extends AbstractColonyModEvent
+{
+    /**
+     * Constructs a colony name style changed event.
+     *
+     * @param colony the colony related to the event.
+     */
+    public ColonyNameStyleChangedModEvent(final @NotNull IColony colony)
+    {
+        super(colony);
+    }
+}

--- a/src/main/java/com/minecolonies/api/util/constant/NbtTagConstants.java
+++ b/src/main/java/com/minecolonies/api/util/constant/NbtTagConstants.java
@@ -72,6 +72,7 @@ public final class NbtTagConstants
     public static final String TAG_PERIOD                 = "period";
     public static final String TAG_IS_BUILT               = "isBuilt";
     public static final String TAG_CUSTOM_NAME            = "customName";
+    public static final String TAG_PRESERVED_NAME         = "preservedName";
     public static final String TAG_OTHER_LEVEL            = "otherLevel";
     public static final String TAG_PASTEABLE              = "isPasteable";
     public static final String TAG_MOURNING               = "mourning";

--- a/src/main/java/com/minecolonies/core/colony/CitizenData.java
+++ b/src/main/java/com/minecolonies/core/colony/CitizenData.java
@@ -816,6 +816,17 @@ public class CitizenData implements ICitizenData
     }
 
     @Override
+    public void regenerateName()
+    {
+        this.name = generateName(random, this.female, getColony(), getColony().getCitizenNameFile());
+        if (getEntity().isPresent())
+        {
+            getEntity().get().setCustomName(Component.literal(this.name));
+        }
+        markDirty(0);
+    }
+
+    @Override
     public void setGender(final boolean isFemale)
     {
         this.female = isFemale;

--- a/src/main/java/com/minecolonies/core/colony/CitizenData.java
+++ b/src/main/java/com/minecolonies/core/colony/CitizenData.java
@@ -246,6 +246,11 @@ public class CitizenData implements ICitizenData
     private String textureSuffix;
 
     /**
+     * Whether this citizen has a preserved name (set by nametag or special visitor).
+     */
+    private boolean hasPreservedName = false;
+
+    /**
      * The status icon to display
      */
     private VisibleCitizenStatus status;
@@ -818,6 +823,11 @@ public class CitizenData implements ICitizenData
     @Override
     public void regenerateName()
     {
+        if (hasPreservedName)
+        {
+            return;
+        }
+
         this.name = generateName(random, this.female, getColony(), getColony().getCitizenNameFile());
         if (getEntity().isPresent())
         {
@@ -1171,6 +1181,21 @@ public class CitizenData implements ICitizenData
     }
 
     @Override
+    public void setName(final String name, final boolean isPreserved)
+    {
+        this.name = name;
+        this.hasPreservedName = isPreserved;
+        markDirty(0);
+    }
+
+    @Override
+    public void setHasPreservedName(final boolean hasPreservedName)
+    {
+        this.hasPreservedName = hasPreservedName;
+        markDirty(0);
+    }
+
+    @Override
     public void setLastPosition(final BlockPos lastPosition)
     {
         this.lastPosition = lastPosition;
@@ -1319,6 +1344,7 @@ public class CitizenData implements ICitizenData
         nbtTagCompound.putBoolean(TAG_PAUSED, paused);
         nbtTagCompound.putBoolean(TAG_CHILD, isChild);
         nbtTagCompound.putInt(TAG_TEXTURE, textureId);
+        nbtTagCompound.putBoolean(TAG_PRESERVED_NAME, hasPreservedName);
 
         nbtTagCompound.put(TAG_NEW_SKILLS, citizenSkillHandler.write());
 
@@ -1422,6 +1448,7 @@ public class CitizenData implements ICitizenData
         paused = nbtTagCompound.getBoolean(TAG_PAUSED);
         isChild = nbtTagCompound.getBoolean(TAG_CHILD);
         textureId = nbtTagCompound.getInt(TAG_TEXTURE);
+        hasPreservedName = nbtTagCompound.getBoolean(TAG_PRESERVED_NAME);
 
         if (nbtTagCompound.contains(TAG_SUFFIX))
         {

--- a/src/main/java/com/minecolonies/core/colony/Colony.java
+++ b/src/main/java/com/minecolonies/core/colony/Colony.java
@@ -1939,6 +1939,14 @@ public class Colony implements IColony
     public void setNameStyle(final String style)
     {
         this.nameStyle = style;
+        for (final ICitizenData citizen : citizenManager.getCitizens())
+        {
+            citizen.regenerateName();
+        }
+        for (final ICivilianData visitor : visitorManager.getCivilianDataMap().values())
+        {
+            visitor.regenerateName();
+        }
         this.markDirty();
     }
 

--- a/src/main/java/com/minecolonies/core/datalistener/CustomVisitorListener.java
+++ b/src/main/java/com/minecolonies/core/datalistener/CustomVisitorListener.java
@@ -233,7 +233,7 @@ public class CustomVisitorListener extends SimpleJsonResourceReloadListener
 
             if (name != null)
             {
-                visitorData.setName(name);
+                visitorData.setName(name, true);
                 visitorData.getEntity().ifPresent(entity -> entity.setCustomName(Component.literal(name)));
             }
 

--- a/src/main/java/com/minecolonies/core/entity/citizen/EntityCitizen.java
+++ b/src/main/java/com/minecolonies/core/entity/citizen/EntityCitizen.java
@@ -365,6 +365,10 @@ public class EntityCitizen extends AbstractEntityCitizen implements IThreatTable
 
         if (!ItemStackUtils.isEmpty(player.getItemInHand(hand)) && player.getItemInHand(hand).is(Items.NAME_TAG))
         {
+            if (citizenData != null)
+            {
+                citizenData.setHasPreservedName(true);
+            }
             return super.checkAndHandleImportantInteractions(player, hand);
         }
 
@@ -1525,7 +1529,7 @@ public class EntityCitizen extends AbstractEntityCitizen implements IThreatTable
     {
         return this.isBaby() ? 0.62F : 1.0F;
     }
-    
+
     /**
      * Called when the mob's health reaches 0.
      *
@@ -1954,7 +1958,7 @@ public class EntityCitizen extends AbstractEntityCitizen implements IThreatTable
     {
         return citizenColonyHandler.getColonyId();
     }
-    
+
     /**
      * Decrease idle saturation.
      * @return saturation.

--- a/src/main/java/com/minecolonies/core/network/messages/server/colony/ColonyNameStyleMessage.java
+++ b/src/main/java/com/minecolonies/core/network/messages/server/colony/ColonyNameStyleMessage.java
@@ -1,6 +1,8 @@
 package com.minecolonies.core.network.messages.server.colony;
 
+import com.minecolonies.api.IMinecoloniesAPI;
 import com.minecolonies.api.colony.IColony;
+import com.minecolonies.api.eventbus.events.colony.ColonyNameStyleChangedModEvent;
 import com.minecolonies.core.network.messages.server.AbstractColonyServerMessage;
 import net.minecraft.network.FriendlyByteBuf;
 import net.minecraftforge.network.NetworkEvent;
@@ -39,6 +41,7 @@ public class ColonyNameStyleMessage extends AbstractColonyServerMessage
     protected void onExecute(NetworkEvent.Context ctxIn, boolean isLogicalServer, IColony colony)
     {
         colony.setNameStyle(style);
+        IMinecoloniesAPI.getInstance().getEventBus().post(new ColonyNameStyleChangedModEvent(colony));
     }
 
     @Override


### PR DESCRIPTION
# Changes proposed in this pull request
- Name style changes now apply instantly to all existing citizens and visitors
- Added ColonyNameStyleChangedModEvent

Previously, when changing the colony name pack (e.g., from Spanish to Norse), existing citizens would keep their old names. This created an inconsistency where players could change citizen appearance instantly with texture styles, but names only updated for newly spawned citizens.

## Testing
- [x] Yes I tested this before submitting it.
- [ ] I also did a multiplayer test.

Review please