### PR TITLE
Fix incorrect filename used in Arabic

### DIFF
--- a/src/main/java/com/minecolonies/api/util/constant/ColonyManagerConstants.java
+++ b/src/main/java/com/minecolonies/api/util/constant/ColonyManagerConstants.java
@@ -38,12 +38,12 @@ public final class ColonyManagerConstants
     /**
      * Colony filename.
      */
-    public static final String FILENAME_COLONY = "colony%d.dat";
+    public static final String FILENAME_COLONY = "colony%s.dat";
 
     /**
      * Colony filename deleted.
      */
-    public static final String FILENAME_COLONY_DELETED = "colony%d.dat.deleted";
+    public static final String FILENAME_COLONY_DELETED = "colony%s.dat.deleted";
 
     /**
      * Log message for missing world cap.

--- a/src/main/java/com/minecolonies/core/client/gui/modules/TabsWindowModule.java
+++ b/src/main/java/com/minecolonies/core/client/gui/modules/TabsWindowModule.java
@@ -171,7 +171,7 @@ public class TabsWindowModule implements IWindowModule
          */
         public ResourceLocation getImage(final Random random)
         {
-            return new ResourceLocation(Constants.MOD_ID, String.format("textures/gui/modules/tab_%s_side%d.png", side, random.nextInt(imageCount) + 1));
+            return new ResourceLocation(Constants.MOD_ID, String.format("textures/gui/modules/tab_%s_side%s.png", side, random.nextInt(imageCount) + 1));
         }
     }
 }

--- a/src/main/java/com/minecolonies/core/util/BackUpHelper.java
+++ b/src/main/java/com/minecolonies/core/util/BackUpHelper.java
@@ -48,7 +48,7 @@ public final class BackUpHelper
     /**
      * Export colony filename scheme
      */
-    public static final String FILENAME_EXPORT = "colony%dExport.zip";
+    public static final String FILENAME_EXPORT = "colony%sExport.zip";
 
     /**
      * Maximum amount of backup zips


### PR DESCRIPTION
Closes [discord report](https://discord.com/channels/139070364159311872/1003402487417548801/1500661902030667826)

# Changes proposed in this pull request
- Fix filename using incorrect digits when system locale is Arabic.
- Also fix some other filename formatting that looks suspicious.

Review please (should port)

Didn't test this, but it seems plausible.  Did do a quick check through other System.format calls too; most seem ok.

In further explanation: `%d` is locale-dependent but `%s` is not.