### PR TITLE
Small field rework

### DIFF
--- a/src/main/java/com/minecolonies/core/blocks/BlockScarecrow.java
+++ b/src/main/java/com/minecolonies/core/blocks/BlockScarecrow.java
@@ -178,7 +178,7 @@ public class BlockScarecrow extends AbstractBlockMinecoloniesDefault<BlockScarec
         final IColony colony = IColonyManager.getInstance().getColonyByPosFromWorld(worldIn, pos);
         if (colony != null)
         {
-            colony.getBuildingManager().addBuildingExtension(FarmField.create(pos));
+            colony.getBuildingManager().addBuildingExtension(FarmField.create(pos, worldIn));
         }
     }
 

--- a/src/main/java/com/minecolonies/core/client/gui/containers/WindowField.java
+++ b/src/main/java/com/minecolonies/core/client/gui/containers/WindowField.java
@@ -11,13 +11,13 @@ import com.minecolonies.api.colony.buildings.views.IBuildingView;
 import com.minecolonies.api.colony.buildingextensions.IBuildingExtension;
 import com.minecolonies.api.colony.buildingextensions.registry.BuildingExtensionRegistries;
 import com.minecolonies.core.items.ItemCrop;
-import com.minecolonies.api.tileentities.AbstractTileEntityScarecrow;
 import com.minecolonies.api.util.constant.Constants;
 import com.minecolonies.core.client.gui.AbstractWindowSkeleton;
 import com.minecolonies.core.client.gui.WindowSelectRes;
 import com.minecolonies.core.colony.buildingextensions.FarmField;
 import com.minecolonies.core.network.messages.server.colony.building.fields.FarmFieldPlotResizeMessage;
 import com.minecolonies.core.network.messages.server.colony.building.fields.FarmFieldUpdateSeedMessage;
+import com.minecolonies.core.tileentities.TileEntityScarecrow;
 import net.minecraft.ChatFormatting;
 import net.minecraft.client.Minecraft;
 import net.minecraft.core.Direction;
@@ -33,11 +33,13 @@ import net.neoforged.neoforge.common.Tags;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
+import java.util.Arrays;
 import java.util.Optional;
 
 import static com.minecolonies.api.util.constant.TranslationConstants.*;
 import static com.minecolonies.api.util.constant.translation.GuiTranslationConstants.FIELD_GUI_ASSIGNED_FARMER;
 import static com.minecolonies.api.util.constant.translation.GuiTranslationConstants.FIELD_GUI_NO_ASSIGNED_FARMER;
+import static com.minecolonies.core.colony.buildingextensions.FarmField.MAX_RANGE;
 
 /**
  * Class which creates the GUI of our field inventory.
@@ -45,11 +47,6 @@ import static com.minecolonies.api.util.constant.translation.GuiTranslationConst
 @OnlyIn(Dist.CLIENT)
 public class WindowField extends AbstractWindowSkeleton
 {
-    /**
-     * The ID for the "not in colony" text.
-     */
-    private static final String NOT_IN_COLONY_TEXT_ID = "not-in-colony";
-
     /**
      * The prefix ID of the directional buttons.
      */
@@ -79,7 +76,7 @@ public class WindowField extends AbstractWindowSkeleton
      * The tile entity of the scarecrow.
      */
     @NotNull
-    private final AbstractTileEntityScarecrow tileEntityScarecrow;
+    private final TileEntityScarecrow tileEntityScarecrow;
 
     /**
      * The farm field instance.
@@ -92,7 +89,7 @@ public class WindowField extends AbstractWindowSkeleton
      *
      * @param tileEntityScarecrow the scarecrow tile entity.
      */
-    public WindowField(@NotNull AbstractTileEntityScarecrow tileEntityScarecrow)
+    public WindowField(@NotNull TileEntityScarecrow tileEntityScarecrow)
     {
         super(new ResourceLocation(Constants.MOD_ID, "gui/windowfield.xml"));
         this.tileEntityScarecrow = tileEntityScarecrow;
@@ -127,7 +124,7 @@ public class WindowField extends AbstractWindowSkeleton
      */
     private void onDirectionalButtonClick(Button button)
     {
-        if (farmField == null || !button.isEnabled())
+        if (!button.isEnabled())
         {
             return;
         }
@@ -140,11 +137,16 @@ public class WindowField extends AbstractWindowSkeleton
             return;
         }
 
-        int newRadius = (farmField.getRadius(direction.get()) % farmField.getMaxRadius()) + 1;
-        farmField.setRadius(direction.get(), newRadius);
+        final int sum = Arrays.stream(tileEntityScarecrow.getFieldSize()).sum();
+        final int leftOver = MAX_RANGE - sum;
+
+        final int currentValue = tileEntityScarecrow.getFieldSize()[direction.get().get2DDataValue()];
+
+        int newRadius = (currentValue % Math.min(currentValue+leftOver, MAX_RANGE)) + 1;
+        tileEntityScarecrow.setFieldSize(direction.get(), newRadius);
         button.setText(Component.literal(String.valueOf(newRadius)));
 
-        new FarmFieldPlotResizeMessage(tileEntityScarecrow.getCurrentColony(), newRadius, direction.get(), farmField.getPosition()).sendToServer();
+        new FarmFieldPlotResizeMessage(newRadius, direction.get(), tileEntityScarecrow.getBlockPos()).sendToServer();
     }
 
     private void updateAll()
@@ -203,16 +205,10 @@ public class WindowField extends AbstractWindowSkeleton
     {
         IColonyView colonyView = getCurrentColony();
 
-        findPaneOfTypeByID(NOT_IN_COLONY_TEXT_ID, Text.class).setVisible(colonyView == null);
         findPaneOfTypeByID(CURRENT_FARMER_TEXT_ID, Text.class).setVisible(colonyView != null);
         findPaneOfTypeByID(SELECT_SEED_BUTTON_ID, ButtonImage.class).setVisible(colonyView != null);
         findPaneOfTypeByID(CURRENT_SEED_TEXT_ID, ItemIcon.class).setVisible(colonyView != null);
         findPaneOfTypeByID(DIRECTIONAL_BUTTON_CENTER_ICON_ID, ItemIcon.class).setVisible(colonyView != null);
-
-        for (Direction dir : Direction.Plane.HORIZONTAL)
-        {
-            findPaneOfTypeByID(DIRECTIONAL_BUTTON_ID_PREFIX + dir.getName(), ButtonImage.class).setVisible(colonyView != null);
-        }
     }
 
     /**
@@ -268,8 +264,7 @@ public class WindowField extends AbstractWindowSkeleton
         for (Direction dir : Direction.Plane.HORIZONTAL)
         {
             ButtonImage button = findPaneOfTypeByID(DIRECTIONAL_BUTTON_ID_PREFIX + dir.getName(), ButtonImage.class);
-            button.setEnabled(farmField != null);
-            button.setText(Component.literal(farmField == null ? "" : Integer.toString(farmField.getRadius(dir))));
+            button.setText(Component.literal(Integer.toString(tileEntityScarecrow.getFieldSize()[dir.get2DDataValue()])));
 
             PaneBuilders.tooltipBuilder()
               .hoverPane(button)

--- a/src/main/java/com/minecolonies/core/colony/buildingextensions/FarmField.java
+++ b/src/main/java/com/minecolonies/core/colony/buildingextensions/FarmField.java
@@ -6,6 +6,7 @@ import com.minecolonies.api.colony.buildingextensions.registry.BuildingExtension
 import com.minecolonies.api.colony.buildingextensions.registry.BuildingExtensionRegistries.BuildingExtensionEntry;
 import com.minecolonies.api.util.Utils;
 import com.minecolonies.api.util.constant.Constants;
+import com.minecolonies.core.tileentities.TileEntityScarecrow;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
 import net.minecraft.core.HolderLookup;
@@ -19,6 +20,7 @@ import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.FenceBlock;
 import net.minecraft.world.level.block.FenceGateBlock;
 import net.minecraft.world.level.block.WallBlock;
+import net.minecraft.world.level.block.entity.BlockEntity;
 import net.minecraft.world.level.block.state.BlockState;
 import org.jetbrains.annotations.NotNull;
 
@@ -34,10 +36,11 @@ public class FarmField extends AbstractBuildingExtension
     /**
      * The max width/length of a field.
      */
-    private static final int MAX_RANGE = 5;
+    public static final int MAX_RANGE = 20;
+    public static final int DEFAULT_RANGE = 5;
 
     private static final String TAG_SEED      = "seed";
-    private static final String TAG_RADIUS    = "radius";
+    public static final  String TAG_RADIUS    = "radius";
     private static final String TAG_MAX_RANGE = "maxRange";
     private static final String TAG_STAGE     = "stage";
 
@@ -51,12 +54,7 @@ public class FarmField extends AbstractBuildingExtension
      * in the same order as {@link Direction}:
      * S, W, N, E
      */
-    private int[] radii = {MAX_RANGE, MAX_RANGE, MAX_RANGE, MAX_RANGE};
-
-    /**
-     * The maximum radius for this field.
-     */
-    private int maxRadius;
+    private int[] radii = {DEFAULT_RANGE, DEFAULT_RANGE, DEFAULT_RANGE, DEFAULT_RANGE};
 
     /**
      * Has the field been planted
@@ -72,17 +70,26 @@ public class FarmField extends AbstractBuildingExtension
     public FarmField(final BuildingExtensionEntry fieldType, final BlockPos position)
     {
         super(fieldType, position);
-        this.maxRadius = MAX_RANGE;
     }
 
     /**
      * Constructor to create new instances
      *
      * @param position the position it is placed in.
+     * @param worldIn
      */
-    public static FarmField create(final BlockPos position)
+    public static FarmField create(final BlockPos position, final Level worldIn)
     {
-        return (FarmField) BuildingExtensionRegistries.farmField.get().produceExtension(position);
+        final FarmField farmField = (FarmField) BuildingExtensionRegistries.farmField.get().produceExtension(position);
+        if (farmField != null)
+        {
+            final BlockEntity fieldBlock = worldIn.getBlockEntity(position);
+            if (fieldBlock instanceof TileEntityScarecrow scarecrow)
+            {
+                farmField.radii = scarecrow.getFieldSize();
+            }
+        }
+        return farmField;
     }
 
     @Override
@@ -98,7 +105,6 @@ public class FarmField extends AbstractBuildingExtension
         CompoundTag compound = super.serializeNBT(provider);
         compound.put(TAG_SEED, seed.saveOptional(provider));
         compound.putIntArray(TAG_RADIUS, radii);
-        compound.putInt(TAG_MAX_RANGE, maxRadius);
         compound.putString(TAG_STAGE, fieldStage.name());
         return compound;
     }
@@ -109,7 +115,6 @@ public class FarmField extends AbstractBuildingExtension
         super.deserializeNBT(provider, compound);
         setSeed(ItemStack.parseOptional(provider, compound.getCompound(TAG_SEED)));
         radii = compound.getIntArray(TAG_RADIUS);
-        maxRadius = compound.getInt(TAG_MAX_RANGE);
         fieldStage = Stage.valueOf(compound.getString(TAG_STAGE));
     }
 
@@ -119,7 +124,6 @@ public class FarmField extends AbstractBuildingExtension
         super.serialize(buf);
         Utils.serializeCodecMess(buf, getSeed());
         buf.writeVarIntArray(radii);
-        buf.writeInt(maxRadius);
         buf.writeEnum(fieldStage);
     }
 
@@ -129,7 +133,6 @@ public class FarmField extends AbstractBuildingExtension
         super.deserialize(buf);
         setSeed(Utils.deserializeCodecMess(buf));
         radii = buf.readVarIntArray();
-        maxRadius = buf.readInt();
         fieldStage = buf.readEnum(Stage.class);
     }
 
@@ -190,16 +193,6 @@ public class FarmField extends AbstractBuildingExtension
     }
 
     /**
-     * Get the max range for this field.
-     *
-     * @return the maximum range.
-     */
-    public int getMaxRadius()
-    {
-        return maxRadius;
-    }
-
-    /**
      * @param direction the direction to get the range for
      * @return the radius
      */
@@ -214,7 +207,7 @@ public class FarmField extends AbstractBuildingExtension
      */
     public void setRadius(Direction direction, int radius)
     {
-        this.radii[direction.get2DDataValue()] = Math.min(radius, maxRadius);
+        this.radii[direction.get2DDataValue()] = Math.min(radius, MAX_RANGE);
     }
 
     /**

--- a/src/main/java/com/minecolonies/core/entity/ai/workers/production/agriculture/EntityAIWorkFarmer.java
+++ b/src/main/java/com/minecolonies/core/entity/ai/workers/production/agriculture/EntityAIWorkFarmer.java
@@ -504,7 +504,7 @@ public class EntityAIWorkFarmer extends AbstractEntityAICrafting<JobFarmer, Buil
 
     protected int getLargestCell(FarmField farmField)
     {
-        return (int) Math.pow(farmField.getMaxRadius() * 2D + 1D, 2);
+        return (int) Math.pow(FarmField.MAX_RANGE * 2D + 1D, 2);
     }
 
     /**
@@ -529,6 +529,7 @@ public class EntityAIWorkFarmer extends AbstractEntityAICrafting<JobFarmer, Buil
                 {
                     return getState();
                 }
+                equipHoe();
 
                 switch ((AIWorkerState) getState())
                 {
@@ -536,7 +537,6 @@ public class EntityAIWorkFarmer extends AbstractEntityAICrafting<JobFarmer, Buil
                     {
                         if (!hoeIfAble(position, farmField))
                         {
-                            didWork = true;
                             return getState();
                         }
                     }
@@ -544,7 +544,6 @@ public class EntityAIWorkFarmer extends AbstractEntityAICrafting<JobFarmer, Buil
                     {
                         if (!tryToPlant(farmField, position))
                         {
-                            didWork = true;
                             return PREPARING;
                         }
                     }
@@ -552,7 +551,6 @@ public class EntityAIWorkFarmer extends AbstractEntityAICrafting<JobFarmer, Buil
                     {
                         if (!harvestIfAble(position))
                         {
-                            didWork = true;
                             return getState();
                         }
                     }
@@ -602,6 +600,7 @@ public class EntityAIWorkFarmer extends AbstractEntityAICrafting<JobFarmer, Buil
         {
             if (mineBlock(position.above()))
             {
+                didWork = true;
                 equipHoe();
                 worker.swing(worker.getUsedItemHand());
                 createCorrectFarmlandForSeed(farmField.getSeed(), position);
@@ -664,6 +663,7 @@ public class EntityAIWorkFarmer extends AbstractEntityAICrafting<JobFarmer, Buil
         {
             if (mineBlock(position.above()))
             {
+                didWork = true;
                 worker.getCitizenColonyHandler().getColonyOrRegister().getStatisticsManager().increment(CROPS_HARVESTED, worker.getCitizenColonyHandler().getColonyOrRegister().getDay());
                 worker.getCitizenExperienceHandler().addExperience(XP_PER_HARVEST);
             }
@@ -766,6 +766,7 @@ public class EntityAIWorkFarmer extends AbstractEntityAICrafting<JobFarmer, Buil
             world.setBlockAndUpdate(position.above(), ((BlockItem) item.getItem()).getBlock().defaultBlockState());
             worker.decreaseSaturationForContinuousAction();
             getInventory().extractItem(slot, 1, false);
+            didWork = true;
         }
         return true;
     }

--- a/src/main/java/com/minecolonies/core/entity/ai/workers/service/EntityAIWorkCook.java
+++ b/src/main/java/com/minecolonies/core/entity/ai/workers/service/EntityAIWorkCook.java
@@ -230,7 +230,7 @@ public class EntityAIWorkCook extends AbstractEntityAIUsesFurnace<JobCook, Build
 
         if (citizenData.getHomeBuilding() != null && citizenData.getHomeBuilding().getBuildingLevelEquivalent() > building.getBuildingLevel() + 1)
         {
-            worker.getCitizenData().triggerInteraction(new StandardInteraction(Component.translatable(POOR_RESTAURANT_INTERACTION), ChatPriority.BLOCKING));
+            worker.getCitizenData().triggerInteraction(new StandardInteraction(Component.translatable(POOR_RESTAURANT_INTERACTION), ChatPriority.IMPORTANT));
         }
 
         String foodName = worker.getInventoryCitizen().getStackInSlot(foodSlot).getDescriptionId();
@@ -360,7 +360,7 @@ public class EntityAIWorkCook extends AbstractEntityAIUsesFurnace<JobCook, Build
 
             if (!hasMinecoloniesFoodInMenu)
             {
-                worker.getCitizenData().triggerInteraction(new StandardInteraction(Component.translatable(POOR_MENU_INTERACTION), ChatPriority.BLOCKING));
+                worker.getCitizenData().triggerInteraction(new StandardInteraction(Component.translatable(POOR_MENU_INTERACTION), ChatPriority.IMPORTANT));
             }
         }
 

--- a/src/main/java/com/minecolonies/core/entity/citizen/citizenhandlers/CitizenFoodHandler.java
+++ b/src/main/java/com/minecolonies/core/entity/citizen/citizenhandlers/CitizenFoodHandler.java
@@ -73,10 +73,10 @@ public class CitizenFoodHandler implements ICitizenFoodHandler
         dirty = true;
         if (lastEatenFoods.size() >= FOOD_QUEUE_SIZE)
         {
-            citizenData.triggerInteraction(new StandardInteraction(Component.translatable(NO + FOOD_DIVERSITY), ChatPriority.IMPORTANT));
-            citizenData.triggerInteraction(new StandardInteraction(Component.translatable(NO + FOOD_QUALITY), ChatPriority.IMPORTANT));
-            citizenData.triggerInteraction(new StandardInteraction(Component.translatable(NO + FOOD_DIVERSITY + URGENT), ChatPriority.BLOCKING));
-            citizenData.triggerInteraction(new StandardInteraction(Component.translatable(NO + FOOD_QUALITY + URGENT), ChatPriority.BLOCKING));
+            citizenData.triggerInteraction(new StandardInteraction(Component.translatable(NO + FOOD_DIVERSITY), ChatPriority.CHITCHAT));
+            citizenData.triggerInteraction(new StandardInteraction(Component.translatable(NO + FOOD_QUALITY), ChatPriority.CHITCHAT));
+            citizenData.triggerInteraction(new StandardInteraction(Component.translatable(NO + FOOD_DIVERSITY + URGENT), ChatPriority.IMPORTANT));
+            citizenData.triggerInteraction(new StandardInteraction(Component.translatable(NO + FOOD_QUALITY + URGENT), ChatPriority.IMPORTANT));
         }
     }
 

--- a/src/main/java/com/minecolonies/core/network/messages/server/colony/building/fields/FarmFieldPlotResizeMessage.java
+++ b/src/main/java/com/minecolonies/core/network/messages/server/colony/building/fields/FarmFieldPlotResizeMessage.java
@@ -1,21 +1,28 @@
 package com.minecolonies.core.network.messages.server.colony.building.fields;
 
+import com.ldtteam.common.network.AbstractServerPlayMessage;
 import com.ldtteam.common.network.PlayMessageType;
 import com.minecolonies.api.colony.IColony;
 import com.minecolonies.api.colony.buildingextensions.registry.BuildingExtensionRegistries;
 import com.minecolonies.api.util.constant.Constants;
 import com.minecolonies.core.colony.buildingextensions.FarmField;
-import com.minecolonies.core.network.messages.server.AbstractColonyServerMessage;
+import com.minecolonies.core.tileentities.TileEntityScarecrow;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
 import net.minecraft.network.RegistryFriendlyByteBuf;
 import net.minecraft.server.level.ServerPlayer;
+import net.minecraft.world.level.block.entity.BlockEntity;
 import net.neoforged.neoforge.network.handling.IPayloadContext;
+
+import java.util.Arrays;
+
+import static com.minecolonies.core.colony.buildingextensions.FarmField.DEFAULT_RANGE;
+import static com.minecolonies.core.colony.buildingextensions.FarmField.MAX_RANGE;
 
 /**
  * Message to change the farmer field plot size.
  */
-public class FarmFieldPlotResizeMessage extends AbstractColonyServerMessage
+public class FarmFieldPlotResizeMessage extends AbstractServerPlayMessage
 {
     public static final PlayMessageType<?> TYPE = PlayMessageType.forServer(Constants.MOD_ID, "farm_field_plot_resize", FarmFieldPlotResizeMessage::new);
 
@@ -39,27 +46,43 @@ public class FarmFieldPlotResizeMessage extends AbstractColonyServerMessage
      * @param direction the specified direction for the new radius
      * @param position  the field position.
      */
-    public FarmFieldPlotResizeMessage(final IColony colony, final int size, final Direction direction, final BlockPos position)
+    public FarmFieldPlotResizeMessage(final int size, final Direction direction, final BlockPos position)
     {
-        super(TYPE, colony);
+        super(TYPE);
         this.size = size;
         this.direction = direction;
         this.position = position;
     }
 
     @Override
-    protected void onExecute(final IPayloadContext ctxIn, final ServerPlayer player, final IColony colony)
+    protected void onExecute(final IPayloadContext ctxIn, final ServerPlayer player)
     {
-        colony.getBuildingManager()
-          .getMatchingBuildingExtension(f -> f.getBuildingExtensionType().equals(BuildingExtensionRegistries.farmField.get()) && f.getPosition().equals(position))
-          .map(m -> (FarmField) m)
-          .ifPresent(field -> field.setRadius(direction, size));
+        final BlockEntity fieldBlock = player.level().getBlockEntity(position);
+        if (fieldBlock instanceof TileEntityScarecrow scarecrow)
+        {
+            final int currentSum = Arrays.stream(scarecrow.getFieldSize()).sum();
+            final int currentDirSize = scarecrow.getFieldSize()[direction.get2DDataValue()];
+
+            if (size < 0 || (size > currentDirSize && currentSum - currentDirSize + size > MAX_RANGE))
+            {
+                return;
+            }
+
+            scarecrow.setFieldSize(direction, size);
+            final IColony colony = scarecrow.getCurrentColony();
+            if (colony != null)
+            {
+                colony.getBuildingManager()
+                    .getMatchingBuildingExtension(f -> f.getBuildingExtensionType().equals(BuildingExtensionRegistries.farmField.get()) && f.getPosition().equals(position))
+                    .map(m -> (FarmField) m)
+                    .ifPresent(field -> field.setRadius(direction, size));
+            }
+        }
     }
 
     @Override
     protected void toBytes(final RegistryFriendlyByteBuf buf)
     {
-        super.toBytes(buf);
         buf.writeInt(size);
         buf.writeInt(direction.get2DDataValue());
         buf.writeBlockPos(position);

--- a/src/main/java/com/minecolonies/core/tileentities/TileEntityScarecrow.java
+++ b/src/main/java/com/minecolonies/core/tileentities/TileEntityScarecrow.java
@@ -5,6 +5,7 @@ import com.minecolonies.api.colony.IColonyManager;
 import com.minecolonies.api.tileentities.AbstractTileEntityScarecrow;
 import com.minecolonies.api.tileentities.ScareCrowType;
 import net.minecraft.core.BlockPos;
+import net.minecraft.core.Direction;
 import net.minecraft.core.HolderLookup;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.network.protocol.game.ClientboundBlockEntityDataPacket;
@@ -12,6 +13,8 @@ import net.minecraft.world.level.block.state.BlockState;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.Random;
+
+import static com.minecolonies.core.colony.buildingextensions.FarmField.*;
 
 /**
  * The scarecrow tile entity to store extra data.
@@ -33,6 +36,13 @@ public class TileEntityScarecrow extends AbstractTileEntityScarecrow
      * The type of the scarecrow.
      */
     private ScareCrowType type;
+
+    /**
+     * The size of the field in all four directions
+     * in the same order as {@link Direction}:
+     * S, W, N, E
+     */
+    private int[] fieldSize = {DEFAULT_RANGE, DEFAULT_RANGE, DEFAULT_RANGE, DEFAULT_RANGE};
 
     /**
      * Creates an instance of the tileEntity.
@@ -64,6 +74,33 @@ public class TileEntityScarecrow extends AbstractTileEntityScarecrow
     }
 
     @Override
+    public void saveAdditional(final CompoundTag compoundTag, final HolderLookup.Provider provider)
+    {
+        super.saveAdditional(compoundTag, provider);
+        compoundTag.putIntArray(TAG_RADIUS, fieldSize);
+    }
+
+    @Override
+    public void loadAdditional(final CompoundTag compoundTag, final HolderLookup.Provider provider)
+    {
+        super.loadAdditional(compoundTag, provider);
+        if (compoundTag.contains(TAG_RADIUS))
+        {
+            fieldSize = compoundTag.getIntArray(TAG_RADIUS);
+        }
+    }
+
+    /**
+     * @param direction the direction for the radius
+     * @param radius    the number of blocks from the scarecrow that the farmer will work with
+     */
+    public void setFieldSize(Direction direction, int radius)
+    {
+        this.fieldSize[direction.get2DDataValue()] = Math.min(radius, MAX_RANGE);
+        setChanged();
+    }
+
+    @Override
     public ClientboundBlockEntityDataPacket getUpdatePacket()
     {
         return ClientboundBlockEntityDataPacket.create(this);
@@ -74,5 +111,14 @@ public class TileEntityScarecrow extends AbstractTileEntityScarecrow
     public CompoundTag getUpdateTag(@NotNull final HolderLookup.Provider provider)
     {
         return saveWithId(provider);
+    }
+
+    /**
+     * Field size.
+     * @return the field size.
+     */
+    public int[] getFieldSize()
+    {
+        return fieldSize;
     }
 }

--- a/src/main/resources/assets/minecolonies/gui/windowfield.xml
+++ b/src/main/resources/assets/minecolonies/gui/windowfield.xml
@@ -6,9 +6,6 @@
     <image source="minecolonies:textures/gui/builderhut/builder_sketch_right.png" size="6 15" pos="140 12"/>
     <text size="130 11" pos="30 14" color="red" textalign="MIDDLE" label="$(block.minecolonies.blockhutfield)"/>
 
-    <text id="not-in-colony" size="164 11" pos="13 55" color="black" textalign="MIDDLE"
-           label="$(com.minecolonies.coremod.gui.workerhuts.fields.notincolony)"/>
-
     <text id="current-farmer" size="164 11" pos="13 30" color="black"/>
 
     <button id="select-seed" size="86 17" pos="13 72" color="black"


### PR DESCRIPTION
Closes #
Closes #

# Changes proposed in this pull request
- Adjust importance of some of the notify messages
- Allow fields to persist the size in the tileEntity (for style designers) (Also allow setting the field size outside of a colony)
- Allow fields to be more dynamic in size (e.g. not only a radius of 5, but they could also be long and thin).
- Adjust some of the farmer logic a little bit

## Testing
- [x] Yes I tested this before submitting it.
- [ ] I also did a multiplayer test.

Review please