### PR TITLE
Fix builder resource tab having improper name

### DIFF
--- a/src/main/java/com/minecolonies/core/colony/buildings/moduleviews/BuildingResourcesModuleView.java
+++ b/src/main/java/com/minecolonies/core/colony/buildings/moduleviews/BuildingResourcesModuleView.java
@@ -136,6 +136,6 @@ public class BuildingResourcesModuleView extends AbstractBuildingModuleView
     @Override
     public Component getDesc()
     {
-        return Component.literal("com.minecolonies.coremod.gui.workerhuts.resourcelist");
+        return Component.translatable("com.minecolonies.coremod.gui.workerhuts.resourcelist");
     }
 }


### PR DESCRIPTION
Closes #11327

# Changes proposed in this pull request
- Fix using translatable instead of literal

## Testing
- [ ] Yes I tested this before submitting it.
- [ ] I also did a multiplayer test.

Review please