### PR TITLE
Prevent recursive ore breaking

### DIFF
--- a/src/main/java/com/minecolonies/api/compatibility/CompatibilityManager.java
+++ b/src/main/java/com/minecolonies/api/compatibility/CompatibilityManager.java
@@ -15,6 +15,8 @@ import com.minecolonies.api.crafting.registry.ModRecipeSerializer;
 import com.minecolonies.api.items.ModTags;
 import com.minecolonies.api.util.*;
 import com.minecolonies.api.util.constant.NbtTagConstants;
+import com.minecolonies.core.colony.crafting.CustomRecipeManager;
+import com.minecolonies.core.colony.crafting.LootTableAnalyzer;
 import com.minecolonies.core.util.FurnaceRecipes;
 import it.unimi.dsi.fastutil.objects.Object2IntLinkedOpenHashMap;
 import net.minecraft.client.multiplayer.ClientLevel;
@@ -483,10 +485,14 @@ public class CompatibilityManager implements ICompatibilityManager
     @Override
     public boolean isOre(@NotNull final ItemStack stack)
     {
-        if (isMineableOre(stack) || stack.is(ModTags.raw_ore) || stack.is(ModTags.breakable_ore))
+        if (isBreakableOre(stack))
+        {
+            return true;
+        }
+        if (isMineableOre(stack) || stack.is(ModTags.raw_ore))
         {
             ItemStack smeltingResult = MinecoloniesAPIProxy.getInstance().getFurnaceRecipes().getSmeltingResult(stack);
-            return stack.is(ModTags.breakable_ore) || !smeltingResult.isEmpty();
+            return !smeltingResult.isEmpty();
         }
 
         return false;
@@ -496,6 +502,31 @@ public class CompatibilityManager implements ICompatibilityManager
     public boolean isMineableOre(@NotNull final ItemStack stack)
     {
         return !isEmpty(stack) && stack.is(Tags.Items.ORES);
+    }
+
+    @Override
+    public boolean isBreakableOre(@NotNull final ItemStack stack)
+    {
+        if (stack.is(ModTags.breakable_ore))
+        {
+            final Block block = Block.byItem(stack.getItem());
+            if (!block.defaultBlockState().isAir())
+            {
+                final List<LootTableAnalyzer.LootDrop> drops = CustomRecipeManager.getInstance().getLootDrops(block.getLootTable());
+                for (final LootTableAnalyzer.LootDrop drop : drops)
+                {
+                    for (final ItemStack dropStack : drop.getItemStacks())
+                    {
+                        if (ItemStackUtils.compareItemStacksIgnoreStackSize(stack, dropStack))
+                        {
+                            return false;   // blocks that drop themselves are not breakable ore
+                        }
+                    }
+                }
+            }
+            return true;
+        }
+        return false;
     }
 
     @Override

--- a/src/main/java/com/minecolonies/api/compatibility/ICompatibilityManager.java
+++ b/src/main/java/com/minecolonies/api/compatibility/ICompatibilityManager.java
@@ -107,6 +107,14 @@ public interface ICompatibilityManager
     boolean isMineableOre(@NotNull ItemStack stack);
 
     /**
+     * Check if a stack belongs to a breakable ore.
+     *
+     * @param stack the stack to test.
+     * @return true if so.
+     */
+    boolean isBreakableOre(@NotNull ItemStack stack);
+
+    /**
      * Get a copy of the list of compost recipes.
      *
      * @return the list of compost recipes, indexed by input item.

--- a/src/main/java/com/minecolonies/core/colony/buildings/workerbuildings/BuildingSmeltery.java
+++ b/src/main/java/com/minecolonies/core/colony/buildings/workerbuildings/BuildingSmeltery.java
@@ -13,6 +13,8 @@ import com.minecolonies.api.util.Utils;
 import com.minecolonies.core.colony.buildings.AbstractBuilding;
 import com.minecolonies.core.colony.buildings.modules.AbstractCraftingBuildingModule;
 import com.minecolonies.core.colony.crafting.CustomRecipe;
+import com.minecolonies.core.colony.crafting.CustomRecipeManager;
+import com.minecolonies.core.colony.crafting.LootTableAnalyzer;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Holder;
 import net.minecraft.core.registries.BuiltInRegistries;
@@ -179,10 +181,14 @@ public class BuildingSmeltery extends AbstractBuilding
             //noinspection ConstantConditions
             for (final Holder<Item> input : BuiltInRegistries.ITEM.getTagOrEmpty(ModTags.breakable_ore))
             {
-                recipes.add(GenericRecipe.builder()
-                        .withInputs(List.of(List.of(input.value().getDefaultInstance())))
-                        .withLootTable(getLootTable(input.value()))
-                        .build());
+                final ResourceKey<LootTable> lootTable = getLootTable(input.value());
+                if (!lootTableIsRecursive(input, lootTable))
+                {
+                    recipes.add(GenericRecipe.builder()
+                            .withInputs(List.of(List.of(input.value().getDefaultInstance())))
+                            .withLootTable(lootTable)
+                            .build());
+                }
             }
 
             return recipes;
@@ -195,6 +201,12 @@ public class BuildingSmeltery extends AbstractBuilding
 
             for (final Holder<Item> input : BuiltInRegistries.ITEM.getTagOrEmpty(ModTags.breakable_ore))
             {
+                final ResourceKey<LootTable> lootTable = getLootTable(input.value());
+                if (lootTableIsRecursive(input, lootTable))
+                {
+                    continue;
+                }
+
                 Block b = Block.byItem(input.value());
                 List<ItemStack> drops = Block.getDrops(b.defaultBlockState(), (ServerLevel) building.getColony().getWorld(), building.getID(), null);
                 for (ItemStack drop : drops)
@@ -207,8 +219,8 @@ public class BuildingSmeltery extends AbstractBuilding
 
                 final RecipeStorage tempRecipe = RecipeStorage.builder()
                         .withInputs(Collections.singletonList(new ItemStorage(new ItemStack(input.value()))))
-                        .withSecondaryOutputs(drops)
-                        .withLootTable(getLootTable(input.value()))
+                        .withSecondaryOutputs(drops)    // this is just a display example
+                        .withLootTable(lootTable)
                         .build();
                 IToken<?> token = IColonyManager.getInstance().getRecipeManager().checkOrAddRecipe(tempRecipe);
                 this.addRecipeToList(token, false);
@@ -225,6 +237,22 @@ public class BuildingSmeltery extends AbstractBuilding
                 pick.enchant(Utils.getRegistryValue(Enchantments.FORTUNE, worker.level()), fortuneLevel);
             }
             return pick;
+        }
+
+        private boolean lootTableIsRecursive(final Holder<Item> input, final ResourceKey<LootTable> lootTable)
+        {
+            final List<LootTableAnalyzer.LootDrop> drops = CustomRecipeManager.getInstance().getLootDrops(lootTable);
+            for (final LootTableAnalyzer.LootDrop drop : drops)
+            {
+                for (final ItemStack stack : drop.getItemStacks())
+                {
+                    if (stack.is(input))
+                    {
+                        return true;
+                    }
+                }
+            }
+            return false;
         }
 
         protected ResourceKey<LootTable> getLootTable(Item item)

--- a/src/main/java/com/minecolonies/core/colony/buildings/workerbuildings/BuildingSmeltery.java
+++ b/src/main/java/com/minecolonies/core/colony/buildings/workerbuildings/BuildingSmeltery.java
@@ -1,5 +1,6 @@
 package com.minecolonies.core.colony.buildings.workerbuildings;
 
+import com.minecolonies.api.IMinecoloniesAPI;
 import com.minecolonies.api.colony.IColony;
 import com.minecolonies.api.colony.IColonyManager;
 import com.minecolonies.api.colony.jobs.registry.JobEntry;
@@ -13,8 +14,6 @@ import com.minecolonies.api.util.Utils;
 import com.minecolonies.core.colony.buildings.AbstractBuilding;
 import com.minecolonies.core.colony.buildings.modules.AbstractCraftingBuildingModule;
 import com.minecolonies.core.colony.crafting.CustomRecipe;
-import com.minecolonies.core.colony.crafting.CustomRecipeManager;
-import com.minecolonies.core.colony.crafting.LootTableAnalyzer;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Holder;
 import net.minecraft.core.registries.BuiltInRegistries;
@@ -120,7 +119,7 @@ public class BuildingSmeltery extends AbstractBuilding
             final ICompatibilityManager compatibility = IColonyManager.getInstance().getCompatibilityManager();
             for (final ItemStack stack : compatibility.getListOfAllItems())
             {
-                if (ItemStackUtils.IS_SMELTABLE.and(compatibility::isOre).and(s -> !s.is(ModTags.breakable_ore)).test(stack))
+                if (ItemStackUtils.IS_SMELTABLE.and(compatibility::isOre).and(s -> !compatibility.isBreakableOre(s)).test(stack))
                 {
                     final ItemStack output = IColonyManager.getInstance().getCompatibilityManager().getFurnaceRecipes().getSmeltingResult(stack);
                     recipes.add(createSmeltingRecipe(stack, output, Blocks.FURNACE));
@@ -177,16 +176,17 @@ public class BuildingSmeltery extends AbstractBuilding
         public List<IGenericRecipe> getAdditionalRecipesForDisplayPurposesOnly(@NotNull final Level world)
         {
             final List<IGenericRecipe> recipes = new ArrayList<>(super.getAdditionalRecipesForDisplayPurposesOnly(world));
+            final ICompatibilityManager compat = IMinecoloniesAPI.getInstance().getColonyManager().getCompatibilityManager();
 
             //noinspection ConstantConditions
             for (final Holder<Item> input : BuiltInRegistries.ITEM.getTagOrEmpty(ModTags.breakable_ore))
             {
-                final ResourceKey<LootTable> lootTable = getLootTable(input.value());
-                if (!lootTableIsRecursive(input, lootTable))
+                final ItemStack inputStack = input.value().getDefaultInstance();
+                if (compat.isBreakableOre(inputStack))
                 {
                     recipes.add(GenericRecipe.builder()
-                            .withInputs(List.of(List.of(input.value().getDefaultInstance())))
-                            .withLootTable(lootTable)
+                            .withInputs(List.of(List.of(inputStack)))
+                            .withLootTable(getLootTable(input.value()))
                             .build());
                 }
             }
@@ -199,10 +199,12 @@ public class BuildingSmeltery extends AbstractBuilding
         {
             super.checkForWorkerSpecificRecipes();
 
+            final ICompatibilityManager compat = IMinecoloniesAPI.getInstance().getColonyManager().getCompatibilityManager();
+
             for (final Holder<Item> input : BuiltInRegistries.ITEM.getTagOrEmpty(ModTags.breakable_ore))
             {
-                final ResourceKey<LootTable> lootTable = getLootTable(input.value());
-                if (lootTableIsRecursive(input, lootTable))
+                final ItemStack inputStack = input.value().getDefaultInstance();
+                if (!compat.isBreakableOre(inputStack))
                 {
                     continue;
                 }
@@ -218,9 +220,9 @@ public class BuildingSmeltery extends AbstractBuilding
                 }
 
                 final RecipeStorage tempRecipe = RecipeStorage.builder()
-                        .withInputs(Collections.singletonList(new ItemStorage(new ItemStack(input.value()))))
+                        .withInputs(Collections.singletonList(new ItemStorage(inputStack)))
                         .withSecondaryOutputs(drops)    // this is just a display example
-                        .withLootTable(lootTable)
+                        .withLootTable(getLootTable(input.value()))
                         .build();
                 IToken<?> token = IColonyManager.getInstance().getRecipeManager().checkOrAddRecipe(tempRecipe);
                 this.addRecipeToList(token, false);
@@ -237,22 +239,6 @@ public class BuildingSmeltery extends AbstractBuilding
                 pick.enchant(Utils.getRegistryValue(Enchantments.FORTUNE, worker.level()), fortuneLevel);
             }
             return pick;
-        }
-
-        private boolean lootTableIsRecursive(final Holder<Item> input, final ResourceKey<LootTable> lootTable)
-        {
-            final List<LootTableAnalyzer.LootDrop> drops = CustomRecipeManager.getInstance().getLootDrops(lootTable);
-            for (final LootTableAnalyzer.LootDrop drop : drops)
-            {
-                for (final ItemStack stack : drop.getItemStacks())
-                {
-                    if (stack.is(input))
-                    {
-                        return true;
-                    }
-                }
-            }
-            return false;
         }
 
         protected ResourceKey<LootTable> getLootTable(Item item)

--- a/src/main/java/com/minecolonies/core/entity/ai/workers/crafting/EntityAIWorkSmelter.java
+++ b/src/main/java/com/minecolonies/core/entity/ai/workers/crafting/EntityAIWorkSmelter.java
@@ -10,7 +10,6 @@ import com.minecolonies.api.crafting.IRecipeStorage;
 import com.minecolonies.api.crafting.ItemStorage;
 import com.minecolonies.api.entity.ai.statemachine.AITarget;
 import com.minecolonies.api.entity.ai.statemachine.states.IAIState;
-import com.minecolonies.api.items.ModTags;
 import com.minecolonies.api.util.InventoryUtils;
 import com.minecolonies.api.util.ItemStackUtils;
 import com.minecolonies.api.util.SoundUtils;
@@ -187,7 +186,7 @@ public class EntityAIWorkSmelter extends AbstractEntityAIUsesFurnace<JobSmelter,
         {
             return false;
         }
-        if (stack.is(ModTags.breakable_ore))
+        if (IColonyManager.getInstance().getCompatibilityManager().isBreakableOre(stack))
         {
             return false;
         }


### PR DESCRIPTION
Closes #11119

# Changes proposed in this pull request
- Prevent the smelter consider "breakable ore" that breaks into itself to actually be breakable.  It's still potentially smeltable though.

## Testing
- [x] Yes I tested this before submitting it.
- [ ] I also did a multiplayer test.

Review please (should backport?)

~Note that the net result of this is that nobody can use the raw redstone ore (since the smelter no longer considers it to be valid ore, and the stone smeltery refuses to learn redstone recipes).  This can be fixed with a compatibility datapack to tag the raw redstone block to the stone smeltery.~