### PR TITLE
Min Smelter Default to 0

### DIFF
--- a/src/main/java/com/minecolonies/core/colony/buildings/modules/BuildingModules.java
+++ b/src/main/java/com/minecolonies/core/colony/buildings/modules/BuildingModules.java
@@ -357,7 +357,7 @@ public class BuildingModules
     public static final BuildingEntry.ModuleProducer<BuildingSmeltery.OreBreakingModule,CraftingModuleView> SMELTER_OREBREAK      =
       new BuildingEntry.ModuleProducer<>("smelter_orebreak", () -> new BuildingSmeltery.OreBreakingModule(ModJobs.smelter.get()), () -> CraftingModuleView::new);
     public static final BuildingEntry.ModuleProducer<SettingsModule,SettingsModuleView> SMELTER_SETTINGS              =
-      new BuildingEntry.ModuleProducer<>("smelter_settings", () -> new SettingsModule().with(BuildingSmeltery.MIN, new IntSetting(16)), () -> SettingsModuleView::new);
+      new BuildingEntry.ModuleProducer<>("smelter_settings", () -> new SettingsModule().with(BuildingSmeltery.MIN, new IntSetting(0)), () -> SettingsModuleView::new);
 
     public static final BuildingEntry.ModuleProducer<CraftingWorkerBuildingModule,WorkerBuildingModuleView> STONEMASON_WORK       =
       new BuildingEntry.ModuleProducer<>("stonemason_work", () -> new CraftingWorkerBuildingModule(ModJobs.stoneMason.get(), Skill.Creativity, Skill.Dexterity, false, (b) -> 1),


### PR DESCRIPTION
# Checklist
- [X] I have read and accept the Contributing Guidelines
- [X] I have tested and confirmed my changes are working on the most recent commit of this pull request
<!--
When using AI we require you to confirm the points in this readme.
Please state in which parts of the code AI was used.
-->
- [ ] I have used AI in the creation of this pull request

# Testing
Verified existing smelter settings did not change from previous value.
Verified changing smelter settings survives a game restart.
Verified placing a new smelter defaults to 0 for this setting.

# Related issues
Closes [Discord Suggestion](https://discord.com/channels/472875599422291968/1510277924018720768/1510277924018720768)

# Changes proposed in this pull request
- Change default protected ore in warehouse from 16 to 0.

Review please
