### PR TITLE
Infinite bowl mitosis

### DIFF
--- a/src/datagen/generated/minecolonies/data/minecolonies/recipes/chicken_broth.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/recipes/chicken_broth.json
@@ -15,6 +15,9 @@
       "item": "minecraft:bowl"
     },
     {
+      "item": "minecraft:bowl"
+    },
+    {
       "item": "minecolonies:large_water_bottle"
     }
   ],

--- a/src/datagen/generated/minecolonies/data/minecolonies/recipes/pea_soup.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/recipes/pea_soup.json
@@ -16,6 +16,9 @@
     },
     {
       "item": "minecraft:bowl"
+    },
+    {
+      "item": "minecraft:bowl"
     }
   ],
   "result": {

--- a/src/datagen/generated/minecolonies/data/minecolonies/recipes/polenta.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/recipes/polenta.json
@@ -13,6 +13,9 @@
     },
     {
       "item": "minecraft:bowl"
+    },
+    {
+      "item": "minecraft:bowl"
     }
   ],
   "result": {

--- a/src/datagen/generated/minecolonies/data/minecolonies/recipes/potato_soup.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/recipes/potato_soup.json
@@ -13,6 +13,9 @@
     },
     {
       "item": "minecraft:bowl"
+    },
+    {
+      "item": "minecraft:bowl"
     }
   ],
   "result": {

--- a/src/datagen/generated/minecolonies/data/minecolonies/recipes/soy_corn_chowder.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/recipes/soy_corn_chowder.json
@@ -15,6 +15,9 @@
       "item": "minecraft:bowl"
     },
     {
+      "item": "minecraft:bowl"
+    },
+    {
       "item": "minecolonies:large_soy_milk_bottle"
     }
   ],

--- a/src/datagen/generated/minecolonies/data/minecolonies/recipes/soy_pea_soup.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/recipes/soy_pea_soup.json
@@ -16,6 +16,9 @@
     },
     {
       "item": "minecraft:bowl"
+    },
+    {
+      "item": "minecraft:bowl"
     }
   ],
   "result": {

--- a/src/datagen/generated/minecolonies/data/minecolonies/recipes/squash_soup.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/recipes/squash_soup.json
@@ -13,6 +13,9 @@
     },
     {
       "item": "minecraft:bowl"
+    },
+    {
+      "item": "minecraft:bowl"
     }
   ],
   "result": {

--- a/src/datagen/generated/minecolonies/data/minecolonies/recipes/yogurt_with_berries.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/recipes/yogurt_with_berries.json
@@ -19,6 +19,9 @@
     },
     {
       "item": "minecraft:bowl"
+    },
+    {
+      "item": "minecraft:bowl"
     }
   ],
   "result": {


### PR DESCRIPTION
Closes #11323 


# Changes proposed in this pull request
- Changed food recipes that produce 2x bowled food items to require 2x bowls to craft, so bowls no longer multiply upon food consumption.


## Testing
- I haven't tested this, full disclosure (sorry!!), but it's a fairly basic change. Feel free to nuke this PR if it sucks.
- [ ] Yes I tested this before submitting it.
- [ ] I also did a multiplayer test.
