### PR TITLE
confirm window for residence with missing infra & tp

### DIFF
--- a/src/main/java/com/minecolonies/api/colony/buildings/views/IBuildingView.java
+++ b/src/main/java/com/minecolonies/api/colony/buildings/views/IBuildingView.java
@@ -10,6 +10,7 @@ import com.minecolonies.api.colony.buildings.registry.BuildingEntry;
 import com.minecolonies.api.colony.requestsystem.request.IRequest;
 import com.minecolonies.api.colony.requestsystem.requester.IRequester;
 import com.minecolonies.api.colony.requestsystem.token.IToken;
+import com.minecolonies.api.crafting.ItemStorage;
 import net.minecraft.core.BlockPos;
 import net.minecraft.network.FriendlyByteBuf;
 import org.jetbrains.annotations.NotNull;
@@ -230,4 +231,13 @@ public interface IBuildingView extends IRequester, IModuleContainerView, ICommon
      * @return the range.
      */
     default int getRange() { return 0; }
+
+    /**
+     * Get lang key of pre-upgrade warning for building level.
+     * @return empty-string by default. Override for respective building.
+     */
+    default String getHoverWarningForLevel()
+    {
+        return "";
+    }
 }

--- a/src/main/java/com/minecolonies/api/util/constant/WindowConstants.java
+++ b/src/main/java/com/minecolonies/api/util/constant/WindowConstants.java
@@ -472,9 +472,14 @@ public final class WindowConstants
     public static final String BUTTON_NEXT_COLOR_ID = "nextColor";
 
     /**
-     * This button will remove the currently rendered structure.
+     * Generic cancel button.
      */
     public static final String BUTTON_CANCEL = "cancel";
+
+    /**
+     * Generic confirm button.
+     */
+    public static final String BUTTON_CONFIRM = "confirm";
 
     /**
      * Move the structure preview forward.
@@ -1162,6 +1167,11 @@ public final class WindowConstants
      * Title label.
      */
     public static final String TITLE_LABEL = "title";
+
+    /**
+     * Warning label.
+     */
+    public static final String WARNING_LABEL = "warning";
 
     /**
      * Crafting switch buttons texture.

--- a/src/main/java/com/minecolonies/core/client/gui/WindowBuildBuilding.java
+++ b/src/main/java/com/minecolonies/core/client/gui/WindowBuildBuilding.java
@@ -2,6 +2,7 @@ package com.minecolonies.core.client.gui;
 
 import com.ldtteam.blockui.Color;
 import com.ldtteam.blockui.Pane;
+import com.ldtteam.blockui.PaneBuilders;
 import com.ldtteam.blockui.controls.Button;
 import com.ldtteam.blockui.controls.ItemIcon;
 import com.ldtteam.blockui.controls.Text;
@@ -125,6 +126,9 @@ public class WindowBuildBuilding extends AbstractWindowSkeleton
         this.building = building;
 
         initStyleNavigation();
+
+        PaneBuilders.singleLineTooltip(Component.translatable(building.getHoverWarningForLevel()), findPaneOfTypeByID(BUTTON_BUILD, Button.class));
+
         registerButton(BUTTON_BUILD, this::confirmClicked);
         registerButton(BUTTON_CANCEL, this::cancelClicked);
         registerButton(BUTTON_REPAIR, this::repairClicked);
@@ -200,6 +204,20 @@ public class WindowBuildBuilding extends AbstractWindowSkeleton
     {
         final BlockPos builder = buildersDropDownList.getSelectedIndex() == 0 ? BlockPos.ZERO : builders.get(buildersDropDownList.getSelectedIndex()).getB();
 
+        if (!building.getHoverWarningForLevel().isEmpty())
+        {
+            new WindowConfirm(this, () -> triggerConfirmAction(builder), "com.minecolonies.core.gui.build.confirm.title", building.getHoverWarningForLevel()).open();
+            return;
+        }
+        triggerConfirmAction(builder);
+    }
+
+    /**
+     * Trigger confirm action.
+     * @param builder the position of the builder that was selected.
+     */
+    private void triggerConfirmAction(final BlockPos builder)
+    {
         Network.getNetwork().sendToServer(new BuildingSetStyleMessage(building, styles.get(stylesDropDownList.getSelectedIndex())));
         if (building.getBuildingLevel() == building.getBuildingMaxLevel())
         {

--- a/src/main/java/com/minecolonies/core/client/gui/WindowConfirm.java
+++ b/src/main/java/com/minecolonies/core/client/gui/WindowConfirm.java
@@ -1,0 +1,29 @@
+package com.minecolonies.core.client.gui;
+
+import com.ldtteam.blockui.controls.Text;
+import com.minecolonies.api.util.constant.Constants;
+import net.minecraft.network.chat.Component;
+import net.minecraft.resources.ResourceLocation;
+
+import static com.minecolonies.api.util.constant.WindowConstants.*;
+
+/**
+ * Confirm/Deny window option. Confirm close, deny return to previous UI.
+ */
+public class WindowConfirm extends AbstractWindowSkeleton
+{
+    /**
+     * Constructor to initiate the confirm window.
+     *
+     * @param parent the parent window.
+     * @param action the action to run on confirm.
+     */
+    public WindowConfirm(final AbstractWindowSkeleton parent, final Runnable action, final String title, final String warning)
+    {
+        super(parent, new ResourceLocation(Constants.MOD_ID, "gui/windowconfirm.xml"));
+        registerButton(BUTTON_CONFIRM, this::close);
+        registerButton(BUTTON_CANCEL, action);
+        findPaneOfTypeByID(TITLE_LABEL, Text.class).setText(Component.translatable(title));
+        findPaneOfTypeByID(WARNING_LABEL, Text.class).setText(Component.translatable(warning));
+    }
+}

--- a/src/main/java/com/minecolonies/core/client/gui/modules/building/ConnectionModuleWindow.java
+++ b/src/main/java/com/minecolonies/core/client/gui/modules/building/ConnectionModuleWindow.java
@@ -15,6 +15,7 @@ import com.minecolonies.api.util.MessageUtils;
 import com.minecolonies.api.util.constant.Constants;
 import com.minecolonies.core.Network;
 import com.minecolonies.core.client.gui.AbstractBuildingWindow;
+import com.minecolonies.core.client.gui.WindowConfirm;
 import com.minecolonies.core.commands.ClickEventWithExecutable;
 import com.minecolonies.core.network.messages.server.colony.TeleportToColonyMessage;
 import net.minecraft.client.Minecraft;
@@ -109,11 +110,13 @@ public class ConnectionModuleWindow extends AbstractBuildingWindow<IBuildingView
         final int dist = (int) BlockPosUtil.dist(connectedColonyData.pos, buildingView.getPosition());
         final int itemCount = externalPlayer ? dist/125 : 0;
 
-        MessageUtils.format("com.minecolonies.core.gui.colonylist.travel.really", connectedColonyData.name)
-            .withPriority(MessageUtils.MessagePriority.IMPORTANT)
-            .withClickEvent(new ClickEventWithExecutable(() -> Network.getNetwork().sendToServer(new TeleportToColonyMessage(mc.level.dimension(), connectedColonyData.id, connectedColonyData.pos, buildingView.getColony().getID(), itemCount))))
-            .sendTo(Minecraft.getInstance().player);
-        this.close();
+        new WindowConfirm(this,
+            () ->
+            {
+                Network.getNetwork().sendToServer(new TeleportToColonyMessage(mc.level.dimension(), connectedColonyData.id, connectedColonyData.pos, buildingView.getColony().getID(), itemCount));
+                close();
+            },
+        Component.translatable("com.minecolonies.coremod.gui.townhall.tp", connectedColonyData.name).getString(), "").open();
     }
 
     /**

--- a/src/main/java/com/minecolonies/core/colony/buildings/views/LivingBuildingView.java
+++ b/src/main/java/com/minecolonies/core/colony/buildings/views/LivingBuildingView.java
@@ -2,7 +2,12 @@ package com.minecolonies.core.colony.buildings.views;
 
 import com.minecolonies.api.colony.IColonyView;
 import com.minecolonies.api.colony.buildings.HiringMode;
+import com.minecolonies.api.colony.buildings.ModBuildings;
+import com.minecolonies.api.colony.buildings.views.IBuildingView;
+import com.minecolonies.api.crafting.ItemStorage;
+import com.minecolonies.api.items.IMinecoloniesFoodItem;
 import com.minecolonies.core.Network;
+import com.minecolonies.core.colony.buildings.modules.BuildingModules;
 import com.minecolonies.core.colony.buildings.moduleviews.LivingBuildingModuleView;
 import com.minecolonies.core.network.messages.server.colony.building.worker.BuildingHiringModeMessage;
 import net.minecraft.core.BlockPos;
@@ -40,7 +45,7 @@ public abstract class LivingBuildingView extends AbstractBuildingView
     /**
      * Removes a resident from the building.
      *
-     * @param index the index to remove it from.
+     * @param id the index to remove it from.
      */
     public void removeResident(final int id)
     {
@@ -83,5 +88,68 @@ public abstract class LivingBuildingView extends AbstractBuildingView
     {
         getModuleViewByType(LivingBuildingModuleView.class).setHiringMode(value);
         Network.getNetwork().sendToServer(new BuildingHiringModeMessage(this, value, getModuleViewByType(LivingBuildingModuleView.class).getProducer().getRuntimeID()));
+    }
+
+    @Override
+    public String getHoverWarningForLevel()
+    {
+        switch (getBuildingLevel())
+        {
+            case 1 ->
+                {
+                    // Have a fisher or farmer
+                    if (getColony().getCommonBuildingManager().hasBuilding(ModBuildings.fisherman.get().getRegistryName(), 1, false)
+                        || getColony().getCommonBuildingManager().hasBuilding(ModBuildings.farmer.get().getRegistryName(), 1, false)
+                    )
+                    {
+                        return "";
+                    }
+                    return "com.minecolonies.core.gui.residence.warning." + (getBuildingLevel() + 1);
+                }
+            case 2 ->
+            {
+                if (checkColonyMenu(getColony(), 1))
+                {
+                    return "";
+                }
+
+                return "com.minecolonies.core.gui.residence.warning." + (getBuildingLevel() + 1);
+            }
+            case 3, 4 ->
+            {
+                if (checkColonyMenu(getColony(), 2))
+                {
+                    return "";
+                }
+
+                return "com.minecolonies.core.gui.residence.warning." + (getBuildingLevel() + 1);
+            }
+            default -> super.getHoverWarningForLevel();
+        }
+        return "";
+    }
+
+    /**
+     * Check if the colony has a dining hall with some min food on the menu.
+     * @param colonyView the colony to check this for.
+     * @param minTier the min food tier.
+     * @return true if so.
+     */
+    private static boolean checkColonyMenu(final IColonyView colonyView, final int minTier)
+    {
+        for (final IBuildingView buildingView : colonyView.getClientBuildingManager().getBuildings().values())
+        {
+            if (buildingView.getBuildingType() == ModBuildings.cook.get())
+            {
+                for (final ItemStorage storage : buildingView.getModuleView(BuildingModules.RESTAURANT_MENU).getMenu())
+                {
+                    if (storage.getItem() instanceof IMinecoloniesFoodItem minecoloniesFoodItem && minecoloniesFoodItem.getTier() >= minTier)
+                    {
+                        return true;
+                    }
+                }
+            }
+        }
+        return false;
     }
 }

--- a/src/main/resources/assets/minecolonies/gui/windowconfirm.xml
+++ b/src/main/resources/assets/minecolonies/gui/windowconfirm.xml
@@ -1,0 +1,11 @@
+<window size="350 170" lightbox="true">
+    <text id="title" size="294 11" pos="23 32" textalign="MIDDLE" color="white" textscale="1.2"/>
+    <text id="warning" size="294 31" pos="23 52" textalign="MIDDLE" color="white"/>
+
+    <button id="cancel" size="86 17" pos="60 120"
+            source="minecolonies:textures/gui/builderhut/builder_button_medium.png"
+            label="$(gui.yes)" color="black"/>
+    <button id="confirm" size="86 17" pos="160 120"
+            source="minecolonies:textures/gui/builderhut/builder_button_medium.png"
+            label="$(gui.cancel)" color="black"/>
+</window>

--- a/src/main/resources/assets/minecolonies/lang/manual_en_us.json
+++ b/src/main/resources/assets/minecolonies/lang/manual_en_us.json
@@ -585,7 +585,7 @@
 
   "com.minecolonies.coremod.gui.townhall.allies": "Allies:",
   "com.minecolonies.coremod.gui.townhall.feuds": "Feuds:",
-  "com.minecolonies.coremod.gui.townhall.tp": "Do you really want to teleport to %s? [YES]",
+  "com.minecolonies.coremod.gui.townhall.tp": "Do you really want to teleport to %s?",
 
   "com.minecolonies.coremod.workorderadded": "Build request created for %s at colony %s! The hut block is at %s %s %s.",
   "com.minecolonies.coremod.decoorderadded": "Decoration request created for colony %s!",
@@ -2995,7 +2995,7 @@
   "com.minecolonies.core.gui.colonylist.set_neutral": "Set Neutral",
   "com.minecolonies.core.gui.colonylist.travel": "Travel",
   "com.minecolonies.core.gui.colonylist.travel.tooltip": "Only possible for Allied colonies",
-  "com.minecolonies.core.gui.colonylist.travel.really": "Do you really want to travel to %s? [YES]",
+  "com.minecolonies.core.gui.colonylist.travel.really": "Do you really want to travel to %s?",
   "com.minecolonies.core.gui.connectioneventlist.desc": "Connection Event List",
   "com.minecolonies.core.gui.connectioneventlist.accept_ally": "Accept Alliance",
   "com.minecolonies.core.gui.connectioneventlist.howto": "How to build an Alliance: \n\n - Build a Gatehouse in your colony.\n\n- Ensure the target colony also has a Gatehouse.\n\n- Place colony signs between the two Gatehouses to create a connection.",
@@ -3036,5 +3036,13 @@
   "entity.minecolonies.cavalry_horse": "Cavalry Horse",
 
   "com.minecolonies.coremod.gui.townhall.prestige": "Colony Ranking",
-  "com.minecolonies.coremod.gui.townhall.prestige.tooltip": "Score reflects the total construction value of your colony, calculated by summing the cost factor of each building."
+  "com.minecolonies.coremod.gui.townhall.prestige.tooltip": "Score reflects the total construction value of your colony, calculated by summing the cost factor of each building.",
+
+  "com.minecolonies.core.gui.residence.warning.2": "Warning: No food production detected. Build a Farm or Fisher's Hut before adding more residents.",
+  "com.minecolonies.core.gui.residence.warning.3": "Warning: Higher-level residents expect regular meals. Build a Dining Hall and setup Minecolonies Food on the menu before upgrading.",
+  "com.minecolonies.core.gui.residence.warning.4": "Warning: Higher-level residents demand varied, cooked meals. Ensure you have a chef alongside your dining hall and a full menu before upgrading.",
+  "com.minecolonies.core.gui.residence.warning.5": "Warning: Your colony may struggle to feed residents at this level. Consider expanding food production and your Dining Hall menu first.",
+
+  "com.minecolonies.core.gui.build.confirm.title": "Are you sure you want to upgrade the building?",
+  "com.minecolonies.core.gui.teleport.confirm.title": "Are you sure you want to teleport now?"
 }


### PR DESCRIPTION
Closes #
Closes #

# Changes proposed in this pull request
- Residence build/upgrade button has a useful tooltip to guide player
- Needs extra confirmation on build if req are not met
- UI confirm for tp not chat confirm

<img width="1545" height="668" alt="image" src="https://github.com/user-attachments/assets/90037f44-aba1-43df-8e25-41d503af2948" />

(Note, button says Yes/Cancel now)

Review please
