### PR TITLE
Rework environmental damage adaption of raiders

### DIFF
--- a/src/main/java/com/minecolonies/api/entity/mobs/AbstractEntityMinecoloniesRaider.java
+++ b/src/main/java/com/minecolonies/api/entity/mobs/AbstractEntityMinecoloniesRaider.java
@@ -20,10 +20,7 @@ import net.minecraft.world.DifficultyInstance;
 import net.minecraft.world.damagesource.DamageSource;
 import net.minecraft.world.effect.MobEffectInstance;
 import net.minecraft.world.effect.MobEffects;
-import net.minecraft.world.entity.Entity;
-import net.minecraft.world.entity.EntityType;
-import net.minecraft.world.entity.MobSpawnType;
-import net.minecraft.world.entity.SpawnGroupData;
+import net.minecraft.world.entity.*;
 import net.minecraft.world.entity.monster.Enemy;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.item.enchantment.EnchantmentHelper;
@@ -72,6 +69,11 @@ public abstract class AbstractEntityMinecoloniesRaider extends AbstractEntityMin
     private static final int COLONY_SET_RAIDED_CHANCE = 20;
 
     /**
+     * Environmental damage cooldown in ticks
+     */
+    private static final int ENV_DAMAGE_COOLDOWN = 30;
+
+    /**
      * The New PathNavigate navigator.
      */
     protected AbstractAdvancedPathNavigate newNavigator;
@@ -115,11 +117,6 @@ public abstract class AbstractEntityMinecoloniesRaider extends AbstractEntityMin
      * Environmental damage cooldown timer
      */
     private int envDmgCooldown = 0;
-
-    /**
-     * Environmental damage interval
-     */
-    private int envDamageInterval = 5;
 
     /**
      * Environmental damage immunity
@@ -294,6 +291,11 @@ public abstract class AbstractEntityMinecoloniesRaider extends AbstractEntityMin
             collisionCounter--;
         }
 
+        if (envDmgCooldown > 0)
+        {
+            envDmgCooldown--;
+        }
+
         if (level().isClientSide)
         {
             super.aiStep();
@@ -302,7 +304,7 @@ public abstract class AbstractEntityMinecoloniesRaider extends AbstractEntityMin
 
         if (currentTick % (random.nextInt(EVERY_X_TICKS) + 1) == 0)
         {
-            envDmgCooldown--;
+
             if (worldTimeAtSpawn == 0)
             {
                 worldTimeAtSpawn = level().getGameTime();
@@ -430,21 +432,28 @@ public abstract class AbstractEntityMinecoloniesRaider extends AbstractEntityMin
     @Override
     public boolean hurt(@NotNull final DamageSource damageSource, final float damage)
     {
-        if (damageSource.getDirectEntity() == null || damageSource.getDirectEntity() instanceof FakePlayer)
+        if (!(damageSource.getEntity() instanceof LivingEntity) || damageSource.getEntity() instanceof FakePlayer)
         {
             if (envDamageImmunity || tempEnvDamageImmunity)
             {
                 return false;
             }
 
-            if (--envDmgCooldown <= 0)
-            {
-                envDmgCooldown = envDamageInterval;
-            }
-            else
+            if (envDmgCooldown > 0)
             {
                 return false;
             }
+
+            float minimumHealthPct = getMinRemainingHealthForEnvironmentalDamage((float) difficulty);
+
+            // Ignores armor/reductions
+            float healthLeftPercent = (getHealth() - damage) / getMaxHealth();
+            if (minimumHealthPct > healthLeftPercent)
+            {
+                return false;
+            }
+
+            envDmgCooldown = ENV_DAMAGE_COOLDOWN;
         }
         else if (!level().isClientSide())
         {
@@ -476,6 +485,18 @@ public abstract class AbstractEntityMinecoloniesRaider extends AbstractEntityMin
     }
 
     /**
+     * Calculates the minimum remaining health percentage for taking environmental damage in relation to difficulty value
+     *
+     * @param difficulty
+     * @return
+     */
+    protected float getMinRemainingHealthForEnvironmentalDamage(final float difficulty)
+    {
+        // 20 - 60% health left, depending on difficulty
+        return Math.min(((difficulty) / 10) + 0.2f, 0.6f);
+    }
+
+    /**
      * Set the colony to raid.
      *
      * @param colony the colony to set.
@@ -497,27 +518,6 @@ public abstract class AbstractEntityMinecoloniesRaider extends AbstractEntityMin
     {
         this.eventID = eventID;
     }
-
-    /**
-     * Sets the environmental damage interval
-     *
-     * @param interval damage interval
-     */
-    public void setEnvDamageInterval(final int interval)
-    {
-        envDamageInterval = interval;
-    }
-
-    /**
-     * Sets the immunity to environmental damage
-     *
-     * @param immunity whether immune
-     */
-    public void setEnvDamageImmunity(final boolean immunity)
-    {
-        envDamageImmunity = immunity;
-    }
-
 
     /**
      * Sets the temporary immunity to environmental damage
@@ -542,12 +542,6 @@ public abstract class AbstractEntityMinecoloniesRaider extends AbstractEntityMin
         super.initStatsFor(baseHealth, difficulty, baseDamage);
 
         this.difficulty = difficulty;
-        this.setEnvDamageInterval((int) (BASE_ENV_DAMAGE_RESIST * difficulty));
-
-        if (difficulty >= 1.4d)
-        {
-            this.setEnvDamageImmunity(true);
-        }
     }
 
     @Override

--- a/src/main/java/com/minecolonies/core/entity/mobs/raider/amazons/EntityAmazonChiefRaider.java
+++ b/src/main/java/com/minecolonies/core/entity/mobs/raider/amazons/EntityAmazonChiefRaider.java
@@ -7,7 +7,6 @@ import net.minecraft.world.entity.ai.attributes.Attributes;
 import net.minecraft.world.level.Level;
 
 import static com.minecolonies.api.entity.mobs.RaiderMobUtils.MOB_ATTACK_DAMAGE;
-import static com.minecolonies.api.util.constant.RaiderConstants.BASE_ENV_DAMAGE_RESIST;
 import static com.minecolonies.api.util.constant.RaiderConstants.CHIEF_BONUS_ARMOR;
 
 /**
@@ -34,7 +33,6 @@ public class EntityAmazonChiefRaider extends AbstractEntityAmazonRaider implemen
         final double chiefArmor = difficulty * CHIEF_BONUS_ARMOR * 2;
         this.getAttribute(Attributes.ARMOR).setBaseValue(chiefArmor);
         this.getAttribute(MOB_ATTACK_DAMAGE.get()).setBaseValue(baseDamage + 1.0);
-        this.setEnvDamageInterval((int) (BASE_ENV_DAMAGE_RESIST * 2 * difficulty));
         this.getAttribute(Attributes.MAX_HEALTH).setBaseValue(baseHealth * 1.5);
         this.setHealth(this.getMaxHealth());
     }

--- a/src/main/java/com/minecolonies/core/entity/mobs/raider/barbarians/EntityChiefBarbarianRaider.java
+++ b/src/main/java/com/minecolonies/core/entity/mobs/raider/barbarians/EntityChiefBarbarianRaider.java
@@ -7,7 +7,6 @@ import net.minecraft.world.entity.ai.attributes.Attributes;
 import net.minecraft.world.level.Level;
 
 import static com.minecolonies.api.entity.mobs.RaiderMobUtils.MOB_ATTACK_DAMAGE;
-import static com.minecolonies.api.util.constant.RaiderConstants.BASE_ENV_DAMAGE_RESIST;
 import static com.minecolonies.api.util.constant.RaiderConstants.CHIEF_BONUS_ARMOR;
 
 /**
@@ -34,7 +33,6 @@ public class EntityChiefBarbarianRaider extends AbstractEntityBarbarianRaider im
         final double chiefArmor = difficulty * CHIEF_BONUS_ARMOR;
         this.getAttribute(Attributes.ARMOR).setBaseValue(chiefArmor);
         this.getAttribute(MOB_ATTACK_DAMAGE.get()).setBaseValue(baseDamage + 1.0);
-        this.setEnvDamageInterval((int) (BASE_ENV_DAMAGE_RESIST * 2 * difficulty));
         this.getAttribute(Attributes.MAX_HEALTH).setBaseValue(baseHealth * 1.5);
         this.setHealth(this.getMaxHealth());
     }

--- a/src/main/java/com/minecolonies/core/entity/mobs/raider/drownedpirates/EntityDrownedCaptainPirateRaider.java
+++ b/src/main/java/com/minecolonies/core/entity/mobs/raider/drownedpirates/EntityDrownedCaptainPirateRaider.java
@@ -9,7 +9,6 @@ import net.minecraft.world.entity.ai.attributes.Attributes;
 import net.minecraft.world.level.Level;
 
 import static com.minecolonies.api.entity.mobs.RaiderMobUtils.MOB_ATTACK_DAMAGE;
-import static com.minecolonies.api.util.constant.RaiderConstants.BASE_ENV_DAMAGE_RESIST;
 
 /**
  * Class for the Chief Pirate entity.
@@ -33,7 +32,6 @@ public class EntityDrownedCaptainPirateRaider extends AbstractDrownedEntityPirat
         super.initStatsFor(baseHealth, difficulty, baseDamage);
         this.getAttribute(Attributes.ARMOR).setBaseValue(-1);
         this.getAttribute(MOB_ATTACK_DAMAGE.get()).setBaseValue(baseDamage);
-        this.setEnvDamageInterval((int) (BASE_ENV_DAMAGE_RESIST * 2 * difficulty));
         this.getAttribute(Attributes.MAX_HEALTH).setBaseValue(baseHealth * 2.0);
         this.setHealth(this.getMaxHealth());
         if (MathUtils.RANDOM.nextInt(100) < 2)

--- a/src/main/java/com/minecolonies/core/entity/mobs/raider/egyptians/EntityPharaoRaider.java
+++ b/src/main/java/com/minecolonies/core/entity/mobs/raider/egyptians/EntityPharaoRaider.java
@@ -7,7 +7,6 @@ import net.minecraft.world.entity.ai.attributes.Attributes;
 import net.minecraft.world.level.Level;
 
 import static com.minecolonies.api.entity.mobs.RaiderMobUtils.MOB_ATTACK_DAMAGE;
-import static com.minecolonies.api.util.constant.RaiderConstants.BASE_ENV_DAMAGE_RESIST;
 import static com.minecolonies.api.util.constant.RaiderConstants.CHIEF_BONUS_ARMOR;
 
 /**
@@ -34,7 +33,6 @@ public class EntityPharaoRaider extends AbstractEntityEgyptianRaider implements 
         final double chiefArmor = difficulty * CHIEF_BONUS_ARMOR;
         this.getAttribute(Attributes.ARMOR).setBaseValue(chiefArmor);
         this.getAttribute(MOB_ATTACK_DAMAGE.get()).setBaseValue(baseDamage + 1.0);
-        this.setEnvDamageInterval((int) (BASE_ENV_DAMAGE_RESIST * 2 * difficulty));
         this.getAttribute(Attributes.MAX_HEALTH).setBaseValue(baseHealth * 4.5);
         this.setHealth(this.getMaxHealth());
     }

--- a/src/main/java/com/minecolonies/core/entity/mobs/raider/norsemen/EntityNorsemenChiefRaider.java
+++ b/src/main/java/com/minecolonies/core/entity/mobs/raider/norsemen/EntityNorsemenChiefRaider.java
@@ -7,7 +7,6 @@ import net.minecraft.world.entity.ai.attributes.Attributes;
 import net.minecraft.world.level.Level;
 
 import static com.minecolonies.api.entity.mobs.RaiderMobUtils.MOB_ATTACK_DAMAGE;
-import static com.minecolonies.api.util.constant.RaiderConstants.BASE_ENV_DAMAGE_RESIST;
 import static com.minecolonies.api.util.constant.RaiderConstants.CHIEF_BONUS_ARMOR;
 
 /**
@@ -33,7 +32,6 @@ public class EntityNorsemenChiefRaider extends AbstractEntityNorsemenRaider impl
         final double chiefArmor = difficulty * CHIEF_BONUS_ARMOR;
         this.getAttribute(Attributes.ARMOR).setBaseValue(chiefArmor);
         this.getAttribute(MOB_ATTACK_DAMAGE.get()).setBaseValue(baseDamage + 1.0);
-        this.setEnvDamageInterval((int) (BASE_ENV_DAMAGE_RESIST * 2 * difficulty));
         this.getAttribute(Attributes.MAX_HEALTH).setBaseValue(baseHealth * 1.5);
         this.setHealth(this.getMaxHealth());
     }

--- a/src/main/java/com/minecolonies/core/entity/mobs/raider/pirates/EntityCaptainPirateRaider.java
+++ b/src/main/java/com/minecolonies/core/entity/mobs/raider/pirates/EntityCaptainPirateRaider.java
@@ -7,7 +7,6 @@ import net.minecraft.world.entity.ai.attributes.Attributes;
 import net.minecraft.world.level.Level;
 
 import static com.minecolonies.api.entity.mobs.RaiderMobUtils.MOB_ATTACK_DAMAGE;
-import static com.minecolonies.api.util.constant.RaiderConstants.BASE_ENV_DAMAGE_RESIST;
 
 /**
  * Class for the Chief Pirate entity.
@@ -32,7 +31,6 @@ public class EntityCaptainPirateRaider extends AbstractEntityPirateRaider implem
         super.initStatsFor(baseHealth, difficulty, baseDamage);
         this.getAttribute(Attributes.ARMOR).setBaseValue(-1);
         this.getAttribute(MOB_ATTACK_DAMAGE.get()).setBaseValue(baseDamage + 2.0);
-        this.setEnvDamageInterval((int) (BASE_ENV_DAMAGE_RESIST * 2 * difficulty));
         this.getAttribute(Attributes.MAX_HEALTH).setBaseValue(baseHealth * 1.3);
         this.setHealth(this.getMaxHealth());
     }

--- a/src/main/java/com/minecolonies/core/network/messages/server/colony/building/AddMinimumStockToBuildingModuleMessage.java
+++ b/src/main/java/com/minecolonies/core/network/messages/server/colony/building/AddMinimumStockToBuildingModuleMessage.java
@@ -7,8 +7,8 @@ import com.minecolonies.api.colony.buildings.views.IBuildingView;
 import com.minecolonies.core.colony.buildings.modules.BuildingModules;
 import com.minecolonies.core.colony.buildings.modules.MinimumStockModule;
 import com.minecolonies.core.network.messages.server.AbstractBuildingServerMessage;
-import net.minecraft.world.item.ItemStack;
 import net.minecraft.network.FriendlyByteBuf;
+import net.minecraft.world.item.ItemStack;
 import net.minecraftforge.network.NetworkEvent;
 import org.jetbrains.annotations.NotNull;
 
@@ -66,7 +66,7 @@ public class AddMinimumStockToBuildingModuleMessage extends AbstractBuildingServ
     @Override
     public void onExecute(final NetworkEvent.Context ctxIn, final boolean isLogicalServer, final IColony colony, final IBuilding building)
     {
-        IBuildingModule minStockModule = building.getFirstModuleOccurance(MinimumStockModule.class);
+        IBuildingModule minStockModule = building.getModule(BuildingModules.MIN_STOCK);
         if (minStockModule != null)
         {
             ((MinimumStockModule) minStockModule).addMinimumStock(itemStack, quantity);


### PR DESCRIPTION
Closes #
Closes #

# Changes proposed in this pull request
- Raiders no longer are fully environmental damage immune, instead we use a hybrid approach allowing the player to weaken them with traps but not kill them. Depending on difficulty the raiders will survive with 20-60% health left.
- Invulnerability frame for environmental damage is now 1.5sec and no longer scales

## Testing
- [ ] Yes I tested this before submitting it.
- [ ] I also did a multiplayer test.

Review please