### PR TITLE
Fix: smelting crafters could not request fuel in 1.20.1

### DIFF
--- a/src/main/java/com/minecolonies/core/entity/ai/workers/crafting/AbstractEntityAIRequestSmelter.java
+++ b/src/main/java/com/minecolonies/core/entity/ai/workers/crafting/AbstractEntityAIRequestSmelter.java
@@ -304,7 +304,7 @@ public abstract class AbstractEntityAIRequestSmelter<J extends AbstractJobCrafte
             }
         }
 
-        return hasFuel;
+        return !hasFuel;
     }
 
     /**


### PR DESCRIPTION
Closes #
Closes #

# Changes proposed in this pull request
- The crafters which use a furnace were changed the other day to request some fuel to keep in stock. Though there is a small logic errer, so they did not request fuel when the building was out of it, and requested more when the building had fuel
  This corrects that mistake

## Testing
- [x] Yes I tested this before submitting it.
- [ ] I also did a multiplayer test.

Review please
