### PR TITLE
fix player tag getting checked instead of entity it interact with

### DIFF
--- a/src/main/java/com/minecolonies/core/colony/permissions/ColonyPermissionEventHandler.java
+++ b/src/main/java/com/minecolonies/core/colony/permissions/ColonyPermissionEventHandler.java
@@ -435,7 +435,7 @@ public class ColonyPermissionEventHandler
             return;
         }
 
-        if (event.getEntity().getType().is(ModTags.freeToInteractWith))
+        if (event.getTarget().getType().is(ModTags.freeToInteractWith))
         {
             return;
         }


### PR DESCRIPTION
the tag minecolonies:allowinteract was being check against the player instead of the entity making it not work

## Testing
- [X] Yes I tested this before submitting it.
- [X] I also did a multiplayer test.

Review please