### PR TITLE
fix: GregTech and modded tool support for recipes

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,1 +1,15 @@
 apply from: 'https://raw.githubusercontent.com/ldtteam/OperaPublicaCreator/main/gradle/mod.gradle'
+
+repositories {
+    maven {
+        name = 'GTCEu Maven'
+        url = 'https://maven.gtceu.com'
+        content {
+            includeGroup 'com.gregtechceu.gtceu'
+        }
+    }
+}
+
+dependencies {
+    runtimeOnly fg.deobf("com.gregtechceu.gtceu:gtceu-1.20.1:7.2.0")
+}

--- a/gradle.properties
+++ b/gradle.properties
@@ -33,7 +33,7 @@ domumOrnamentumVersion=1.20.1-1.0.288-snapshot
 multiPistonVersion=1.20-1.2.30-ALPHA
 
 jei_mcversion=1.20.1
-jei_version=15.1.0.19
+jei_version=15.20.0.105
 jmapApiVersion=1.20-1.9-SNAPSHOT
 jmapMcVersion=1.20
 jmapVersion=5.9.8

--- a/src/main/java/com/minecolonies/api/crafting/RecipeStorage.java
+++ b/src/main/java/com/minecolonies/api/crafting/RecipeStorage.java
@@ -161,7 +161,7 @@ public class RecipeStorage implements IRecipeStorage
             this.input = recipe.getInput();
             this.primaryOutput = recipe.getPrimaryOutput();
             this.alternateOutputs = recipe.getAlternateOutputs();
-            this.secondaryOutputs = recipe.getSecondaryOutputs();
+            this.secondaryOutputs = recipe.getCraftingToolsAndSecondaryOutputs();
             this.intermediate = recipe.getIntermediate();
             this.gridSize = recipe.getGridSize();
             this.token = null;

--- a/src/main/java/com/minecolonies/api/crafting/RecipeStorage.java
+++ b/src/main/java/com/minecolonies/api/crafting/RecipeStorage.java
@@ -161,7 +161,7 @@ public class RecipeStorage implements IRecipeStorage
             this.input = recipe.getInput();
             this.primaryOutput = recipe.getPrimaryOutput();
             this.alternateOutputs = recipe.getAlternateOutputs();
-            this.secondaryOutputs = recipe.getCraftingToolsAndSecondaryOutputs();
+            this.secondaryOutputs = recipe.getSecondaryOutputs();
             this.intermediate = recipe.getIntermediate();
             this.gridSize = recipe.getGridSize();
             this.token = null;
@@ -378,15 +378,31 @@ public class RecipeStorage implements IRecipeStorage
                 this.secondaryOutputs.add(container);
             }
 
+            boolean isToolDetected = false;
             for (ItemStack result : this.secondaryOutputs)
             {
                 if (ItemStackUtils.compareItemStacksIgnoreStackSize(inputItem.getItemStack(), result, false, true))
                 {
-                    inputItem = new ItemStorage(inputItem.getItemStack(), inputItem.getAmount(), true, inputItem.shouldIgnoreNBTValue);
+                    // For damageable tools (eg. GregTech), also set ignoreNBT=true since durability is stored in NBT
+                    final boolean ignoreNBT = inputItem.shouldIgnoreNBTValue || inputItem.getItemStack().isDamageableItem();
+                    inputItem = new ItemStorage(inputItem.getItemStack(), inputItem.getAmount(), true, ignoreNBT);
                     this.tools.add(result);
                     this.secondaryOutputs.remove(result);
+                    isToolDetected = true;
                     break;
                 }
+            }
+
+            // Check if this is a damageable item (e.g., GregTech tools, modded tools)
+            // These items are not consumed in crafting but take durability damage
+            // Set both ignoreDamageValue=true and ignoreNBT=true since GregTech stores
+            // crafting durability in NBT which changes with each use
+            if (!isToolDetected && inputItem.getItemStack().isDamageableItem())
+            {
+                inputItem = new ItemStorage(inputItem.getItemStack(), inputItem.getAmount(), true, true);
+                final ItemStack toolStack = inputItem.getItemStack().copy();
+                toolStack.setCount(inputItem.getAmount());
+                this.tools.add(toolStack);
             }
 
             ItemStorage storage = inputItem.copy();
@@ -455,7 +471,7 @@ public class RecipeStorage implements IRecipeStorage
             final int availableCount = InventoryUtils.getItemCountInItemHandlers(
               ImmutableList.copyOf(inventories),
               itemStack -> !ItemStackUtils.isEmpty(itemStack)
-                             && ItemStackUtils.compareItemStacksIgnoreStackSize(itemStack, stack, false, !storage.ignoreNBT()));
+                             && ItemStackUtils.compareItemStacksIgnoreStackSize(itemStack, stack, !storage.ignoreDamageValue(), !storage.ignoreNBT()));
 
             if (!canFulfillItemStorage(qty, existingRequirements, availableCount, storage))
             {
@@ -475,7 +491,7 @@ public class RecipeStorage implements IRecipeStorage
             final ItemStack stack = storage.getItemStack();
             final int availableCount = InventoryUtils.getItemCountInItemHandlers(citizen,
               itemStack -> !ItemStackUtils.isEmpty(itemStack)
-                             && ItemStackUtils.compareItemStacksIgnoreStackSize(itemStack, stack, false, !storage.ignoreNBT()))
+                             && ItemStackUtils.compareItemStacksIgnoreStackSize(itemStack, stack, !storage.ignoreDamageValue(), !storage.ignoreNBT()))
                                          + InventoryUtils.getCountFromBuilding(building, storage);;
 
             if (!canFulfillItemStorage(qty, existingRequirements, availableCount, storage))
@@ -599,7 +615,7 @@ public class RecipeStorage implements IRecipeStorage
     {
         if(hash == 0)
         {
-            hash = Objects.hash(cleanedInput, 
+            hash = Objects.hash(cleanedInput,
             primaryOutput.getItem(),
             primaryOutput.getCount(),
             intermediate,
@@ -698,10 +714,10 @@ public class RecipeStorage implements IRecipeStorage
 
             for (final IItemHandler handler : handlers)
             {
-                boolean isTool = ItemStackUtils.compareItemStackListIgnoreStackSize(tools, stack, false, !storage.ignoreNBT());
+                boolean isTool = ItemStackUtils.compareItemStackListIgnoreStackSize(tools, stack, !storage.ignoreDamageValue(), !storage.ignoreNBT());
                 int slotOfStack =
                   InventoryUtils.findFirstSlotInItemHandlerNotEmptyWith(handler, itemStack ->
-                          ItemStackUtils.compareItemStacksIgnoreStackSize(itemStack, stack, false, !storage.ignoreNBT()) &&
+                          ItemStackUtils.compareItemStacksIgnoreStackSize(itemStack, stack, !storage.ignoreDamageValue(), !storage.ignoreNBT()) &&
                                   (!isTool || !stack.isDamageableItem() || ItemStackUtils.getDurability(itemStack) > 0));
 
                 while (slotOfStack != -1 && amountNeeded > 0)
@@ -741,7 +757,7 @@ public class RecipeStorage implements IRecipeStorage
                         if (amountNeeded > 0)
                         {
                             slotOfStack = InventoryUtils.findFirstSlotInItemHandlerNotEmptyWith(handler,
-                            itemStack -> !ItemStackUtils.isEmpty(itemStack) && ItemStackUtils.compareItemStacksIgnoreStackSize(itemStack, stack, false, !storage.ignoreNBT()));
+                            itemStack -> !ItemStackUtils.isEmpty(itemStack) && ItemStackUtils.compareItemStacksIgnoreStackSize(itemStack, stack, !storage.ignoreDamageValue(), !storage.ignoreNBT()));
                         }
                     }
                 }
@@ -848,7 +864,7 @@ public class RecipeStorage implements IRecipeStorage
             }
         }
 
-        return null; 
+        return null;
     }
 
     @Override
@@ -860,7 +876,7 @@ public class RecipeStorage implements IRecipeStorage
     @Override
     public ResourceLocation getRecipeSource()
     {
-        return recipeSource; 
+        return recipeSource;
     }
 
     @NotNull

--- a/src/main/java/com/minecolonies/api/crafting/RecipeStorage.java
+++ b/src/main/java/com/minecolonies/api/crafting/RecipeStorage.java
@@ -513,32 +513,23 @@ public class RecipeStorage implements IRecipeStorage
     private boolean canFulfillItemStorage(final int qty, final Map<ItemStorage, Integer> existingRequirements, int availableCount, final ItemStorage storage)
     {
         final ItemStack stack = storage.getItemStack();
-        final int neededCount;
+        final boolean isTool;
         if(!secondaryOutputs.isEmpty() || !tools.isEmpty())
         {
-            if(!ItemStackUtils.compareItemStackListIgnoreStackSize(this.getCraftingToolsAndSecondaryOutputs(), stack, false, !storage.ignoreNBT()))
-            {
-                neededCount = storage.getAmount() * qty;
-            }
-            else
-            {
-                neededCount = storage.getAmount();
-            }
+            isTool = ItemStackUtils.compareItemStackListIgnoreStackSize(this.getCraftingToolsAndSecondaryOutputs(), stack, false, !storage.ignoreNBT());
         }
         else
         {
             final ItemStack container = stack.getCraftingRemainingItem();
-            if(ItemStackUtils.isEmpty(container) || !ItemStackUtils.compareItemStacksIgnoreStackSize(stack, container, false, !storage.ignoreNBT()))
-            {
-                neededCount = storage.getAmount() * qty;
-            }
-            else
-            {
-                neededCount = storage.getAmount();
-            }
+            isTool = !ItemStackUtils.isEmpty(container) && ItemStackUtils.compareItemStacksIgnoreStackSize(stack, container, false, !storage.ignoreNBT());
         }
+        final int neededCount = isTool ? storage.getAmount() : storage.getAmount() * qty;
 
-        return availableCount >= neededCount + existingRequirements.getOrDefault(storage, 0);
+        final int requiredCount = isTool
+            ? Math.max(neededCount, existingRequirements.getOrDefault(storage, 0))
+            : neededCount + existingRequirements.getOrDefault(storage, 0);
+
+        return availableCount >= requiredCount;
     }
 
     @Override

--- a/src/main/java/com/minecolonies/core/colony/buildings/modules/AbstractCraftingBuildingModule.java
+++ b/src/main/java/com/minecolonies/core/colony/buildings/modules/AbstractCraftingBuildingModule.java
@@ -363,11 +363,17 @@ public abstract class AbstractCraftingBuildingModule extends AbstractBuildingMod
         {
             for (final ItemStorage itemStorage : recipeStorage.getA().getCleanedInput())
             {
-                int amount = itemStorage.getAmount() * recipeStorage.getB();
-                if (recipeOutputs.containsKey(itemStorage))
-                {
-                    amount += recipeOutputs.get(itemStorage);
-                }
+                final boolean isTool = ItemStackUtils.compareItemStackListIgnoreStackSize(
+                    recipeStorage.getA().getCraftingTools(),
+                    itemStorage.getItemStack(),
+                    !itemStorage.ignoreDamageValue(),
+                    !itemStorage.ignoreNBT()
+                );
+
+                final int amount = isTool
+                    ? Math.max(itemStorage.getAmount(), recipeOutputs.getOrDefault(itemStorage, 0))
+                    : itemStorage.getAmount() * recipeStorage.getB() + recipeOutputs.getOrDefault(itemStorage, 0);
+
                 recipeOutputs.put(itemStorage, amount);
             }
         }
@@ -802,7 +808,7 @@ public abstract class AbstractCraftingBuildingModule extends AbstractBuildingMod
         return storage.fullfillRecipe(builder.create(RecipeStorage.recipeLootParameters), handlers);
     }
 
-    @Override 
+    @Override
     public ItemStack getCraftingTool(final AbstractEntityCitizen worker)
     {
         return worker != null ? worker.getMainHandItem() : ItemStack.EMPTY;

--- a/src/main/java/com/minecolonies/core/colony/crafting/RecipeStorageFactory.java
+++ b/src/main/java/com/minecolonies/core/colony/crafting/RecipeStorageFactory.java
@@ -131,7 +131,7 @@ public class RecipeStorageFactory implements IRecipeStorageFactory
         compound.put(ALTOUTPUT_TAG, altOutputTagList);
 
         @NotNull final ListTag secOutputTagList = new ListTag();
-        for (@NotNull final ItemStack stack : recipeStorage.getCraftingToolsAndSecondaryOutputs())
+        for (@NotNull final ItemStack stack : recipeStorage.getSecondaryOutputs())
         {
             @NotNull final CompoundTag neededRes = new CompoundTag();
             stack.save(neededRes);
@@ -236,8 +236,8 @@ public class RecipeStorageFactory implements IRecipeStorageFactory
         packetBuffer.writeVarInt(input.getAlternateOutputs().size());
         input.getAlternateOutputs().forEach(stack -> packetBuffer.writeItem(stack));
 
-        packetBuffer.writeVarInt(input.getCraftingToolsAndSecondaryOutputs().size());
-        input.getCraftingToolsAndSecondaryOutputs().forEach(stack -> packetBuffer.writeItem(stack));
+        packetBuffer.writeVarInt(input.getSecondaryOutputs().size());
+        input.getSecondaryOutputs().forEach(stack -> packetBuffer.writeItem(stack));
 
         packetBuffer.writeResourceLocation(input.getRequiredTool().getRegistryName());
 

--- a/src/main/java/com/minecolonies/core/colony/requestsystem/resolvers/core/AbstractCraftingProductionResolver.java
+++ b/src/main/java/com/minecolonies/core/colony/requestsystem/resolvers/core/AbstractCraftingProductionResolver.java
@@ -165,23 +165,23 @@ public abstract class AbstractCraftingProductionResolver<C extends AbstractCraft
             {
                 final ItemStack craftingHelperStack = ingredient.getItemStack().copy();
                 final ItemStack container = ingredient.getItemStack().getCraftingRemainingItem();
-                //if recipe secondary produces craftinghelperstack, don't add it by count, add it once. If it's in the tools list, check to see if we need it first. 
+                // Tools and returned items aren't consumed, so don't multiply by recipe count
                 if(!storage.getSecondaryOutputs().isEmpty() && ItemStackUtils.compareItemStackListIgnoreStackSize(storage.getSecondaryOutputs(), craftingHelperStack, false, true))
                 {
-                    materialRequests.add(createNewRequestForStack(manager, craftingHelperStack, ingredient.getAmount(), ingredient.getAmount(), false));
+                    materialRequests.add(createNewRequestForStack(manager, ingredient, ingredient.getAmount(), ingredient.getAmount()));
                 }
                 else if(!storage.getCraftingTools().isEmpty() && ItemStackUtils.compareItemStackListIgnoreStackSize(storage.getCraftingTools(), craftingHelperStack, false, true))
                 {
                     int requiredForDurability = craftingHelperStack.isDamageableItem() ? (int) Math.ceil((double) count / ingredient.getRemainingDurablityValue()) : ingredient.getAmount();
-                    materialRequests.add(createNewRequestForStack(manager, craftingHelperStack, requiredForDurability, requiredForDurability, false));
+                    materialRequests.add(createNewRequestForStack(manager, ingredient, requiredForDurability, requiredForDurability));
                 }
                 else if (!ItemStackUtils.isEmpty(container) && ItemStackUtils.compareItemStacksIgnoreStackSize(container, craftingHelperStack, false, true))
                 {
-                    materialRequests.add(createNewRequestForStack(manager, craftingHelperStack, ingredient.getAmount(), ingredient.getAmount(), false));
-                } 
+                    materialRequests.add(createNewRequestForStack(manager, ingredient, ingredient.getAmount(), ingredient.getAmount()));
+                }
                 else
                 {
-                    materialRequests.add(createNewRequestForStack(manager, craftingHelperStack, ingredient.getAmount() * count, ingredient.getAmount() * minCount, true ));
+                    materialRequests.add(createNewRequestForStack(manager, ingredient, ingredient.getAmount() * count, ingredient.getAmount() * minCount));
                 }
             }
         }
@@ -189,9 +189,9 @@ public abstract class AbstractCraftingProductionResolver<C extends AbstractCraft
     }
 
     @Nullable
-    protected IToken<?> createNewRequestForStack(@NotNull final IRequestManager manager, final ItemStack stack, final int count, final int minCount, final boolean matchMeta)
+    protected IToken<?> createNewRequestForStack(@NotNull final IRequestManager manager, final ItemStorage itemStorage, final int count, final int minCount)
     {
-        final Stack stackRequest = new Stack(stack, matchMeta, true, ItemStack.EMPTY, count, minCount);
+        final Stack stackRequest = new Stack(itemStorage.getItemStack(), !itemStorage.ignoreDamageValue(), !itemStorage.ignoreNBT(), ItemStack.EMPTY, count, minCount);
         return manager.createRequest(this, stackRequest);
     }
 

--- a/src/main/java/com/minecolonies/core/entity/ai/workers/crafting/AbstractEntityAICrafting.java
+++ b/src/main/java/com/minecolonies/core/entity/ai/workers/crafting/AbstractEntityAICrafting.java
@@ -388,9 +388,9 @@ public abstract class AbstractEntityAICrafting<J extends AbstractJobCrafter<?, J
             {
                 remaining = inputStorage.getAmount() * remainingOpsCount;
             }
-            if (InventoryUtils.getCountFromBuilding(building, itemStack -> ItemStackUtils.compareItemStacksIgnoreStackSize(itemStack, inputStorage.getItemStack(), false, true))
+            if (InventoryUtils.getCountFromBuilding(building, itemStack -> ItemStackUtils.compareItemStacksIgnoreStackSize(itemStack, inputStorage.getItemStack(), !inputStorage.ignoreDamageValue(), !inputStorage.ignoreNBT()))
                   + InventoryUtils.getItemCountInItemHandler(worker.getInventoryCitizen(),
-              itemStack -> ItemStackUtils.compareItemStacksIgnoreStackSize(itemStack, inputStorage.getItemStack(), false, true))
+              itemStack -> ItemStackUtils.compareItemStacksIgnoreStackSize(itemStack, inputStorage.getItemStack(), !inputStorage.ignoreDamageValue(), !inputStorage.ignoreNBT()))
                   + getExtendedCount(inputStorage.getItemStack())
                   < remaining)
             {
@@ -452,7 +452,8 @@ public abstract class AbstractEntityAICrafting<J extends AbstractJobCrafter<?, J
         final List<ItemStorage> input = storage.getCleanedInput();
         for (final ItemStorage inputStorage : input)
         {
-            final Predicate<ItemStack> predicate = stack -> !ItemStackUtils.isEmpty(stack) && new Stack(stack, false).matches(inputStorage.getItemStack());
+            final Predicate<ItemStack> predicate = stack -> !ItemStackUtils.isEmpty(stack)
+                && ItemStackUtils.compareItemStacksIgnoreStackSize(stack, inputStorage.getItemStack(), !inputStorage.ignoreDamageValue(), !inputStorage.ignoreNBT());
             final int invCount = InventoryUtils.getItemCountInItemHandler(worker.getInventoryCitizen(), predicate);
             final ItemStack container = inputStorage.getItemStack().getCraftingRemainingItem();
             final int remaining;

--- a/src/main/java/com/minecolonies/core/network/messages/server/colony/building/worker/AddRemoveRecipeMessage.java
+++ b/src/main/java/com/minecolonies/core/network/messages/server/colony/building/worker/AddRemoveRecipeMessage.java
@@ -25,6 +25,7 @@ import net.minecraftforge.network.NetworkEvent;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.List;
+import java.util.stream.Collectors;
 
 import static com.minecolonies.api.util.constant.TranslationConstants.MESSAGE_RECIPE_SAVED;
 import static com.minecolonies.api.util.constant.TranslationConstants.UNABLE_TO_ADD_RECIPE_MESSAGE;
@@ -88,10 +89,14 @@ public class AddRemoveRecipeMessage extends AbstractBuildingServerMessage<IBuild
     {
         super(building);
         this.remove = remove;
+        // Filter out damageable items (tools) from additionalOutputs, they will be auto-detected in processInputsAndTools
+        final List<ItemStack> actualSecondaryOutputs = additionalOutputs.stream()
+                .filter(stack -> !stack.isDamageableItem())
+                .collect(Collectors.toList());
         this.storage = RecipeStorage.builder()
                 .withInputs(input)
                 .withPrimaryOutput(primaryOutput)
-                .withSecondaryOutputs(additionalOutputs)
+                .withSecondaryOutputs(actualSecondaryOutputs)
                 .withGridSize(gridSize)
                 .withIntermediate(gridSize == 1 ? Blocks.FURNACE : Blocks.AIR)
                 .build();


### PR DESCRIPTION
# Changes proposed in this pull request
Fix GregTech and modded tool recipes by properly handling tools that store durability in NBT.

- Set `ignoreNBT=true` for damageable items so tools match regardless of durability changes
- Fix comparison flags to respect `ignoreDamageValue`/`ignoreNBT` 
- Filter tools from secondaryOutputs to prevent duplication

Tools with NBT-stored durability (GregTech saws, etc.) weren't recognized after first use, preventing recipe crafting.

**Needs more testing**
Multiplayer, various modded tools, enchanted tools.
I don't have full understanding of the whole picture and probably missed something / a better solution. Feel free to add commits

## Testing
- [x] Yes I tested this before submitting it.
- [ ] I also did a multiplayer test.

## Todo
- [ ] More testing
- [ ] Clean up (eg. temp draft dependency)