### PR TITLE
NPE protection

### DIFF
--- a/src/main/java/com/minecolonies/core/colony/buildings/AbstractBuildingContainer.java
+++ b/src/main/java/com/minecolonies/core/colony/buildings/AbstractBuildingContainer.java
@@ -215,7 +215,8 @@ public abstract class AbstractBuildingContainer extends AbstractSchematicProvide
     @Override
     public @Nullable IItemHandler getItemHandlerCap(Direction direction)
     {
-        return getTileEntity().getItemHandlerCap(direction);
+        final AbstractTileEntityColonyBuilding tileEntity = getTileEntity();
+        return tileEntity == null ? null : tileEntity.getItemHandlerCap(direction);
     }
 
     //------------------------- !End! Capabilities handling for minecolonies buildings -------------------------//


### PR DESCRIPTION
Closes None

# Changes proposed in this pull request
- Adds NPE protection to address this stack trace:
```
java.lang.NullPointerException: Cannot invoke "com.minecolonies.api.tileentities.AbstractTileEntityColonyBuilding.getItemHandlerCap(net.minecraft.core.Direction)" because the return value of "com.minecolonies.core.colony.buildings.AbstractBuildingContainer.getTileEntity()" is null
	at TRANSFORMER/minecoloniescom.minecolonies.core.colony.buildings.AbstractBuildingContainer.getItemHandlerCap(AbstractBuildingContainer.java:218) ~[minecolonies-1.1.1305-1.21.1-snapshot.jar%23472!/:1.1.1305-1.21.1-snapshot]
	at TRANSFORMER/minecoloniescom.minecolonies.api.util.IItemHandlerCapProvider.getItemHandlerCap(IItemHandlerCapProvider.java:32) ~[minecolonies-1.1.1305-1.21.1-snapshot.jar%23472!/:1.1.1305-1.21.1-snapshot]
```

Can occur if a block is referenced while the chunk is not loaded, or if it has been removed recently.

Review please
