### PR TITLE
Update PathingStuckHandler.java

### DIFF
--- a/src/main/java/com/minecolonies/core/entity/pathfinding/navigation/PathingStuckHandler.java
+++ b/src/main/java/com/minecolonies/core/entity/pathfinding/navigation/PathingStuckHandler.java
@@ -368,7 +368,7 @@ public class PathingStuckHandler<NAV extends PathNavigation & IMinecoloniesNavig
         if (rand.nextDouble() < chanceToByPassMovingAway ||
             (lastStuckLevel == 1 || ((lastStuckLevel >= 3 && lastStuckLevel <= 8) && !(canBreakBlocks || canBuildLeafBridges || canPlaceLadders) && rand.nextBoolean())))
         {
-            if (navigator.getPath() != null)
+            if (navigator.getPath() != null && navigator.getPath().getNextNodeIndex() > 0)
             {
                 moveAwayStartPos = navigator.getPath().getNodePos(navigator.getPath().getNextNodeIndex() - 1);
             }


### PR DESCRIPTION
Closes #11643 

# Changes proposed in this pull request
- Placed a simple check in PathingStuckHandler.tryUnstuck() to guard against the possibility of one of the retry paths attempting to index path node -1

Testing - prior to the fix I received:
```
Caused by: java.lang.ArrayIndexOutOfBoundsException: Index -1 out of bounds for length 33
        at java.base/java.util.Arrays$ArrayList.get(Arrays.java:4266) ~[?:?] {}
        at TRANSFORMER/minecraftnet.minecraft.world.level.pathfinder.Path.getNodePos(Path.java:97) ~[server-1.21.1-20240808.144430-srg.jar%23324!/:?] {re:classloading}
        at TRANSFORMER/minecoloniescom.minecolonies.core.entity.pathfinding.navigation.PathingStuckHandler.tryUnstuck(PathingStuckHandler.java:373)
```
clearly indicating the location.  Post fix this did not occur.

Review please
