### PR TITLE
Show helpful tooltips for dyed items

### DIFF
--- a/src/main/java/com/minecolonies/api/compatibility/CompatibilityManager.java
+++ b/src/main/java/com/minecolonies/api/compatibility/CompatibilityManager.java
@@ -18,6 +18,7 @@ import com.minecolonies.api.util.*;
 import com.minecolonies.core.colony.crafting.CustomRecipeManager;
 import com.minecolonies.core.colony.crafting.LootTableAnalyzer;
 import com.minecolonies.core.generation.ItemNbtCalculator;
+import it.unimi.dsi.fastutil.ints.*;
 import it.unimi.dsi.fastutil.objects.Object2IntLinkedOpenHashMap;
 import net.minecraft.client.multiplayer.ClientLevel;
 import net.minecraft.core.registries.BuiltInRegistries;
@@ -140,6 +141,11 @@ public class CompatibilityManager implements ICompatibilityManager
      * Mapping of itemstorage to creativemodetab.
      */
     private final Map<ItemStorage, CreativeModeTab> creativeModeTabMap = new HashMap<>();
+
+    /**
+     * Cached mapping of items and colors to dyes.
+     */
+    private final Int2ObjectMap<Int2IntMap> dyeColorMap = new Int2ObjectOpenHashMap<>();
 
     /**
      * Instantiates the compatibilityManager.
@@ -831,5 +837,37 @@ public class CompatibilityManager implements ICompatibilityManager
     public int getNumberOfSaplings()
     {
         return saplings.size();
+    }
+
+    @Override
+    public Optional<DyeColor> getDyeColor(final ItemStack stack)
+    {
+        if (stack.getItem() instanceof final DyeableLeatherItem dyeable)
+        {
+            final int color = dyeable.getColor(stack);
+            if (color != DyeableLeatherItem.DEFAULT_LEATHER_COLOR)
+            {
+                final ItemStack undyedStack = stack.copy();
+                dyeable.clearColor(undyedStack);
+
+                final int dyeId = dyeColorMap.computeIfAbsent(Item.getId(undyedStack.getItem()), id ->
+                {
+                    final Int2IntMap map = new Int2IntOpenHashMap();
+                    for (final DyeColor dye : DyeColor.values())
+                    {
+                        final ItemStack dyed = DyeableLeatherItem.dyeArmor(undyedStack, List.of(DyeItem.byColor(dye)));
+                        if (!dyed.isEmpty())
+                        {
+                            map.put(dyeable.getColor(dyed), dye.getId());
+                        }
+                    }
+                    return map;
+                }).getOrDefault(color, -1);
+
+                return dyeId < 0 ? Optional.empty() : Optional.of(DyeColor.byId(dyeId));
+            }
+        }
+
+        return Optional.empty();
     }
 }

--- a/src/main/java/com/minecolonies/api/compatibility/ICompatibilityManager.java
+++ b/src/main/java/com/minecolonies/api/compatibility/ICompatibilityManager.java
@@ -7,9 +7,7 @@ import net.minecraft.client.multiplayer.ClientLevel;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.network.FriendlyByteBuf;
 import net.minecraft.resources.ResourceLocation;
-import net.minecraft.world.item.CreativeModeTab;
-import net.minecraft.world.item.Item;
-import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.*;
 import net.minecraft.world.item.crafting.RecipeManager;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.Block;
@@ -19,6 +17,7 @@ import org.jetbrains.annotations.Nullable;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import java.util.function.Predicate;
 
@@ -239,4 +238,11 @@ public interface ICompatibilityManager
      * @return the number of saplings.
      */
     int getNumberOfSaplings();
+
+    /**
+     * Try to work out what dye needs to be used to produce the given color.
+     * @param stack the already-dyed stack.
+     * @return      the dye color required, or empty if there is no such dye.
+     */
+    Optional<DyeColor> getDyeColor(ItemStack stack);
 }

--- a/src/main/java/com/minecolonies/api/configuration/ClientConfiguration.java
+++ b/src/main/java/com/minecolonies/api/configuration/ClientConfiguration.java
@@ -13,6 +13,7 @@ public class ClientConfiguration extends AbstractConfiguration
     public final ForgeConfigSpec.IntValue buildgogglerange;
     public final ForgeConfigSpec.BooleanValue colonyteamborders;
     public final ForgeConfigSpec.BooleanValue holidayFeatures;
+    public final ForgeConfigSpec.BooleanValue showdyetooltips;
 
     /**
      * Builds client configuration.
@@ -28,6 +29,7 @@ public class ClientConfiguration extends AbstractConfiguration
         buildgogglerange = defineInteger(builder, "buildgogglerange", 50, 1, 250);
         colonyteamborders = defineBoolean(builder, "colonyteamborders", true);
         holidayFeatures = defineBoolean(builder, "holidayfeatures", true);
+        showdyetooltips = defineBoolean(builder, "showdyetooltips", true);
 
         swapToCategory(builder, "pathfinding");
 

--- a/src/main/java/com/minecolonies/core/event/ClientEventHandler.java
+++ b/src/main/java/com/minecolonies/core/event/ClientEventHandler.java
@@ -158,8 +158,9 @@ public class ClientEventHandler
             {
                 event.getToolTip().removeIf(line -> line.getContents() instanceof TranslatableContents t && t.getKey().equals("item.dyed"));
                 event.getToolTip().add(1, Component.translatable("%s: %s",
-                    Component.translatable("item.dyed").withStyle(Style.EMPTY.withColor(ChatFormatting.GRAY).withItalic(true)),
-                    Component.translatable("color.minecraft." + c.getName()).withStyle(Style.EMPTY.withColor(c.getTextColor()))));
+                    Component.translatable("item.dyed"),
+                    Component.translatable("color.minecraft." + c.getName()).withStyle(Style.EMPTY.withColor(c.getTextColor()).withItalic(false)))
+                    .withStyle(Style.EMPTY.withColor(ChatFormatting.GRAY).withItalic(true)));
             });
         }
 

--- a/src/main/java/com/minecolonies/core/event/ClientEventHandler.java
+++ b/src/main/java/com/minecolonies/core/event/ClientEventHandler.java
@@ -40,12 +40,11 @@ import net.minecraft.core.BlockPos;
 import net.minecraft.network.chat.Component;
 import net.minecraft.network.chat.MutableComponent;
 import net.minecraft.network.chat.Style;
+import net.minecraft.network.chat.contents.TranslatableContents;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.InteractionHand;
 import net.minecraft.world.InteractionResult;
-import net.minecraft.world.item.BlockItem;
-import net.minecraft.world.item.Item;
-import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.*;
 import net.minecraft.world.level.block.Block;
 import net.minecraft.world.phys.HitResult;
 import net.minecraftforge.api.distmarker.Dist;
@@ -151,6 +150,17 @@ public class ClientEventHandler
         if (extraItemTooltips.containsKey(stack.getItem()))
         {
             event.getToolTip().add(extraItemTooltips.get(stack.getItem()));
+        }
+
+        if (stack.getItem() instanceof DyeableLeatherItem && IMinecoloniesAPI.getInstance().getConfig().getClient().showdyetooltips.get())
+        {
+            IMinecoloniesAPI.getInstance().getColonyManager().getCompatibilityManager().getDyeColor(stack).ifPresent(c ->
+            {
+                event.getToolTip().removeIf(line -> line.getContents() instanceof TranslatableContents t && t.getKey().equals("item.dyed"));
+                event.getToolTip().add(1, Component.translatable("%s: %s",
+                    Component.translatable("item.dyed").withStyle(Style.EMPTY.withColor(ChatFormatting.GRAY).withItalic(true)),
+                    Component.translatable("color.minecraft." + c.getName()).withStyle(Style.EMPTY.withColor(c.getTextColor()))));
+            });
         }
 
         IColony colony = IMinecoloniesAPI.getInstance().getColonyManager().getIColony(event.getEntity().level, event.getEntity().blockPosition());

--- a/src/main/resources/assets/minecolonies/lang/manual_en_us.json
+++ b/src/main/resources/assets/minecolonies/lang/manual_en_us.json
@@ -39,6 +39,9 @@
   "minecolonies.config.colonyteamborders": "Show Colony Borders in Team Colors",
   "minecolonies.config.colonyteamborders.comment": "When true, the colony borders shown when holding the build tool will be in the colony's team color. When false, the colony you're inside will be white and any other colony will be red.",
 
+  "minecolonies.config.showdyetooltips": "Show Dye Color tooltips for Leather Items",
+  "minecolonies.config.showdyetooltips.comment": "When true, dyed leather items will show a tooltip so that you know what color to use.",
+
   "minecolonies.config.diseasemodifier": "Disease Modifier",
   "minecolonies.config.diseasemodifier.comment": "How common diseases are. 1 = Very common, 100 = extremely rare.",
   "minecolonies.config.diseases": "Diseases",


### PR DESCRIPTION
Closes [discord request](https://discord.com/channels/472875599422291968/473575384445878273/1479807305930506302) (mostly)

# Changes proposed in this pull request
- Modifies the tooltip for leather armor so that it shows the actual dye color required for this particular item.
    - Intended to help understand requests from blueprints that use dyed armor on stands.
    - Only works on single-dyed armor, not multi-colored armor.
    - Can be disabled in client config if you have another mod that does this.
<img width="150" height="50" alt="image" src="https://github.com/user-attachments/assets/6c8c7a39-ce62-4e77-9690-2afe24330ae9" />

Review please (should port)
