### PR TITLE
Fix view clearing field ownership

### DIFF
--- a/src/main/java/com/minecolonies/core/colony/buildingextensions/AbstractBuildingExtension.java
+++ b/src/main/java/com/minecolonies/core/colony/buildingextensions/AbstractBuildingExtension.java
@@ -146,6 +146,10 @@ public abstract class AbstractBuildingExtension implements IBuildingExtension
         {
             buildingId = BlockPosUtil.read(compound, TAG_OWNER);
         }
+        else
+        {
+            buildingId = null;
+        }
     }
 
     @Override
@@ -164,6 +168,10 @@ public abstract class AbstractBuildingExtension implements IBuildingExtension
         if (buf.readBoolean())
         {
             buildingId = buf.readBlockPos();
+        }
+        else
+        {
+            buildingId = null;
         }
     }
 


### PR DESCRIPTION
Closes None

# Changes proposed in this pull request
- Clear ownership on extension view deserialization when cleared on server.

It was possible for the Farmer field list to not be up to date when the server cleared ownership with FarmerFieldsModule.freeExtension().

Review please
