### PR TITLE
Guard fix/ state group AI add

### DIFF
--- a/src/main/java/com/minecolonies/api/entity/ai/statemachine/basestatemachine/BasicStateMachine.java
+++ b/src/main/java/com/minecolonies/api/entity/ai/statemachine/basestatemachine/BasicStateMachine.java
@@ -96,6 +96,7 @@ public class BasicStateMachine<T extends IStateMachineTransition<S>, S extends I
      *
      * @param transition the transition to add
      */
+    @Override
     public void addTransition(final T transition)
     {
         if (transition.getState() != null)
@@ -105,6 +106,28 @@ public class BasicStateMachine<T extends IStateMachineTransition<S>, S extends I
         if (transition instanceof IStateMachineEvent)
         {
             eventTransitionMap.computeIfAbsent(((IStateMachineEvent<?>) transition).getEventType(), k -> new ArrayList<>()).add(transition);
+        }
+    }
+
+    @Override
+    public void addTransitionGroup(final List<S> stateGroup, final T transition)
+    {
+        if (transition.getState() != null)
+        {
+            throw new RuntimeException("Only transitions without a state may act as group transitions");
+        }
+
+        for (final S state : stateGroup)
+        {
+            if (state != null)
+            {
+                transitionMap.computeIfAbsent(state, k -> new ArrayList<>()).add(0, transition);
+            }
+        }
+
+        if (transition instanceof IStateMachineEvent)
+        {
+            eventTransitionMap.computeIfAbsent(((IStateMachineEvent<?>) transition).getEventType(), k -> new ArrayList<>()).add(0, transition);
         }
     }
 

--- a/src/main/java/com/minecolonies/api/entity/ai/statemachine/basestatemachine/BasicTransition.java
+++ b/src/main/java/com/minecolonies/api/entity/ai/statemachine/basestatemachine/BasicTransition.java
@@ -41,7 +41,7 @@ public class BasicTransition<S extends IState> implements IStateMachineTransitio
     /**
      * The name of the transition
      */
-    private final Component name;
+    private Component name;
 
     /**
      * Creating a new transition from State A to B under condition C
@@ -144,5 +144,12 @@ public class BasicTransition<S extends IState> implements IStateMachineTransitio
         }
 
         return "Unknown";
+    }
+
+    @Override
+    public BasicTransition<S> withName(final String name)
+    {
+        this.name = Component.literal(name);
+        return this;
     }
 }

--- a/src/main/java/com/minecolonies/api/entity/ai/statemachine/basestatemachine/IStateMachine.java
+++ b/src/main/java/com/minecolonies/api/entity/ai/statemachine/basestatemachine/IStateMachine.java
@@ -5,6 +5,8 @@ import com.minecolonies.api.entity.ai.statemachine.transitions.IStateMachineTran
 import net.minecraft.network.chat.Component;
 import org.jetbrains.annotations.NotNull;
 
+import java.util.List;
+
 /**
  * Statemachine interface, implement to add more statemachine types. Contains all needed functions for a basic statemachine
  *
@@ -19,6 +21,13 @@ public interface IStateMachine<T extends IStateMachineTransition<S>, S extends I
      * @param transition the transition to add.
      */
     void addTransition(final T transition);
+
+    /**
+     * Add a transition to a group of states has higher priority than normal transitions
+     *
+     * @param transition the transition to add
+     */
+    void addTransitionGroup(List<S> stateGroup, T transition);
 
     /**
      * Removes a transition from the machine's transition table

--- a/src/main/java/com/minecolonies/api/entity/ai/statemachine/transitions/IStateMachineTransition.java
+++ b/src/main/java/com/minecolonies/api/entity/ai/statemachine/transitions/IStateMachineTransition.java
@@ -35,4 +35,6 @@ public interface IStateMachineTransition<S extends IState>
      * @return name
      */
     Component getName();
+
+    IStateMachineTransition withName(String name);
 }

--- a/src/main/java/com/minecolonies/core/entity/ai/BehaviourStateGroup.java
+++ b/src/main/java/com/minecolonies/core/entity/ai/BehaviourStateGroup.java
@@ -1,0 +1,17 @@
+package com.minecolonies.core.entity.ai;
+
+import com.minecolonies.api.entity.ai.statemachine.states.AIWorkerState;
+import com.minecolonies.api.entity.ai.statemachine.states.IAIState;
+
+import java.util.List;
+
+/**
+ * Class holding various groups of AI States which define a behaviour set
+ */
+public final class BehaviourStateGroup
+{
+    /**
+     * States in which guards should switch to fighting when there is an enemy
+     */
+    public static final List<IAIState> GUARD_ABORT_AND_FIGHT = List.of(AIWorkerState.NEEDS_ITEM, AIWorkerState.INVENTORY_FULL);
+}

--- a/src/main/java/com/minecolonies/core/entity/ai/workers/AbstractAISkeleton.java
+++ b/src/main/java/com/minecolonies/core/entity/ai/workers/AbstractAISkeleton.java
@@ -15,6 +15,7 @@ import net.minecraft.world.level.Level;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.Arrays;
+import java.util.List;
 
 import static com.minecolonies.api.entity.citizen.AbstractEntityCitizen.ENTITY_AI_TICKRATE;
 
@@ -71,6 +72,16 @@ public abstract class AbstractAISkeleton<J extends IJob<?>> implements ITickingS
     public void registerTarget(final TickingTransition<IAIState> target)
     {
         stateMachine.addTransition(target);
+    }
+
+    /**
+     * Register a target for a group of states
+     *
+     * @param target the target to register.
+     */
+    public void registerGroupTarget(final List<IAIState> states, final TickingTransition<IAIState> target)
+    {
+        stateMachine.addTransitionGroup(states, target);
     }
 
     /**

--- a/src/main/java/com/minecolonies/core/entity/ai/workers/guard/DruidCombatAI.java
+++ b/src/main/java/com/minecolonies/core/entity/ai/workers/guard/DruidCombatAI.java
@@ -2,8 +2,10 @@ package com.minecolonies.core.entity.ai.workers.guard;
 
 import com.google.common.collect.ImmutableList;
 import com.minecolonies.api.colony.guardtype.registry.ModGuardTypes;
+import com.minecolonies.api.entity.ai.combat.CombatAIStates;
 import com.minecolonies.api.entity.ai.combat.threat.IThreatTableEntity;
 import com.minecolonies.api.entity.ai.statemachine.tickratestatemachine.ITickRateStateMachine;
+import com.minecolonies.api.entity.ai.statemachine.tickratestatemachine.TickingTransition;
 import com.minecolonies.api.entity.citizen.Skill;
 import com.minecolonies.api.items.ModItems;
 import com.minecolonies.api.util.BlockPosUtil;
@@ -40,6 +42,7 @@ import java.util.function.BiPredicate;
 
 import static com.minecolonies.api.research.util.ResearchConstants.DRUID_USE_POTIONS;
 import static com.minecolonies.api.util.constant.GuardConstants.*;
+import static com.minecolonies.core.entity.ai.BehaviourStateGroup.GUARD_ABORT_AND_FIGHT;
 import static com.minecolonies.core.entity.ai.workers.guard.AbstractEntityAIFight.SPEED_LEVEL_BONUS;
 
 /**
@@ -98,6 +101,9 @@ public class DruidCombatAI extends AttackMoveAI<EntityCitizen>
       final AbstractEntityAIGuard parentAI)
     {
         super(owner, stateMachine);
+
+        stateMachine.addTransitionGroup(GUARD_ABORT_AND_FIGHT, new TickingTransition(this::checkForTarget, () -> CombatAIStates.ATTACKING, 5).withName("busy_checkTarget"));
+        stateMachine.addTransitionGroup(GUARD_ABORT_AND_FIGHT, new TickingTransition(this::searchNearbyTarget, () -> CombatAIStates.ATTACKING, 80).withName("busy_searchTarget"));
 
         this.parentAI = parentAI;
         combatPathingOptions = new PathingOptions();

--- a/src/main/java/com/minecolonies/core/entity/ai/workers/guard/KnightCombatAI.java
+++ b/src/main/java/com/minecolonies/core/entity/ai/workers/guard/KnightCombatAI.java
@@ -52,6 +52,7 @@ import static com.minecolonies.api.util.constant.NbtTagConstants.TAG_BANNER_PATT
 import static com.minecolonies.api.util.constant.StatisticsConstants.MOBS_KILLED;
 import static com.minecolonies.api.util.constant.StatisticsConstants.MOB_KILLED;
 import static com.minecolonies.core.colony.buildings.modules.BuildingModules.STATS_MODULE;
+import static com.minecolonies.core.entity.ai.BehaviourStateGroup.GUARD_ABORT_AND_FIGHT;
 import static com.minecolonies.core.entity.ai.workers.guard.AbstractEntityAIFight.SPEED_LEVEL_BONUS;
 import static com.minecolonies.core.entity.ai.workers.guard.AbstractEntityAIGuard.PATROL_DEVIATION_RAID_POINT;
 
@@ -101,6 +102,8 @@ public class KnightCombatAI extends AttackMoveAI<EntityCitizen>
 
         this.parentAI = parentAI;
         stateMachine.addTransition(new TickingTransition<>(CombatAIStates.ATTACKING, () -> true, this::attackProtect, 8));
+        stateMachine.addTransitionGroup(GUARD_ABORT_AND_FIGHT, new TickingTransition(this::checkForTarget, () -> CombatAIStates.ATTACKING, 5).withName("busy_checkTarget"));
+        stateMachine.addTransitionGroup(GUARD_ABORT_AND_FIGHT, new TickingTransition(this::searchNearbyTarget, () -> CombatAIStates.ATTACKING, 80).withName("busy_searchTarget"));
     }
 
     /**

--- a/src/main/java/com/minecolonies/core/entity/ai/workers/guard/RangerCombatAI.java
+++ b/src/main/java/com/minecolonies/core/entity/ai/workers/guard/RangerCombatAI.java
@@ -1,6 +1,8 @@
 package com.minecolonies.core.entity.ai.workers.guard;
 
+import com.minecolonies.api.entity.ai.combat.CombatAIStates;
 import com.minecolonies.api.entity.ai.statemachine.tickratestatemachine.ITickRateStateMachine;
+import com.minecolonies.api.entity.ai.statemachine.tickratestatemachine.TickingTransition;
 import com.minecolonies.api.entity.citizen.Skill;
 import com.minecolonies.api.entity.citizen.VisibleCitizenStatus;
 import com.minecolonies.api.equipment.ModEquipmentTypes;
@@ -44,6 +46,7 @@ import static com.minecolonies.api.util.constant.GuardConstants.*;
 import static com.minecolonies.api.util.constant.StatisticsConstants.MOBS_KILLED;
 import static com.minecolonies.api.util.constant.StatisticsConstants.MOB_KILLED;
 import static com.minecolonies.core.colony.buildings.modules.BuildingModules.STATS_MODULE;
+import static com.minecolonies.core.entity.ai.BehaviourStateGroup.GUARD_ABORT_AND_FIGHT;
 import static com.minecolonies.core.entity.ai.workers.guard.AbstractEntityAIFight.SPEED_LEVEL_BONUS;
 import static com.minecolonies.core.entity.ai.workers.guard.AbstractEntityAIGuard.PATROL_DEVIATION_RAID_POINT;
 
@@ -93,6 +96,9 @@ public class RangerCombatAI extends AttackMoveAI<EntityCitizen>
       final AbstractEntityAIGuard parentAI)
     {
         super(owner, stateMachine);
+
+        stateMachine.addTransitionGroup(GUARD_ABORT_AND_FIGHT, new TickingTransition(this::checkForTarget, () -> CombatAIStates.ATTACKING, 5).withName("busy_checkTarget"));
+        stateMachine.addTransitionGroup(GUARD_ABORT_AND_FIGHT, new TickingTransition(this::searchNearbyTarget, () -> CombatAIStates.ATTACKING, 80).withName("busy_searchTarget"));
 
         this.parentAI = parentAI;
         combatPathingOptions = new PathingOptions();


### PR DESCRIPTION
Closes #
Closes #

# Changes proposed in this pull request
- Introduces state group transitions, which allow declaring a transition for a group of source states, with the speciality that those get checked first before normally added transitions. This is to allow transitions from one "type" of states, e.g. working into eating for example.
- Add utility to directly name transitions
- Fix guards now switching to attacking when needed

## Testing
- [ x] Yes I tested this before submitting it.
- [ ] I also did a multiplayer test.

Review please