### PR TITLE
Allow an option to light up a scarecrow with a lantern

### DIFF
--- a/src/main/java/com/minecolonies/core/blocks/BlockScarecrow.java
+++ b/src/main/java/com/minecolonies/core/blocks/BlockScarecrow.java
@@ -5,6 +5,7 @@ import com.minecolonies.api.blocks.interfaces.IBuildingBrowsableBlock;
 import com.minecolonies.api.colony.IColony;
 import com.minecolonies.api.colony.IColonyManager;
 import com.minecolonies.api.colony.buildingextensions.registry.BuildingExtensionRegistries;
+import com.minecolonies.api.util.InventoryUtils;
 import com.minecolonies.api.util.constant.Constants;
 import com.minecolonies.core.client.gui.containers.WindowField;
 import com.minecolonies.core.colony.buildingextensions.FarmField;
@@ -12,11 +13,13 @@ import com.minecolonies.core.tileentities.TileEntityScarecrow;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
 import net.minecraft.resources.ResourceLocation;
+import net.minecraft.sounds.SoundSource;
 import net.minecraft.world.InteractionHand;
 import net.minecraft.world.InteractionResult;
 import net.minecraft.world.entity.LivingEntity;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.Items;
 import net.minecraft.world.item.context.BlockPlaceContext;
 import net.minecraft.world.level.BlockGetter;
 import net.minecraft.world.level.Explosion;
@@ -27,15 +30,20 @@ import net.minecraft.world.level.block.entity.BlockEntity;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.block.state.StateDefinition;
 import net.minecraft.world.level.block.state.properties.BlockStateProperties;
+import net.minecraft.world.level.block.state.properties.BooleanProperty;
 import net.minecraft.world.level.block.state.properties.DoubleBlockHalf;
 import net.minecraft.world.level.block.state.properties.EnumProperty;
 import net.minecraft.world.level.material.MapColor;
+import net.minecraft.world.level.storage.loot.LootParams;
 import net.minecraft.world.phys.BlockHitResult;
 import net.minecraft.world.phys.shapes.CollisionContext;
 import net.minecraft.world.phys.shapes.Shapes;
 import net.minecraft.world.phys.shapes.VoxelShape;
+import net.minecraftforge.items.wrapper.InvWrapper;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
+
+import java.util.List;
 
 /**
  * The net.minecraft.core.Directions, placement and activation.
@@ -45,19 +53,27 @@ public class BlockScarecrow extends AbstractBlockMinecoloniesDefault<BlockScarec
 {
     public static final EnumProperty<DoubleBlockHalf> HALF = BlockStateProperties.DOUBLE_BLOCK_HALF;
 
+    public static final BooleanProperty LANTERN = BooleanProperty.create("lantern");
+
     /**
      * Constructor called on block placement.
      */
     public BlockScarecrow()
     {
         super(Properties.of().mapColor(MapColor.WOOD).sound(SoundType.WOOD).strength(HARDNESS, RESISTANCE));
-        this.registerDefaultState(this.defaultBlockState().setValue(FACING, Direction.NORTH).setValue(HALF, DoubleBlockHalf.LOWER));
+        this.registerDefaultState(this.defaultBlockState().setValue(FACING, Direction.NORTH).setValue(HALF, DoubleBlockHalf.LOWER).setValue(LANTERN, false));
     }
 
     @Override
     public ResourceLocation getRegistryName()
     {
         return new ResourceLocation(Constants.MOD_ID, REGISTRY_NAME);
+    }
+
+    @Override
+    public int getLightEmission(final BlockState state, final BlockGetter level, final BlockPos pos)
+    {
+        return state.getValue(LANTERN) ? Blocks.LANTERN.defaultBlockState().getLightEmission(level, pos) : 0;
     }
 
     @Nullable
@@ -72,14 +88,16 @@ public class BlockScarecrow extends AbstractBlockMinecoloniesDefault<BlockScarec
     }
 
     @Override
-    public InteractionResult use(
-      final BlockState state,
-      final Level worldIn,
-      final BlockPos pos,
-      final Player player,
-      final InteractionHand hand,
-      final BlockHitResult ray)
+    public InteractionResult use(final BlockState state, final Level worldIn, final BlockPos pos, final Player player, final InteractionHand hand, final BlockHitResult ray)
     {
+        if (player.getItemInHand(hand).is(Items.LANTERN) && !state.getValue(LANTERN))
+        {
+            worldIn.setBlock(pos, state.setValue(LANTERN, true), 3);
+            worldIn.playSound(player, pos, Blocks.LANTERN.getSoundType(Blocks.LANTERN.defaultBlockState()).getPlaceSound(), SoundSource.BLOCKS, 1.0f, 1.0f);
+            InventoryUtils.reduceStackInItemHandler(new InvWrapper(player.getInventory()), player.getItemInHand(hand));
+            return InteractionResult.CONSUME;
+        }
+
         // If the world is client, open the inventory of the field.
         if (worldIn.isClientSide)
         {
@@ -146,6 +164,34 @@ public class BlockScarecrow extends AbstractBlockMinecoloniesDefault<BlockScarec
     }
 
     @Override
+    public void neighborChanged(final BlockState state, final Level worldIn, final BlockPos pos, final Block block, final BlockPos fromPos, final boolean isMoving)
+    {
+        super.neighborChanged(state, worldIn, pos, block, fromPos, isMoving);
+        final DoubleBlockHalf half = state.getValue(HALF);
+        final BlockPos otherPos = half == DoubleBlockHalf.LOWER ? pos.above() : pos.below();
+        if (!fromPos.equals(otherPos))
+        {
+            return;
+        }
+        final BlockState otherState = worldIn.getBlockState(otherPos);
+        if (otherState.getBlock() == this && otherState.getValue(HALF) != half && otherState.getValue(LANTERN) != state.getValue(LANTERN))
+        {
+            worldIn.setBlock(pos, state.setValue(LANTERN, otherState.getValue(LANTERN)), UPDATE_ALL);
+        }
+    }
+
+    @Override
+    public List<ItemStack> getDrops(final BlockState state, final LootParams.Builder params)
+    {
+        final List<ItemStack> drops = super.getDrops(state, params);
+        if (state.getValue(HALF) == DoubleBlockHalf.LOWER && state.getValue(LANTERN))
+        {
+            drops.add(new ItemStack(Items.LANTERN));
+        }
+        return drops;
+    }
+
+    @Override
     public void wasExploded(final Level worldIn, final BlockPos pos, final Explosion explosionIn)
     {
         notifyColonyAboutDestruction(worldIn, pos);
@@ -207,7 +253,7 @@ public class BlockScarecrow extends AbstractBlockMinecoloniesDefault<BlockScarec
     @Override
     protected void createBlockStateDefinition(StateDefinition.Builder<Block, BlockState> builder)
     {
-        builder.add(HALF, FACING);
+        builder.add(HALF, FACING, LANTERN);
     }
 
     /**

--- a/src/main/java/com/minecolonies/core/client/render/TileEntityScarecrowRenderer.java
+++ b/src/main/java/com/minecolonies/core/client/render/TileEntityScarecrowRenderer.java
@@ -10,14 +10,20 @@ import com.minecolonies.core.event.ClientRegistryHandler;
 import com.mojang.blaze3d.vertex.PoseStack;
 import com.mojang.blaze3d.vertex.VertexConsumer;
 import com.mojang.math.Axis;
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.renderer.LightTexture;
 import net.minecraft.client.renderer.MultiBufferSource;
 import net.minecraft.client.renderer.RenderType;
-import net.minecraft.client.renderer.blockentity.BlockEntityRendererProvider;
-import net.minecraft.client.resources.model.Material;
-import net.minecraft.client.renderer.texture.TextureAtlas;
 import net.minecraft.client.renderer.blockentity.BlockEntityRenderer;
+import net.minecraft.client.renderer.blockentity.BlockEntityRendererProvider;
+import net.minecraft.client.renderer.texture.OverlayTexture;
+import net.minecraft.client.renderer.texture.TextureAtlas;
+import net.minecraft.client.resources.model.Material;
+import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
 import net.minecraft.resources.ResourceLocation;
+import net.minecraft.world.level.LightLayer;
+import net.minecraft.world.level.block.Blocks;
 import net.minecraft.world.level.block.state.properties.DoubleBlockHalf;
 import net.minecraftforge.api.distmarker.Dist;
 import net.minecraftforge.api.distmarker.OnlyIn;
@@ -129,6 +135,39 @@ public class TileEntityScarecrowRenderer implements BlockEntityRenderer<Abstract
 
         final VertexConsumer vertexConsumer = getMaterial(te).buffer(iRenderTypeBuffer, RenderType::entitySolid);
         this.model.renderToBuffer(matrixStack, vertexConsumer, lightA, lightB, 1.0F, 1.0F, 1.0F, 1.0F);
+
+        if (te.getBlockState().getValue(BlockScarecrow.LANTERN))
+        {
+            renderLantern(matrixStack, iRenderTypeBuffer, te.getBlockPos(), te.getLevel());
+        }
+
+        matrixStack.popPose();
+    }
+
+    // Pixel-to-block scale used by the model
+    private static final float PX = 1f / 16f;
+
+    private static void renderLantern(final PoseStack matrixStack, final MultiBufferSource buffer, final BlockPos pos, final net.minecraft.world.level.Level level)
+    {
+        matrixStack.pushPose();
+
+        matrixStack.mulPose(Axis.ZP.rotationDegrees(180f));
+        matrixStack.translate(0.6f, -0.6f, -0.375f);
+
+        matrixStack.scale(0.75f, 0.65f, 0.75f);
+
+        final int blockLight = level.getBrightness(LightLayer.BLOCK, pos);
+        final int skyLight = level.getBrightness(LightLayer.SKY, pos);
+
+        Minecraft.getInstance()
+            .getBlockRenderer()
+            .renderSingleBlock(
+                Blocks.LANTERN.defaultBlockState(),
+                matrixStack,
+                buffer,
+                LightTexture.pack(blockLight, skyLight),
+                OverlayTexture.NO_OVERLAY);
+
         matrixStack.popPose();
     }
 

--- a/src/main/java/com/minecolonies/core/client/render/TileEntityScarecrowRenderer.java
+++ b/src/main/java/com/minecolonies/core/client/render/TileEntityScarecrowRenderer.java
@@ -144,9 +144,6 @@ public class TileEntityScarecrowRenderer implements BlockEntityRenderer<Abstract
         matrixStack.popPose();
     }
 
-    // Pixel-to-block scale used by the model
-    private static final float PX = 1f / 16f;
-
     private static void renderLantern(final PoseStack matrixStack, final MultiBufferSource buffer, final BlockPos pos, final net.minecraft.world.level.Level level)
     {
         matrixStack.pushPose();

--- a/src/main/java/com/minecolonies/core/placementhandlers/FieldPlacementHandler.java
+++ b/src/main/java/com/minecolonies/core/placementhandlers/FieldPlacementHandler.java
@@ -9,6 +9,7 @@ import net.minecraft.core.BlockPos;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.util.Tuple;
 import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.Items;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.DoorBlock;
 import net.minecraft.world.level.block.entity.BlockEntity;
@@ -72,6 +73,10 @@ public class FieldPlacementHandler implements IPlacementHandler
         if (blockState.getValue(DoorBlock.HALF).equals(DoubleBlockHalf.LOWER))
         {
             itemList.add(BlockUtils.getItemStackFromBlockState(blockState));
+            if (blockState.getValue(BlockScarecrow.LANTERN))
+            {
+                itemList.add(new ItemStack(Items.LANTERN));
+            }
         }
 
         return itemList;


### PR DESCRIPTION
# Checklist
- [X] I have read and accept the Contributing Guidelines
- [X] I have tested and confirmed my changes are working on the most recent commit of this pull request
<!--
When using AI we require you to confirm the points in this readme.
Please state in which parts of the code AI was used.
-->
- [ ] I have used AI in the creation of this pull request

# Related issues
Closes [discord request](https://discord.com/channels/472875599422291968/1508099338650521803)

# Changes proposed in this pull request
- Blockstate property to control whether the lantern is active or not, rather than a whole container implementation
- Due to the fact this is a blockstate property schematic designers can choose to turn this option on by default
- Proper neighbouring handling like doors to make sure the prop is synced through both blocks
- Breaking the block drops the lantern out
- Lantern is visually rendered when equipped with some extra render code in the TileEntityScarecrowRenderer
- Placement handler adds extra requirement to provide a lantern if the blockstate property for lantern is true

It is not possible to remove the lantern from the field unless you break the block, because I couldn't think of a nice way to right click the lantern out considering the block already has a GUI on it.

See it in action here:
https://gyazo.com/3e3abdf1a088e4dc05a79763835fdfac

Review please
