### PR TITLE
fix: citizen AI and combat improvements

### DIFF
--- a/src/main/java/com/minecolonies/api/entity/ai/combat/threat/ThreatTable.java
+++ b/src/main/java/com/minecolonies/api/entity/ai/combat/threat/ThreatTable.java
@@ -65,6 +65,12 @@ public class ThreatTable<T extends LivingEntity & IThreatTableEntity>
         {
             return;
         }
+
+        final ThreatTableEntry currentTarget = (currentTargetIndex >= 0 && currentTargetIndex < threatList.size())
+            ? threatList.get(currentTargetIndex) : null;
+        threatList.removeIf(entry -> !entry.getEntity().isAlive());
+        currentTargetIndex = currentTarget != null ? Math.max(0, threatList.indexOf(currentTarget)) : 0;
+
         ThreatTableEntry threatTableEntry = null;
         int index = threatList.size();
 

--- a/src/main/java/com/minecolonies/api/entity/ai/combat/threat/ThreatTable.java
+++ b/src/main/java/com/minecolonies/api/entity/ai/combat/threat/ThreatTable.java
@@ -65,12 +65,6 @@ public class ThreatTable<T extends LivingEntity & IThreatTableEntity>
         {
             return;
         }
-
-        final ThreatTableEntry currentTarget = (currentTargetIndex >= 0 && currentTargetIndex < threatList.size())
-            ? threatList.get(currentTargetIndex) : null;
-        threatList.removeIf(entry -> !entry.getEntity().isAlive());
-        currentTargetIndex = currentTarget != null ? Math.max(0, threatList.indexOf(currentTarget)) : 0;
-
         ThreatTableEntry threatTableEntry = null;
         int index = threatList.size();
 

--- a/src/main/java/com/minecolonies/api/entity/ai/statemachine/basestatemachine/BasicStateMachine.java
+++ b/src/main/java/com/minecolonies/api/entity/ai/statemachine/basestatemachine/BasicStateMachine.java
@@ -67,7 +67,7 @@ public class BasicStateMachine<T extends IStateMachineTransition<S>, S extends I
     private int         historyIndex   = -1;
     private Component[] stateHistory   = new Component[20];
 
-    DateTimeFormatter SIMPLE_TIME = new DateTimeFormatterBuilder()
+    private static final DateTimeFormatter SIMPLE_TIME = new DateTimeFormatterBuilder()
         .appendValue(HOUR_OF_DAY, 2)
         .appendLiteral(':')
         .appendValue(MINUTE_OF_HOUR, 2)

--- a/src/main/java/com/minecolonies/core/entity/citizen/EntityCitizen.java
+++ b/src/main/java/com/minecolonies/core/entity/citizen/EntityCitizen.java
@@ -165,6 +165,8 @@ public class EntityCitizen extends AbstractEntityCitizen implements IThreatTable
      */
     private ICitizenInventoryHandler  citizenInventoryHandler;
 
+    private LazyOptional<IItemHandler> itemHandlerOptional = LazyOptional.empty();
+
     /**
      * The citizen colony handler.
      */
@@ -998,8 +1000,10 @@ public class EntityCitizen extends AbstractEntityCitizen implements IThreatTable
     {
         if (data != null)
         {
+            itemHandlerOptional.invalidate();
             this.citizenData = (ICitizenData) data;
             data.initEntityValues();
+            itemHandlerOptional = LazyOptional.of(this.citizenData::getInventory);
         }
     }
 
@@ -1309,7 +1313,7 @@ public class EntityCitizen extends AbstractEntityCitizen implements IThreatTable
             }
 
             final IColony attackerColony = ((EntityCitizen) sourceEntity).citizenColonyHandler.getColonyOrRegister();
-            if (attackerColony != null && citizenColonyHandler.getColonyOrRegister() != null && MineColonies.getConfig().getServer().pvp_mode.get())
+            if (!level.isClientSide && attackerColony != null && citizenColonyHandler.getColonyOrRegister() != null && MineColonies.getConfig().getServer().pvp_mode.get())
             {
                 final IPermissions permission = attackerColony.getPermissions();
                 citizenColonyHandler.getColonyOrRegister().getPermissions().addPlayer(permission.getOwner(), permission.getOwnerName(), permission.getRank(permission.HOSTILE_RANK_ID));
@@ -1464,6 +1468,8 @@ public class EntityCitizen extends AbstractEntityCitizen implements IThreatTable
 
         callForHelpCooldown = CALL_HELP_CD;
 
+        final BlockPos selfPos = blockPosition();
+
         List<AbstractEntityCitizen> possibleGuards = new ArrayList<>();
 
         for (final ICitizenData entry : getCitizenColonyHandler().getColonyOrRegister().getCitizenManager().getCitizens())
@@ -1472,7 +1478,7 @@ public class EntityCitizen extends AbstractEntityCitizen implements IThreatTable
             {
                 // Checking for guard nearby
                 if (entry.getJob() instanceof AbstractJobGuard && entry.getId() != citizenData.getId()
-                      && BlockPosUtil.getDistanceSquared(entry.getEntity().get().blockPosition(), blockPosition()) < guardHelpRange && entry.getJob().getWorkerAI() != null)
+                    && BlockPosUtil.getDistanceSquared(entry.getEntity().get().blockPosition(), selfPos) < guardHelpRange && entry.getJob().getWorkerAI() != null)
                 {
                     final ThreatTable table = ((EntityCitizen) entry.getEntity().get()).getThreatTable();
                     table.addThreat((LivingEntity) attacker, 0);
@@ -1484,7 +1490,7 @@ public class EntityCitizen extends AbstractEntityCitizen implements IThreatTable
             }
         }
 
-        Collections.sort(possibleGuards, Comparator.comparingInt(guard -> (int) blockPosition().distSqr(guard.blockPosition())));
+        possibleGuards.sort(Comparator.comparingInt(guard -> (int) selfPos.distSqr(guard.blockPosition())));
 
         for (int i = 0; i < possibleGuards.size() && i <= CALL_TO_HELP_AMOUNT; i++)
         {
@@ -1723,14 +1729,10 @@ public class EntityCitizen extends AbstractEntityCitizen implements IThreatTable
     {
         if (capability == ForgeCapabilities.ITEM_HANDLER)
         {
-            final ICitizenData data = getCitizenData();
-            if (data == null)
+            if (itemHandlerOptional.isPresent()) 
             {
-                return super.getCapability(capability, facing);
+                return itemHandlerOptional.cast();
             }
-            final InventoryCitizen inv = data.getInventory();
-
-            return LazyOptional.of(() -> (T) inv);
         }
 
         return super.getCapability(capability, facing);
@@ -1760,6 +1762,7 @@ public class EntityCitizen extends AbstractEntityCitizen implements IThreatTable
     @Override
     public void setRemoved(final RemovalReason reason)
     {
+        itemHandlerOptional.invalidate();
         citizenColonyHandler.onCitizenRemoved();
         super.setRemoved(reason);
     }


### PR DESCRIPTION
getCapability - LazyOptional.of() was being called on every invocation. It has been cached as a field and is now invalidated in setRemoved().
callForHelp - this.blockPosition() was being called on every comparison in the sort comparator. It is now pre-fetched as selfPos.
checkIfValidDamageSource - Although addPlayer() is server-side, it was also running on the client side. !level.isClientSide has been added.
BasicStateMachine - DateTimeFormatter was being created separately for each instance. It has been made static final.


Closes #
Closes #

# Changes proposed in this pull request
-
-

Review please
