### PR TITLE
Guard BED index (port)

### DIFF
--- a/src/main/java/com/minecolonies/core/entity/ai/minimal/EntityAISleep.java
+++ b/src/main/java/com/minecolonies/core/entity/ai/minimal/EntityAISleep.java
@@ -166,7 +166,7 @@ public class EntityAISleep implements IStateAI
                 final List<BlockPos> bedList = hut.getModule(BuildingModules.BED).getRegisteredBlocks();
                 final int index = hut.getFirstModuleOccurance(AbstractAssignedCitizenModule.class).getAssignedCitizen().indexOf(citizen.getCitizenData());
 
-                if (index < bedList.size())
+                if (index >= 0 && index < bedList.size())
                 {
                     final BlockPos pos = bedList.get(index);
                     if (WorldUtil.isEntityBlockLoaded(citizen.level(), pos))


### PR DESCRIPTION
Closes None

# Changes proposed in this pull request
Safeguard assigned citizen indexing use in bed list (indexOf returns -1 if object not found in list).
Symptom manifested with this stack trace:
```
	at java.base/jdk.internal.util.Preconditions.outOfBounds(Preconditions.java:100) ~[?:?]
	at java.base/jdk.internal.util.Preconditions.outOfBoundsCheckIndex(Preconditions.java:106) ~[?:?]
	at java.base/jdk.internal.util.Preconditions.checkIndex(Preconditions.java:302) ~[?:?]
	at java.base/java.util.Objects.checkIndex(Objects.java:385) ~[?:?]
	at java.base/java.util.ArrayList.get(ArrayList.java:427) ~[?:?]
	at TRANSFORMER/minecolonies@1.1.1155-1.21.1-snapshot/com.minecolonies.core.entity.ai.minimal.EntityAISleep.findBedAndTryToSleep(EntityAISleep.java:168) ~[minecolonies-1.1.1155-1.21.1-snapshot.jar%23202!/:1.1.1155-1.21.1-snapshot]
	at TRANSFORMER/minecolonies@1.1.1155-1.21.1-snapshot/com.minecolonies.core.entity.ai.minimal.EntityAISleep.findBed(EntityAISleep.java:141)
```

## Testing
- [X] Yes I tested this before submitting it.
- [ ] I also did a multiplayer test.

Review please