### PR TITLE
 Porting 1.21 Item Compat API to main

### DIFF
--- a/src/main/java/com/minecolonies/api/compatibility/Compatibility.java
+++ b/src/main/java/com/minecolonies/api/compatibility/Compatibility.java
@@ -4,6 +4,7 @@ import com.minecolonies.api.compatibility.dynamictrees.DynamicTreeProxy;
 import com.minecolonies.api.compatibility.resourcefulbees.IBeehiveCompat;
 import com.minecolonies.api.compatibility.tinkers.SlimeTreeProxy;
 import com.minecolonies.api.compatibility.tinkers.TinkersToolProxy;
+import com.minecolonies.api.crafting.ItemStorage;
 import com.minecolonies.api.equipment.registry.EquipmentTypeEntry;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.NonNullList;
@@ -11,6 +12,8 @@ import net.minecraft.resources.ResourceKey;
 import net.minecraft.world.damagesource.DamageType;
 import net.minecraft.world.item.Item;
 import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.Tier;
+import net.minecraft.world.item.Tiers;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.LevelAccessor;
 import net.minecraft.world.level.block.Block;
@@ -18,7 +21,11 @@ import net.minecraft.world.level.block.state.BlockState;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
+import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
+import java.util.function.Predicate;
 
 /**
  * This class is to store the methods that call the methods to check for miscellaneous compatibility problems.
@@ -29,6 +36,131 @@ public final class Compatibility
     private Compatibility()
     {
         throw new IllegalAccessError("Utility class");
+    }
+
+    private record TierEntry(@NotNull Tier tier, int level) {}
+
+    private static final Map<ItemStorage, TierEntry> itemTierRegistry = new HashMap<>();
+    private static final List<Predicate<ItemStack>> customWeaponRecognizers = new ArrayList<>();
+
+    // Ordered by level 0–5. Level 5 maps to Netherite (the highest vanilla Tier).
+    private static final Tiers[] LEVEL_TO_TIER = {
+        Tiers.WOOD, Tiers.STONE, Tiers.IRON, Tiers.DIAMOND, Tiers.NETHERITE, Tiers.NETHERITE
+    };
+
+    private static Tiers tierForLevel(final int level)
+    {
+        return LEVEL_TO_TIER[Math.min(Math.max(level, 0), LEVEL_TO_TIER.length - 1)];
+    }
+
+    /**
+     * Register an item with an explicit Tier object and pre-computed level.
+     * Always overwrites any existing entry — intended for mod compat hooks.
+     *
+     * @param item  the item to register.
+     * @param tier  the Tier object to associate.
+     * @param level the equipment level integer.
+     */
+    public static void registerItemTier(@NotNull final Item item, @NotNull final Tier tier, final int level)
+    {
+        itemTierRegistry.put(new ItemStorage(new ItemStack(item), true, true), new TierEntry(tier, level));
+    }
+
+    /**
+     * Register an item by level only.
+     * The closest matching vanilla {@link Tiers} instance is stored so that
+     * {@link #getItemTier} never returns null for a registered item.
+     * Always overwrites any existing entry — intended for mod compat hooks.
+     *
+     * @param item  the item to register.
+     * @param level the equipment level integer.
+     */
+    public static void registerItemTier(@NotNull final Item item, final int level)
+    {
+        itemTierRegistry.put(new ItemStorage(new ItemStack(item), true, true), new TierEntry(tierForLevel(level), level));
+    }
+
+    /**
+     * Register an item with an explicit Tier and level only if not already registered.
+     * Used by auto-population so explicit mod registrations are never overwritten.
+     *
+     * @param item  the item to register.
+     * @param tier  the Tier object to associate.
+     * @param level the equipment level integer.
+     */
+    public static void registerItemTierIfAbsent(@NotNull final Item item, @NotNull final Tier tier, final int level)
+    {
+        itemTierRegistry.putIfAbsent(new ItemStorage(new ItemStack(item), true, true), new TierEntry(tier, level));
+    }
+
+    /**
+     * Register an item by level only if not already registered.
+     * The closest matching vanilla {@link Tiers} instance is stored.
+     * Used by auto-population so explicit mod registrations are never overwritten.
+     *
+     * @param item  the item to register.
+     * @param level the equipment level integer.
+     */
+    public static void registerItemTierIfAbsent(@NotNull final Item item, final int level)
+    {
+        itemTierRegistry.putIfAbsent(new ItemStorage(new ItemStack(item), true, true), new TierEntry(tierForLevel(level), level));
+    }
+
+    /**
+     * Return the Tier associated with this stack.
+     * Returns {@code null} only when the item has not been registered.
+     * Items registered without a real Tier (armor, bow, etc.) return the closest
+     * matching vanilla {@link Tiers} instance.
+     *
+     * @param stack the item stack.
+     * @return the registered Tier, or null if not registered.
+     */
+    @Nullable
+    public static Tier getItemTier(final ItemStack stack)
+    {
+        final TierEntry entry = itemTierRegistry.get(new ItemStorage(stack, true));
+        return entry != null ? entry.tier() : null;
+    }
+
+    /**
+     * Return the pre-computed equipment level for this stack, or -1 if not registered.
+     *
+     * @param stack the item stack.
+     * @return the equipment level, or -1.
+     */
+    public static int getItemLevel(final ItemStack stack)
+    {
+        final TierEntry entry = itemTierRegistry.get(new ItemStorage(stack, true));
+        return entry != null ? entry.level() : -1;
+    }
+
+    /**
+     * Register a custom weapon recognizer. The predicate should return true if the stack
+     * is a weapon that should be treated as a sword by colonists (e.g. maces, javelins).
+     *
+     * @param recognizer the predicate to register.
+     */
+    public static void registerWeaponRecognizer(final Predicate<ItemStack> recognizer)
+    {
+        customWeaponRecognizers.add(recognizer);
+    }
+
+    /**
+     * Query all registered weapon recognizers.
+     *
+     * @param stack the item stack.
+     * @return true if any recognizer claims the stack as a weapon.
+     */
+    public static boolean isCustomWeapon(final ItemStack stack)
+    {
+        for (final Predicate<ItemStack> recognizer : customWeaponRecognizers)
+        {
+            if (recognizer.test(stack))
+            {
+                return true;
+            }
+        }
+        return false;
     }
 
     public static IJeiProxy jeiProxy = new IJeiProxy() {};

--- a/src/main/java/com/minecolonies/api/equipment/ModEquipmentTypes.java
+++ b/src/main/java/com/minecolonies/api/equipment/ModEquipmentTypes.java
@@ -7,6 +7,7 @@ import com.minecolonies.api.items.ModItems;
 import com.minecolonies.api.util.ItemStackUtils;
 import com.minecolonies.api.util.constant.Constants;
 import com.minecolonies.api.util.constant.translation.ToolTranslationConstants;
+import net.minecraft.core.registries.BuiltInRegistries;
 import net.minecraft.network.chat.Component;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.entity.EquipmentSlot;
@@ -86,73 +87,64 @@ public class ModEquipmentTypes
 
         sword = register("sword",
           builder -> builder.setDisplayName(Component.translatable(ToolTranslationConstants.TOOL_TYPE_SWORD))
-                       .setIsEquipment((itemStack, equipmentType) -> canPerformDefaultActions(itemStack, ToolActions.DEFAULT_SWORD_ACTIONS) || Compatibility.isTinkersWeapon(
-                         itemStack))
-                       .setEquipmentLevel((itemStack, equipmentType) -> {
-                      if (Compatibility.isTinkersWeapon(itemStack))
-                      {
-                          return Compatibility.getToolLevel(itemStack);
-                      }
-                      else if (itemStack.getItem() instanceof final TieredItem tieredItem)
-                      {
-                          return tieredItem.getTier().getLevel();
-                      }
-                      return -1;
-                  })
+                       .setIsEquipment((itemStack, equipmentType) -> canPerformDefaultActions(itemStack, ToolActions.DEFAULT_SWORD_ACTIONS)
+                                                                     || Compatibility.isTinkersWeapon(itemStack)
+                                                                     || Compatibility.isCustomWeapon(itemStack))
+                       .setEquipmentLevel(ModEquipmentTypes::vanillaToolLevel)
                   .build());
 
         bow = register("bow",
           builder -> builder.setDisplayName(Component.translatable(ToolTranslationConstants.TOOL_TYPE_BOW))
                        .setIsEquipment((itemStack, equipmentType) -> itemStack.getItem() instanceof BowItem)
-                       .setEquipmentLevel((itemStack, equipmentType) -> durabilityBasedLevel(itemStack, Items.BOW.getMaxDamage()))
+                       .setEquipmentLevel((itemStack, equipmentType) -> Compatibility.getItemLevel(itemStack))
                   .build());
 
         fishing_rod = register("rod",
           builder -> builder.setDisplayName(Component.translatable(ToolTranslationConstants.TOOL_TYPE_FISHING_ROD))
                        .setIsEquipment((itemStack, equipmentType) -> canPerformDefaultActions(itemStack, ToolActions.DEFAULT_FISHING_ROD_ACTIONS))
-                       .setEquipmentLevel((itemStack, equipmentType) -> durabilityBasedLevel(itemStack, Items.FISHING_ROD.getMaxDamage()))
+                       .setEquipmentLevel((itemStack, equipmentType) -> Compatibility.getItemLevel(itemStack))
                   .build());
 
         shears = register("shears",
           builder -> builder.setDisplayName(Component.translatable(ToolTranslationConstants.TOOL_TYPE_SHEARS))
                        .setIsEquipment((itemStack, equipmentType) -> canPerformDefaultActions(itemStack, ToolActions.DEFAULT_SHEARS_ACTIONS))
-                       .setEquipmentLevel((itemStack, equipmentType) -> durabilityBasedLevel(itemStack, Items.SHEARS.getMaxDamage()))
+                       .setEquipmentLevel((itemStack, equipmentType) -> Compatibility.getItemLevel(itemStack))
                   .build());
 
         shield = register("shield",
           builder -> builder.setDisplayName(Component.translatable(ToolTranslationConstants.TOOL_TYPE_SHIELD))
                        .setIsEquipment((itemStack, equipmentType) -> canPerformDefaultActions(itemStack, ToolActions.DEFAULT_SHIELD_ACTIONS))
-                       .setEquipmentLevel((itemStack, equipmentType) -> durabilityBasedLevel(itemStack, Items.SHIELD.getMaxDamage()))
+                       .setEquipmentLevel((itemStack, equipmentType) -> Compatibility.getItemLevel(itemStack))
                   .build());
 
         helmet = register("helmet",
           builder -> builder.setDisplayName(Component.translatable(ToolTranslationConstants.TOOL_TYPE_HELMET))
                        .setIsEquipment((itemStack, equipmentType) -> itemStack.getItem() instanceof ArmorItem armor && EquipmentSlot.HEAD.equals(armor.getEquipmentSlot()))
-                       .setEquipmentLevel((itemStack, equipmentType) -> ItemStackUtils.getArmorLevel(itemStack))
+                       .setEquipmentLevel((itemStack, equipmentType) -> Compatibility.getItemLevel(itemStack))
                   .build());
 
         leggings = register("leggings",
           builder -> builder.setDisplayName(Component.translatable(ToolTranslationConstants.TOOL_TYPE_LEGGINGS))
                        .setIsEquipment((itemStack, equipmentType) -> itemStack.getItem() instanceof ArmorItem armor && EquipmentSlot.LEGS.equals(armor.getEquipmentSlot()))
-                       .setEquipmentLevel((itemStack, equipmentType) -> ItemStackUtils.getArmorLevel(itemStack))
+                       .setEquipmentLevel((itemStack, equipmentType) -> Compatibility.getItemLevel(itemStack))
                   .build());
 
         chestplate = register("chestplate",
           builder -> builder.setDisplayName(Component.translatable(ToolTranslationConstants.TOOL_TYPE_CHEST_PLATE))
                        .setIsEquipment((itemStack, equipmentType) -> itemStack.getItem() instanceof ArmorItem armor && EquipmentSlot.CHEST.equals(armor.getEquipmentSlot()))
-                       .setEquipmentLevel((itemStack, equipmentType) -> ItemStackUtils.getArmorLevel(itemStack))
+                       .setEquipmentLevel((itemStack, equipmentType) -> Compatibility.getItemLevel(itemStack))
                   .build());
 
         boots = register("boots",
           builder -> builder.setDisplayName(Component.translatable(ToolTranslationConstants.TOOL_TYPE_BOOTS))
                        .setIsEquipment((itemStack, equipmentType) -> itemStack.getItem() instanceof ArmorItem armor && EquipmentSlot.FEET.equals(armor.getEquipmentSlot()))
-                       .setEquipmentLevel((itemStack, equipmentType) ->ItemStackUtils.getArmorLevel(itemStack))
+                       .setEquipmentLevel((itemStack, equipmentType) -> Compatibility.getItemLevel(itemStack))
                   .build());
 
         flint_and_steel = register("flintandsteel",
           builder -> builder.setDisplayName(Component.translatable(ToolTranslationConstants.TOOL_TYPE_LIGHTER))
                        .setIsEquipment((itemStack, equipmentType) -> itemStack.getItem() instanceof FlintAndSteelItem)
-                       .setEquipmentLevel((itemStack, equipmentType) -> durabilityBasedLevel(itemStack, Items.FLINT_AND_STEEL.getMaxDamage()))
+                       .setEquipmentLevel((itemStack, equipmentType) -> Compatibility.getItemLevel(itemStack))
                   .build());
 
         lead = register("lead",
@@ -164,9 +156,8 @@ public class ModEquipmentTypes
         spear = register("spear",
           builder -> builder.setDisplayName(Component.translatable(ToolTranslationConstants.TOOL_TYPE_SPEAR))
                       .setIsEquipment((itemStack, equipmentType) -> itemStack.is(ModItems.spear))
-                      .setEquipmentLevel((itemStack, equipmentType) -> durabilityBasedLevel(itemStack, ModItems.spear.getMaxDamage()))
+                      .setEquipmentLevel((itemStack, equipmentType) -> Compatibility.getItemLevel(itemStack))
                   .build());
-
     }
 
     /**
@@ -203,15 +194,11 @@ public class ModEquipmentTypes
      */
     public static int vanillaToolLevel(final ItemStack itemStack, final EquipmentTypeEntry equipmentType)
     {
-        if (Compatibility.isTinkersTool(itemStack, equipmentType))
+        if (Compatibility.isTinkersTool(itemStack, equipmentType) || Compatibility.isTinkersWeapon(itemStack))
         {
             return Compatibility.getToolLevel(itemStack);
         }
-        else if (itemStack.getItem() instanceof final TieredItem tieredItem)  // most tools
-        {
-            return tieredItem.getTier().getLevel();
-        }
-        return -1;
+        return Compatibility.getItemLevel(itemStack);
     }
 
     /**
@@ -228,6 +215,63 @@ public class ModEquipmentTypes
         }
 
         return Math.min(itemStack.getMaxDamage() / vanillaItemDurability, 5);
+    }
+
+    /**
+     * Populate the tier registry with every item currently in the game.
+     * Called once during FMLCommonSetupEvent via MineColonies.preInit.
+     */
+    @SuppressWarnings("null")
+    public static void initRegisterEquipmentTiers()
+    {
+        final int bowRef     = new ItemStack(Items.BOW).getMaxDamage();
+        final int rodRef     = new ItemStack(Items.FISHING_ROD).getMaxDamage();
+        final int shearsRef  = new ItemStack(Items.SHEARS).getMaxDamage();
+        final int shieldRef  = new ItemStack(Items.SHIELD).getMaxDamage();
+        final int flintRef   = new ItemStack(Items.FLINT_AND_STEEL).getMaxDamage();
+        final int tridentRef = new ItemStack(Items.TRIDENT).getMaxDamage();
+
+        for (final Item item : BuiltInRegistries.ITEM)
+        {
+            final ItemStack dummy = new ItemStack(item);
+
+            if (item instanceof final TieredItem tiered)
+            {
+                Compatibility.registerItemTierIfAbsent(item, tiered.getTier(), (int) tiered.getTier().getAttackDamageBonus());
+            }
+            else if (item instanceof ArmorItem)
+            {
+                final int level = ItemStackUtils.getArmorLevel(dummy);
+                if (level > 0)
+                {
+                    Compatibility.registerItemTierIfAbsent(item, level);
+                }
+            }
+            else if (item instanceof BowItem)
+            {
+                Compatibility.registerItemTierIfAbsent(item, durabilityBasedLevel(dummy, bowRef));
+            }
+            else if (canPerformDefaultActions(dummy, ToolActions.DEFAULT_FISHING_ROD_ACTIONS))
+            {
+                Compatibility.registerItemTierIfAbsent(item, durabilityBasedLevel(dummy, rodRef));
+            }
+            else if (canPerformDefaultActions(dummy, ToolActions.DEFAULT_SHEARS_ACTIONS))
+            {
+                Compatibility.registerItemTierIfAbsent(item, durabilityBasedLevel(dummy, shearsRef));
+            }
+            else if (canPerformDefaultActions(dummy, ToolActions.DEFAULT_SHIELD_ACTIONS))
+            {
+                Compatibility.registerItemTierIfAbsent(item, durabilityBasedLevel(dummy, shieldRef));
+            }
+            else if (item instanceof FlintAndSteelItem)
+            {
+                Compatibility.registerItemTierIfAbsent(item, durabilityBasedLevel(dummy, flintRef));
+            }
+            else if (item instanceof TridentItem)
+            {
+                Compatibility.registerItemTierIfAbsent(item, durabilityBasedLevel(dummy, tridentRef));
+            }
+        }
     }
 
     /**

--- a/src/main/java/com/minecolonies/core/MineColonies.java
+++ b/src/main/java/com/minecolonies/core/MineColonies.java
@@ -199,6 +199,7 @@ public class MineColonies
 
         event.enqueueWork(ModLootConditions::init);
         event.enqueueWork(ModTags::init);
+        event.enqueueWork(ModEquipmentTypes::initRegisterEquipmentTiers);
     }
 
     @SubscribeEvent


### PR DESCRIPTION
feat(compat): porting changes from  version/1.21 to main. see #11647 for details

# Checklist
- [x] I have read and accept the Contributing Guidelines
- [x] I have tested and confirmed my changes are working on the most recent commit of this pull request
<!--
When using AI we require you to confirm the points in this readme.
Please state in which parts of the code AI was used.
-->
- [x] I have used AI in the creation of this pull request

i have used AI to summarize the differences between 1.21 and main, so that i did not have to read 777 (at the time) commits.

# Related issues
Closes #
Closes #

# Changes proposed in this pull request
-
-

Review please
