### PR TITLE
Don't allow removing datapack recipes unless holding Ctrl

### DIFF
--- a/src/main/java/com/minecolonies/core/client/gui/modules/WindowListRecipes.java
+++ b/src/main/java/com/minecolonies/core/client/gui/modules/WindowListRecipes.java
@@ -1,6 +1,7 @@
 package com.minecolonies.core.client.gui.modules;
 
 import com.ldtteam.blockui.Pane;
+import com.ldtteam.blockui.PaneBuilders;
 import com.ldtteam.blockui.controls.*;
 import com.ldtteam.blockui.views.ScrollingList;
 import com.minecolonies.api.colony.buildings.views.IBuildingView;
@@ -189,13 +190,24 @@ public class WindowListRecipes extends AbstractModuleWindow
                 {
                     if (module.isRecipeAlterationAllowed())
                     {
-                        removeButton.setVisible(true);
-                        removeButton.setEnabled(recipe.getRecipeSource() == null || Screen.hasControlDown());
+                        removeButton.on();
+                        if (recipe.getRecipeSource() != null && !Screen.hasControlDown())
+                        {
+                            removeButton.disable();
+                            PaneBuilders.tooltipBuilder()
+                                .append(Component.translatable("com.minecolonies.coremod.gui.workerhuts.removebuiltin",
+                                    Component.translatable("key.keyboard.left.control")))
+                                .hoverPane(removeButton)
+                                .build();
+                        }
+                        else
+                        {
+                            removeButton.setHoverPane(null);
+                        }
                     }
                     else
                     {
-                        removeButton.setVisible(false);
-                        removeButton.setEnabled(false);
+                        removeButton.off();
                     }
                 }
 

--- a/src/main/java/com/minecolonies/core/client/gui/modules/WindowListRecipes.java
+++ b/src/main/java/com/minecolonies/core/client/gui/modules/WindowListRecipes.java
@@ -184,12 +184,18 @@ public class WindowListRecipes extends AbstractModuleWindow
                 List<ItemStack> displayStacks = recipe.getRecipeType().getOutputDisplayStacks();
                 icon.setItem(displayStacks.get((lifeCount / LIFE_COUNT_DIVIDER) % (displayStacks.size())));
 
-                if (!module.isRecipeAlterationAllowed())
+                final Button removeButton = rowPane.findPaneOfTypeByID(BUTTON_REMOVE, Button.class);
+                if (removeButton != null)
                 {
-                    final Button removeButton = rowPane.findPaneOfTypeByID(BUTTON_REMOVE, Button.class);
-                    if (removeButton != null)
+                    if (module.isRecipeAlterationAllowed())
+                    {
+                        removeButton.setVisible(true);
+                        removeButton.setEnabled(recipe.getRecipeSource() == null || Screen.hasControlDown());
+                    }
+                    else
                     {
                         removeButton.setVisible(false);
+                        removeButton.setEnabled(false);
                     }
                 }
 

--- a/src/main/resources/assets/minecolonies/lang/manual_en_us.json
+++ b/src/main/resources/assets/minecolonies/lang/manual_en_us.json
@@ -1005,6 +1005,7 @@
   "com.minecolonies.coremod.gui.recipe.done": "Successfully saved recipe!",
   "com.minecolonies.coremod.gui.workerhuts.listrecipes": "List of Recipes",
   "com.minecolonies.coremod.gui.workerhuts.recipestatus": "%s of %s",
+  "com.minecolonies.coremod.gui.workerhuts.removebuiltin": "This is a built-in recipe and you should disable it rather than removing it. Hold %s if something broke and you need to reset it.",
   "com.minecolonies.coremod.resolvers.crafter.private": "Crafting",
   "com.minecolonies.coremod.gui.workerhuts.switchstyle": "Switch Style",
   "com.minecolonies.coremod.gui.townhall.toolow": "Town Hall level too low!",


### PR DESCRIPTION
Closes #6708
Closes #11248

# Changes proposed in this pull request
- Disable the "remove recipe" button for datapack-added recipes.
    - The button can still be clicked if you hold the Ctrl key, just in case something derps and you need to reset it.
    - There's a tooltip telling the player this.

## Testing
- [x] Yes I tested this before submitting it.
- [ ] I also did a multiplayer test.

Review please (should port)