### PR TITLE
Fix Clipboard item decorator render layer

### DIFF
--- a/src/main/java/com/minecolonies/core/client/render/ClipBoardDecorator.java
+++ b/src/main/java/com/minecolonies/core/client/render/ClipBoardDecorator.java
@@ -83,12 +83,12 @@ public class ClipBoardDecorator implements IItemDecorator
                             {
                                 final PoseStack ps = graphics.pose();
                                 ps.pushPose();
-                                ps.translate(0, 0, 500);
+                                ps.translate(0, 0, 200);
                                 graphics.drawCenteredString(font,
                                   Component.literal(count + ""),
                                   xOffset + 15,
                                   yOffset - 2,
-                                  0xFF4500 | (255 << 24));
+                                  0xFFFF4500);
                                 ps.popPose();
                                 return true;
                             }


### PR DESCRIPTION
Before:
<img width="246" height="113" alt="image" src="https://github.com/user-attachments/assets/593877b0-1af6-4940-bc42-1d7d577f6f6c" />
After:
<img width="161" height="77" alt="image" src="https://github.com/user-attachments/assets/f2bc4661-1b56-4551-b47a-36f99cd00136" />

Since there wasn't a tracking issue, relevant discord message: https://discord.com/channels/139070364159311872/372217492547829762/1435373950422093945


# Changes proposed in this pull request
- Moves the pose stack translation back by 300 so that it does not conflict with the tooltip render layer

## Testing
- [x] Yes I tested this before submitting it.
- [ ] I also did a multiplayer test.

Review please