### PR TITLE
Fix Multiplayer Research

### DIFF
--- a/src/main/java/com/minecolonies/core/research/GlobalResearch.java
+++ b/src/main/java/com/minecolonies/core/research/GlobalResearch.java
@@ -189,7 +189,7 @@ public class GlobalResearch implements IGlobalResearch
             return true;
         }
 
-        final IItemHandler playerInventory = new InvWrapper(Minecraft.getInstance().player.getInventory());
+        final IItemHandler playerInventory = new InvWrapper(player.getInventory());
 
         ICommonBuilding buildingInv = BuildingUtils.commonBuildingFromPosition(player.level(), universityPos);
 


### PR DESCRIPTION
Closes #11530

# Changes proposed in this pull request
- The sided Player passed into the hasEnoughResources function was not used for getting the player inventory, causing the exception shown in the logs with 11530.

Review please
