### PR TITLE
Fix: fuel workers got stuck when fuel run out

### DIFF
--- a/src/main/java/com/minecolonies/core/colony/buildings/modules/AbstractCraftingBuildingModule.java
+++ b/src/main/java/com/minecolonies/core/colony/buildings/modules/AbstractCraftingBuildingModule.java
@@ -1089,10 +1089,9 @@ public abstract class AbstractCraftingBuildingModule extends AbstractBuildingMod
                 {
                     if (stackPredicate.test(fuel.getItemStack()))
                     {
-                        return super.getFirstFulfillableRecipe(stackPredicate, count, considerReservation);
+                        return null;
                     }
                 }
-                return null;
             }
             return super.getFirstFulfillableRecipe(stackPredicate, count, considerReservation);
         }


### PR DESCRIPTION
Closes #11335
Closes #

# Changes proposed in this pull request
- Furnace crafters, like the brick worker, were only allowed to craft own fuels when there were none left, whereas I had the feeling that code was added to prevent them making their own fuel, to avoid deadlocks
  The logic looked like it was reversed (returning null when none of the fuel items were being made in the current crafting request, instead of returning null when any fuel item matched)
  This PR fixes that

## Testing
- [ ] Yes I tested this before submitting it.
- [ ] I also did a multiplayer test.

Review please
