### PR TITLE
Include food ingredients in audit

### DIFF
--- a/src/main/java/com/minecolonies/core/compatibility/CraftingTagAuditor.java
+++ b/src/main/java/com/minecolonies/core/compatibility/CraftingTagAuditor.java
@@ -445,7 +445,7 @@ public class CraftingTagAuditor
                                     @NotNull final MinecraftServer server) throws IOException
     {
         writeItemHeaders(writer);
-        writer.write(",nutrition,maxlevel,tier,foodvalue,fullhealth,ingredients");
+        writer.write(",nutrition,maxlevel,tier,foodvalue,fullhealth,tags,output,ingredients");
         writer.newLine();
 
         for (final ItemStack item : getAllItems())
@@ -470,6 +470,14 @@ public class CraftingTagAuditor
             writer.write(Double.toString(FoodUtils.getFoodValue(item, properties, 0)));
             writer.write(',');
             writer.write(Double.toString(FULL_SATURATION / FoodUtils.getFoodValue(item, properties, 0)));
+            writer.write(',');
+            writer.write('"' + item.getTags()
+                .map(t -> t.location().toString())
+                .sorted()
+                .collect(Collectors.joining(",")) + '"');
+            writer.write(',');
+            writer.write(Integer.toString(cachedFoodRecipes.getOrDefault(new ItemStorage(item), List.of())
+                    .stream().mapToInt(r -> r.getPrimaryOutput().getCount()).max().orElse(0)));
             writer.write(',');
             writer.write('"' + cachedFoodRecipes.getOrDefault(new ItemStorage(item), List.of())
                 .stream().map(r -> r.getInputs().stream()

--- a/src/main/java/com/minecolonies/core/compatibility/CraftingTagAuditor.java
+++ b/src/main/java/com/minecolonies/core/compatibility/CraftingTagAuditor.java
@@ -43,6 +43,7 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.*;
+import java.util.stream.Collectors;
 
 import static com.minecolonies.api.util.constant.CitizenConstants.FULL_SATURATION;
 import static com.minecolonies.api.util.constant.Constants.MOD_ID;
@@ -58,6 +59,8 @@ import static com.minecolonies.api.util.constant.Constants.MOD_ID;
  */
 public class CraftingTagAuditor
 {
+    private static Map<ItemStorage, List<IGenericRecipe>> cachedFoodRecipes = new HashMap<>();
+
     /**
      * Run the auditor to generate the output file.
      * @param server the current Minecraft server
@@ -320,6 +323,7 @@ public class CraftingTagAuditor
         }
         writer.newLine();
 
+        cachedFoodRecipes.clear();
         for (final ItemStack item : getAllItems())
         {
             writeItemData(writer, item);
@@ -337,6 +341,16 @@ public class CraftingTagAuditor
                 writeCrafterValue(writer, crafterMap, herder);
             }
             writer.newLine();
+
+            if (ItemStackUtils.ISFOOD.test(item))
+            {
+                cachedFoodRecipes.put(new ItemStorage(item), crafterMap.values().stream()
+                    .flatMap(List::stream)
+                    .filter(Objects::nonNull)
+                    .collect(Collectors.toCollection(() -> Collections.newSetFromMap(new IdentityHashMap<>())))
+                    .stream()
+                    .toList());
+            }
         }
     }
 
@@ -431,7 +445,7 @@ public class CraftingTagAuditor
                                     @NotNull final MinecraftServer server) throws IOException
     {
         writeItemHeaders(writer);
-        writer.write(",nutrition,maxlevel,tier,foodvalue,fullhealth");
+        writer.write(",nutrition,maxlevel,tier,foodvalue,fullhealth,ingredients");
         writer.newLine();
 
         for (final ItemStack item : getAllItems())
@@ -456,6 +470,14 @@ public class CraftingTagAuditor
             writer.write(Double.toString(FoodUtils.getFoodValue(item, properties, 0)));
             writer.write(',');
             writer.write(Double.toString(FULL_SATURATION / FoodUtils.getFoodValue(item, properties, 0)));
+            writer.write(',');
+            writer.write('"' + cachedFoodRecipes.getOrDefault(new ItemStorage(item), List.of())
+                .stream().map(r -> r.getInputs().stream()
+                    .map(List::getFirst)
+                    .sorted(Comparator.comparingInt(ItemStack::getCount).reversed())
+                    .map(s -> s.getCount() + "x " + s.getDisplayName().getString())
+                    .collect(Collectors.joining(",")))
+                .collect(Collectors.joining(" OR ")) + '"');
             writer.newLine();
         }
     }


### PR DESCRIPTION
# Checklist
- [x] I have read and accept the Contributing Guidelines
<!--
When using AI we require you to confirm the points in this readme.
Please state in which parts of the code AI was used.
-->
- [ ] I have used AI in the creation of this pull request

# Related issues
Closes [discord request](https://discord.com/channels/139070364159311872/400699000237326338/1508053368457789561)

# Changes proposed in this pull request
- Adds ingredient list to food audit

Review please (could backport)

[Spreadsheet](<https://docs.google.com/spreadsheets/d/1qCcc1Sy-PjxXcQjXkYXm73JtMIoOee5QNxHO0yfLpf4/edit?gid=1343555397#gid=1343555397>)
Reminder: nutrition is how many half-shanks it gives a player; foodvalue is how many half-shanks it gives a citizen (without research), and fullhealth is how many items must be eaten at foodvalue to go from 0 to full citizen saturation.

Some alternative ingredients are listed but some are not, depending on how the recipes are defined.  This is indicative only.