### PR TITLE
Fix: Crafter infinite loop due to ingredient/craft count mismatch

### DIFF
--- a/src/main/java/com/minecolonies/core/entity/ai/workers/crafting/AbstractEntityAICrafting.java
+++ b/src/main/java/com/minecolonies/core/entity/ai/workers/crafting/AbstractEntityAICrafting.java
@@ -405,7 +405,9 @@ public abstract class AbstractEntityAICrafting<J extends AbstractJobCrafter<?, J
 
             if (!isToolOrContainer)
             {
-                availableOpsCount = Math.min(Math.min(availableCount, currentRequest.getRequest().getCount()), availableOpsCount);
+                // Convert available ingredient count to possible recipe iterations
+                final int possibleIterations = availableCount / inputStorage.getAmount();
+                availableOpsCount = Math.min(possibleIterations, availableOpsCount);
             }
         }
 


### PR DESCRIPTION
# Changes proposed in this pull request
- Fixed infinite loop where crafter workers would get stuck between `QUERY_ITEMS` and `GET_RECIPE` states
- Corrected `availableOpsCount` calculation to convert ingredient quantities to craft iterations instead of comparing incompatible units (e.g., comparing 48 sticks with 22 crafts)

### Example logs

```
[22:52:21] [Server thread/WARN] [minecolonies/]: [CRAFTING DEBUG] getRecipe - Recipe: Ladder
[22:52:21] [Server thread/WARN] [minecolonies/]: [CRAFTING DEBUG]   Output per craft (countPerIteration): 3
[22:52:21] [Server thread/WARN] [minecolonies/]: [CRAFTING DEBUG]   Requested count: 22
[22:52:21] [Server thread/WARN] [minecolonies/]: [CRAFTING DEBUG]   availableOpsCount: 22
[22:52:21] [Server thread/WARN] [minecolonies/]: [CRAFTING DEBUG]   doneOpsCount: 0
[22:52:21] [Server thread/WARN] [minecolonies/]: [CRAFTING DEBUG]   Setting maxCraftingCount to: 22
[22:52:21] [Server thread/WARN] [minecolonies/]: [CRAFTING DEBUG]   Setting craftCounter to: 0
[22:52:22] [Server thread/WARN] [minecolonies/]: [CRAFTING DEBUG] checkForItems - Item: Stick
[22:52:22] [Server thread/WARN] [minecolonies/]: [CRAFTING DEBUG]   inputAmount (per recipe): 7
[22:52:22] [Server thread/WARN] [minecolonies/]: [CRAFTING DEBUG]   maxCraftingCount: 22
[22:52:22] [Server thread/WARN] [minecolonies/]: [CRAFTING DEBUG]   remaining (calculated): 154
[22:52:22] [Server thread/WARN] [minecolonies/]: [CRAFTING DEBUG]   invCount: 48
[22:52:22] [Server thread/WARN] [minecolonies/]: [CRAFTING DEBUG]   inProgressCount: 0
[22:52:22] [Server thread/WARN] [minecolonies/]: [CRAFTING DEBUG]   craftCounter: 0
[22:52:22] [Server thread/WARN] [minecolonies/]: [CRAFTING DEBUG]   progressOpsCount: 0
[22:52:22] [Server thread/WARN] [minecolonies/]: [CRAFTING DEBUG]   CHECK FAILED: invCount(48) + inProgressCount(0) <= 0: false
[22:52:22] [Server thread/WARN] [minecolonies/]: [CRAFTING DEBUG]   CHECK FAILED: invCount(48) + ((craftCounter(0) + progressOps(0)) * inputAmount(7)) = 48 < remaining(154): true
[22:52:22] [Server thread/WARN] [minecolonies/]: [CRAFTING DEBUG]   Items NOT in building, nulling recipe and returning to GET_RECIPE (LOOP!)
```

Code calculated 154 sticks needed (7 x 22 crafts) when worker only has 48 sticks. Should calculate 6 crafts possible (42 sticks needed).

## Testing
- [x] Yes I tested this before submitting it.
- [ ] I also did a multiplayer test.

Review please