### PR TITLE
Fix crusher and fletcher things

### DIFF
--- a/src/datagen/generated/minecolonies/data/minecolonies/crafterrecipes/crusher/gravel1.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/crafterrecipes/crusher/gravel1.json
@@ -8,7 +8,6 @@
     }
   ],
   "intermediate": "minecraft:air",
-  "loot-table": "minecolonies:recipes/gravel",
   "not-research-id": "minecolonies:effects/crushing11unlock",
   "result": "minecraft:gravel"
 }

--- a/src/datagen/generated/minecolonies/data/minecolonies/crafterrecipes/crusher/gravel2.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/crafterrecipes/crusher/gravel2.json
@@ -7,7 +7,6 @@
     }
   ],
   "intermediate": "minecraft:air",
-  "loot-table": "minecolonies:recipes/gravel",
   "research-id": "minecolonies:effects/crushing11unlock",
   "result": "minecraft:gravel"
 }

--- a/src/datagen/generated/minecolonies/data/minecolonies/crafterrecipes/crusher/sand1.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/crafterrecipes/crusher/sand1.json
@@ -8,6 +8,7 @@
     }
   ],
   "intermediate": "minecraft:air",
+  "loot-table": "minecolonies:recipes/gravel",
   "not-research-id": "minecolonies:effects/crushing11unlock",
   "result": "minecraft:sand"
 }

--- a/src/datagen/generated/minecolonies/data/minecolonies/crafterrecipes/crusher/sand2.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/crafterrecipes/crusher/sand2.json
@@ -7,6 +7,7 @@
     }
   ],
   "intermediate": "minecraft:air",
+  "loot-table": "minecolonies:recipes/gravel",
   "research-id": "minecolonies:effects/crushing11unlock",
   "result": "minecraft:sand"
 }

--- a/src/main/java/com/minecolonies/api/crafting/ItemStorage.java
+++ b/src/main/java/com/minecolonies/api/crafting/ItemStorage.java
@@ -47,7 +47,7 @@ public class ItemStorage
      */
     public ItemStorage(@NotNull final ItemStack stack, final int amount, final boolean ignoreDamageValue)
     {
-        this.stack = stack.copyWithCount(1);
+        this.stack = stack;
         this.shouldIgnoreDamageValue = ignoreDamageValue;
         this.shouldIgnoreNBTValue = ignoreDamageValue;
         this.amount = amount;
@@ -63,7 +63,7 @@ public class ItemStorage
      */
     public ItemStorage(@NotNull final ItemStack stack, final int amount, final boolean ignoreDamageValue, final boolean ignoreNBTValue)
     {
-        this.stack = stack.copyWithCount(1);
+        this.stack = stack;
         this.shouldIgnoreDamageValue = ignoreDamageValue;
         this.shouldIgnoreNBTValue = ignoreNBTValue;
         this.amount = amount;
@@ -89,7 +89,7 @@ public class ItemStorage
      */
     public ItemStorage(@NotNull final ItemStack stack, final boolean ignoreDamageValue, final boolean shouldIgnoreNBTValue)
     {
-        this.stack = stack.copyWithCount(1);
+        this.stack = stack;
         this.shouldIgnoreDamageValue = ignoreDamageValue;
         this.shouldIgnoreNBTValue = shouldIgnoreNBTValue;
         this.amount = ItemStackUtils.getSize(stack);
@@ -103,7 +103,7 @@ public class ItemStorage
      */
     public ItemStorage(@NotNull final ItemStack stack, final boolean ignoreDamageValue)
     {
-        this.stack = stack.copyWithCount(1);
+        this.stack = stack;
         this.shouldIgnoreDamageValue = ignoreDamageValue;
         this.shouldIgnoreNBTValue = false;
         this.amount = ItemStackUtils.getSize(stack);
@@ -116,7 +116,7 @@ public class ItemStorage
      */
     public ItemStorage(@NotNull final ItemStack stack)
     {
-        this.stack = stack.copyWithCount(1);
+        this.stack = stack;
         this.shouldIgnoreDamageValue = false;
         this.shouldIgnoreNBTValue = false;
         this.amount = ItemStackUtils.getSize(stack);
@@ -325,10 +325,8 @@ public class ItemStorage
      */
     public ItemStorage copy()
     {
-        ItemStorage newInstance = new ItemStorage(stack.copy(), shouldIgnoreDamageValue, shouldIgnoreNBTValue);
-        newInstance.setAmount(amount);
-        return newInstance;
-    }    
+        return new ItemStorage(stack.copy(), amount, shouldIgnoreDamageValue, shouldIgnoreNBTValue);
+    }
 
     /**
      * Get an immutable version of this item storage

--- a/src/main/java/com/minecolonies/api/crafting/ItemStorage.java
+++ b/src/main/java/com/minecolonies/api/crafting/ItemStorage.java
@@ -2,6 +2,7 @@ package com.minecolonies.api.crafting;
 
 import com.google.gson.JsonObject;
 import com.minecolonies.api.util.ItemStackUtils;
+import com.minecolonies.core.util.GsonHelper;
 import net.minecraft.world.item.Item;
 import net.minecraft.world.item.ItemStack;
 import org.jetbrains.annotations.NotNull;
@@ -46,7 +47,7 @@ public class ItemStorage
      */
     public ItemStorage(@NotNull final ItemStack stack, final int amount, final boolean ignoreDamageValue)
     {
-        this.stack = stack;
+        this.stack = stack.copyWithCount(1);
         this.shouldIgnoreDamageValue = ignoreDamageValue;
         this.shouldIgnoreNBTValue = ignoreDamageValue;
         this.amount = amount;
@@ -62,7 +63,7 @@ public class ItemStorage
      */
     public ItemStorage(@NotNull final ItemStack stack, final int amount, final boolean ignoreDamageValue, final boolean ignoreNBTValue)
     {
-        this.stack = stack;
+        this.stack = stack.copyWithCount(1);
         this.shouldIgnoreDamageValue = ignoreDamageValue;
         this.shouldIgnoreNBTValue = ignoreNBTValue;
         this.amount = amount;
@@ -88,7 +89,7 @@ public class ItemStorage
      */
     public ItemStorage(@NotNull final ItemStack stack, final boolean ignoreDamageValue, final boolean shouldIgnoreNBTValue)
     {
-        this.stack = stack;
+        this.stack = stack.copyWithCount(1);
         this.shouldIgnoreDamageValue = ignoreDamageValue;
         this.shouldIgnoreNBTValue = shouldIgnoreNBTValue;
         this.amount = ItemStackUtils.getSize(stack);
@@ -102,7 +103,7 @@ public class ItemStorage
      */
     public ItemStorage(@NotNull final ItemStack stack, final boolean ignoreDamageValue)
     {
-        this.stack = stack;
+        this.stack = stack.copyWithCount(1);
         this.shouldIgnoreDamageValue = ignoreDamageValue;
         this.shouldIgnoreNBTValue = false;
         this.amount = ItemStackUtils.getSize(stack);
@@ -115,7 +116,7 @@ public class ItemStorage
      */
     public ItemStorage(@NotNull final ItemStack stack)
     {
-        this.stack = stack;
+        this.stack = stack.copyWithCount(1);
         this.shouldIgnoreDamageValue = false;
         this.shouldIgnoreNBTValue = false;
         this.amount = ItemStackUtils.getSize(stack);
@@ -152,34 +153,10 @@ public class ItemStorage
     {
         if (jObject.has(ITEM_PROP))
         {
-            final ItemStack parsedStack = ItemStackUtils.idToItemStack(jObject.get(ITEM_PROP).getAsString());
-            if(jObject.has(COUNT_PROP))
-            {
-                parsedStack.setCount(jObject.get(COUNT_PROP).getAsInt());
-                this.amount = jObject.get(COUNT_PROP).getAsInt();
-            }
-            else
-            {
-                this.amount = parsedStack.getCount();
-            }
-            this.stack = parsedStack;
-            if(jObject.has(MATCHTYPE_PROP))
-            {
-                String matchType = jObject.get(MATCHTYPE_PROP).getAsString();
-                if(matchType.equals(MATCH_NBTIGNORE))
-                {
-                    this.shouldIgnoreNBTValue = true;
-                }
-                else // includes "exact"
-                {
-                    this.shouldIgnoreNBTValue = false;
-                }
-            }
-            else
-            {
-                this.shouldIgnoreNBTValue = false;
-            }
-            this.shouldIgnoreDamageValue= true;
+            this.stack = ItemStackUtils.idToItemStack(jObject.get(ITEM_PROP).getAsString());
+            this.amount = GsonHelper.getAsInt(jObject, COUNT_PROP, 1);
+            this.shouldIgnoreNBTValue = GsonHelper.getAsString(jObject, MATCHTYPE_PROP, "exact").equals(MATCH_NBTIGNORE);
+            this.shouldIgnoreDamageValue = true;
         }
         else
         {

--- a/src/main/java/com/minecolonies/core/colony/crafting/CustomRecipe.java
+++ b/src/main/java/com/minecolonies/core/colony/crafting/CustomRecipe.java
@@ -267,7 +267,8 @@ public class CustomRecipe
                 {
                     JsonObject ingredient = e.getAsJsonObject();
                     ItemStorage parsed = new ItemStorage(ingredient);
-                    if(!parsed.isEmpty()) {
+                    if (!parsed.isEmpty())
+                    {
                         recipe.inputs.add(parsed);
                     }
                 }
@@ -815,7 +816,7 @@ public class CustomRecipe
 
             IRecipeManager recipeManager = IColonyManager.getInstance().getRecipeManager();
             IToken<?> cachedRecipeToken = recipeManager.getRecipeId(cachedRecipeStorage);
-            if(cachedRecipeToken != null && !cachedRecipeToken.equals(cachedRecipeStorage.getToken()))
+            if (cachedRecipeToken != null && !cachedRecipeToken.equals(cachedRecipeStorage.getToken()))
             {
                 cachedRecipeStorage = (RecipeStorage) recipeManager.getRecipes().get(cachedRecipeToken);
             }

--- a/src/main/java/com/minecolonies/core/colony/crafting/ItemStorageFactory.java
+++ b/src/main/java/com/minecolonies/core/colony/crafting/ItemStorageFactory.java
@@ -55,10 +55,7 @@ public class ItemStorageFactory implements IItemStorageFactory
     @Override
     public ItemStorage getNewInstance(@NotNull final ItemStack stack, final int size, final boolean ignoreDamage, final boolean ignoreNBT)
     {
-        ItemStorage newItem = new ItemStorage(stack, ignoreDamage, ignoreNBT);
-        newItem.setAmount(size);
-        return newItem;
-
+        return new ItemStorage(stack, size, ignoreDamage, ignoreNBT);
     }
 
     @NotNull
@@ -79,7 +76,8 @@ public class ItemStorageFactory implements IItemStorageFactory
     @Override
     public ItemStorage deserialize(@NotNull final IFactoryController controller, @NotNull final CompoundTag nbt)
     {
-        final ItemStack stack = ItemStack.of(nbt.getCompound(TAG_STACK)).copyWithCount(1);
+        final ItemStack stack = ItemStack.of(nbt.getCompound(TAG_STACK));
+        stack.setCount(1);
         final int size = nbt.getInt(TAG_SIZE);
         final boolean ignoreNBT = nbt.getBoolean(TAG_SHOULDIGNORENBT);
         final boolean ignoreDamage = nbt.getBoolean(TAG_SHOULDIGNOREDAMAGE);

--- a/src/main/java/com/minecolonies/core/colony/crafting/ItemStorageFactory.java
+++ b/src/main/java/com/minecolonies/core/colony/crafting/ItemStorageFactory.java
@@ -79,7 +79,7 @@ public class ItemStorageFactory implements IItemStorageFactory
     @Override
     public ItemStorage deserialize(@NotNull final IFactoryController controller, @NotNull final CompoundTag nbt)
     {
-        final ItemStack stack = ItemStack.of(nbt.getCompound(TAG_STACK));
+        final ItemStack stack = ItemStack.of(nbt.getCompound(TAG_STACK)).copyWithCount(1);
         final int size = nbt.getInt(TAG_SIZE);
         final boolean ignoreNBT = nbt.getBoolean(TAG_SHOULDIGNORENBT);
         final boolean ignoreDamage = nbt.getBoolean(TAG_SHOULDIGNOREDAMAGE);

--- a/src/main/java/com/minecolonies/core/entity/ai/workers/AbstractEntityAIBasic.java
+++ b/src/main/java/com/minecolonies/core/entity/ai/workers/AbstractEntityAIBasic.java
@@ -1594,7 +1594,8 @@ public abstract class AbstractEntityAIBasic<J extends AbstractJob<?, J>, B exten
      */
     public boolean checkIfRequestForItemExistOrCreate(@NotNull final ItemStack stack)
     {
-        return checkIfRequestForItemExistOrCreate(stack, stack.getCount(), stack.getCount());
+        final int amount = stack.getCount();
+        return checkIfRequestForItemExistOrCreate(stack.copyWithCount(1), amount, amount);
     }
 
     /**
@@ -1607,22 +1608,7 @@ public abstract class AbstractEntityAIBasic<J extends AbstractJob<?, J>, B exten
      */
     public boolean checkIfRequestForItemExistOrCreate(@NotNull final ItemStack stack, final int count, final int minCount)
     {
-        if (InventoryUtils.hasItemInItemHandler(worker.getInventoryCitizen(),
-          s -> ItemStackUtils.compareItemStacksIgnoreStackSize(s, stack)))
-        {
-            return true;
-        }
-
-        if (building.getOpenRequestsOfTypeFiltered(worker.getCitizenData(), TypeConstants.DELIVERABLE,
-          (IRequest<? extends IDeliverable> r) -> r.getRequest().matches(stack)).isEmpty()
-              && building.getCompletedRequestsOfTypeFiltered(worker.getCitizenData(), TypeConstants.DELIVERABLE,
-          (IRequest<? extends IDeliverable> r) -> r.getRequest().matches(stack)).isEmpty())
-        {
-            final Stack stackRequest = new Stack(stack, count, minCount);
-            worker.getCitizenData().createRequest(stackRequest);
-        }
-
-        return false;
+        return checkIfRequestForItemExistOrCreate(stack, count, minCount, true, false);
     }
 
     /**
@@ -1655,7 +1641,8 @@ public abstract class AbstractEntityAIBasic<J extends AbstractJob<?, J>, B exten
      */
     public boolean checkIfRequestForItemExistOrCreateAsync(@NotNull final ItemStack stack)
     {
-        return checkIfRequestForItemExistOrCreateAsync(stack, stack.getCount(), stack.getCount());
+        final int amount = stack.getCount();
+        return checkIfRequestForItemExistOrCreateAsync(stack.copyWithCount(1), amount, amount);
     }
 
     /**
@@ -1681,6 +1668,21 @@ public abstract class AbstractEntityAIBasic<J extends AbstractJob<?, J>, B exten
      * @return true if in the inventory, else false.
      */
     public boolean checkIfRequestForItemExistOrCreateAsync(@NotNull final ItemStack stack, final int count, final int minCount, final boolean matchNBT)
+    {
+        return checkIfRequestForItemExistOrCreate(stack, count, minCount, matchNBT, true);
+    }
+
+    /**
+     * Check if a stack has been requested already or is in the inventory. If not in the inventory and not requested already, create request
+     *
+     * @param stack    the requested stack.
+     * @param count    the total count.
+     * @param minCount the minimum count.
+     * @param matchNBT if nbt has to be matched.
+     * @param async    if should be an async request.
+     * @return true if in the inventory, else false.
+     */
+    public boolean checkIfRequestForItemExistOrCreate(@NotNull final ItemStack stack, final int count, final int minCount, final boolean matchNBT, final boolean async)
     {
         if (stack.isEmpty())
         {
@@ -1711,7 +1713,14 @@ public abstract class AbstractEntityAIBasic<J extends AbstractJob<?, J>, B exten
           (IRequest<? extends IDeliverable> r) -> r.getRequest().matches(stack)).isEmpty())
         {
             final Stack stackRequest = new Stack(stack, updatedCount, updatedMinCount, matchNBT);
-            worker.getCitizenData().createRequestAsync(stackRequest);
+            if (async)
+            {
+                worker.getCitizenData().createRequestAsync(stackRequest);
+            }
+            else
+            {
+                worker.getCitizenData().createRequest(stackRequest);
+            }
         }
 
         return false;

--- a/src/main/java/com/minecolonies/core/generation/defaults/workers/DefaultCrusherCraftingProvider.java
+++ b/src/main/java/com/minecolonies/core/generation/defaults/workers/DefaultCrusherCraftingProvider.java
@@ -46,11 +46,11 @@ public class DefaultCrusherCraftingProvider extends CustomRecipeProvider
         crush(consumer, "bonemeal2", new ItemStack(Items.BONE), new ItemStack(Items.BONE_MEAL, 5), withGildedHammer);
         crush(consumer, "bonemeal3", new ItemStack(Items.BONE_BLOCK), new ItemStack(Items.BONE_MEAL, 9));
 
-        crush(consumer, "gravel1", new ItemStack(Items.COBBLESTONE, 2), new ItemStack(Items.GRAVEL), noGildedHammer, gravelLoot);
-        crush(consumer, "gravel2", new ItemStack(Items.COBBLESTONE), new ItemStack(Items.GRAVEL), withGildedHammer, gravelLoot);
+        crush(consumer, "gravel1", new ItemStack(Items.COBBLESTONE, 2), new ItemStack(Items.GRAVEL), noGildedHammer);
+        crush(consumer, "gravel2", new ItemStack(Items.COBBLESTONE), new ItemStack(Items.GRAVEL), withGildedHammer);
 
-        crush(consumer, "sand1", new ItemStack(Items.GRAVEL, 2), new ItemStack(Items.SAND), noGildedHammer);
-        crush(consumer, "sand2", new ItemStack(Items.GRAVEL), new ItemStack(Items.SAND), withGildedHammer);
+        crush(consumer, "sand1", new ItemStack(Items.GRAVEL, 2), new ItemStack(Items.SAND), noGildedHammer, gravelLoot);
+        crush(consumer, "sand2", new ItemStack(Items.GRAVEL), new ItemStack(Items.SAND), withGildedHammer, gravelLoot);
 
         crush(consumer, "clay1", new ItemStack(Items.SAND, 2), new ItemStack(Items.CLAY), noGildedHammer);
         crush(consumer, "clay2", new ItemStack(Items.SAND), new ItemStack(Items.CLAY), withGildedHammer);


### PR DESCRIPTION
Closes #11300

# Changes proposed in this pull request
- Makes the crusher produce flint from crushing gravel, not crushing cobble.
- Simplifies AI request logic and fix sync logic not accounting for existing items correctly.
    - Probably not thoroughly tested, but seems sane.
    - In particular this replaces a check for "has any amount of the item -> request none" with "has some amount -> request enough to top off".
- Ensure persisted and otherwise `ItemStorage` uses unit stacks to avoid request warnings.

## Testing
- [x] Yes I tested this before submitting it.
- [ ] I also did a multiplayer test.

Review please (needs selective porting)