### PR TITLE
Simplify permissions

### DIFF
--- a/src/main/java/com/minecolonies/api/colony/permissions/Action.java
+++ b/src/main/java/com/minecolonies/api/colony/permissions/Action.java
@@ -8,7 +8,7 @@ public enum Action
     //counts for citizen and huts.
     ACCESS_HUTS(0),
     //If guards can attack, player can attack back
-    GUARDS_ATTACK(1),
+    // GUARDS_ATTACK(1), replaced by hostile type
     PLACE_HUTS(2),
     BREAK_HUTS(3),
     //Including promote, demote and remove.
@@ -30,11 +30,11 @@ public enum Action
     ATTACK_CITIZEN(18),
     ATTACK_ENTITY(19),
     //has access to allowed list, "hostile+" or "neutral+"
-    ACCESS_FREE_BLOCKS(20),
+    // ACCESS_FREE_BLOCKS(20), replaced by all minus hostile
     TELEPORT_TO_COLONY(21),
     EXPLODE(22),
-    RECEIVE_MESSAGES_FAR_AWAY(23),
-    CAN_KEEP_COLONY_ACTIVE_WHILE_AWAY(24),
+    // RECEIVE_MESSAGES_FAR_AWAY(23), replaced by colony manager
+    // CAN_KEEP_COLONY_ACTIVE_WHILE_AWAY(24), replaced by colony manager
     RALLY_GUARDS(25),
     HURT_CITIZEN(26),
     HURT_VISITOR(27),

--- a/src/main/java/com/minecolonies/api/colony/permissions/IPermissions.java
+++ b/src/main/java/com/minecolonies/api/colony/permissions/IPermissions.java
@@ -91,14 +91,6 @@ public interface IPermissions
     String getOwnerName();
 
     /**
-     * Checks if a user is a subscriber.
-     *
-     * @param player {@link Player} to check for subscription.
-     * @return True is subscriber, otherwise false.
-     */
-    boolean isSubscriber(@NotNull Player player);
-
-    /**
      * Returns whether the player is a member of the colony.
      *
      * @param player {@link Player} to check.

--- a/src/main/java/com/minecolonies/api/colony/permissions/OldRank.java
+++ b/src/main/java/com/minecolonies/api/colony/permissions/OldRank.java
@@ -5,26 +5,9 @@ package com.minecolonies.api.colony.permissions;
  */
 public enum OldRank
 {
-    OWNER(true),
-    OFFICER(true),
-    FRIEND(true),
-    NEUTRAL(false),
-    HOSTILE(false);
-
-    /**
-     * Is the OldRank a subscriber to certain events.
-     */
-    public final boolean isSubscriber;
-
-    /**
-     * Ranks enum constructor.
-     * <p>
-     * Subscribers are receiving events from the colony. They are either citizens or near enough. Ranks with true are automatically subscribed to the colony.
-     *
-     * @param isSubscriber boolean whether auto-subscribed to this colony.
-     */
-    OldRank(final boolean isSubscriber)
-    {
-        this.isSubscriber = isSubscriber;
-    }
+    OWNER,
+    OFFICER,
+    FRIEND,
+    NEUTRAL,
+    HOSTILE;
 }

--- a/src/main/java/com/minecolonies/api/colony/permissions/Rank.java
+++ b/src/main/java/com/minecolonies/api/colony/permissions/Rank.java
@@ -6,11 +6,6 @@ import java.util.Objects;
 
 public class Rank
 {
-
-    /**
-     * Whether the rank is automatically a subscriber to certain events
-     */
-    private boolean isSubscriber;
     /**
      * The name of the rank
      */
@@ -44,23 +39,21 @@ public class Rank
      *
      * @param id           the id of the rank
      * @param name         the name of the rank
-     * @param isSubscriber whether the rank is a subscriber
      * @param isInitial    whether the rank is an initial rank
      */
-    public Rank(int id, long permissionData, String name, boolean isSubscriber, boolean isInitial, boolean isColonyManager, boolean isHostile)
+    public Rank(int id, long permissionData, String name, boolean isInitial, boolean isColonyManager, boolean isHostile)
     {
         this.id = id;
         this.permissionData = permissionData;
         this.name = name;
-        this.isSubscriber = isSubscriber;
         this.isInitial = isInitial;
         this.isColonyManager = isColonyManager;
         this.isHostile = isHostile;
     }
 
-    public Rank(int id, String name, boolean isSubscriber, boolean isInitial)
+    public Rank(int id, String name, boolean isInitial)
     {
-        this(id, 0L, name, isSubscriber, isInitial, false, false);
+        this(id, 0L, name, isInitial, false, false);
     }
 
     /**
@@ -70,15 +63,6 @@ public class Rank
     public int getId()
     {
         return id;
-    }
-
-    /**
-     * Get whether the rank is a subscriber to certain colony events
-     * @return true if so
-     */
-    public boolean isSubscriber()
-    {
-        return isSubscriber;
     }
 
     /**
@@ -125,12 +109,6 @@ public class Rank
     {
         this.isHostile = isHostile;
     }
-
-    /**
-     * Set whether this rank is a subscriber (receives certain colony events)
-     * @param isSubscriber whether the rank is a subscriber
-     */
-    public void setSubscriber(boolean isSubscriber) { this.isSubscriber = isSubscriber; }
 
     @Override
     public boolean equals(final Object o)

--- a/src/main/java/com/minecolonies/api/util/constant/WindowConstants.java
+++ b/src/main/java/com/minecolonies/api/util/constant/WindowConstants.java
@@ -976,7 +976,6 @@ public final class WindowConstants
     public static final String TOWNHALL_PERM_LIST         = "permissionsList";
     public static final String TOWNHALL_PERM_SETTINGS     = "permissionsSettings";
     public static final String TOWNHALL_PERM_MODE_TOGGLE  = "permissionsModeToggle";
-    public static final String TOWNHALL_BUTTON_SUBSCRIBER = "setSubscriber";
     public static final String TOWNHALL_RANK_TYPE_PICKER  = "rankTypePicker";
 
     /**

--- a/src/main/java/com/minecolonies/core/MineColonies.java
+++ b/src/main/java/com/minecolonies/core/MineColonies.java
@@ -327,7 +327,6 @@ public class MineColonies
         PermissionsMessage.AddRank.TYPE.register(registry);
         PermissionsMessage.RemoveRank.TYPE.register(registry);
         PermissionsMessage.EditRankType.TYPE.register(registry);
-        PermissionsMessage.SetSubscriber.TYPE.register(registry);
 
         //  Colony Request messages
         BuildRequestMessage.TYPE.register(registry);

--- a/src/main/java/com/minecolonies/core/client/gui/townhall/WindowPermissionsPage.java
+++ b/src/main/java/com/minecolonies/core/client/gui/townhall/WindowPermissionsPage.java
@@ -131,7 +131,6 @@ public class WindowPermissionsPage extends AbstractWindowTownHall
         registerButton(BUTTON_ADD_RANK, this::addRank);
         registerButton(TOWNHALL_RANK_BUTTON, this::onRankButtonClicked);
         registerButton(BUTTON_REMOVE_RANK, this::onRemoveRankButtonClicked);
-        registerButton(TOWNHALL_BUTTON_SUBSCRIBER, this::setSubscriber);
         registerButton(BUTTON_ADD_PLAYER_OR_FAKEPLAYER, this::addPlayerToColonyClicked);
 
         registerButton(BUTTON_OPEN_ONLINE_PLAYER_LIST, this::onPickPlayer);
@@ -206,21 +205,6 @@ public class WindowPermissionsPage extends AbstractWindowTownHall
             final PermissionEvent user = buildingView.getPermissionEvents().get(row);
             new PermissionsMessage.AddPlayerOrFakePlayer(buildingView.getColony(), user.getName(), user.getId()).sendToServer();
         }
-    }
-
-    /**
-     * Toggle the subscriber flag on client
-     * Send message to change it on server
-     *
-     * @param button the button clicked
-     */
-    private void setSubscriber(Button button)
-    {
-        new PermissionsMessage.SetSubscriber(buildingView.getColony(), actionsRank, !actionsRank.isSubscriber()).sendToServer();
-        actionsRank.setSubscriber(!actionsRank.isSubscriber());
-        button.setText(Component.translatableEscape(actionsRank.isSubscriber()
-            ? COM_MINECOLONIES_COREMOD_GUI_WORKERHUTS_RETRIEVE_ON
-            : COM_MINECOLONIES_COREMOD_GUI_WORKERHUTS_RETRIEVE_OFF));
     }
 
     /**
@@ -354,9 +338,6 @@ public class WindowPermissionsPage extends AbstractWindowTownHall
         }
 
         findPaneOfTypeByID(TOWNHALL_RANK_TYPE_PICKER, DropDownList.class).setSelectedIndex(actionsRank.isColonyManager() ? 0 : (actionsRank.isHostile() ? 1 : 2));
-        findPaneOfTypeByID(TOWNHALL_BUTTON_SUBSCRIBER, Button.class).setText(Component.translatableEscape(actionsRank.isSubscriber()
-            ? COM_MINECOLONIES_COREMOD_GUI_WORKERHUTS_RETRIEVE_ON
-            : COM_MINECOLONIES_COREMOD_GUI_WORKERHUTS_RETRIEVE_OFF));
     }
 
     /**
@@ -434,9 +415,6 @@ public class WindowPermissionsPage extends AbstractWindowTownHall
             findPaneOfTypeByID(BUTTON_REMOVE_RANK, Button.class).setEnabled(!actionsRank.isInitial());
 
             findPaneOfTypeByID(TOWNHALL_RANK_TYPE_PICKER, DropDownList.class).setSelectedIndex(actionsRank.isColonyManager() ? 0 : (actionsRank.isHostile() ? 1 : 2));
-            findPaneOfTypeByID(TOWNHALL_BUTTON_SUBSCRIBER, Button.class).setText(Component.translatableEscape(actionsRank.isSubscriber()
-                ? COM_MINECOLONIES_COREMOD_GUI_WORKERHUTS_RETRIEVE_ON
-                : COM_MINECOLONIES_COREMOD_GUI_WORKERHUTS_RETRIEVE_OFF));
         }
     }
 

--- a/src/main/java/com/minecolonies/core/colony/Colony.java
+++ b/src/main/java/com/minecolonies/core/colony/Colony.java
@@ -529,7 +529,7 @@ public class Colony implements IColony
         {
             for (final ServerPlayer sub : getPackageManager().getCloseSubscribers())
             {
-                if (getPermissions().hasPermission(sub, Action.CAN_KEEP_COLONY_ACTIVE_WHILE_AWAY))
+                if (getPermissions().getRank(sub).isColonyManager())
                 {
                     this.forceLoadTimer = getConfig().getServer().loadtime.get() * 20 * 60;
                     pendingChunks.addAll(pendingToUnloadChunks);
@@ -1440,7 +1440,7 @@ public class Colony implements IColony
 
         for (final ServerPlayer player : packageManager.getImportantColonyPlayers())
         {
-            if (permissions.hasPermission(player, Action.RECEIVE_MESSAGES_FAR_AWAY))
+            if (permissions.getRank(player).isColonyManager())
             {
                 playerList.add(player);
             }

--- a/src/main/java/com/minecolonies/core/colony/permissions/ColonyPermissionEventHandler.java
+++ b/src/main/java/com/minecolonies/core/colony/permissions/ColonyPermissionEventHandler.java
@@ -373,7 +373,7 @@ public class ColonyPermissionEventHandler
 
             final Permissions perms = colony.getPermissions();
 
-            if (isFreeToInteractWith(block, event.getPos()) && perms.hasPermission(event.getEntity(), Action.ACCESS_FREE_BLOCKS))
+            if (isFreeToInteractWith(block, event.getPos()) && !perms.getRank(event.getEntity()).isHostile())
             {
                 return;
             }
@@ -465,7 +465,7 @@ public class ColonyPermissionEventHandler
     public void on(final PlayerInteractEvent.EntityInteract event)
     {
         if (isFreeToInteractWith(null, event.getPos())
-              && colony.getPermissions().hasPermission(event.getEntity(), Action.ACCESS_FREE_BLOCKS))
+              && !colony.getPermissions().getRank(event.getEntity()).isHostile())
         {
             return;
         }
@@ -543,8 +543,7 @@ public class ColonyPermissionEventHandler
     @SubscribeEvent
     public void on(final PlayerInteractEvent.EntityInteractSpecific event)
     {
-        if (isFreeToInteractWith(null, event.getPos())
-              && colony.getPermissions().hasPermission(event.getEntity(), Action.ACCESS_FREE_BLOCKS))
+        if (isFreeToInteractWith(null, event.getPos()) && !colony.getPermissions().getRank(event.getEntity()).isHostile())
         {
             return;
         }
@@ -630,7 +629,7 @@ public class ColonyPermissionEventHandler
               && event.getSource().getEntity() instanceof EntityCitizen
               && ((EntityCitizen) event.getSource().getEntity()).getCitizenColonyHandler().getColonyId() == colony.getID()
               && colony.getRaiderManager().isRaided()
-              && !colony.getPermissions().hasPermission((Player) event.getEntity(), Action.GUARDS_ATTACK))
+              && !colony.getPermissions().getRank((Player) event.getEntity()).isHostile())
         {
             event.setNewDamage(0.0f);
         }
@@ -660,7 +659,7 @@ public class ColonyPermissionEventHandler
             if (event.getTarget() instanceof EntityCitizen)
             {
                 final AbstractEntityCitizen citizen = (AbstractEntityCitizen) event.getTarget();
-                if (citizen.getCitizenJobHandler().getColonyJob() instanceof AbstractJobGuard && perms.hasPermission(event.getEntity(), Action.GUARDS_ATTACK))
+                if (citizen.getCitizenJobHandler().getColonyJob() instanceof AbstractJobGuard && perms.getRank(event.getEntity()).isHostile())
                 {
                     return;
                 }

--- a/src/main/java/com/minecolonies/core/colony/permissions/Permissions.java
+++ b/src/main/java/com/minecolonies/core/colony/permissions/Permissions.java
@@ -43,7 +43,6 @@ public class Permissions implements IPermissions
     private static final String TAG_OWNER_ID        = "ownerid";
     private static final String TAG_FULLY_ABANDONED = "fully_abandoned";
     private static final String TAG_RANKS           = "ranks";
-    private static final String TAG_SUBSCRIBER      = "is_subscriber";
     private static final String TAG_INITIAL         = "is_initial";
     private static final String TAG_COLONY_MANAGER  = "is_colony_manager";
     private static final String TAG_HOSTILE         = "is_hostile";
@@ -69,10 +68,11 @@ public class Permissions implements IPermissions
          */
         for (Action a : Action.values())
         {
-            if (a != Action.GUARDS_ATTACK
-                  && a != Action.EDIT_PERMISSIONS && a != Action.MANAGE_HUTS
-                  && a != Action.TELEPORT_TO_COLONY && a != Action.EXPLODE
-                  && a != Action.CAN_KEEP_COLONY_ACTIVE_WHILE_AWAY && a != Action.RALLY_GUARDS)
+            if (a != Action.EDIT_PERMISSIONS
+                && a != Action.MANAGE_HUTS
+                && a != Action.TELEPORT_TO_COLONY
+                && a != Action.EXPLODE
+                && a != Action.RALLY_GUARDS)
             {
                 fullyAbandonedPermissionsFlag |= a.getFlag();
             }
@@ -119,7 +119,7 @@ public class Permissions implements IPermissions
     /**
      * Special OP rank.
      */
-    private static final Rank OP_RANK = new Rank(-1, "OP", false, true);
+    private static final Rank OP_RANK = new Rank(-1, "OP", true);
     static {
         OP_RANK.addPermission(Action.ACCESS_HUTS);
         OP_RANK.addPermission(Action.USE_SCAN_TOOL);
@@ -132,7 +132,6 @@ public class Permissions implements IPermissions
         OP_RANK.addPermission(Action.ATTACK_CITIZEN);
         OP_RANK.addPermission(Action.ATTACK_ENTITY);
         OP_RANK.addPermission(Action.TELEPORT_TO_COLONY);
-        OP_RANK.addPermission(Action.ACCESS_FREE_BLOCKS);
         OP_RANK.addPermission(Action.ACCESS_TOGGLEABLES);
         OP_RANK.addPermission(Action.PLACE_HUTS);
         OP_RANK.addPermission(Action.BREAK_HUTS);
@@ -167,7 +166,7 @@ public class Permissions implements IPermissions
         {
             String name = oldRank.name();
             name = name.substring(0, 1).toUpperCase(Locale.US) + name.substring(1).toLowerCase(Locale.US);
-            Rank rank = new Rank(oldRank.ordinal(), name, oldRank.isSubscriber, true);
+            Rank rank = new Rank(oldRank.ordinal(), name, true);
             ranks.put(rank.getId(), rank);
             switch (oldRank)
             {
@@ -184,8 +183,6 @@ public class Permissions implements IPermissions
                     rank.addPermission(Action.BREAK_BLOCKS);
                     rank.addPermission(Action.FILL_BUCKET);
                     rank.addPermission(Action.OPEN_CONTAINER);
-                    rank.addPermission(Action.RECEIVE_MESSAGES_FAR_AWAY);
-                    rank.addPermission(Action.CAN_KEEP_COLONY_ACTIVE_WHILE_AWAY);
                     rank.addPermission(Action.RALLY_GUARDS);
                     rank.addPermission(Action.MAP_BORDER);
                     rank.addPermission(Action.MAP_DEATHS);
@@ -205,12 +202,10 @@ public class Permissions implements IPermissions
                     rank.addPermission(Action.ACCESS_TOGGLEABLES);
                     rank.addPermission(Action.MAP_BORDER);
                 case NEUTRAL:
-                    rank.addPermission(Action.ACCESS_FREE_BLOCKS);
                     rank.addPermission(Action.ACCESS_TOGGLEABLES);
                     rank.addPermission(Action.MAP_BORDER);
                     break;
                 case HOSTILE:
-                    rank.addPermission(Action.GUARDS_ATTACK);
                     rank.addPermission(Action.HURT_CITIZEN);
                     rank.addPermission(Action.HURT_VISITOR);
                     rank.addPermission(Action.MAP_BORDER);
@@ -344,12 +339,11 @@ public class Permissions implements IPermissions
                 final CompoundTag rankCompound = rankTagList.getCompound(i);
                 final int id = rankCompound.getInt(TAG_ID);
                 final String name = rankCompound.getString(TAG_NAME);
-                final boolean isSubscriber = rankCompound.getBoolean(TAG_SUBSCRIBER);
                 final boolean isInitial = rankCompound.getBoolean(TAG_INITIAL);
                 final boolean isColonyManager = rankCompound.getBoolean(TAG_COLONY_MANAGER);
                 final boolean isHostile = rankCompound.getBoolean(TAG_HOSTILE);
 
-                final Rank rank = new Rank(id, 0L, name, isSubscriber, isInitial, isColonyManager, isHostile);
+                final Rank rank = new Rank(id, 0L, name, isInitial, isColonyManager, isHostile);
                 ranks.put(id, rank);
                 upgradePermissions(version, rank);
             }
@@ -570,7 +564,6 @@ public class Permissions implements IPermissions
             @NotNull final CompoundTag rankCompound = new CompoundTag();
             rankCompound.putInt(TAG_ID, rank.getId());
             rankCompound.putString(TAG_NAME, rank.getName());
-            rankCompound.putBoolean(TAG_SUBSCRIBER, rank.isSubscriber());
             rankCompound.putBoolean(TAG_INITIAL, rank.isInitial());
             rankCompound.putBoolean(TAG_COLONY_MANAGER, rank.isColonyManager());
             rankCompound.putBoolean(TAG_HOSTILE, rank.isHostile());
@@ -643,8 +636,7 @@ public class Permissions implements IPermissions
     @Override
     public boolean hasPermission(final Rank rank, @NotNull final Action action)
     {
-        if (rank == getRankNeutral() && (action == Action.CAN_KEEP_COLONY_ACTIVE_WHILE_AWAY
-            || action == Action.RECEIVE_MESSAGES_FAR_AWAY || action == Action.EDIT_PERMISSIONS || action == Action.TELEPORT_TO_COLONY))
+        if (rank == getRankNeutral() && (action == Action.EDIT_PERMISSIONS || action == Action.TELEPORT_TO_COLONY))
         {
             return false;
         }
@@ -911,29 +903,6 @@ public class Permissions implements IPermissions
     }
 
     /**
-     * Checks if a user is a subscriber.
-     *
-     * @param player {@link Player} to check for subscription.
-     * @return True is subscriber, otherwise false.
-     */
-    @Override
-    public boolean isSubscriber(@NotNull final Player player)
-    {
-        return isSubscriber(player.getGameProfile().getId());
-    }
-
-    /**
-     * See {@link #isSubscriber(Player)}.
-     *
-     * @param player {@link UUID} of the player.
-     * @return True if subscriber, otherwise false.
-     */
-    private boolean isSubscriber(final UUID player)
-    {
-        return getRank(player).isSubscriber();
-    }
-
-    /**
      * Returns if the instance is dirty.
      *
      * @return True if dirty, otherwise false.
@@ -965,7 +934,6 @@ public class Permissions implements IPermissions
             buf.writeVarInt(rank.getId());
             buf.writeLong(rank.getPermissions());
             buf.writeUtf(rank.getName());
-            buf.writeBoolean(rank.isSubscriber());
             buf.writeBoolean(rank.isInitial());
             buf.writeBoolean(rank.isColonyManager());
             buf.writeBoolean(rank.isHostile());
@@ -1091,7 +1059,7 @@ public class Permissions implements IPermissions
                 break;
             }
         }
-        Rank rank = new Rank(id, name, false, false);
+        Rank rank = new Rank(id, name, false);
         ranks.put(id, rank);
         markDirty();
     }

--- a/src/main/java/com/minecolonies/core/colony/permissions/PermissionsView.java
+++ b/src/main/java/com/minecolonies/core/colony/permissions/PermissionsView.java
@@ -24,7 +24,7 @@ import java.util.stream.Collectors;
 public class PermissionsView implements IPermissions
 {
     /** this rank is used if something asks for permissions before they have been synched from server */
-    private static final Rank MISSINGNO_RANK = new Rank(-1, "missingno", false, true);
+    private static final Rank MISSINGNO_RANK = new Rank(-1, "missingno", true);
 
     @NotNull
     private final Map<UUID, ColonyPlayer>  players     = new HashMap<>();
@@ -233,7 +233,7 @@ public class PermissionsView implements IPermissions
         for (int i = 0; i < ranksSize; ++i)
         {
             final int id = buf.readVarInt();
-            final Rank rank = new Rank(id, buf.readLong(), buf.readUtf(32767), buf.readBoolean(), buf.readBoolean(), buf.readBoolean(), buf.readBoolean());
+            final Rank rank = new Rank(id, buf.readLong(), buf.readUtf(32767), buf.readBoolean(), buf.readBoolean(), buf.readBoolean());
             ranks.put(id, rank);
         }
         userRank = ranks.get(buf.readVarInt());
@@ -317,12 +317,6 @@ public class PermissionsView implements IPermissions
             }
         }
         return ownerName;
-    }
-
-    @Override
-    public boolean isSubscriber(@NotNull final Player player)
-    {
-        return false;
     }
 
     @Override

--- a/src/main/java/com/minecolonies/core/entity/ai/workers/guard/AbstractEntityAIGuard.java
+++ b/src/main/java/com/minecolonies/core/entity/ai/workers/guard/AbstractEntityAIGuard.java
@@ -830,8 +830,7 @@ public abstract class AbstractEntityAIGuard<J extends AbstractJobGuard<J>, B ext
         }
 
         // Players
-        if (entity instanceof Player && (colony.getPermissions().hasPermission((Player) entity, Action.GUARDS_ATTACK)
-                                           || colony.isValidAttackingPlayer((Player) entity)))
+        if (entity instanceof Player && (colony.getPermissions().getRank((Player) entity).isHostile() || colony.isValidAttackingPlayer((Player) entity)))
         {
             return true;
         }

--- a/src/main/java/com/minecolonies/core/event/EventHandler.java
+++ b/src/main/java/com/minecolonies/core/event/EventHandler.java
@@ -357,8 +357,7 @@ public class EventHandler
             final ServerPlayer player = (ServerPlayer) event.getEntity();
             for (final IColony colony : IColonyManager.getInstance().getAllColonies())
             {
-                if (colony.getPermissions().hasPermission(player, Action.CAN_KEEP_COLONY_ACTIVE_WHILE_AWAY)
-                      || colony.getPermissions().hasPermission(player, Action.RECEIVE_MESSAGES_FAR_AWAY))
+                if (colony.getPermissions().getRank(player).isColonyManager())
                 {
                     colony.getPackageManager().addImportantColonyPlayer(player);
                     colony.getPackageManager().sendColonyViewPackets();

--- a/src/main/java/com/minecolonies/core/network/messages/PermissionsMessage.java
+++ b/src/main/java/com/minecolonies/core/network/messages/PermissionsMessage.java
@@ -12,7 +12,6 @@ import com.minecolonies.api.colony.permissions.Rank;
 import com.minecolonies.api.util.SoundUtils;
 import com.minecolonies.api.util.constant.Constants;
 import com.minecolonies.core.colony.Colony;
-import com.minecolonies.core.entity.other.FireArrowEntity;
 import com.minecolonies.core.network.messages.server.AbstractColonyServerMessage;
 import io.netty.buffer.Unpooled;
 import net.minecraft.core.registries.Registries;
@@ -520,65 +519,6 @@ public class PermissionsMessage
                     rank.setColonyManager(false);
                     break;
             }
-            colony.markDirty();
-        }
-
-        @Override
-        @Nullable
-        protected Action permissionNeeded()
-        {
-            return Action.EDIT_PERMISSIONS;
-        }
-    }
-
-    /**
-     * Message to change whether a rank is a subscriber to certain colony events
-     */
-    public static class SetSubscriber extends AbstractColonyServerMessage
-    {
-        public static final PlayMessageType<?> TYPE = PlayMessageType.forServer(Constants.MOD_ID, "permission_set_subscriber", SetSubscriber::new);
-
-        /**
-         * the rank ID
-         */
-        private final int rankId;
-        /**
-         * the new isSubscriber state
-         */
-        private final boolean isSubscriber;
-
-        /**
-         * Constructor to change whether the given rank is a subscriber
-         * @param colony the colony of the rank
-         * @param rank the rank
-         * @param isSubscriber whether the rank should be a subscriber
-         */
-        public SetSubscriber(@NotNull final IColonyView colony, @NotNull final Rank rank, final boolean isSubscriber)
-        {
-            super(TYPE, colony);
-            this.rankId = rank.getId();
-            this.isSubscriber = isSubscriber;
-        }
-
-        @Override
-        protected void toBytes(final RegistryFriendlyByteBuf buf)
-        {
-            super.toBytes(buf);
-            buf.writeInt(rankId);
-            buf.writeBoolean(isSubscriber);
-        }
-
-        protected SetSubscriber(final RegistryFriendlyByteBuf buf, final PlayMessageType<?> type)
-        {
-            super(buf, type);
-            this.rankId = buf.readInt();
-            this.isSubscriber = buf.readBoolean();
-        }
-
-        @Override
-        protected void onExecute(final IPayloadContext ctxIn, final ServerPlayer player, final IColony colony)
-        {
-            colony.getPermissions().getRank(rankId).setSubscriber(isSubscriber);
             colony.markDirty();
         }
 

--- a/src/main/resources/assets/minecolonies/gui/townhall/layoutpermissions.xml
+++ b/src/main/resources/assets/minecolonies/gui/townhall/layoutpermissions.xml
@@ -79,15 +79,7 @@
                 </view>
             </dropdown>
 
-            <text id="isSubscriber" size="98 11" pos="201 60" label="Is Subscriber:" color="black"/>
-            <button id="setSubscriber"
-                         size="29 15"
-                         pos="301 57"
-                         color="black"
-                         label="$(com.minecolonies.coremod.gui.workerhuts.retrieveOff)"
-                         source="minecolonies:textures/gui/builderhut/builder_button_very_small.png"/>
-
-            <list id="rankList" size="138 120" pos="201 77">
+            <list id="rankList" size="150 130" pos="201 60">
                 <box size="100% 21" linewidth="1">
                     <text id="name" size="110 18" pos="2 2" color="black"/>
                     <button id="trigger" size="29 15" pos="2 3" align="TOP_RIGHT" color="black"


### PR DESCRIPTION
Closes #
Closes #

# Changes proposed in this pull request
- Remove unused isSubscriber option
- Move hostile options like attack guards to hostile type instead of being a permission that confuses player
- Move loading colony & messages to colony manager instead of separate perms
- Remove free block perms and make it !hostile

## Testing
- [ ] Yes I tested this before submitting it.
- [ ] I also did a multiplayer test.

Review please