### PR TITLE
feat(tools): Adding compatibility for mods that dettach item tier fro…

### DIFF
--- a/src/main/java/com/minecolonies/api/compatibility/Compatibility.java
+++ b/src/main/java/com/minecolonies/api/compatibility/Compatibility.java
@@ -116,7 +116,7 @@ public final class Compatibility
     @Nullable
     public static Tier getItemTier(final ItemStack stack)
     {
-        final TierEntry entry = itemTierRegistry.get(new ItemStorage(stack, true, true));
+        final TierEntry entry = itemTierRegistry.get(new ItemStorage(stack, true));
         return entry != null ? entry.tier() : null;
     }
 
@@ -128,7 +128,7 @@ public final class Compatibility
      */
     public static int getItemLevel(final ItemStack stack)
     {
-        final TierEntry entry = itemTierRegistry.get(new ItemStorage(stack, true, true));
+        final TierEntry entry = itemTierRegistry.get(new ItemStorage(stack, true));
         return entry != null ? entry.level() : -1;
     }
 

--- a/src/main/java/com/minecolonies/api/compatibility/Compatibility.java
+++ b/src/main/java/com/minecolonies/api/compatibility/Compatibility.java
@@ -4,10 +4,14 @@ import com.minecolonies.api.compatibility.dynamictrees.DynamicTreeProxy;
 import com.minecolonies.api.compatibility.resourcefulbees.IBeehiveCompat;
 import com.minecolonies.api.compatibility.tinkers.SlimeTreeProxy;
 import com.minecolonies.api.compatibility.tinkers.TinkersToolProxy;
+import com.minecolonies.api.crafting.ItemStorage;
 import com.minecolonies.api.equipment.registry.EquipmentTypeEntry;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.NonNullList;
+import net.minecraft.world.item.Item;
 import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.Tier;
+import net.minecraft.world.item.Tiers;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.LevelAccessor;
 import net.minecraft.world.level.block.Block;
@@ -20,8 +24,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Predicate;
-import java.util.function.ToIntBiFunction;
-import net.minecraft.world.item.Item;
 
 /**
  * This class is to store the methods that call the methods to check for miscellaneous compatibility problems.
@@ -34,21 +36,100 @@ public final class Compatibility
         throw new IllegalAccessError("Utility class");
     }
 
-    private static final Map<Item, ToIntBiFunction<ItemStack, EquipmentTypeEntry>> customLevelProviders = new HashMap<>();
+    private record TierEntry(@NotNull Tier tier, int level) {}
+
+    private static final Map<ItemStorage, TierEntry> itemTierRegistry = new HashMap<>();
     private static final List<Predicate<ItemStack>> customWeaponRecognizers = new ArrayList<>();
 
-    /**
-     * Register a custom equipment level provider. The function should return the
-     * equipment level (0–N) for a recognised stack. Only items where the vanialla
-     * behaviour is not intended need to be registered.
-     * Called before the vanilla getAttackDamageBonus() fallback.
-     *
-     * @param provider the level provider to register.
-     */
-    public static void registerEquipmentLevelProvider(final Item item,
-        final ToIntBiFunction<ItemStack, EquipmentTypeEntry> provider)
+    // Ordered by level 0–5. Level 5 maps to Netherite (the highest vanilla Tier).
+    private static final Tiers[] LEVEL_TO_TIER = {
+        Tiers.WOOD, Tiers.STONE, Tiers.IRON, Tiers.DIAMOND, Tiers.NETHERITE, Tiers.NETHERITE
+    };
+
+    private static Tiers tierForLevel(final int level)
     {
-        customLevelProviders.put(item, provider);
+        return LEVEL_TO_TIER[Math.min(Math.max(level, 0), LEVEL_TO_TIER.length - 1)];
+    }
+
+    /**
+     * Register an item with an explicit Tier object and pre-computed level.
+     * Always overwrites any existing entry — intended for mod compat hooks.
+     *
+     * @param item  the item to register.
+     * @param tier  the Tier object to associate.
+     * @param level the equipment level integer.
+     */
+    public static void registerItemTier(@NotNull final Item item, @NotNull final Tier tier, final int level)
+    {
+        itemTierRegistry.put(new ItemStorage(new ItemStack(item), true, true), new TierEntry(tier, level));
+    }
+
+    /**
+     * Register an item by level only.
+     * The closest matching vanilla {@link Tiers} instance is stored so that
+     * {@link #getItemTier} never returns null for a registered item.
+     * Always overwrites any existing entry — intended for mod compat hooks.
+     *
+     * @param item  the item to register.
+     * @param level the equipment level integer.
+     */
+    public static void registerItemTier(@NotNull final Item item, final int level)
+    {
+        itemTierRegistry.put(new ItemStorage(new ItemStack(item), true, true), new TierEntry(tierForLevel(level), level));
+    }
+
+    /**
+     * Register an item with an explicit Tier and level only if not already registered.
+     * Used by auto-population so explicit mod registrations are never overwritten.
+     *
+     * @param item  the item to register.
+     * @param tier  the Tier object to associate.
+     * @param level the equipment level integer.
+     */
+    public static void registerItemTierIfAbsent(@NotNull final Item item, @NotNull final Tier tier, final int level)
+    {
+        itemTierRegistry.putIfAbsent(new ItemStorage(new ItemStack(item), true, true), new TierEntry(tier, level));
+    }
+
+    /**
+     * Register an item by level only if not already registered.
+     * The closest matching vanilla {@link Tiers} instance is stored.
+     * Used by auto-population so explicit mod registrations are never overwritten.
+     *
+     * @param item  the item to register.
+     * @param level the equipment level integer.
+     */
+    public static void registerItemTierIfAbsent(@NotNull final Item item, final int level)
+    {
+        itemTierRegistry.putIfAbsent(new ItemStorage(new ItemStack(item), true, true), new TierEntry(tierForLevel(level), level));
+    }
+
+    /**
+     * Return the Tier associated with this stack.
+     * Returns {@code null} only when the item has not been registered.
+     * Items registered without a real Tier (armor, bow, etc.) return the closest
+     * matching vanilla {@link Tiers} instance.
+     *
+     * @param stack the item stack.
+     * @return the registered Tier, or null if not registered.
+     */
+    @Nullable
+    public static Tier getItemTier(final ItemStack stack)
+    {
+        final TierEntry entry = itemTierRegistry.get(new ItemStorage(stack, true, true));
+        return entry != null ? entry.tier() : null;
+    }
+
+    /**
+     * Return the pre-computed equipment level for this stack, or -1 if not registered.
+     *
+     * @param stack the item stack.
+     * @return the equipment level, or -1.
+     */
+    public static int getItemLevel(final ItemStack stack)
+    {
+        final TierEntry entry = itemTierRegistry.get(new ItemStorage(stack, true, true));
+        return entry != null ? entry.level() : -1;
     }
 
     /**
@@ -78,12 +159,6 @@ public final class Compatibility
             }
         }
         return false;
-    }
-
-    public static int getCustomEquipmentLevel(final ItemStack stack, final EquipmentTypeEntry equipmentType)
-    {
-        final ToIntBiFunction<ItemStack, EquipmentTypeEntry> provider = customLevelProviders.get(stack.getItem());
-        return provider != null ? provider.applyAsInt(stack, equipmentType) : -1;
     }
 
     public static IJeiProxy jeiProxy = new IJeiProxy() {};

--- a/src/main/java/com/minecolonies/api/compatibility/Compatibility.java
+++ b/src/main/java/com/minecolonies/api/compatibility/Compatibility.java
@@ -15,7 +15,10 @@ import net.minecraft.world.level.block.state.BlockState;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
+import java.util.ArrayList;
 import java.util.List;
+import java.util.function.BiFunction;
+import java.util.function.Predicate;
 
 /**
  * This class is to store the methods that call the methods to check for miscellaneous compatibility problems.
@@ -26,6 +29,63 @@ public final class Compatibility
     private Compatibility()
     {
         throw new IllegalAccessError("Utility class");
+    }
+
+    private static final List<BiFunction<ItemStack, EquipmentTypeEntry, Integer>> customLevelProviders = new ArrayList<>();
+    private static final List<Predicate<ItemStack>> customWeaponRecognizers = new ArrayList<>();
+
+    /**
+     * Register a custom equipment level provider. The function should return the
+     * equipment level (0–N) for a recognised stack, or -1 to pass through to the
+     * next provider. Called before the vanilla getAttackDamageBonus() fallback.
+     *
+     * @param provider the level provider to register.
+     */
+    public static void registerEquipmentLevelProvider(final BiFunction<ItemStack, EquipmentTypeEntry, Integer> provider)
+    {
+        customLevelProviders.add(provider);
+    }
+
+    /**
+     * Register a custom weapon recognizer. The predicate should return true if the stack
+     * is a weapon that should be treated as a sword by colonists (e.g. maces, javelins).
+     *
+     * @param recognizer the predicate to register.
+     */
+    public static void registerWeaponRecognizer(final Predicate<ItemStack> recognizer)
+    {
+        customWeaponRecognizers.add(recognizer);
+    }
+
+    /**
+     * Query all registered weapon recognizers.
+     *
+     * @param stack the item stack.
+     * @return true if any recognizer claims the stack as a weapon.
+     */
+    public static boolean isCustomWeapon(final ItemStack stack)
+    {
+        for (final Predicate<ItemStack> recognizer : customWeaponRecognizers)
+        {
+            if (recognizer.test(stack))
+            {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    public static int getCustomEquipmentLevel(final ItemStack stack, final EquipmentTypeEntry equipmentType)
+    {
+        for (final BiFunction<ItemStack, EquipmentTypeEntry, Integer> provider : customLevelProviders)
+        {
+            final int level = provider.apply(stack, equipmentType);
+            if (level >= 0)
+            {
+                return level;
+            }
+        }
+        return -1;
     }
 
     public static IJeiProxy jeiProxy = new IJeiProxy() {};

--- a/src/main/java/com/minecolonies/api/compatibility/Compatibility.java
+++ b/src/main/java/com/minecolonies/api/compatibility/Compatibility.java
@@ -16,9 +16,12 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
-import java.util.function.BiFunction;
+import java.util.Map;
 import java.util.function.Predicate;
+import java.util.function.ToIntBiFunction;
+import net.minecraft.world.item.Item;
 
 /**
  * This class is to store the methods that call the methods to check for miscellaneous compatibility problems.
@@ -31,19 +34,21 @@ public final class Compatibility
         throw new IllegalAccessError("Utility class");
     }
 
-    private static final List<BiFunction<ItemStack, EquipmentTypeEntry, Integer>> customLevelProviders = new ArrayList<>();
+    private static final Map<Item, ToIntBiFunction<ItemStack, EquipmentTypeEntry>> customLevelProviders = new HashMap<>();
     private static final List<Predicate<ItemStack>> customWeaponRecognizers = new ArrayList<>();
 
     /**
      * Register a custom equipment level provider. The function should return the
-     * equipment level (0–N) for a recognised stack, or -1 to pass through to the
-     * next provider. Called before the vanilla getAttackDamageBonus() fallback.
+     * equipment level (0–N) for a recognised stack. Only items where the vanialla
+     * behaviour is not intended need to be registered.
+     * Called before the vanilla getAttackDamageBonus() fallback.
      *
      * @param provider the level provider to register.
      */
-    public static void registerEquipmentLevelProvider(final BiFunction<ItemStack, EquipmentTypeEntry, Integer> provider)
+    public static void registerEquipmentLevelProvider(final Item item,
+        final ToIntBiFunction<ItemStack, EquipmentTypeEntry> provider)
     {
-        customLevelProviders.add(provider);
+        customLevelProviders.put(item, provider);
     }
 
     /**
@@ -77,15 +82,8 @@ public final class Compatibility
 
     public static int getCustomEquipmentLevel(final ItemStack stack, final EquipmentTypeEntry equipmentType)
     {
-        for (final BiFunction<ItemStack, EquipmentTypeEntry, Integer> provider : customLevelProviders)
-        {
-            final int level = provider.apply(stack, equipmentType);
-            if (level >= 0)
-            {
-                return level;
-            }
-        }
-        return -1;
+        final ToIntBiFunction<ItemStack, EquipmentTypeEntry> provider = customLevelProviders.get(stack.getItem());
+        return provider != null ? provider.applyAsInt(stack, equipmentType) : -1;
     }
 
     public static IJeiProxy jeiProxy = new IJeiProxy() {};

--- a/src/main/java/com/minecolonies/api/equipment/ModEquipmentTypes.java
+++ b/src/main/java/com/minecolonies/api/equipment/ModEquipmentTypes.java
@@ -84,20 +84,10 @@ public class ModEquipmentTypes
 
         sword = register("sword",
           builder -> builder.setDisplayName(Component.translatable(ToolTranslationConstants.TOOL_TYPE_SWORD))
-                       .setIsEquipment((itemStack, equipmentType) -> canPerformDefaultActions(itemStack, ItemAbilities.DEFAULT_SWORD_ACTIONS) || Compatibility.isTinkersWeapon(
-                         itemStack))
-                       .setEquipmentLevel((itemStack, equipmentType) -> {
-                      if (Compatibility.isTinkersWeapon(itemStack))
-                      {
-                          return Compatibility.getToolLevel(itemStack);
-                      }
-                      else if (itemStack.getItem() instanceof final TieredItem tieredItem)
-                      {
-                          // todo: Think about sth smarter in the future
-                          return (int) tieredItem.getTier().getAttackDamageBonus();
-                      }
-                      return -1;
-                  })
+                       .setIsEquipment((itemStack, equipmentType) -> canPerformDefaultActions(itemStack, ItemAbilities.DEFAULT_SWORD_ACTIONS)
+                                                                     || Compatibility.isTinkersWeapon(itemStack)
+                                                                     || Compatibility.isCustomWeapon(itemStack))
+                       .setEquipmentLevel(ModEquipmentTypes::vanillaToolLevel)
                   .build());
 
         bow = register("bow",
@@ -199,7 +189,13 @@ public class ModEquipmentTypes
         {
             return Compatibility.getToolLevel(itemStack);
         }
-        else if (itemStack.getItem() instanceof final TieredItem tieredItem)  // most tools
+        final int customLevel = Compatibility.getCustomEquipmentLevel(itemStack, equipmentType);
+        // for mods that use getAttackDamageBonus in differen ranges like tfc
+        if (customLevel >= 0)
+        {
+            return customLevel;
+        }
+        if (itemStack.getItem() instanceof final TieredItem tieredItem)  // most tools
         {
             // todo: Think about sth smarter in the future
             return (int) tieredItem.getTier().getAttackDamageBonus();

--- a/src/main/java/com/minecolonies/api/equipment/ModEquipmentTypes.java
+++ b/src/main/java/com/minecolonies/api/equipment/ModEquipmentTypes.java
@@ -8,6 +8,7 @@ import com.minecolonies.api.util.constant.Constants;
 import com.minecolonies.api.util.constant.translation.ToolTranslationConstants;
 import com.minecolonies.apiimp.CommonMinecoloniesAPIImpl;
 import net.minecraft.core.Registry;
+import net.minecraft.core.registries.BuiltInRegistries;
 import net.minecraft.network.chat.Component;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.entity.EquipmentSlot;
@@ -93,55 +94,55 @@ public class ModEquipmentTypes
         bow = register("bow",
           builder -> builder.setDisplayName(Component.translatable(ToolTranslationConstants.TOOL_TYPE_BOW))
                        .setIsEquipment((itemStack, equipmentType) -> itemStack.getItem() instanceof BowItem)
-                       .setEquipmentLevel((itemStack, equipmentType) -> durabilityBasedLevel(itemStack, Items.BOW.getMaxDamage(itemStack)))
+                       .setEquipmentLevel((itemStack, equipmentType) -> Compatibility.getItemLevel(itemStack))
                   .build());
 
         fishing_rod = register("rod",
           builder -> builder.setDisplayName(Component.translatable(ToolTranslationConstants.TOOL_TYPE_FISHING_ROD))
                        .setIsEquipment((itemStack, equipmentType) -> canPerformDefaultActions(itemStack, ItemAbilities.DEFAULT_FISHING_ROD_ACTIONS))
-                       .setEquipmentLevel((itemStack, equipmentType) -> durabilityBasedLevel(itemStack, Items.FISHING_ROD.getMaxDamage(itemStack)))
+                       .setEquipmentLevel((itemStack, equipmentType) -> Compatibility.getItemLevel(itemStack))
                   .build());
 
         shears = register("shears",
           builder -> builder.setDisplayName(Component.translatable(ToolTranslationConstants.TOOL_TYPE_SHEARS))
                        .setIsEquipment((itemStack, equipmentType) -> canPerformDefaultActions(itemStack, ItemAbilities.DEFAULT_SHEARS_ACTIONS))
-                       .setEquipmentLevel((itemStack, equipmentType) -> durabilityBasedLevel(itemStack, Items.SHEARS.getMaxDamage(itemStack)))
+                       .setEquipmentLevel((itemStack, equipmentType) -> Compatibility.getItemLevel(itemStack))
                   .build());
 
         shield = register("shield",
           builder -> builder.setDisplayName(Component.translatable(ToolTranslationConstants.TOOL_TYPE_SHIELD))
                        .setIsEquipment((itemStack, equipmentType) -> canPerformDefaultActions(itemStack, ItemAbilities.DEFAULT_SHIELD_ACTIONS))
-                       .setEquipmentLevel((itemStack, equipmentType) -> durabilityBasedLevel(itemStack, Items.SHIELD.getMaxDamage(itemStack)))
+                       .setEquipmentLevel((itemStack, equipmentType) -> Compatibility.getItemLevel(itemStack))
                   .build());
 
         helmet = register("helmet",
           builder -> builder.setDisplayName(Component.translatable(ToolTranslationConstants.TOOL_TYPE_HELMET))
                        .setIsEquipment((itemStack, equipmentType) -> itemStack.getItem() instanceof ArmorItem armor && EquipmentSlot.HEAD.equals(armor.getEquipmentSlot()))
-                       .setEquipmentLevel((itemStack, equipmentType) -> ItemStackUtils.getArmorLevel(itemStack))
+                       .setEquipmentLevel((itemStack, equipmentType) -> Compatibility.getItemLevel(itemStack))
                   .build());
 
         leggings = register("leggings",
           builder -> builder.setDisplayName(Component.translatable(ToolTranslationConstants.TOOL_TYPE_LEGGINGS))
                        .setIsEquipment((itemStack, equipmentType) -> itemStack.getItem() instanceof ArmorItem armor && EquipmentSlot.LEGS.equals(armor.getEquipmentSlot()))
-                       .setEquipmentLevel((itemStack, equipmentType) -> ItemStackUtils.getArmorLevel(itemStack))
+                       .setEquipmentLevel((itemStack, equipmentType) -> Compatibility.getItemLevel(itemStack))
                   .build());
 
         chestplate = register("chestplate",
           builder -> builder.setDisplayName(Component.translatable(ToolTranslationConstants.TOOL_TYPE_CHEST_PLATE))
                        .setIsEquipment((itemStack, equipmentType) -> itemStack.getItem() instanceof ArmorItem armor && EquipmentSlot.CHEST.equals(armor.getEquipmentSlot()))
-                       .setEquipmentLevel((itemStack, equipmentType) -> ItemStackUtils.getArmorLevel(itemStack))
+                       .setEquipmentLevel((itemStack, equipmentType) -> Compatibility.getItemLevel(itemStack))
                   .build());
 
         boots = register("boots",
           builder -> builder.setDisplayName(Component.translatable(ToolTranslationConstants.TOOL_TYPE_BOOTS))
                        .setIsEquipment((itemStack, equipmentType) -> itemStack.getItem() instanceof ArmorItem armor && EquipmentSlot.FEET.equals(armor.getEquipmentSlot()))
-                       .setEquipmentLevel((itemStack, equipmentType) ->ItemStackUtils.getArmorLevel(itemStack))
+                       .setEquipmentLevel((itemStack, equipmentType) -> Compatibility.getItemLevel(itemStack))
                   .build());
 
         flint_and_steel = register("flintandsteel",
           builder -> builder.setDisplayName(Component.translatable(ToolTranslationConstants.TOOL_TYPE_LIGHTER))
                        .setIsEquipment((itemStack, equipmentType) -> itemStack.getItem() instanceof FlintAndSteelItem)
-                       .setEquipmentLevel((itemStack, equipmentType) -> durabilityBasedLevel(itemStack, Items.FLINT_AND_STEEL.getMaxDamage(itemStack)))
+                       .setEquipmentLevel((itemStack, equipmentType) -> Compatibility.getItemLevel(itemStack))
                   .build());
 
         lead = register("lead",
@@ -189,18 +190,7 @@ public class ModEquipmentTypes
         {
             return Compatibility.getToolLevel(itemStack);
         }
-        final int customLevel = Compatibility.getCustomEquipmentLevel(itemStack, equipmentType);
-        // for mods that use getAttackDamageBonus in differen ranges like tfc
-        if (customLevel >= 0)
-        {
-            return customLevel;
-        }
-        if (itemStack.getItem() instanceof final TieredItem tieredItem)  // most tools
-        {
-            // todo: Think about sth smarter in the future
-            return (int) tieredItem.getTier().getAttackDamageBonus();
-        }
-        return -1;
+        return Compatibility.getItemLevel(itemStack);
     }
 
     /**
@@ -217,6 +207,58 @@ public class ModEquipmentTypes
         }
 
         return Math.min(itemStack.getMaxDamage() / vanillaItemDurability, 5);
+    }
+
+    /**
+     * Populate the tier registry with every item currently in the game.
+     * Called once during FMLCommonSetupEvent via MineColonies.preInit.
+     */
+    @SuppressWarnings("null")
+    public static void initVanillaEquipmentTiers()
+    {
+        final int bowRef    = new ItemStack(Items.BOW).getMaxDamage();
+        final int rodRef    = new ItemStack(Items.FISHING_ROD).getMaxDamage();
+        final int shearsRef = new ItemStack(Items.SHEARS).getMaxDamage();
+        final int shieldRef = new ItemStack(Items.SHIELD).getMaxDamage();
+        final int flintRef  = new ItemStack(Items.FLINT_AND_STEEL).getMaxDamage();
+
+        for (final Item item : BuiltInRegistries.ITEM)
+        {
+            final ItemStack dummy = new ItemStack(item);
+
+            if (item instanceof final TieredItem tiered)
+            {
+                Compatibility.registerItemTierIfAbsent(item, tiered.getTier(), (int) tiered.getTier().getAttackDamageBonus());
+            }
+            else if (item instanceof ArmorItem)
+            {
+                final int level = ItemStackUtils.getArmorLevel(dummy);
+                if (level > 0)
+                {
+                    Compatibility.registerItemTierIfAbsent(item, level);
+                }
+            }
+            else if (item instanceof BowItem)
+            {
+                Compatibility.registerItemTierIfAbsent(item, durabilityBasedLevel(dummy, bowRef));
+            }
+            else if (canPerformDefaultActions(dummy, ItemAbilities.DEFAULT_FISHING_ROD_ACTIONS))
+            {
+                Compatibility.registerItemTierIfAbsent(item, durabilityBasedLevel(dummy, rodRef));
+            }
+            else if (canPerformDefaultActions(dummy, ItemAbilities.DEFAULT_SHEARS_ACTIONS))
+            {
+                Compatibility.registerItemTierIfAbsent(item, durabilityBasedLevel(dummy, shearsRef));
+            }
+            else if (canPerformDefaultActions(dummy, ItemAbilities.DEFAULT_SHIELD_ACTIONS))
+            {
+                Compatibility.registerItemTierIfAbsent(item, durabilityBasedLevel(dummy, shieldRef));
+            }
+            else if (item instanceof FlintAndSteelItem)
+            {
+                Compatibility.registerItemTierIfAbsent(item, durabilityBasedLevel(dummy, flintRef));
+            }
+        }
     }
 
     /**

--- a/src/main/java/com/minecolonies/api/equipment/ModEquipmentTypes.java
+++ b/src/main/java/com/minecolonies/api/equipment/ModEquipmentTypes.java
@@ -214,7 +214,7 @@ public class ModEquipmentTypes
      * Called once during FMLCommonSetupEvent via MineColonies.preInit.
      */
     @SuppressWarnings("null")
-    public static void initVanillaEquipmentTiers()
+    public static void initRegisterEquipmentTiers()
     {
         final int bowRef    = new ItemStack(Items.BOW).getMaxDamage();
         final int rodRef    = new ItemStack(Items.FISHING_ROD).getMaxDamage();

--- a/src/main/java/com/minecolonies/api/equipment/ModEquipmentTypes.java
+++ b/src/main/java/com/minecolonies/api/equipment/ModEquipmentTypes.java
@@ -185,7 +185,7 @@ public class ModEquipmentTypes
      */
     public static int vanillaToolLevel(final ItemStack itemStack, final EquipmentTypeEntry equipmentType)
     {
-        if (Compatibility.isTinkersTool(itemStack, equipmentType))
+        if (Compatibility.isTinkersTool(itemStack, equipmentType) || Compatibility.isTinkersWeapon(itemStack))
         {
             return Compatibility.getToolLevel(itemStack);
         }

--- a/src/main/java/com/minecolonies/core/MineColonies.java
+++ b/src/main/java/com/minecolonies/core/MineColonies.java
@@ -218,6 +218,7 @@ public class MineColonies
 
         event.enqueueWork(ModLootConditions::init);
         event.enqueueWork(ModTags::init);
+        event.enqueueWork(ModEquipmentTypes::initVanillaEquipmentTiers);
     }
 
     /**

--- a/src/main/java/com/minecolonies/core/MineColonies.java
+++ b/src/main/java/com/minecolonies/core/MineColonies.java
@@ -218,7 +218,7 @@ public class MineColonies
 
         event.enqueueWork(ModLootConditions::init);
         event.enqueueWork(ModTags::init);
-        event.enqueueWork(ModEquipmentTypes::initVanillaEquipmentTiers);
+        event.enqueueWork(ModEquipmentTypes::initRegisterEquipmentTiers);
     }
 
     /**


### PR DESCRIPTION
…m damage (example: tfc)

- Compatibility.java: Adding to external registration hooks to allow for registering any tools and weapons and armor with an additional hook to map tools to item levels in any compat mod
- ModEquipmentTypes.java: fix sword registry to use vanillaToolLevel function like all other items; Extending vanillaToolLevel to include the new getCustomEquipmentLevel allowing for registering without using getAttackDamageBonus.

Closes #
Closes #

# Changes proposed in this pull request
-
-

Review please
