### PR TITLE
Recipe tweaks

### DIFF
--- a/src/main/java/com/minecolonies/core/client/gui/modules/building/WindowListRecipes.java
+++ b/src/main/java/com/minecolonies/core/client/gui/modules/building/WindowListRecipes.java
@@ -137,6 +137,7 @@ public class WindowListRecipes extends AbstractModuleWindow<CraftingModuleView>
     {
         final int row = recipeList.getListElementIndexByPane(button);
         final IRecipeStorage data = moduleView.getRecipes().get(row);
+        moduleView.removeRecipe(row);
         new AddRemoveRecipeMessage(buildingView, true, data, moduleView.getProducer().getRuntimeID()).sendToServer();
     }
 
@@ -220,7 +221,7 @@ public class WindowListRecipes extends AbstractModuleWindow<CraftingModuleView>
                 {
                     rowPane.findPaneOfTypeByID("gradient", Gradient.class).setVisible(true);
                     rowPane.findPaneOfTypeByID(BUTTON_TOGGLE, Button.class).setText(Component.translatableEscape("com.minecolonies.coremod.gui.recipe.enable"));
-                    rowPane.findPaneOfTypeByID(BUTTON_TOGGLE, Button.class).setVisible(moduleView.getActiveRecipes() < moduleView.getMaxRecipes());
+                    rowPane.findPaneOfTypeByID(BUTTON_TOGGLE, Button.class).setVisible(recipe.getRecipeSource() != null || moduleView.getActiveRecipes() < moduleView.getMaxRecipes());
                 }
                 else
                 {

--- a/src/main/java/com/minecolonies/core/colony/buildings/modules/AbstractCraftingBuildingModule.java
+++ b/src/main/java/com/minecolonies/core/colony/buildings/modules/AbstractCraftingBuildingModule.java
@@ -156,7 +156,15 @@ public abstract class AbstractCraftingBuildingModule extends AbstractBuildingMod
      */
     private int getActiveRecipes()
     {
-        return Math.max(0, recipes.size() - disabledRecipes.size());
+        // count up only active recipes that are *not* automatic
+        final HashSet<IToken<?>> activeRecipes = new HashSet<>(recipes);
+        disabledRecipes.forEach(activeRecipes::remove);
+        activeRecipes.removeIf(token ->
+        {
+            final IRecipeStorage storage = IColonyManager.getInstance().getRecipeManager().getRecipes().get(token);
+            return (storage == null || storage.getRecipeSource() != null);
+        });
+        return activeRecipes.size();
     }
 
     /**
@@ -322,7 +330,8 @@ public abstract class AbstractCraftingBuildingModule extends AbstractBuildingMod
 
         recipesDirty = false;
 
-        buf.writeInt(getMaxRecipes());
+        buf.writeVarInt(getActiveRecipes());
+        buf.writeVarInt(getMaxRecipes());
         buf.writeUtf(getId());
         buf.writeBoolean(isVisible());
     }

--- a/src/main/java/com/minecolonies/core/colony/buildings/modules/AbstractCraftingBuildingModule.java
+++ b/src/main/java/com/minecolonies/core/colony/buildings/modules/AbstractCraftingBuildingModule.java
@@ -551,7 +551,7 @@ public abstract class AbstractCraftingBuildingModule extends AbstractBuildingMod
                 }
                 if(duplicateFound == null)
                 {
-                    addRecipeToList(recipeToken, true);
+                    addRecipeToList(recipeToken, false);
                     building.getColony().getRequestManager().onColonyUpdate(request -> request.getRequest() instanceof IDeliverable iDeliverable && iDeliverable.matches(recipeStorage.getPrimaryOutput()));
                     markDirty();
                 }

--- a/src/main/java/com/minecolonies/core/colony/buildings/moduleviews/CraftingModuleView.java
+++ b/src/main/java/com/minecolonies/core/colony/buildings/moduleviews/CraftingModuleView.java
@@ -58,6 +58,11 @@ public class CraftingModuleView extends AbstractBuildingModuleView
     protected final List<IRecipeStorage> disabledRecipes = new ArrayList<>();
 
     /**
+     * The active recipes.
+     */
+    private int activeRecipes;
+
+    /**
      * The max recipes.
      */
     private int maxRecipes;
@@ -116,7 +121,8 @@ public class CraftingModuleView extends AbstractBuildingModuleView
             }
         }
 
-        this.maxRecipes = buf.readInt();
+        this.activeRecipes = buf.readVarInt();
+        this.maxRecipes = buf.readVarInt();
         this.id = buf.readUtf(32767);
         this.isVisible = buf.readBoolean();
     }
@@ -209,7 +215,11 @@ public class CraftingModuleView extends AbstractBuildingModuleView
      */
     public void removeRecipe(int index)
     {
-        recipes.remove(index);
+        final IRecipeStorage doomed = recipes.remove(index);
+        if (doomed.getRecipeSource() == null && !disabledRecipes.contains(doomed))
+        {
+            --activeRecipes;
+        }
     }
 
     /**
@@ -240,7 +250,7 @@ public class CraftingModuleView extends AbstractBuildingModuleView
 
     public int getActiveRecipes()
     {
-        return Math.max(0, recipes.size() - disabledRecipes.size());
+        return activeRecipes;
     }
 
     public int getMaxRecipes()
@@ -265,10 +275,18 @@ public class CraftingModuleView extends AbstractBuildingModuleView
         if (disabledRecipes.contains(storage))
         {
             disabledRecipes.remove(storage);
+            if (storage.getRecipeSource() == null)
+            {
+                ++activeRecipes;
+            }
         }
         else
         {
             disabledRecipes.add(storage);
+            if (storage.getRecipeSource() == null)
+            {
+                --activeRecipes;
+            }
         }
     }
 

--- a/src/main/java/com/minecolonies/core/colony/buildings/workerbuildings/BuildingMechanic.java
+++ b/src/main/java/com/minecolonies/core/colony/buildings/workerbuildings/BuildingMechanic.java
@@ -92,12 +92,6 @@ public class BuildingMechanic extends AbstractBuilding
             return item instanceof MinecartItem
                      || (item instanceof BlockItem && ((BlockItem) item).getBlock() instanceof HopperBlock);
         }
-
-        @Override
-        protected int getMaxRecipes()
-        {
-            return super.getMaxRecipes() + 5;     // grant a few extra to offset all the built-in recipes
-        }
     }
 
     public static class DOCraftingModule extends AbstractCraftingBuildingModule.Domum


### PR DESCRIPTION
Closes #11518

# Changes proposed in this pull request
- Automatic recipes are now added to the bottom of the list rather than the top (lowest priority).
- Automatic recipes do not consume a recipe-learning slot any more.
- Removed the tiny max slot count buff for the mechanic (intended to offset their high auto-recipe count at low levels).

Review please (could backport)