### PR TITLE
Fix certain blocks not dropping inventories

### DIFF
--- a/src/main/java/com/minecolonies/api/blocks/AbstractColonyBlock.java
+++ b/src/main/java/com/minecolonies/api/blocks/AbstractColonyBlock.java
@@ -10,6 +10,7 @@ import com.minecolonies.api.colony.buildings.views.IBuildingView;
 import com.minecolonies.api.colony.permissions.Action;
 import com.minecolonies.api.entity.ai.workers.util.IBuilderUndestroyable;
 import com.minecolonies.api.items.ItemBlockHut;
+import com.minecolonies.api.tileentities.AbstractTileEntityColonyBuilding;
 import com.minecolonies.api.tileentities.MinecoloniesTileEntities;
 import com.minecolonies.core.tileentities.TileEntityColonyBuilding;
 import com.minecolonies.api.util.*;
@@ -141,6 +142,17 @@ public abstract class AbstractColonyBlock<B extends AbstractColonyBlock<B>> exte
         final TileEntityColonyBuilding building = (TileEntityColonyBuilding) MinecoloniesTileEntities.BUILDING.get().create(blockPos, blockState);
         building.registryName = this.getBuildingEntry().getRegistryName();
         return building;
+    }
+
+    @Override
+    public void onRemove(final @NotNull BlockState blockState, final @NotNull Level level, final @NotNull BlockPos pos, final @NotNull BlockState newBlockState, final boolean p_60519_)
+    {
+        final BlockEntity tileentity = level.getBlockEntity(pos);
+        if (tileentity instanceof AbstractTileEntityColonyBuilding tileEntityColonyBuilding)
+        {
+            InventoryUtils.dropItemHandler(tileEntityColonyBuilding.getInventory(), level, pos.getX(), pos.getY(), pos.getZ());
+        }
+        super.onRemove(blockState, level, pos, newBlockState, p_60519_);
     }
 
     /**

--- a/src/main/java/com/minecolonies/core/blocks/BlockMinecoloniesGrave.java
+++ b/src/main/java/com/minecolonies/core/blocks/BlockMinecoloniesGrave.java
@@ -5,7 +5,6 @@ import com.minecolonies.api.blocks.types.GraveType;
 import com.minecolonies.api.colony.IColony;
 import com.minecolonies.api.colony.IColonyManager;
 import com.minecolonies.api.colony.permissions.Action;
-import com.minecolonies.api.tileentities.AbstractTileEntityGrave;
 import com.minecolonies.core.tileentities.TileEntityGrave;
 import com.minecolonies.api.util.InventoryUtils;
 import com.minecolonies.api.util.constant.Constants;
@@ -28,9 +27,7 @@ import net.minecraft.world.phys.shapes.VoxelShape;
 import net.minecraft.world.phys.shapes.Shapes;
 import net.minecraft.world.level.BlockGetter;
 import net.minecraft.world.level.Level;
-import net.minecraft.server.level.ServerLevel;
 import net.minecraftforge.network.NetworkHooks;
-import net.minecraftforge.items.IItemHandler;
 import org.jetbrains.annotations.NotNull;
 
 import javax.annotation.Nullable;
@@ -145,18 +142,6 @@ public class BlockMinecoloniesGrave extends AbstractBlockMinecoloniesGrave<Block
     }
 
     @Override
-    public void spawnAfterBreak(final BlockState state, final ServerLevel worldIn, final BlockPos pos, final ItemStack stack, final boolean p_222953_)
-    {
-        final BlockEntity tileentity = worldIn.getBlockEntity(pos);
-        if (tileentity instanceof TileEntityGrave)
-        {
-            final IItemHandler handler = ((AbstractTileEntityGrave) tileentity).getInventory();
-            InventoryUtils.dropItemHandler(handler, worldIn, pos.getX(), pos.getY(), pos.getZ());
-        }
-        super.spawnAfterBreak(state, worldIn, pos, stack, p_222953_);
-    }
-
-    @Override
     public InteractionResult use(
       final BlockState state,
       final Level worldIn,
@@ -221,14 +206,13 @@ public class BlockMinecoloniesGrave extends AbstractBlockMinecoloniesGrave<Block
         if (state.getBlock() != newState.getBlock())
         {
             BlockEntity tileEntity = worldIn.getBlockEntity(pos);
-            if (tileEntity instanceof TileEntityGrave)
+            if (tileEntity instanceof TileEntityGrave tileEntityGrave)
             {
-                TileEntityGrave tileEntityGrave = (TileEntityGrave) tileEntity;
                 InventoryUtils.dropItemHandler(tileEntityGrave.getInventory(),
-                  worldIn,
-                  tileEntityGrave.getBlockPos().getX(),
-                  tileEntityGrave.getBlockPos().getY(),
-                  tileEntityGrave.getBlockPos().getZ());
+                    worldIn,
+                    tileEntityGrave.getBlockPos().getX(),
+                    tileEntityGrave.getBlockPos().getY(),
+                    tileEntityGrave.getBlockPos().getZ());
                 worldIn.updateNeighbourForOutputSignal(pos, this);
             }
 

--- a/src/main/java/com/minecolonies/core/blocks/BlockMinecoloniesRack.java
+++ b/src/main/java/com/minecolonies/core/blocks/BlockMinecoloniesRack.java
@@ -7,7 +7,6 @@ import com.minecolonies.api.blocks.types.RackType;
 import com.minecolonies.api.colony.IColony;
 import com.minecolonies.api.colony.IColonyManager;
 import com.minecolonies.api.colony.permissions.Action;
-import com.minecolonies.api.tileentities.AbstractTileEntityRack;
 import com.minecolonies.api.util.InventoryUtils;
 import com.minecolonies.api.util.constant.Constants;
 import com.minecolonies.core.tileentities.TileEntityRack;
@@ -16,7 +15,6 @@ import it.unimi.dsi.fastutil.longs.Long2ObjectOpenHashMap;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
 import net.minecraft.resources.ResourceLocation;
-import net.minecraft.server.level.ServerLevel;
 import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.world.InteractionHand;
 import net.minecraft.world.InteractionResult;
@@ -39,7 +37,6 @@ import net.minecraft.world.phys.BlockHitResult;
 import net.minecraft.world.phys.shapes.CollisionContext;
 import net.minecraft.world.phys.shapes.Shapes;
 import net.minecraft.world.phys.shapes.VoxelShape;
-import net.minecraftforge.items.IItemHandler;
 import net.minecraftforge.network.NetworkHooks;
 import org.jetbrains.annotations.NotNull;
 
@@ -218,18 +215,6 @@ public class BlockMinecoloniesRack extends AbstractBlockMinecoloniesRack<BlockMi
         }
 
         return super.updateShape(state, dir, neighbourState, level, pos, neighbourPos);
-    }
-
-    @Override
-    public void spawnAfterBreak(final BlockState state, final ServerLevel worldIn, final BlockPos pos, final ItemStack stack, final boolean p_222953_)
-    {
-        final BlockEntity tileentity = worldIn.getBlockEntity(pos);
-        if (tileentity instanceof TileEntityRack)
-        {
-            final IItemHandler handler = ((AbstractTileEntityRack) tileentity).getInventory();
-            InventoryUtils.dropItemHandler(handler, worldIn, pos.getX(), pos.getY(), pos.getZ());
-        }
-        super.spawnAfterBreak(state, worldIn, pos, stack, p_222953_);
     }
 
     @Override

--- a/src/main/java/com/minecolonies/core/colony/buildings/AbstractBuilding.java
+++ b/src/main/java/com/minecolonies/core/colony/buildings/AbstractBuilding.java
@@ -440,11 +440,6 @@ public abstract class AbstractBuilding extends AbstractBuildingContainer
 
         if (tileEntityNew != null)
         {
-            InventoryUtils.dropItemHandler(tileEntityNew.getInventory(),
-              world,
-              tileEntityNew.getPosition().getX(),
-              tileEntityNew.getPosition().getY(),
-              tileEntityNew.getPosition().getZ());
             world.updateNeighbourForOutputSignal(this.getPosition(), block);
         }
 


### PR DESCRIPTION
Closes [discord report](https://discord.com/channels/139070364159311872/1003402487417548801/1424806171574927545) stash drops no items on break

# Changes proposed in this pull request
- Made any "colony" block implement onRemove so drops are properly handled from the inventory, this previously took place as part of the building#onDestroy, but moved it here so it also acts upon the postbox/stash
- Removed the `spawnAfterBreak` methods in other classes, as these seemed to do absolutely nothing

## Testing
- [X] Yes I tested this before submitting it.
- [ ] I also did a multiplayer test.

Review please