### PR TITLE
Fix builder resource tab having improper name [1.21]

### DIFF
--- a/src/main/java/com/minecolonies/core/colony/buildings/moduleviews/BuildingResourcesModuleView.java
+++ b/src/main/java/com/minecolonies/core/colony/buildings/moduleviews/BuildingResourcesModuleView.java
@@ -137,6 +137,6 @@ public class BuildingResourcesModuleView extends AbstractBuildingModuleView
     @Override
     public Component getDesc()
     {
-        return Component.literal("com.minecolonies.coremod.gui.workerhuts.resourcelist");
+        return Component.translatableEscape("com.minecolonies.coremod.gui.workerhuts.resourcelist");
     }
 }


### PR DESCRIPTION
See #11344 