### PR TITLE
Fix tag-based research

### DIFF
--- a/src/main/java/com/minecolonies/api/research/IGlobalResearch.java
+++ b/src/main/java/com/minecolonies/api/research/IGlobalResearch.java
@@ -4,7 +4,6 @@ import net.minecraft.core.BlockPos;
 import net.minecraft.network.chat.contents.TranslatableContents;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.entity.player.Player;
-import net.minecraft.world.item.Item;
 import net.minecraft.world.item.ItemStack;
 import net.neoforged.neoforge.common.crafting.SizedIngredient;
 import org.jetbrains.annotations.NotNull;
@@ -203,9 +202,9 @@ public interface IGlobalResearch
      * - It has the same Item
      * - It does NOT carry enchantments, custom names, etc.
      */
-    public static boolean isPlayerResearchMatch(ItemStack stack, Item cost)
+    public static boolean isPlayerResearchMatch(ItemStack stack, final SizedIngredient sizedIngredient)
     {
-        if (stack.isEmpty() || stack.getItem() != cost)
+        if (stack.isEmpty() || !sizedIngredient.ingredient().test(stack))
         {
             return false;
         }
@@ -223,13 +222,8 @@ public interface IGlobalResearch
      * A stack "matches" a research ingredient if:
      * - It has the same Item (even if they are enchanted or have a custom name)
      */
-    public static boolean isUniversityResearchMatch(ItemStack stack, Item cost)
+    public static boolean isUniversityResearchMatch(ItemStack stack, final SizedIngredient sizedIngredient)
     {
-        if (stack.isEmpty() || stack.getItem() != cost)
-        {
-            return false;
-        }
-
-        return true;
+        return !stack.isEmpty() && sizedIngredient.ingredient().test(stack);
     }
 }

--- a/src/main/java/com/minecolonies/core/client/gui/WindowResearchTree.java
+++ b/src/main/java/com/minecolonies/core/client/gui/WindowResearchTree.java
@@ -10,7 +10,6 @@ import com.minecolonies.api.colony.buildings.registry.IBuildingRegistry;
 import com.minecolonies.api.colony.buildings.views.IBuildingView;
 import com.minecolonies.api.crafting.ItemStorage;
 import com.minecolonies.api.research.*;
-import com.minecolonies.api.research.IResearchEffect;
 import com.minecolonies.api.research.requirements.BuildingAlternatesResearchRequirement;
 import com.minecolonies.api.research.requirements.BuildingResearchRequirement;
 import com.minecolonies.api.research.util.ResearchState;

--- a/src/main/java/com/minecolonies/core/research/GlobalResearch.java
+++ b/src/main/java/com/minecolonies/core/research/GlobalResearch.java
@@ -6,16 +6,12 @@ import com.minecolonies.api.colony.buildings.ICommonBuilding;
 import com.minecolonies.api.research.*;
 import com.minecolonies.api.research.util.ResearchState;
 import com.minecolonies.api.util.InventoryUtils;
-import com.minecolonies.api.util.Log;
 import com.minecolonies.core.util.BuildingUtils;
 
-import net.minecraft.client.Minecraft;
 import net.minecraft.core.BlockPos;
 import net.minecraft.network.chat.contents.TranslatableContents;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.entity.player.Player;
-import net.minecraft.world.item.Item;
-import net.minecraft.world.item.ItemStack;
 import net.neoforged.neoforge.common.crafting.SizedIngredient;
 import net.neoforged.neoforge.items.IItemHandler;
 import net.neoforged.neoforge.items.wrapper.InvWrapper;
@@ -197,29 +193,40 @@ public class GlobalResearch implements IGlobalResearch
 
         for (final SizedIngredient ingredient : costList)
         {
-            int totalCount = 0;
-            for (final ItemStack cost : ingredient.getItems())
+            final int required = ingredient.count();
+            if (required <= 0)
             {
-                Item costItem = cost.getItem();
+                continue;
+            }
 
-                if (buildingInv != null)
-                {
-                    final int count = InventoryUtils.hasBuildingEnoughElseCount(buildingInv, stack -> IGlobalResearch.isUniversityResearchMatch(stack, costItem), cost.getCount());
-                    totalCount += count;
-                }
+            int buildingCount = 0;
+            int playerCount = 0;
 
-                if (totalCount < cost.getCount())
-                {
-                    final int count = InventoryUtils.getItemCountInItemHandler(playerInventory, stack -> IGlobalResearch.isPlayerResearchMatch(stack, costItem));
-                    totalCount += count;
-                }
+            // 1) Count from university/building inventory (allows enchanted/custom named)
+            if (buildingInv != null)
+            {
+                buildingCount += InventoryUtils.hasBuildingEnoughElseCount(
+                    buildingInv,
+                    stack -> IGlobalResearch.isUniversityResearchMatch(stack, ingredient),
+                    required
+                );
+            }
 
-                if (totalCount < cost.getCount())
-                {
-                    return false;
-                }
+            // 2) If still short, count from player inventory (reject enchanted/custom named)
+            if (buildingCount < required)
+            {
+                playerCount = InventoryUtils.getItemCountInItemHandler(
+                    playerInventory,
+                    stack -> IGlobalResearch.isPlayerResearchMatch(stack, ingredient)
+                );
+            }
+
+            if ((buildingCount + playerCount) < required)
+            {
+                return false;
             }
         }
+
         return true;
     }
 

--- a/src/main/java/com/minecolonies/core/research/LocalResearchTree.java
+++ b/src/main/java/com/minecolonies/core/research/LocalResearchTree.java
@@ -6,8 +6,6 @@ import com.minecolonies.api.colony.IColony;
 import com.minecolonies.api.colony.requestsystem.StandardFactoryController;
 import com.minecolonies.api.crafting.ItemStorage;
 import com.minecolonies.api.research.*;
-import com.minecolonies.api.research.IResearchEffect;
-import com.minecolonies.api.research.IResearchEffectManager;
 import com.minecolonies.api.research.util.ResearchState;
 import com.minecolonies.api.util.*;
 import com.minecolonies.core.colony.buildings.workerbuildings.BuildingUniversity;
@@ -190,12 +188,32 @@ public class LocalResearchTree implements ILocalResearchTree
             // We know the university or player has the items, so now we can remove them safely.
             for (final SizedIngredient cost : research.getCostList())
             {
-                for (ItemStack researchCostStack : cost.getItems())
+                final int required = cost.count();
+                if (required <= 0)
                 {
-                    ItemStorage itemsToTake = new ItemStorage(researchCostStack);
-                    InventoryUtils.reduceBuildingThenPlayerInventory(building,  player, itemsToTake, stack -> IGlobalResearch.isUniversityResearchMatch(stack, researchCostStack.getItem()), stack -> IGlobalResearch.isPlayerResearchMatch(stack, researchCostStack.getItem()));
+                    continue;
                 }
 
+                // ItemStorage needs an ItemStack; for tag-based ingredients we just pick any representative
+                // and set the count to the total required. Predicates will enforce the actual match.
+                final ItemStack[] candidates = cost.getItems();
+                if (candidates == null || candidates.length == 0)
+                {
+                    continue;
+                }
+
+                final ItemStack representative = candidates[0].copy();
+                representative.setCount(required);
+
+                final ItemStorage itemsToTake = new ItemStorage(representative);
+
+                InventoryUtils.reduceBuildingThenPlayerInventory(
+                    building,
+                    player,
+                    itemsToTake,
+                    stack -> IGlobalResearch.isUniversityResearchMatch(stack, cost),
+                    stack -> IGlobalResearch.isPlayerResearchMatch(stack, cost)
+                );
             }
 
             MessageUtils.format(MESSAGE_RESEARCH_STARTED, MutableComponent.create(research.getName())).sendTo(player);


### PR DESCRIPTION
Closes reported problem with tag-based research costs (i.e. woodworking)
# Changes proposed in this pull request
- Rework predicates and calling functions to handle tag-based comparisons

# Testing
University inventory only
Player inventory only
Costs split across inventory
Enchanted item cost NOT taken from player inventory.
Enchanted item cost IS taken from university inventory.
Tag-based research costs (woodwork)
Research costs involving multiple items
Creative research (recognizing it does not overcome building level requirements).

Review please
