### PR TITLE
Fixes command selector arguments missing leading @

### DIFF
--- a/src/main/java/com/minecolonies/core/commands/arguments/ColonyIdArgument.java
+++ b/src/main/java/com/minecolonies/core/commands/arguments/ColonyIdArgument.java
@@ -130,7 +130,7 @@ public class ColonyIdArgument extends MultipleOptionsArgument<Integer>
         @Override
         public boolean matches(final String value)
         {
-            return Objects.equals(value, "here");
+            return Objects.equals(value, "@here");
         }
 
         @Override
@@ -147,7 +147,7 @@ public class ColonyIdArgument extends MultipleOptionsArgument<Integer>
         @Override
         public void createSuggestions(final Level world, final SharedSuggestionProvider suggestionProvider, final SuggestionsBuilder builder)
         {
-            builder.suggest("here", Component.translatable("com.minecolonies.command.argument.colony.here"));
+            builder.suggest("@here", Component.translatable("com.minecolonies.command.argument.colony.here"));
         }
     }
 
@@ -156,7 +156,7 @@ public class ColonyIdArgument extends MultipleOptionsArgument<Integer>
         @Override
         public boolean matches(final String value)
         {
-            return Objects.equals(value, "mine");
+            return Objects.equals(value, "@mine");
         }
 
         @Override
@@ -168,7 +168,7 @@ public class ColonyIdArgument extends MultipleOptionsArgument<Integer>
         @Override
         public void createSuggestions(final Level world, final SharedSuggestionProvider suggestionProvider, final SuggestionsBuilder builder)
         {
-            builder.suggest("mine", Component.translatable("com.minecolonies.command.argument.colony.mine"));
+            builder.suggest("@mine", Component.translatable("com.minecolonies.command.argument.colony.mine"));
         }
     }
 

--- a/src/main/java/com/minecolonies/core/commands/arguments/MultiColonyIdArgument.java
+++ b/src/main/java/com/minecolonies/core/commands/arguments/MultiColonyIdArgument.java
@@ -89,7 +89,7 @@ public class MultiColonyIdArgument extends MultipleOptionsArgument<List<Integer>
         @Override
         public boolean matches(final String value)
         {
-            return Objects.equals(value, "all");
+            return Objects.equals(value, "@all");
         }
 
         @Override
@@ -101,7 +101,7 @@ public class MultiColonyIdArgument extends MultipleOptionsArgument<List<Integer>
         @Override
         public void createSuggestions(final Level world, final SharedSuggestionProvider suggestionProvider, final SuggestionsBuilder builder)
         {
-            builder.suggest("all", Component.translatable("com.minecolonies.command.argument.colony.all"));
+            builder.suggest("@all", Component.translatable("com.minecolonies.command.argument.colony.all"));
         }
     }
 

--- a/src/main/java/com/minecolonies/core/commands/arguments/MultipleOptionsArgument.java
+++ b/src/main/java/com/minecolonies/core/commands/arguments/MultipleOptionsArgument.java
@@ -84,7 +84,16 @@ public abstract class MultipleOptionsArgument<TValue> implements ArgumentType<Mu
     {
         if (reader.canRead())
         {
-            final String argumentValue = reader.readString();
+            final String argumentValue;
+            if (reader.peek() == '@')
+            {
+                reader.skip();
+                argumentValue = "@" + reader.readString();
+            }
+            else
+            {
+                argumentValue = reader.readString();
+            }
             for (final ArgumentOption<TValue> allowedOption : allowedOptions)
             {
                 if (allowedOption.matches(argumentValue))


### PR DESCRIPTION
Fixes [inconsistency](https://github.com/ldtteam/minecolonies/pull/11287#issuecomment-3475445391)

# Changes proposed in this pull request
- Renames colony selector arguments back to `@here` and `@mine`, and changes `all` to `@all` to match for consistency with Minecraft conventions and existing Discord tricks.

## Testing
- [x] Yes I tested this before submitting it.
- [ ] I also did a multiplayer test.

Review please (should port)