### PR TITLE
Handle walk to build site better

### DIFF
--- a/src/main/java/com/minecolonies/core/entity/ai/workers/AbstractEntityAIStructure.java
+++ b/src/main/java/com/minecolonies/core/entity/ai/workers/AbstractEntityAIStructure.java
@@ -173,7 +173,11 @@ public abstract class AbstractEntityAIStructure<J extends AbstractJobStructure<?
           /*
            * Check if we have to build something.
            */
-          new AITarget(IDLE, this::isThereAStructureToBuild, () -> START_BUILDING, 10),
+          new AITarget(IDLE, START_WORKING, 10),
+          /*
+           * Start working at the building.
+           */
+          new AITarget(START_WORKING, this::startWorkingAtOwnBuilding, TICKS_SECOND),
           /*
            * Build the structure and foundation of the building.
            */
@@ -184,6 +188,19 @@ public abstract class AbstractEntityAIStructure<J extends AbstractJobStructure<?
           new AITarget(COMPLETE_BUILD, this::completeBuild, STANDARD_DELAY),
           new AITarget(PICK_UP, this::pickUpMaterial, 5)
         );
+    }
+
+    /**
+     * Start working at own building. Override for worker specific implementations.
+     * @return next state.
+     */
+    protected IAIState startWorkingAtOwnBuilding()
+    {
+        if (isThereAStructureToBuild())
+        {
+            return START_BUILDING;
+        }
+        return IDLE;
     }
 
     /**

--- a/src/main/java/com/minecolonies/core/entity/ai/workers/builder/EntityAIStructureBuilder.java
+++ b/src/main/java/com/minecolonies/core/entity/ai/workers/builder/EntityAIStructureBuilder.java
@@ -69,10 +69,6 @@ public class EntityAIStructureBuilder extends AbstractEntityAIStructureWithWorkO
     public EntityAIStructureBuilder(@NotNull final JobBuilder job)
     {
         super(job);
-        super.registerTargets(
-            new AITarget(IDLE, START_WORKING, 10),
-            new AITarget(START_WORKING, this::checkForWorkOrder, this::startWorkingAtOwnBuilding, TICKS_SECOND)
-        );
         worker.setCanPickUpLoot(true);
     }
 
@@ -146,13 +142,24 @@ public class EntityAIStructureBuilder extends AbstractEntityAIStructureWithWorkO
         return !checkForWorkOrder();
     }
 
-    private IAIState startWorkingAtOwnBuilding()
+    @Override
+    protected IAIState startWorkingAtOwnBuilding()
     {
         if (!walkToBuilding())
         {
             return getState();
         }
-        return LOAD_STRUCTURE;
+
+        if (checkForWorkOrder())
+        {
+            final IAIState state = super.startWorkingAtOwnBuilding();
+            if (state == IDLE)
+            {
+                return LOAD_STRUCTURE;
+            }
+            return state;
+        }
+        return IDLE;
     }
 
     /**

--- a/src/main/java/com/minecolonies/core/entity/ai/workers/production/EntityAIQuarrier.java
+++ b/src/main/java/com/minecolonies/core/entity/ai/workers/production/EntityAIQuarrier.java
@@ -11,7 +11,6 @@ import com.minecolonies.api.colony.IColonyManager;
 import com.minecolonies.api.colony.buildings.IBuilding;
 import com.minecolonies.api.colony.interactionhandling.ChatPriority;
 import com.minecolonies.api.colony.workorders.IBuilderWorkOrder;
-import com.minecolonies.api.entity.ai.statemachine.AITarget;
 import com.minecolonies.api.entity.ai.statemachine.states.IAIState;
 import com.minecolonies.api.entity.citizen.VisibleCitizenStatus;
 import com.minecolonies.api.tileentities.AbstractTileEntityColonyBuilding;
@@ -46,7 +45,6 @@ import java.util.List;
 
 import static com.ldtteam.structurize.placement.AbstractBlueprintIterator.NULL_POS;
 import static com.minecolonies.api.entity.ai.statemachine.states.AIWorkerState.*;
-import static com.minecolonies.api.util.constant.Constants.TICKS_SECOND;
 import static com.minecolonies.api.util.constant.StatisticsConstants.*;
 import static com.minecolonies.api.util.constant.TranslationConstants.QUARRY_MINER_FINISHED_QUARRY;
 import static com.minecolonies.api.util.constant.TranslationConstants.QUARRY_MINER_NO_QUARRY;
@@ -83,14 +81,6 @@ public class EntityAIQuarrier extends AbstractEntityAIStructureWithWorkOrder<Job
     public EntityAIQuarrier(@NotNull final JobQuarrier job)
     {
         super(job);
-        super.registerTargets(
-          /*
-           * If IDLE - switch to start working.
-           */
-          new AITarget(IDLE, START_WORKING, 1),
-          new AITarget(START_WORKING, this::startWorkingAtOwnBuilding, TICKS_SECOND),
-          new AITarget(BUILDING_STEP, this::structureStep, STANDARD_DELAY)
-        );
         worker.setCanPickUpLoot(true);
     }
 
@@ -102,7 +92,8 @@ public class EntityAIQuarrier extends AbstractEntityAIStructureWithWorkOrder<Job
 
     //Miner wants to work but is not at building
     @NotNull
-    private IAIState startWorkingAtOwnBuilding()
+    @Override
+    protected IAIState startWorkingAtOwnBuilding()
     {
         worker.getCitizenData().setVisibleStatus(VisibleCitizenStatus.WORKING);
 
@@ -126,8 +117,13 @@ public class EntityAIQuarrier extends AbstractEntityAIStructureWithWorkOrder<Job
             return getState();
         }
 
-        //Miner is at building
-        return LOAD_STRUCTURE;
+        final IAIState state = super.startWorkingAtOwnBuilding();
+        if (state == IDLE)
+        {
+            return LOAD_STRUCTURE;
+        }
+
+        return state;
     }
 
     @Override

--- a/src/main/java/com/minecolonies/core/entity/ai/workers/production/EntityAIStructureMiner.java
+++ b/src/main/java/com/minecolonies/core/entity/ai/workers/production/EntityAIStructureMiner.java
@@ -152,8 +152,6 @@ public class EntityAIStructureMiner extends AbstractEntityAIStructureWithWorkOrd
           /*
            * If IDLE - switch to start working.
            */
-          new AITarget(IDLE, START_WORKING, 1),
-          new AITarget(START_WORKING, this::startWorkingAtOwnBuilding, TICKS_SECOND),
           new AITarget(PREPARING, MINER_CHECK_MINESHAFT, 1),
           new AITarget(MINER_WALKING_TO_LADDER, this::goToLadder, TICKS_SECOND),
           new AITarget(MINER_REPAIRING_LADDER, this::repairLadder, STANDARD_DELAY),
@@ -173,7 +171,8 @@ public class EntityAIStructureMiner extends AbstractEntityAIStructureWithWorkOrd
 
     //Miner wants to work but is not at building
     @NotNull
-    private IAIState startWorkingAtOwnBuilding()
+    @Override
+    protected IAIState startWorkingAtOwnBuilding()
     {
         worker.getCitizenData().setVisibleStatus(VisibleCitizenStatus.WORKING);
         if ((building.getLadderLocation() == null || worker.getY() >= building.getPosition().getY()) && !walkToBuilding())
@@ -195,6 +194,12 @@ public class EntityAIStructureMiner extends AbstractEntityAIStructureWithWorkOrd
                 building.setWorkOrder(list.get(0));
                 return LOAD_STRUCTURE;
             }
+        }
+
+        final IAIState nextState = super.startWorkingAtOwnBuilding();
+        if (nextState != IDLE)
+        {
+            return nextState;
         }
 
         //Miner is at building


### PR DESCRIPTION
Closes #
Closes #

# Changes proposed in this pull request
- Builders/Miners/Quarriers had some not very deterministic go to work handling due to multiple AI State path options, united this now and handled it over overriding the right method
-

## Testing
- [x] Yes I tested this before submitting it.
- [ ] I also did a multiplayer test.

Review please