### PR TITLE
Fish and chips with extra fish DLC 1.20

### DIFF
--- a/src/datagen/generated/minecolonies/data/minecolonies/recipes/fish_n_chips.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/recipes/fish_n_chips.json
@@ -12,7 +12,7 @@
       "item": "minecolonies:durum"
     },
     {
-      "item": "minecraft:salmon"
+      "tag": "minecraft:fishes"
     },
     {
       "item": "minecraft:potato"

--- a/src/main/java/com/minecolonies/core/generation/defaults/DefaultRecipeProvider.java
+++ b/src/main/java/com/minecolonies/core/generation/defaults/DefaultRecipeProvider.java
@@ -997,7 +997,7 @@ public class DefaultRecipeProvider extends RecipeProvider
           .requires(ModBlocks.blockGarlic)
           .requires(ModBlocks.blockOnion)
           .requires(ModBlocks.blockDurum)
-          .requires(Items.SALMON)
+          .requires(ItemTags.FISHES)
           .requires(Items.POTATO)
           .unlockedBy("has_durum", has(ModBlocks.blockDurum))
           .save(consumer, new ResourceLocation(MOD_ID, "fish_n_chips"));


### PR DESCRIPTION
# Changes proposed in this pull request
- Backport #11549

Review please (do not port)

This tag is not quite as nice as the 1.21 one since it includes both raw and cooked fish, but I don't think that's enough of a silliness to be worth making a new tag with only the raw fish.
