### PR TITLE
Fix to update shields with banner when changed

### DIFF
--- a/src/main/java/com/minecolonies/api/colony/jobs/IJobWithColonyFlag.java
+++ b/src/main/java/com/minecolonies/api/colony/jobs/IJobWithColonyFlag.java
@@ -1,0 +1,12 @@
+package com.minecolonies.api.colony.jobs;
+
+/**
+ * Interface for workers that make use of the colony flag (e.g. the knight).
+ */
+public interface IJobWithColonyFlag
+{
+    /**
+     * What to do when the colony flag changes.
+     */
+    void onColonyFlagChanged();
+}

--- a/src/main/java/com/minecolonies/api/colony/managers/interfaces/ICitizenManager.java
+++ b/src/main/java/com/minecolonies/api/colony/managers/interfaces/ICitizenManager.java
@@ -177,4 +177,9 @@ public interface ICitizenManager extends IEntityManager
      * Post building load actions
      */
     void afterBuildingLoad();
+
+    /**
+     * Called when flag is changed
+     */
+    void onFlagChange();
 }

--- a/src/main/java/com/minecolonies/core/colony/Colony.java
+++ b/src/main/java/com/minecolonies/core/colony/Colony.java
@@ -70,6 +70,7 @@ import java.util.concurrent.ConcurrentHashMap;
 
 import static com.minecolonies.api.colony.ColonyState.*;
 import static com.minecolonies.api.entity.ai.statemachine.tickratestatemachine.TickRateConstants.MAX_TICKRATE;
+import static com.minecolonies.api.research.util.ResearchConstants.SHIELD_USAGE;
 import static com.minecolonies.api.util.constant.ColonyConstants.*;
 import static com.minecolonies.api.util.constant.Constants.DEFAULT_STYLE;
 import static com.minecolonies.api.util.constant.Constants.TICKS_SECOND;
@@ -683,6 +684,10 @@ public class Colony implements IColony
     public void setColonyFlag(ListTag colonyFlag)
     {
         this.colonyFlag = colonyFlag;
+        if (researchManager.getResearchEffects().getEffectStrength(SHIELD_USAGE) > 0)
+        {
+            citizenManager.onFlagChange();
+        }
         markDirty();
     }
 

--- a/src/main/java/com/minecolonies/core/colony/jobs/JobKnight.java
+++ b/src/main/java/com/minecolonies/core/colony/jobs/JobKnight.java
@@ -1,5 +1,6 @@
 package com.minecolonies.core.colony.jobs;
 
+import com.minecolonies.api.colony.jobs.IJobWithColonyFlag;
 import com.minecolonies.core.util.citizenutils.CitizenItemUtils;
 import net.minecraft.resources.ResourceLocation;
 import com.minecolonies.api.client.render.modeltype.ModModelTypes;
@@ -28,7 +29,7 @@ import static com.minecolonies.api.util.constant.NbtTagConstants.TAG_BANNER_PATT
  *
  * @author Asherslab
  */
-public class JobKnight extends AbstractJobGuard<JobKnight>
+public class JobKnight extends AbstractJobGuard<JobKnight> implements IJobWithColonyFlag
 {
     /**
      * Desc of knight job.
@@ -61,9 +62,9 @@ public class JobKnight extends AbstractJobGuard<JobKnight>
 
             // +1 Heart every 2 level
             final AttributeModifier healthModLevel =
-              new AttributeModifier(GUARD_HEALTH_MOD_LEVEL_NAME,
-                getCitizen().getCitizenSkillHandler().getLevel(Skill.Stamina) + KNIGHT_HP_BONUS,
-                AttributeModifier.Operation.ADDITION);
+                new AttributeModifier(GUARD_HEALTH_MOD_LEVEL_NAME,
+                    getCitizen().getCitizenSkillHandler().getLevel(Skill.Stamina) + KNIGHT_HP_BONUS,
+                    AttributeModifier.Operation.ADDITION);
             AttributeModifierUtils.addHealthModifier(citizen, healthModLevel);
         }
     }
@@ -77,8 +78,8 @@ public class JobKnight extends AbstractJobGuard<JobKnight>
     @Override
     public boolean ignoresDamage(@NotNull final DamageSource damageSource)
     {
-        if(damageSource.is(DamageTypeTags.IS_EXPLOSION) && this.getColony().getResearchManager().getResearchEffects().getEffectStrength(SHIELD_USAGE) > 0
-                && InventoryUtils.findFirstSlotInItemHandlerWith(this.getCitizen().getInventory(), Items.SHIELD) != -1)
+        if (damageSource.is(DamageTypeTags.IS_EXPLOSION) && this.getColony().getResearchManager().getResearchEffects().getEffectStrength(SHIELD_USAGE) > 0
+            && InventoryUtils.findFirstSlotInItemHandlerWith(this.getCitizen().getInventory(), Items.SHIELD) != -1)
         {
             if (!this.getCitizen().getEntity().isPresent())
             {
@@ -97,5 +98,16 @@ public class JobKnight extends AbstractJobGuard<JobKnight>
             return true;
         }
         return super.ignoresDamage(damageSource);
+    }
+
+    @Override
+    public void onColonyFlagChanged()
+    {
+        final AbstractEntityCitizen worker = this.getCitizen().getEntity().get();
+        CitizenItemUtils.setHeldItem(worker, InteractionHand.OFF_HAND, InventoryUtils.findFirstSlotInItemHandlerWith(this.getCitizen().getInventory(), Items.SHIELD));
+        worker.startUsingItem(InteractionHand.OFF_HAND);
+        ItemStack shieldStack = worker.getInventoryCitizen().getHeldItem(InteractionHand.OFF_HAND);
+        CompoundTag nbt = shieldStack.getOrCreateTagElement("BlockEntityTag");
+        nbt.put(TAG_BANNER_PATTERNS, worker.getCitizenColonyHandler().getColonyOrRegister().getColonyFlag());
     }
 }

--- a/src/main/java/com/minecolonies/core/colony/jobs/JobKnight.java
+++ b/src/main/java/com/minecolonies/core/colony/jobs/JobKnight.java
@@ -103,11 +103,14 @@ public class JobKnight extends AbstractJobGuard<JobKnight> implements IJobWithCo
     @Override
     public void onColonyFlagChanged()
     {
-        final AbstractEntityCitizen worker = this.getCitizen().getEntity().get();
-        CitizenItemUtils.setHeldItem(worker, InteractionHand.OFF_HAND, InventoryUtils.findFirstSlotInItemHandlerWith(this.getCitizen().getInventory(), Items.SHIELD));
-        worker.startUsingItem(InteractionHand.OFF_HAND);
-        ItemStack shieldStack = worker.getInventoryCitizen().getHeldItem(InteractionHand.OFF_HAND);
-        CompoundTag nbt = shieldStack.getOrCreateTagElement("BlockEntityTag");
-        nbt.put(TAG_BANNER_PATTERNS, worker.getCitizenColonyHandler().getColonyOrRegister().getColonyFlag());
+        if (this.getCitizen().getEntity().isPresent())
+        {
+            final AbstractEntityCitizen worker = this.getCitizen().getEntity().get();
+            CitizenItemUtils.setHeldItem(worker, InteractionHand.OFF_HAND, InventoryUtils.findFirstSlotInItemHandlerWith(this.getCitizen().getInventory(), Items.SHIELD));
+            worker.startUsingItem(InteractionHand.OFF_HAND);
+            ItemStack shieldStack = worker.getInventoryCitizen().getHeldItem(InteractionHand.OFF_HAND);
+            CompoundTag nbt = shieldStack.getOrCreateTagElement("BlockEntityTag");
+            nbt.put(TAG_BANNER_PATTERNS, worker.getCitizenColonyHandler().getColonyOrRegister().getColonyFlag());
+        }
     }
 }

--- a/src/main/java/com/minecolonies/core/colony/managers/CitizenManager.java
+++ b/src/main/java/com/minecolonies/core/colony/managers/CitizenManager.java
@@ -8,6 +8,7 @@ import com.minecolonies.api.colony.ICivilianData;
 import com.minecolonies.api.colony.IColony;
 import com.minecolonies.api.colony.buildings.HiringMode;
 import com.minecolonies.api.colony.buildings.IBuilding;
+import com.minecolonies.api.colony.jobs.IJobWithColonyFlag;
 import com.minecolonies.api.colony.managers.interfaces.ICitizenManager;
 import com.minecolonies.api.entity.ModEntities;
 import com.minecolonies.api.entity.citizen.AbstractCivilianEntity;
@@ -707,6 +708,18 @@ public class CitizenManager implements ICitizenManager
         for(final ICitizenData data: citizens.values())
         {
             data.onBuildingLoad();
+        }
+    }
+
+    @Override
+    public void onFlagChange()
+    {
+        for (ICitizenData citizen : this.getCitizens())
+        {
+            if (citizen.getEntity().isPresent() && citizen.getJob() instanceof IJobWithColonyFlag flagUser)
+            {
+                flagUser.onColonyFlagChanged();
+            }
         }
     }
 }


### PR DESCRIPTION
Fixes #11105.

# Changes proposed in this pull request
- Fixed guard shield banners to switch to the new colony flag whenever a ColonyFlagMessage is executed.
- There are still a few issues with the guard shield banners where if the shield is picked up by or placed into their inventory, the shield banner will not change to the colony flag. Also, if you take the shield out of their inventory the guard will still have it equipped, and the shield will not update to the correct state. I figured these could be fixed in a subsequent PR.

## Testing
- [x] Yes I tested this before submitting it.
- [ ] I also did a multiplayer test.

Review please