### PR TITLE
Use derived spawn point.

### DIFF
--- a/src/main/java/com/minecolonies/core/colony/managers/VisitorManager.java
+++ b/src/main/java/com/minecolonies/core/colony/managers/VisitorManager.java
@@ -262,7 +262,7 @@ public class VisitorManager implements IVisitorManager
                     }
 
                     citizenEntity.setUUID(data.getUUID());
-                    citizenEntity.setPos(spawnLocation.getX() + HALF_A_BLOCK, spawnLocation.getY() + SLIGHTLY_UP, spawnLocation.getZ() + HALF_A_BLOCK);
+                    citizenEntity.setPos(calculatedSpawn.getX() + HALF_A_BLOCK, calculatedSpawn.getY() + SLIGHTLY_UP, calculatedSpawn.getZ() + HALF_A_BLOCK);
                     world.addFreshEntity(citizenEntity);
 
                     citizenEntity.setCitizenId(data.getId());


### PR DESCRIPTION
Closes: None

# Changes proposed in this pull request
- Visitor manager was calculating a "good" spawn point based on a proximity reference point, but then ignoring the calculated spawn point.  This adjusts the entity position set to use the calculated spawn point.

Review please
