### PR TITLE
Level 0 Home Safeguard

### DIFF
--- a/src/main/java/com/minecolonies/core/colony/CitizenData.java
+++ b/src/main/java/com/minecolonies/core/colony/CitizenData.java
@@ -1641,7 +1641,7 @@ public class CitizenData implements ICitizenData
             return;
         }
 
-        final int homeBuildingLevel = homeBuilding == null ? 1 : homeBuilding.getBuildingLevel();
+        final int homeBuildingLevel = homeBuilding == null ? 1 : Math.max(homeBuilding.getBuildingLevel(), 1);
         if (leisureTime > 0)
         {
             leisureTime -= tickRate;


### PR DESCRIPTION
Closes: Eliminates this exception if a citizen is in a house that is level 0.

```
Condition check for state ACTIVE threw an exception:
java.lang.IllegalArgumentException: bound must be positive
	at java.base/java.util.Random.nextInt(Random.java:557) ~[?:?]
	at TRANSFORMER/minecolonies@1.1.1241-1.21.1-snapshot/com.minecolonies.core.colony.CitizenData.update(CitizenData.java:1649) ~[minecolonies-1.1.1241-1.21.1-snapshot.jar%23202!/:1.1.1241-1.21.1-snapshot]
```

# Changes proposed in this pull request
- Safeguard Level 0 homeBuildings as already done for Null homeBuilding.

Review please
