### PR TITLE
Improve builder lava safety and pathfinding on 1.21

### DIFF
--- a/src/main/java/com/minecolonies/core/debug/messages/QueryCitizenAIHistoryMessage.java
+++ b/src/main/java/com/minecolonies/core/debug/messages/QueryCitizenAIHistoryMessage.java
@@ -6,6 +6,7 @@ import com.minecolonies.api.colony.ICitizenDataView;
 import com.minecolonies.api.colony.IColony;
 import com.minecolonies.api.util.constant.Constants;
 import com.minecolonies.core.debug.DebugPlayerManager;
+import com.minecolonies.core.entity.ai.workers.AbstractEntityAIBasic;
 import com.minecolonies.core.entity.citizen.EntityCitizen;
 import com.minecolonies.core.network.messages.server.AbstractColonyServerMessage;
 import net.minecraft.network.RegistryFriendlyByteBuf;
@@ -61,11 +62,18 @@ public class QueryCitizenAIHistoryMessage extends AbstractColonyServerMessage
 
         if (citizen.getEntity().get() instanceof EntityCitizen entityCitizen)
         {
-            MutableComponent message = Component.literal("Citizen AI: ").append(entityCitizen.getCitizenAI().getHistory());
+            entityCitizen.getCitizenAI().setHistoryEnabled(true, 20);
+            MutableComponent message = Component.literal("Citizen AI:\n").append(entityCitizen.getCitizenAI().getHistory());
 
             if (entityCitizen.getCitizenJobHandler().getColonyJob() != null)
             {
-                message.append(Component.literal("Job AI: ").append(entityCitizen.getCitizenJobHandler().getWorkAI().getStateAI().getHistory()));
+                final var workAI = entityCitizen.getCitizenJobHandler().getWorkAI();
+                workAI.getStateAI().setHistoryEnabled(true, 20);
+                message.append(Component.literal("\n\nJob AI:\n")).append(workAI.getStateAI().getHistory());
+                if (workAI instanceof AbstractEntityAIBasic<?, ?> debugWorkAI)
+                {
+                    message.append(Component.literal("\n\n")).append(debugWorkAI.getDebugInfo());
+                }
             }
 
             new DebugOutputMessage(message, true).sendToPlayer(player);

--- a/src/main/java/com/minecolonies/core/entity/ai/workers/AbstractEntityAIBasic.java
+++ b/src/main/java/com/minecolonies/core/entity/ai/workers/AbstractEntityAIBasic.java
@@ -45,6 +45,7 @@ import com.mojang.authlib.GameProfile;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
 import net.minecraft.network.chat.Component;
+import net.minecraft.network.chat.MutableComponent;
 import net.minecraft.server.level.ServerLevel;
 import net.minecraft.tags.TagKey;
 import net.minecraft.world.InteractionHand;
@@ -257,6 +258,31 @@ public abstract class AbstractEntityAIBasic<J extends AbstractJob<?, J>, B exten
            */
           new AIEventTarget(AIBlockingEventType.AI_BLOCKING, this::isStartingPaused, INVENTORY_FULL, TICKS_SECOND)
         );
+    }
+
+    /**
+     * Debug information for the worker AI, used by the citizen debug window.
+     */
+    public Component getDebugInfo()
+    {
+        final MutableComponent info = Component.literal("Work AI debug:\n");
+        info.append(Component.literal("state=" + getState() + "\n"));
+        info.append(Component.literal("currentWorkingLocation=" + formatDebugPos(currentWorkingLocation) + "\n"));
+        info.append(Component.literal("walkTo=" + formatDebugPos(walkTo) + "\n"));
+        info.append(Component.literal("statusPosition=" + formatDebugPos(worker.getCitizenData().getStatusPosition()) + "\n"));
+        if (building != null)
+        {
+            info.append(Component.literal("workBuilding=" + formatDebugPos(building.getPosition()) + "\n"));
+        }
+        return info;
+    }
+
+    /**
+     * Format a block position for debug output.
+     */
+    protected static String formatDebugPos(@Nullable final BlockPos pos)
+    {
+        return pos == null ? "null" : pos.toShortString();
     }
 
     /**

--- a/src/main/java/com/minecolonies/core/entity/ai/workers/AbstractEntityAIStructure.java
+++ b/src/main/java/com/minecolonies/core/entity/ai/workers/AbstractEntityAIStructure.java
@@ -33,6 +33,8 @@ import com.minecolonies.core.entity.ai.workers.util.BuildingProgressStage;
 import com.minecolonies.core.entity.ai.workers.util.BuildingStructureHandler;
 import com.minecolonies.core.tileentities.TileEntityDecorationController;
 import net.minecraft.core.BlockPos;
+import net.minecraft.network.chat.Component;
+import net.minecraft.network.chat.MutableComponent;
 import net.minecraft.sounds.SoundEvents;
 import net.minecraft.tags.BlockTags;
 import net.minecraft.world.InteractionHand;
@@ -187,6 +189,28 @@ public abstract class AbstractEntityAIStructure<J extends AbstractJobStructure<?
           new AITarget(COMPLETE_BUILD, this::completeBuild, STANDARD_DELAY),
           new AITarget(PICK_UP, this::pickUpMaterial, 5)
         );
+    }
+
+    @Override
+    public Component getDebugInfo()
+    {
+        final MutableComponent info = Component.empty().append(super.getDebugInfo());
+        info.append(Component.literal("Structure debug:\n"));
+        info.append(Component.literal("limitReached=" + limitReached + "\n"));
+        info.append(Component.literal("workFrom=" + formatDebugPos(workFrom) + "\n"));
+        info.append(Component.literal("prevBlockPosition=" + formatDebugPos(prevBlockPosition) + "\n"));
+        info.append(Component.literal("blockToMine=" + formatDebugPos(blockToMine) + "\n"));
+        info.append(Component.literal("gotoPos=" + formatDebugPos(gotoPos) + "\n"));
+        info.append(Component.literal("currentBuildingPosition=" + formatDebugPos(getCurrentBuildingPosition()) + "\n"));
+        if (structurePlacer != null && structurePlacer.getB() != null)
+        {
+            info.append(Component.literal("stage=" + String.valueOf(structurePlacer.getB().getStage()) + "\n"));
+        }
+
+        final Tuple<BlockPos, BuildingProgressStage> progress = getProgressPos();
+        info.append(Component.literal("progressPos=" + (progress == null ? "null" : formatDebugPos(progress.getA())) + "\n"));
+        info.append(Component.literal("progressStage=" + (progress == null ? "null" : String.valueOf(progress.getB())) + "\n"));
+        return info;
     }
 
     /**

--- a/src/main/java/com/minecolonies/core/entity/ai/workers/builder/EntityAIStructureBuilder.java
+++ b/src/main/java/com/minecolonies/core/entity/ai/workers/builder/EntityAIStructureBuilder.java
@@ -7,9 +7,11 @@ import com.minecolonies.api.colony.workorders.IWorkOrder;
 import com.minecolonies.api.colony.workorders.WorkOrderType;
 import com.minecolonies.api.entity.ai.statemachine.states.IAIState;
 import com.minecolonies.api.util.BlockPosUtil;
+import com.minecolonies.api.util.Log;
 import com.minecolonies.api.util.MessageUtils;
 import com.minecolonies.api.util.Tuple;
 import com.minecolonies.api.util.WorldUtil;
+import com.minecolonies.core.MineColonies;
 import com.minecolonies.core.colony.buildings.modules.settings.BuilderModeSetting;
 import com.minecolonies.core.colony.buildings.workerbuildings.BuildingBuilder;
 import com.minecolonies.core.colony.jobs.JobBuilder;
@@ -17,20 +19,26 @@ import com.minecolonies.core.colony.workorders.WorkOrderBuilding;
 import com.minecolonies.core.entity.ai.workers.AbstractEntityAIStructureWithWorkOrder;
 import com.minecolonies.core.entity.ai.workers.util.BuildingProgressStage;
 import com.minecolonies.core.entity.ai.workers.util.BuildingStructureHandler;
+import com.minecolonies.core.entity.pathfinding.PathfindingUtils;
+import com.minecolonies.core.entity.pathfinding.navigation.EntityNavigationUtils;
 import com.minecolonies.core.entity.pathfinding.navigation.MinecoloniesAdvancedPathNavigate;
 import com.minecolonies.core.entity.pathfinding.pathjobs.PathJobMoveCloseToXNearY;
 import com.minecolonies.core.entity.pathfinding.pathresults.PathResult;
 import net.minecraft.ChatFormatting;
 import net.minecraft.core.BlockPos;
+import net.minecraft.core.Direction;
 import net.minecraft.network.chat.Component;
 import net.minecraft.network.chat.HoverEvent;
 import net.minecraft.network.chat.MutableComponent;
 import net.minecraft.world.entity.Entity;
 import net.minecraft.world.entity.monster.Monster;
 import net.minecraft.world.level.block.Block;
+import net.minecraft.world.level.block.FallingBlock;
 import net.minecraft.world.level.block.state.BlockState;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
+import static com.minecolonies.api.util.constant.CitizenConstants.INITIAL_RUN_SPEED_AVOID;
 import static com.minecolonies.api.entity.ai.statemachine.states.AIWorkerState.*;
 import static com.minecolonies.api.util.constant.TranslationConstants.COM_MINECOLONIES_COREMOD_ENTITY_BUILDER_MANUAL_SUFFIX;
 
@@ -55,9 +63,129 @@ public class EntityAIStructureBuilder extends AbstractEntityAIStructureWithWorkO
     private static final int LEVEL_TO_PURGE_MOBS = 4;
 
     /**
+     * Tick interval for regular lava checks near the active work site.
+     */
+    private static final int LAVA_CHECK_INTERVAL = 15;
+
+    /**
+     * Faster re-check interval shortly after a lava hit was detected.
+     */
+    private static final int LAVA_CHECK_INTERVAL_WHEN_THREATENED = 5;
+
+    /**
+     * Window in which the builder stays on the faster lava re-check interval.
+     */
+    private static final int LAVA_CHECK_RECENT_THREAT_WINDOW = 40;
+
+    /**
+     * Short retry delay after completing a lava retreat.
+     */
+    private static final int LAVA_RETRY_DELAY = 15;
+
+    /**
+     * Longer retry delay once the same lava hazard keeps blocking the same work target.
+     */
+    private static final int LAVA_PERSISTENT_RETRY_DELAY = 100;
+
+    /**
+     * Amount of repeated detections before treating the hazard as persistent.
+     */
+    private static final int LAVA_PERSISTENT_THREAT_THRESHOLD = 3;
+
+    /**
+     * Window in which repeated detections count towards the persistent hazard threshold.
+     */
+    private static final int LAVA_PERSISTENT_THREAT_WINDOW = 80;
+
+    /**
+     * Minimum distance to open from a lava hazard before continuing work.
+     */
+    private static final int LAVA_RETREAT_DISTANCE = 4;
+
+    /**
+     * Only check for lava when already near the current work target.
+     */
+    private static final int LAVA_CHECK_ACTIVATION_DISTANCE = 12;
+
+    /**
+     * Keep using stands clearly outside the most recently blocked lava hazard zone for the same work target.
+     */
+    private static final int LAVA_BLOCKED_STAND_DISTANCE = 6;
+
+    /**
+     * Search slightly beyond the retreat radius when looking for an alternative safe stand.
+     */
+    private static final int LAVA_SAFE_STAND_SEARCH_RADIUS = 6;
+
+    /**
+     * Maximum safe fall height after breaking the block currently supporting the builder.
+     */
+    private static final int MAX_SAFE_MINING_FALL_DISTANCE = 2;
+
+    /**
+     * Short retry delay after choosing a different stand for a mining action.
+     */
+    private static final int MINING_STAND_RETRY_DELAY = 5;
+
+    /**
      * Current goto path
      */
     PathResult gotoPath = null;
+
+    /**
+     * Active worksite hazard the builder is currently retreating from.
+     */
+    @Nullable
+    private BlockPos activeHazardRetreatPos = null;
+
+    /**
+     * Last tick on which the builder performed a lava check.
+     */
+    private long lastLavaCheckTick = -LAVA_CHECK_INTERVAL;
+
+    /**
+     * Last tick on which the builder detected a lava threat.
+     */
+    private long lastLavaThreatTick = -LAVA_CHECK_RECENT_THREAT_WINDOW;
+
+    /**
+     * Last work position used for throttling lava checks.
+     */
+    @Nullable
+    private BlockPos lastLavaCheckTarget = null;
+
+    /**
+     * Last worker position used for throttling lava checks.
+     */
+    @Nullable
+    private BlockPos lastLavaCheckStandPos = null;
+
+    /**
+     * Last lava hazard position used for repeat detection.
+     */
+    @Nullable
+    private BlockPos lastHazardPos = null;
+
+    /**
+     * Last work target blocked by the current lava hazard.
+     */
+    @Nullable
+    private BlockPos lastHazardTarget = null;
+
+    /**
+     * Last tick on which the same lava hazard was recorded.
+     */
+    private long lastHazardTick = Long.MIN_VALUE;
+
+    /**
+     * Repeated detections for the same hazard/target pair.
+     */
+    private int repeatedHazardDetections = 0;
+
+    /**
+     * Tick until which retrying the same blocked work target should be delayed.
+     */
+    private long hazardRetryBlockedUntilTick = Long.MIN_VALUE;
 
     /**
      * Initialize the builder and add all his tasks.
@@ -68,6 +196,538 @@ public class EntityAIStructureBuilder extends AbstractEntityAIStructureWithWorkO
     {
         super(job);
         worker.setCanPickUpLoot(true);
+    }
+
+    /**
+     * Reset builder-local lava hazard bookkeeping.
+     */
+    private void resetLavaHazardState()
+    {
+        activeHazardRetreatPos = null;
+        lastLavaCheckTick = -LAVA_CHECK_INTERVAL;
+        lastLavaThreatTick = -LAVA_CHECK_RECENT_THREAT_WINDOW;
+        lastLavaCheckTarget = null;
+        lastLavaCheckStandPos = null;
+        lastHazardPos = null;
+        lastHazardTarget = null;
+        lastHazardTick = Long.MIN_VALUE;
+        repeatedHazardDetections = 0;
+        hazardRetryBlockedUntilTick = Long.MIN_VALUE;
+    }
+
+    /**
+     * Cancel the cached goto path if one is still active.
+     */
+    private void cancelPendingGotoPath()
+    {
+        if (gotoPath != null)
+        {
+            gotoPath.cancel();
+            gotoPath = null;
+        }
+    }
+
+    /**
+     * True when pathfinding debug output is enabled for the current world.
+     */
+    private boolean isPathfindingDebugEnabled()
+    {
+        return MineColonies.getConfig().getServer().pathfindingDebugVerbosity.get() > 0;
+    }
+
+    /**
+     * Emit a compact builder-specific debug line while pathfinding debug is enabled.
+     */
+    private void logHazardDebug(@NotNull final String message)
+    {
+        if (isPathfindingDebugEnabled())
+        {
+            Log.getLogger().info("Builder {} ({}): {}", worker.getCitizenData().getName(), worker.getCitizenData().getId(), message);
+        }
+    }
+
+    @Override
+    public Component getDebugInfo()
+    {
+        final MutableComponent info = Component.empty().append(super.getDebugInfo());
+        info.append(Component.literal("Builder debug:\n"));
+        if (building.getWorkOrder() != null)
+        {
+            info.append(Component.literal("workOrderType=" + building.getWorkOrder().getWorkOrderType() + "\n"));
+            info.append(Component.literal("workOrderLocation=" + formatDebugPos(building.getWorkOrder().getLocation()) + "\n"));
+        }
+        info.append(Component.literal("gotoPath=" + getGotoPathState() + "\n"));
+        info.append(Component.literal("activeHazardRetreatPos=" + formatDebugPos(activeHazardRetreatPos) + "\n"));
+        info.append(Component.literal("lastLavaCheckTarget=" + formatDebugPos(lastLavaCheckTarget) + "\n"));
+        info.append(Component.literal("lastLavaCheckStandPos=" + formatDebugPos(lastLavaCheckStandPos) + "\n"));
+        info.append(Component.literal("lastLavaThreatTick=" + lastLavaThreatTick + "\n"));
+        info.append(Component.literal("lastHazardPos=" + formatDebugPos(lastHazardPos) + "\n"));
+        info.append(Component.literal("lastHazardTarget=" + formatDebugPos(lastHazardTarget) + "\n"));
+        info.append(Component.literal("repeatedHazardDetections=" + repeatedHazardDetections + "\n"));
+        info.append(Component.literal("hazardRetryBlockedUntilTick=" + hazardRetryBlockedUntilTick + "\n"));
+        return info;
+    }
+
+    /**
+     * Compact debug label for the cached goto path.
+     */
+    private String getGotoPathState()
+    {
+        if (gotoPath == null)
+        {
+            return "null";
+        }
+
+        if (gotoPath.isCancelled())
+        {
+            return "cancelled";
+        }
+
+        if (gotoPath.isDone())
+        {
+            return gotoPath.getPath() == null ? "done-no-path" : "done-with-path";
+        }
+
+        return "running";
+    }
+
+    @Override
+    public void resetCurrentStructure()
+    {
+        super.resetCurrentStructure();
+        cancelPendingGotoPath();
+        resetLavaHazardState();
+    }
+
+    /**
+     * Continue an already triggered retreat from a nearby worksite hazard.
+     *
+     * @return true while the builder is still handling the retreat.
+     */
+    private boolean handleActiveHazardRetreat()
+    {
+        if (activeHazardRetreatPos == null)
+        {
+            return false;
+        }
+
+        if (BlockPosUtil.getDistance2D(worker.blockPosition(), activeHazardRetreatPos) >= LAVA_RETREAT_DISTANCE)
+        {
+            logHazardDebug("lava retreat completed at " + formatDebugPos(worker.blockPosition()) + ", hazard=" + formatDebugPos(activeHazardRetreatPos));
+            activeHazardRetreatPos = null;
+            worker.getNavigation().stop();
+            setDelay(getHazardRetryDelay());
+            return true;
+        }
+
+        if (!EntityNavigationUtils.walkAwayFrom(worker, activeHazardRetreatPos, LAVA_RETREAT_DISTANCE, INITIAL_RUN_SPEED_AVOID, true))
+        {
+            return true;
+        }
+
+        logHazardDebug("lava retreat path finished at " + formatDebugPos(worker.blockPosition()) + ", hazard=" + formatDebugPos(activeHazardRetreatPos));
+        activeHazardRetreatPos = null;
+        setDelay(getHazardRetryDelay());
+        return true;
+    }
+
+    /**
+     * Get the currently applicable retry delay after a lava retreat.
+     */
+    private int getHazardRetryDelay()
+    {
+        final long remainingTicks = hazardRetryBlockedUntilTick - world.getGameTime();
+        return remainingTicks > 0 ? (int) Math.min(Integer.MAX_VALUE, remainingTicks) : LAVA_RETRY_DELAY;
+    }
+
+    /**
+     * Delay retriggering the same blocked work target while the lava hazard is still considered persistent.
+     */
+    private boolean isHazardRetryBlocked(@NotNull final BlockPos currentBlock)
+    {
+        if (lastHazardTarget == null || !currentBlock.equals(lastHazardTarget))
+        {
+            return false;
+        }
+
+        final long remainingTicks = hazardRetryBlockedUntilTick - world.getGameTime();
+        if (remainingTicks <= 0)
+        {
+            return false;
+        }
+
+        cancelPendingGotoPath();
+        worker.getNavigation().stop();
+        setDelay((int) Math.min(Integer.MAX_VALUE, remainingTicks));
+        return true;
+    }
+
+    /**
+     * Record repeated lava detections for the same work target and widen the retry delay if needed.
+     */
+    private void rememberHazardRetry(@NotNull final BlockPos hazardPos, @NotNull final BlockPos currentBlock)
+    {
+        final long gameTime = world.getGameTime();
+        final boolean sameHazard = lastHazardPos != null
+            && BlockPosUtil.getDistance2D(hazardPos, lastHazardPos) <= LAVA_BLOCKED_STAND_DISTANCE
+            && currentBlock.equals(lastHazardTarget)
+            && gameTime - lastHazardTick <= LAVA_PERSISTENT_THREAT_WINDOW;
+
+        repeatedHazardDetections = sameHazard ? repeatedHazardDetections + 1 : 1;
+        lastHazardPos = hazardPos;
+        lastHazardTarget = currentBlock.immutable();
+        lastHazardTick = gameTime;
+        hazardRetryBlockedUntilTick = gameTime + (repeatedHazardDetections >= LAVA_PERSISTENT_THREAT_THRESHOLD ? LAVA_PERSISTENT_RETRY_DELAY : LAVA_RETRY_DELAY);
+
+        if (repeatedHazardDetections == LAVA_PERSISTENT_THREAT_THRESHOLD)
+        {
+            logHazardDebug("persistent lava hazard at " + formatDebugPos(lastHazardPos)
+                + ", workTarget=" + formatDebugPos(lastHazardTarget)
+                + ", backing off for " + LAVA_PERSISTENT_RETRY_DELAY + " ticks");
+        }
+    }
+
+    /**
+     * Check whether the current situation warrants a fresh lava scan.
+     */
+    private boolean shouldCheckForLava(@NotNull final BlockPos currentBlock)
+    {
+        if (workFrom == null && BlockPosUtil.getDistance2D(worker.blockPosition(), currentBlock) > LAVA_CHECK_ACTIVATION_DISTANCE)
+        {
+            return false;
+        }
+
+        final BlockPos standPos = worker.blockPosition();
+        final long gameTime = world.getGameTime();
+        final int interval = gameTime - lastLavaThreatTick <= LAVA_CHECK_RECENT_THREAT_WINDOW
+            ? LAVA_CHECK_INTERVAL_WHEN_THREATENED
+            : LAVA_CHECK_INTERVAL;
+
+        if (currentBlock.equals(lastLavaCheckTarget)
+              && standPos.equals(lastLavaCheckStandPos)
+              && gameTime - lastLavaCheckTick < interval)
+        {
+            return false;
+        }
+
+        lastLavaCheckTick = gameTime;
+        lastLavaCheckTarget = currentBlock.immutable();
+        lastLavaCheckStandPos = standPos.immutable();
+        return true;
+    }
+
+    /**
+     * Find lava that is actually dangerous to the builder's current position.
+     */
+    @Nullable
+    private BlockPos findCurrentStandLava(@NotNull final BlockPos currentBlock)
+    {
+        if (!shouldCheckForLava(currentBlock))
+        {
+            return null;
+        }
+
+        final BlockPos.MutableBlockPos cursor = new BlockPos.MutableBlockPos();
+        return findLavaNearStand(cursor, worker.blockPosition());
+    }
+
+    /**
+     * Get the builder's currently planned working stand if one is already known.
+     */
+    @Nullable
+    private BlockPos getPlannedWorkingStand()
+    {
+        if (workFrom != null)
+        {
+            return workFrom;
+        }
+
+        if (gotoPath != null && gotoPath.isDone() && gotoPath.getPath() != null)
+        {
+            return gotoPath.getPath().getTarget();
+        }
+
+        return null;
+    }
+
+    /**
+     * Determine whether a candidate stand is usable for building without stepping into a lava hazard.
+     */
+    private boolean isSafeWorkingStand(@NotNull final BlockPos currentBlock, @NotNull final BlockPos stand, final BlockPos.MutableBlockPos cursor)
+    {
+        if (BlockPosUtil.getDistance2D(stand, currentBlock) > 5)
+        {
+            return false;
+        }
+
+        if (stand.getX() == currentBlock.getX() && stand.getZ() == currentBlock.getZ() && stand.getY() >= currentBlock.getY())
+        {
+            return false;
+        }
+
+        if (isBlockedByRecentHazard(currentBlock, stand))
+        {
+            return false;
+        }
+
+        return canUseMiningStand(stand) && findLavaNearStand(cursor, stand) == null;
+    }
+
+    /**
+     * Avoid retrying stands that stay inside the last blocked lava zone for the same work target.
+     */
+    private boolean isBlockedByRecentHazard(@NotNull final BlockPos currentBlock, @NotNull final BlockPos stand)
+    {
+        return lastHazardPos != null
+                 && lastHazardTarget != null
+                 && currentBlock.equals(lastHazardTarget)
+                 && BlockPosUtil.getDistance2D(stand, lastHazardPos) <= LAVA_BLOCKED_STAND_DISTANCE;
+    }
+
+    /**
+     * Find a safe stand close to the preferred work position before the builder commits to it.
+     */
+    @Nullable
+    private BlockPos findSafeWorkingStand(@NotNull final BlockPos currentBlock, @Nullable final BlockPos preferredStand)
+    {
+        if (preferredStand == null)
+        {
+            return null;
+        }
+
+        final BlockPos.MutableBlockPos cursor = new BlockPos.MutableBlockPos();
+        final BlockPos currentStand = worker.blockPosition();
+        if (isSafeWorkingStand(currentBlock, currentStand, cursor))
+        {
+            return currentStand.immutable();
+        }
+
+        if (isSafeWorkingStand(currentBlock, preferredStand, cursor))
+        {
+            return preferredStand;
+        }
+
+        for (int radius = 1; radius <= LAVA_SAFE_STAND_SEARCH_RADIUS; radius++)
+        {
+            for (int dx = -radius; dx <= radius; dx++)
+            {
+                for (int dz = -radius; dz <= radius; dz++)
+                {
+                    if (Math.max(Math.abs(dx), Math.abs(dz)) != radius)
+                    {
+                        continue;
+                    }
+
+                    final BlockPos candidate = preferredStand.offset(dx, 0, dz);
+                    if (isSafeWorkingStand(currentBlock, candidate, cursor))
+                    {
+                        return candidate;
+                    }
+                }
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * Reject an unsafe working stand, record the blocking hazard, and optionally reroute to a nearby safe one.
+     */
+    @Nullable
+    private BlockPos resolveWorkingStand(@NotNull final BlockPos currentBlock, @Nullable final BlockPos preferredStand)
+    {
+        if (preferredStand == null)
+        {
+            return null;
+        }
+
+        final BlockPos safeStand = findSafeWorkingStand(currentBlock, preferredStand);
+        if (safeStand != null)
+        {
+            if (!safeStand.equals(preferredStand))
+            {
+                logHazardDebug("rerouted stand from " + formatDebugPos(preferredStand)
+                    + " to " + formatDebugPos(safeStand)
+                    + ", target=" + formatDebugPos(currentBlock));
+            }
+            return safeStand;
+        }
+
+        final BlockPos.MutableBlockPos cursor = new BlockPos.MutableBlockPos();
+        final BlockPos lavaPos = findLavaNearStand(cursor, preferredStand);
+        if (lavaPos != null)
+        {
+            lastLavaThreatTick = world.getGameTime();
+            rememberHazardRetry(lavaPos, currentBlock);
+            logHazardDebug("rejecting unsafe stand=" + formatDebugPos(preferredStand)
+                + ", hazard=" + formatDebugPos(lavaPos)
+                + ", target=" + formatDebugPos(currentBlock));
+        }
+
+        return null;
+    }
+
+    /**
+     * Find lava at a stand position or directly adjacent to it at the same height band.
+     */
+    @Nullable
+    private BlockPos findLavaNearStand(final BlockPos.MutableBlockPos cursor, final BlockPos stand)
+    {
+        for (int dx = -1; dx <= 1; dx++)
+        {
+            for (int dz = -1; dz <= 1; dz++)
+            {
+                BlockPos lavaPos = findLavaAtOrAbove(cursor, stand.offset(dx, 0, dz));
+                if (lavaPos != null)
+                {
+                    return lavaPos;
+                }
+
+                lavaPos = findLavaAtOrAbove(cursor, stand.offset(dx, -1, dz));
+                if (lavaPos != null)
+                {
+                    return lavaPos;
+                }
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * Find lava at the given position or directly above it.
+     */
+    @Nullable
+    private BlockPos findLavaAtOrAbove(final BlockPos.MutableBlockPos cursor, final BlockPos origin)
+    {
+        if (isLavaAt(cursor, origin.getX(), origin.getY(), origin.getZ()))
+        {
+            return cursor.immutable();
+        }
+
+        if (isLavaAt(cursor, origin.getX(), origin.getY() + 1, origin.getZ()))
+        {
+            return cursor.immutable();
+        }
+
+        return null;
+    }
+
+    /**
+     * Cheap lava check for a single block position.
+     */
+    private boolean isLavaAt(final BlockPos.MutableBlockPos cursor, final int x, final int y, final int z)
+    {
+        cursor.set(x, y, z);
+        return PathfindingUtils.isLava(world, cursor, world.getBlockState(cursor), world.getFluidState(cursor));
+    }
+
+    /**
+     * Start a retreat after detecting a nearby worksite hazard.
+     */
+    private void retreatFromHazard(@NotNull final BlockPos hazardPos, @NotNull final BlockPos currentBlock)
+    {
+        final BlockPos plannedStand = getPlannedWorkingStand();
+        activeHazardRetreatPos = new BlockPos(hazardPos.getX(), worker.blockPosition().getY(), hazardPos.getZ());
+        rememberHazardRetry(activeHazardRetreatPos, currentBlock);
+        logHazardDebug("detected dangerous lava near stand=" + formatDebugPos(plannedStand)
+            + ", retreating from " + formatDebugPos(activeHazardRetreatPos)
+            + ", target=" + formatDebugPos(currentBlock));
+        workFrom = null;
+        prevBlockPosition = null;
+        cancelPendingGotoPath();
+        worker.getNavigation().stop();
+    }
+
+    /**
+     * Determine whether a specific stand position would make mining this block unsafe.
+     */
+    private boolean isUnsafeMiningStand(@NotNull final BlockPos blockToMine, @NotNull final BlockPos standPos)
+    {
+        if (blockToMine.equals(standPos.below()) && wouldCauseUnsafeFall(blockToMine))
+        {
+            return true;
+        }
+
+        return blockToMine.equals(standPos.above()) && isFallingBlock(world.getBlockState(blockToMine.above()));
+    }
+
+    /**
+     * Try to find a nearby stand position from which the mining action is still safe.
+     */
+    @Nullable
+    private BlockPos findAlternativeMiningStand(@NotNull final BlockPos blockToMine, @NotNull final BlockPos currentStand)
+    {
+        if (!isUnsafeMiningStand(blockToMine, currentStand))
+        {
+            return null;
+        }
+
+        final BlockPos center = new BlockPos(blockToMine.getX(), currentStand.getY(), blockToMine.getZ());
+        final BlockPos.MutableBlockPos cursor = new BlockPos.MutableBlockPos();
+        for (final Direction direction : Direction.Plane.HORIZONTAL)
+        {
+            final BlockPos candidate = center.relative(direction);
+            if (canUseMiningStand(candidate)
+                  && !isUnsafeMiningStand(blockToMine, candidate)
+                  && !isBlockedByRecentHazard(blockToMine, candidate)
+                  && findLavaNearStand(cursor, candidate) == null)
+            {
+                return candidate;
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * Count whether breaking the support block below the builder would exceed the allowed fall depth.
+     */
+    private boolean wouldCauseUnsafeFall(@NotNull final BlockPos supportBlock)
+    {
+        int emptyBlocksBelow = 0;
+        final BlockPos.MutableBlockPos cursor = supportBlock.mutable().move(Direction.DOWN);
+        while (cursor.getY() >= world.getMinBuildHeight())
+        {
+            final BlockState state = world.getBlockState(cursor);
+            if (state.blocksMotion() || !state.getFluidState().isEmpty())
+            {
+                return false;
+            }
+
+            emptyBlocksBelow++;
+            if (emptyBlocksBelow > MAX_SAFE_MINING_FALL_DISTANCE)
+            {
+                return true;
+            }
+
+            cursor.move(Direction.DOWN);
+        }
+
+        return true;
+    }
+
+    /**
+     * True if the block would fall once its support is removed.
+     */
+    private boolean isFallingBlock(@NotNull final BlockState state)
+    {
+        return state.getBlock() instanceof FallingBlock;
+    }
+
+    /**
+     * Basic stand-position validation for builder mining repositioning.
+     */
+    private boolean canUseMiningStand(@NotNull final BlockPos standPos)
+    {
+        final BlockState floor = world.getBlockState(standPos.below());
+        final BlockState feet = world.getBlockState(standPos);
+        final BlockState head = world.getBlockState(standPos.above());
+        return floor.blocksMotion()
+                 && !feet.blocksMotion()
+                 && feet.getFluidState().isEmpty()
+                 && !head.blocksMotion()
+                 && head.getFluidState().isEmpty();
     }
 
     @Override
@@ -97,6 +757,8 @@ public class EntityAIStructureBuilder extends AbstractEntityAIStructureWithWorkO
     {
         if (!building.hasWorkOrder())
         {
+            cancelPendingGotoPath();
+            resetLavaHazardState();
             building.setProgressPos(null, BuildingProgressStage.CLEAR);
             worker.getCitizenData().setStatusPosition(null);
             return false;
@@ -106,6 +768,8 @@ public class EntityAIStructureBuilder extends AbstractEntityAIStructureWithWorkO
 
         if (wo == null)
         {
+            cancelPendingGotoPath();
+            resetLavaHazardState();
             building.setWorkOrder(null);
             building.setProgressPos(null, null);
             worker.getCitizenData().setStatusPosition(null);
@@ -115,6 +779,8 @@ public class EntityAIStructureBuilder extends AbstractEntityAIStructureWithWorkO
         final IBuilding building = job.getColony().getServerBuildingManager().getBuilding(wo.getLocation());
         if (building == null && wo instanceof WorkOrderBuilding && wo.getWorkOrderType() != WorkOrderType.REMOVE)
         {
+            cancelPendingGotoPath();
+            resetLavaHazardState();
             this.building.complete(worker.getCitizenData());
             return false;
         }
@@ -125,6 +791,7 @@ public class EntityAIStructureBuilder extends AbstractEntityAIStructureWithWorkO
     @Override
     public void setStructurePlacer(final BuildingStructureHandler<JobBuilder, BuildingBuilder> structure)
     {
+        resetLavaHazardState();
         if (building.getWorkOrder().getIteratorType().isEmpty())
         {
             final String mode = BuilderModeSetting.getActualValue(building);
@@ -187,9 +854,31 @@ public class EntityAIStructureBuilder extends AbstractEntityAIStructureWithWorkO
     }
 
     @Override
-    protected boolean mineBlock(@NotNull final BlockPos blockToMine, @NotNull final BlockPos safeStand)
+    protected boolean mineBlock(@NotNull final BlockPos blockToMine, @Nullable final BlockPos safeStand)
     {
-        return mineBlock(blockToMine, safeStand, true, !IColonyManager.getInstance().getCompatibilityManager().isOre(world.getBlockState(blockToMine)), null);
+        final BlockPos standPos = safeStand == null ? worker.blockPosition() : safeStand;
+        final BlockPos alternativeStand = findAlternativeMiningStand(blockToMine, standPos);
+        if (alternativeStand != null)
+        {
+            workFrom = alternativeStand;
+            prevBlockPosition = null;
+            cancelPendingGotoPath();
+            worker.getNavigation().stop();
+            setDelay(MINING_STAND_RETRY_DELAY);
+            return false;
+        }
+
+        if (isUnsafeMiningStand(blockToMine, standPos))
+        {
+            workFrom = null;
+            prevBlockPosition = null;
+            cancelPendingGotoPath();
+            worker.getNavigation().stop();
+            setDelay(MINING_STAND_RETRY_DELAY);
+            return false;
+        }
+
+        return mineBlock(blockToMine, standPos, true, !IColonyManager.getInstance().getCompatibilityManager().isOre(world.getBlockState(blockToMine)), null);
     }
 
     @Override
@@ -207,10 +896,39 @@ public class EntityAIStructureBuilder extends AbstractEntityAIStructureWithWorkO
     @Override
     public boolean walkToConstructionSite(final BlockPos currentBlock)
     {
+        if (handleActiveHazardRetreat())
+        {
+            return false;
+        }
+
+        if (isHazardRetryBlocked(currentBlock))
+        {
+            return false;
+        }
+
+        final BlockPos lavaPos = findCurrentStandLava(currentBlock);
+        if (lavaPos != null)
+        {
+            lastLavaThreatTick = world.getGameTime();
+            retreatFromHazard(lavaPos, currentBlock);
+            handleActiveHazardRetreat();
+            return false;
+        }
+
         if (workFrom != null && workFrom.getX() == currentBlock.getX() && workFrom.getZ() == currentBlock.getZ() && workFrom.getY() >= currentBlock.getY())
         {
             // Reset working position when standing ontop
             workFrom = null;
+        }
+
+        if (workFrom != null)
+        {
+            workFrom = resolveWorkingStand(currentBlock, workFrom);
+            if (workFrom == null)
+            {
+                setDelay(getHazardRetryDelay());
+                return false;
+            }
         }
 
         if (workFrom == null)
@@ -230,9 +948,14 @@ public class EntityAIStructureBuilder extends AbstractEntityAIStructureWithWorkO
             {
                 if (gotoPath.getPath() != null)
                 {
-                    workFrom = gotoPath.getPath().getTarget();
+                    workFrom = resolveWorkingStand(currentBlock, gotoPath.getPath().getTarget());
                 }
                 gotoPath = null;
+                if (workFrom == null)
+                {
+                    setDelay(getHazardRetryDelay());
+                    return false;
+                }
             }
 
             if (prevBlockPosition != null)

--- a/src/main/java/com/minecolonies/core/entity/pathfinding/PathfindingUtils.java
+++ b/src/main/java/com/minecolonies/core/entity/pathfinding/PathfindingUtils.java
@@ -354,6 +354,35 @@ public class PathfindingUtils
     }
 
     /**
+     * Check whether lava is within one block of the given position, including directly above or below.
+     * This is used as a safety buffer so pathing keeps a gap instead of only avoiding lava blocks themselves.
+     *
+     * @param world the world.
+     * @param pos   the center position of the entity space to validate.
+     * @return true when lava is at or immediately around the given position.
+     */
+    public static boolean isLavaNearby(@NotNull final BlockGetter world, @NotNull final BlockPos pos)
+    {
+        final BlockPos.MutableBlockPos cursor = new BlockPos.MutableBlockPos();
+        for (int dy = -1; dy <= 1; dy++)
+        {
+            for (int dx = -1; dx <= 1; dx++)
+            {
+                for (int dz = -1; dz <= 1; dz++)
+                {
+                    cursor.set(pos.getX() + dx, pos.getY() + dy, pos.getZ() + dz);
+                    if (isLava(world, cursor, null, null))
+                    {
+                        return true;
+                    }
+                }
+            }
+        }
+
+        return false;
+    }
+
+    /**
      * Checks if the given state is a ladder, or if pathing options allow a different type of climbable
      *
      * @param blockState
@@ -445,6 +474,7 @@ public class PathfindingUtils
         final Block block = blockState.getBlock();
 
         return blockState.is(ModTags.dangerousBlocks) ||
+            block == Blocks.LAVA ||
             block instanceof FireBlock ||
             block instanceof CampfireBlock ||
             block instanceof MagmaBlock ||

--- a/src/main/java/com/minecolonies/core/entity/pathfinding/SurfaceType.java
+++ b/src/main/java/com/minecolonies/core/entity/pathfinding/SurfaceType.java
@@ -93,6 +93,11 @@ public enum SurfaceType
             return SurfaceType.NOT_PASSABLE;
         }
 
+        if ((pathingOptions == null || !pathingOptions.canPassDanger()) && PathfindingUtils.isLavaNearby(world, pos.above()))
+        {
+            return SurfaceType.NOT_PASSABLE;
+        }
+
         if ((block instanceof PanelBlock || block instanceof TrapdoorBlock) && !blockState.getValue(TrapdoorBlock.OPEN))
         {
             return SurfaceType.WALKABLE;

--- a/src/main/java/com/minecolonies/core/entity/pathfinding/navigation/EntityNavigationUtils.java
+++ b/src/main/java/com/minecolonies/core/entity/pathfinding/navigation/EntityNavigationUtils.java
@@ -190,6 +190,22 @@ public class EntityNavigationUtils
      */
     public static boolean walkAwayFrom(final AbstractFastMinecoloniesEntity entity, final BlockPos avoid, final int distance, final double speed)
     {
+        return walkAwayFrom(entity, avoid, distance, speed, false);
+    }
+
+    /**
+     * Walks away from a given position.
+     *
+     * @param safeDestination whether the resulting retreat target must be path-safe.
+     * @return true when arrived.
+     */
+    public static boolean walkAwayFrom(
+        final AbstractFastMinecoloniesEntity entity,
+        final BlockPos avoid,
+        final int distance,
+        final double speed,
+        final boolean safeDestination)
+    {
         final MinecoloniesAdvancedPathNavigate nav = ((MinecoloniesAdvancedPathNavigate) entity.getNavigation());
         boolean isOnRightTask = (nav.getPathResult() != null && PathJobMoveAwayFromLocation.isJobFor(nav.getPathResult().getJob(), distance, avoid));
 
@@ -205,7 +221,7 @@ public class EntityNavigationUtils
                 }
             }
 
-            nav.walkAwayFrom(avoid, distance, speed, false);
+            nav.walkAwayFrom(avoid, distance, speed, safeDestination);
         }
 
         return false;

--- a/src/main/java/com/minecolonies/core/entity/pathfinding/pathjobs/AbstractPathJob.java
+++ b/src/main/java/com/minecolonies/core/entity/pathfinding/pathjobs/AbstractPathJob.java
@@ -1343,6 +1343,11 @@ public abstract class AbstractPathJob implements Callable<Path>, IPathJob
             return false;
         }
 
+        if (!pathingOptions.canPassDanger() && PathfindingUtils.isLavaNearby(world, tempWorldPos.set(x, y, z)))
+        {
+            return false;
+        }
+
         if (!block.isAir())
         {
             final VoxelShape shape = block.getCollisionShape(world, tempWorldPos.set(x, y, z));
@@ -1422,8 +1427,9 @@ public abstract class AbstractPathJob implements Callable<Path>, IPathJob
                     return true;
                 }
 
-                if (ShapeUtil.isEmpty(shape) || ShapeUtil.max(shape, Direction.Axis.Y) <= 0.1
-                    && !PathfindingUtils.isLiquid((block)) && (block.getBlock() != Blocks.SNOW || block.getValue(SnowLayerBlock.LAYERS) == 1))
+                if ((ShapeUtil.isEmpty(shape) || ShapeUtil.max(shape, Direction.Axis.Y) <= 0.1)
+                    && !PathfindingUtils.isLiquid(block)
+                    && (block.getBlock() != Blocks.SNOW || block.getValue(SnowLayerBlock.LAYERS) == 1))
                 {
                     final PathType pathType = block.getBlockPathType(world, tempWorldPos.set(x, y, z), entity);
                     if (pathType == null || pathType.getMalus() < 0)
@@ -1451,12 +1457,29 @@ public abstract class AbstractPathJob implements Callable<Path>, IPathJob
     protected boolean isPassable(final int x, final int y, final int z, final boolean head, final MNode parent)
     {
         final BlockState state = cachedBlockLookup.getBlockState(x, y, z);
+        if (!pathingOptions.canPassDanger() && PathfindingUtils.isLavaNearby(world, tempWorldPos.set(x, y, z)))
+        {
+            return false;
+        }
+
         final VoxelShape shape = state.getCollisionShape(world, tempWorldPos.set(x, y, z));
         if (ShapeUtil.isEmpty(shape) || ShapeUtil.max(shape, Direction.Axis.Y) <= 0.1)
         {
-            return !head
-                     || !(state.getBlock() instanceof WoolCarpetBlock || state.getBlock() instanceof FloatingCarpetBlock || state.getBlock() instanceof WaterlilyBlock)
-                     || PathfindingUtils.isLadder(state, pathingOptions);
+            if (head
+                  && (state.getBlock() instanceof WoolCarpetBlock
+                      || state.getBlock() instanceof FloatingCarpetBlock
+                      || state.getBlock() instanceof WaterlilyBlock)
+                  && !PathfindingUtils.isLadder(state, pathingOptions))
+            {
+                return false;
+            }
+
+            if (!state.isAir())
+            {
+                return isPassable(state, x, y, z, parent, head);
+            }
+
+            return true;
         }
         return isPassable(state, x, y, z, parent, head);
     }


### PR DESCRIPTION
## Summary
This PR ports and stabilizes our builder and pathing lava-safety changes for the 1.21 branch.

## Changes
- add worker and structure AI debug output for in-game inspection
- improve builder retreat and safe-stand handling around lava hazards
- avoid repeated retries on the same blocked hazardous target
- fix central pathfinding so flowing lava is treated as unsafe
- add a one-block lava safety margin in central pathfinding

## Validation
- 1.21 build passes
- 1.21 test task passes
- in-game behavior verified around flowing lava and builder work positions

## Review note
The main intended behavior change is stricter rejection of paths directly adjacent to lava.