### PR TITLE
Fix: Too many torches being requested in Colonial medium quarry in 1.20

### DIFF
--- a/src/main/java/com/minecolonies/core/entity/ai/workers/util/LayerBlueprintIterator.java
+++ b/src/main/java/com/minecolonies/core/entity/ai/workers/util/LayerBlueprintIterator.java
@@ -115,6 +115,17 @@ public class LayerBlueprintIterator extends AbstractBlueprintIteratorWrapper
     }
 
     @Override
+    public BlockPos getPrevProgressPos()
+    {
+        final BlockPos prevProgressPos = delegate.getPrevProgressPos();
+        if (prevProgressPos.equals(NULL_POS))
+        {
+            return NULL_POS;
+        }
+        return prevProgressPos.atY(layer);
+    }
+
+    @Override
     public BlueprintPositionInfo getBluePrintPositionInfo(final BlockPos localPos)
     {
         // localPos is relative to the original blueprint, so we need to use the original blueprint to retrieve the information


### PR DESCRIPTION
Closes #
Closes #

# Changes proposed in this pull request
- The prevProgressPos of the iterator was broken for the LayeredBlueprintIterator for quarries, as it was not properly delegated from the backing iterator to the layer iterator.
  It always returned `NULL_POS` instead. In case of a Colonial medium quarry, as it reached its limits whilst halfway through a layer,
  that meant it started anew on that layer in the next colony tick, so it was endlessly getting the same torches as requirements, and never progressing 
  This PR fixing the delegation, such that the layerBlueprintIterator can pick up where it left off

Review please
