### PR TITLE
Prevent recursive ore breaking (#11243)

### DIFF
--- a/src/main/java/com/minecolonies/api/compatibility/CompatibilityManager.java
+++ b/src/main/java/com/minecolonies/api/compatibility/CompatibilityManager.java
@@ -16,6 +16,8 @@ import com.minecolonies.api.items.CheckedNbtKey;
 import com.minecolonies.api.items.ModTags;
 import com.minecolonies.api.util.*;
 import com.minecolonies.core.generation.ItemNbtCalculator;
+import com.minecolonies.core.colony.crafting.CustomRecipeManager;
+import com.minecolonies.core.colony.crafting.LootTableAnalyzer;
 import it.unimi.dsi.fastutil.objects.Object2IntLinkedOpenHashMap;
 import net.minecraft.client.multiplayer.ClientLevel;
 import net.minecraft.core.registries.BuiltInRegistries;
@@ -482,10 +484,14 @@ public class CompatibilityManager implements ICompatibilityManager
     @Override
     public boolean isOre(@NotNull final ItemStack stack)
     {
-        if (isMineableOre(stack) || stack.is(ModTags.raw_ore) || stack.is(ModTags.breakable_ore))
+        if (isBreakableOre(stack))
+        {
+            return true;
+        }
+        if (isMineableOre(stack) || stack.is(ModTags.raw_ore))
         {
             ItemStack smeltingResult = MinecoloniesAPIProxy.getInstance().getFurnaceRecipes().getSmeltingResult(stack);
-            return stack.is(ModTags.breakable_ore) || !smeltingResult.isEmpty();
+            return !smeltingResult.isEmpty();
         }
 
         return false;
@@ -495,6 +501,31 @@ public class CompatibilityManager implements ICompatibilityManager
     public boolean isMineableOre(@NotNull final ItemStack stack)
     {
         return !isEmpty(stack) && stack.is(Tags.Items.ORES);
+    }
+
+    @Override
+    public boolean isBreakableOre(@NotNull final ItemStack stack)
+    {
+        if (stack.is(ModTags.breakable_ore))
+        {
+            final Block block = Block.byItem(stack.getItem());
+            if (!block.defaultBlockState().isAir())
+            {
+                final List<LootTableAnalyzer.LootDrop> drops = CustomRecipeManager.getInstance().getLootDrops(block.getLootTable());
+                for (final LootTableAnalyzer.LootDrop drop : drops)
+                {
+                    for (final ItemStack dropStack : drop.getItemStacks())
+                    {
+                        if (ItemStackUtils.compareItemStacksIgnoreStackSize(stack, dropStack))
+                        {
+                            return false;   // blocks that drop themselves are not breakable ore
+                        }
+                    }
+                }
+            }
+            return true;
+        }
+        return false;
     }
 
     @Override

--- a/src/main/java/com/minecolonies/api/compatibility/ICompatibilityManager.java
+++ b/src/main/java/com/minecolonies/api/compatibility/ICompatibilityManager.java
@@ -105,6 +105,14 @@ public interface ICompatibilityManager
     boolean isMineableOre(@NotNull ItemStack stack);
 
     /**
+     * Check if a stack belongs to a breakable ore.
+     *
+     * @param stack the stack to test.
+     * @return true if so.
+     */
+    boolean isBreakableOre(@NotNull ItemStack stack);
+
+    /**
      * Get a copy of the list of compost recipes.
      *
      * @return the list of compost recipes, indexed by input item.

--- a/src/main/java/com/minecolonies/core/colony/buildings/workerbuildings/BuildingSmeltery.java
+++ b/src/main/java/com/minecolonies/core/colony/buildings/workerbuildings/BuildingSmeltery.java
@@ -1,5 +1,6 @@
 package com.minecolonies.core.colony.buildings.workerbuildings;
 
+import com.minecolonies.api.IMinecoloniesAPI;
 import com.minecolonies.api.colony.IColony;
 import com.minecolonies.api.colony.IColonyManager;
 import com.minecolonies.api.colony.jobs.registry.JobEntry;
@@ -115,7 +116,7 @@ public class BuildingSmeltery extends AbstractBuilding
             final ICompatibilityManager compatibility = IColonyManager.getInstance().getCompatibilityManager();
             for (final ItemStack stack : compatibility.getListOfAllItems())
             {
-                if (ItemStackUtils.IS_SMELTABLE.and(compatibility::isOre).and(s -> !s.is(ModTags.breakable_ore)).test(stack))
+                if (ItemStackUtils.IS_SMELTABLE.and(compatibility::isOre).and(s -> !compatibility.isBreakableOre(s)).test(stack))
                 {
                     final ItemStack output = FurnaceRecipes.getInstance().getSmeltingResult(stack);
                     recipes.add(createSmeltingRecipe(stack, output, Blocks.FURNACE));
@@ -172,14 +173,19 @@ public class BuildingSmeltery extends AbstractBuilding
         public List<IGenericRecipe> getAdditionalRecipesForDisplayPurposesOnly(@NotNull final Level world)
         {
             final List<IGenericRecipe> recipes = new ArrayList<>(super.getAdditionalRecipesForDisplayPurposesOnly(world));
+            final ICompatibilityManager compat = IMinecoloniesAPI.getInstance().getColonyManager().getCompatibilityManager();
 
             //noinspection ConstantConditions
             for (final Item input : ForgeRegistries.ITEMS.tags().getTag(ModTags.breakable_ore))
             {
-                recipes.add(GenericRecipe.builder()
-                        .withInputs(List.of(List.of(input.getDefaultInstance())))
-                        .withLootTable(getLootTable(input))
-                        .build());
+                final ItemStack inputStack = input.getDefaultInstance();
+                if (compat.isBreakableOre(inputStack))
+                {
+                    recipes.add(GenericRecipe.builder()
+                            .withInputs(List.of(List.of(inputStack)))
+                            .withLootTable(getLootTable(input))
+                            .build());
+                }
             }
 
             return recipes;
@@ -190,8 +196,16 @@ public class BuildingSmeltery extends AbstractBuilding
         {
             super.checkForWorkerSpecificRecipes();
 
+            final ICompatibilityManager compat = IMinecoloniesAPI.getInstance().getColonyManager().getCompatibilityManager();
+
             for (final Item input : ForgeRegistries.ITEMS.tags().getTag(ModTags.breakable_ore))
             {
+                final ItemStack inputStack = input.getDefaultInstance();
+                if (!compat.isBreakableOre(inputStack))
+                {
+                    continue;
+                }
+
                 Block b = Block.byItem(input);
                 List<ItemStack> drops = Block.getDrops(b.defaultBlockState(), (ServerLevel) building.getColony().getWorld(), building.getID(), null);
                 for (ItemStack drop : drops)
@@ -203,8 +217,8 @@ public class BuildingSmeltery extends AbstractBuilding
                 }
 
                 final RecipeStorage tempRecipe = RecipeStorage.builder()
-                        .withInputs(Collections.singletonList(new ItemStorage(new ItemStack(input))))
-                        .withSecondaryOutputs(drops)
+                        .withInputs(Collections.singletonList(new ItemStorage(inputStack)))
+                        .withSecondaryOutputs(drops)    // this is just a display example
                         .withLootTable(getLootTable(input))
                         .build();
                 IToken<?> token = IColonyManager.getInstance().getRecipeManager().checkOrAddRecipe(tempRecipe);

--- a/src/main/java/com/minecolonies/core/entity/ai/workers/crafting/EntityAIWorkSmelter.java
+++ b/src/main/java/com/minecolonies/core/entity/ai/workers/crafting/EntityAIWorkSmelter.java
@@ -10,7 +10,6 @@ import com.minecolonies.api.crafting.IRecipeStorage;
 import com.minecolonies.api.crafting.ItemStorage;
 import com.minecolonies.api.entity.ai.statemachine.AITarget;
 import com.minecolonies.api.entity.ai.statemachine.states.IAIState;
-import com.minecolonies.api.items.ModTags;
 import com.minecolonies.api.util.InventoryUtils;
 import com.minecolonies.api.util.ItemStackUtils;
 import com.minecolonies.api.util.SoundUtils;
@@ -190,7 +189,7 @@ public class EntityAIWorkSmelter extends AbstractEntityAIUsesFurnace<JobSmelter,
         {
             return false;
         }
-        if (stack.is(ModTags.breakable_ore))
+        if (IColonyManager.getInstance().getCompatibilityManager().isBreakableOre(stack))
         {
             return false;
         }


### PR DESCRIPTION
Prevent the smelter consider "breakable ore" that breaks into itself to actually be breakable. It's still potentially smeltable though.

# Changes proposed in this pull request
- Port #11243

## Testing
- [ ] Yes I tested this before submitting it.
- [ ] I also did a multiplayer test.

Review please (do not port)