### PR TITLE
Fix postbox minimum stock not working [1.21]

### DIFF
--- a/src/main/java/com/minecolonies/core/network/messages/server/colony/building/AddMinimumStockToBuildingModuleMessage.java
+++ b/src/main/java/com/minecolonies/core/network/messages/server/colony/building/AddMinimumStockToBuildingModuleMessage.java
@@ -3,11 +3,9 @@ package com.minecolonies.core.network.messages.server.colony.building;
 import com.ldtteam.common.network.PlayMessageType;
 import com.minecolonies.api.colony.IColony;
 import com.minecolonies.api.colony.buildings.IBuilding;
-import com.minecolonies.api.colony.buildings.modules.IBuildingModule;
 import com.minecolonies.api.colony.buildings.views.IBuildingView;
 import com.minecolonies.api.util.Utils;
 import com.minecolonies.api.util.constant.Constants;
-import com.minecolonies.core.colony.buildings.modules.BuildingModules;
 import com.minecolonies.core.colony.buildings.modules.MinimumStockModule;
 import com.minecolonies.core.network.messages.server.AbstractBuildingServerMessage;
 import net.minecraft.network.RegistryFriendlyByteBuf;
@@ -65,10 +63,10 @@ public class AddMinimumStockToBuildingModuleMessage extends AbstractBuildingServ
     @Override
     protected void onExecute(final IPayloadContext ctxIn, final ServerPlayer player, final IColony colony, final IBuilding building)
     {
-        IBuildingModule minStockModule = building.getModule(BuildingModules.MIN_STOCK);
+        final MinimumStockModule minStockModule = building.getFirstModuleOccurance(MinimumStockModule.class);
         if (minStockModule != null)
         {
-            ((MinimumStockModule) minStockModule).addMinimumStock(itemStack, quantity);
+            minStockModule.addMinimumStock(itemStack, quantity);
         }
     }
 }


### PR DESCRIPTION
Closes #11408 

# Changes proposed in this pull request
- Fix incorrect building module getter causing postbox minimum stock modules to no longer work.

## Testing
- [X] Yes I tested this before submitting it.
- [ ] I also did a multiplayer test.

Review please