### PR TITLE
Fix Enchanter scroll quests for the 1.20.1 quest schema

### DIFF
--- a/src/main/resources/data/minecolonies/colony/quests/general/adayinthefield.json
+++ b/src/main/resources/data/minecolonies/colony/quests/general/adayinthefield.json
@@ -53,10 +53,8 @@
       "type": "minecolonies:delivery",
       "details": {
         "target": 0,
-        "item": {
-          "id": "minecolonies:scroll_tp",
-          "count": 3
-        },
+        "item": "minecolonies:scroll_tp",
+        "qty": 3,
         "next-objective": 2
       }
     },
@@ -110,28 +108,22 @@
     {
       "type": "minecolonies:item",
       "details": {
-        "item": {
-          "id": "minecolonies:scroll_area_tp",
-          "count": 1
-        }
+        "item": "minecolonies:scroll_area_tp",
+        "qty": 1
       }
     },
     {
       "type": "minecolonies:item",
       "details": {
-        "item": {
-          "id": "minecolonies:scroll_tp",
-          "count": 3
-        }
+        "item": "minecolonies:scroll_tp",
+        "qty": 3
       }
     },
     {
       "type": "minecolonies:item",
       "details": {
-        "item": {
-          "id": "minecraft:blue_orchid",
-          "count": 3
-        }
+        "item": "minecraft:blue_orchid",
+        "qty": 3
       }
     },
     {

--- a/src/main/resources/data/minecolonies/colony/quests/general/ancientmagic.json
+++ b/src/main/resources/data/minecolonies/colony/quests/general/ancientmagic.json
@@ -69,9 +69,8 @@
       "type": "minecolonies:delivery",
       "details": {
         "target": 1,
-        "item": {
-          "id": "minecolonies:scroll_buff"
-        },
+        "item": "minecolonies:scroll_buff",
+        "qty": 1,
         "next-objective": 2
       }
     },
@@ -111,43 +110,25 @@
     {
       "type": "minecolonies:item",
       "details": {
-        "item": {
-          "id": "minecraft:potion",
-          "count": 1,
-          "components": {
-            "minecraft:potion_contents": {
-              "potion": "minecraft:luck"
-            }
-          }
-        }
+        "item": "minecraft:potion",
+        "qty": 1,
+        "nbt": "{Potion:\"minecraft:luck\"}"
       }
     },
     {
       "type": "minecolonies:item",
       "details": {
-        "item": {
-          "id": "minecraft:potion",
-          "count": 1,
-          "components": {
-            "minecraft:potion_contents": {
-              "potion": "minecraft:luck"
-            }
-          }
-        }
+        "item": "minecraft:potion",
+        "qty": 1,
+        "nbt": "{Potion:\"minecraft:luck\"}"
       }
     },
     {
       "type": "minecolonies:item",
       "details": {
-        "item": {
-          "id": "minecraft:potion",
-          "count": 1,
-          "components": {
-            "minecraft:potion_contents": {
-              "potion": "minecraft:luck"
-            }
-          }
-        }
+        "item": "minecraft:potion",
+        "qty": 1,
+        "nbt": "{Potion:\"minecraft:luck\"}"
       }
     },
     {

--- a/src/main/resources/data/minecolonies/colony/quests/general/apromisetokeep.json
+++ b/src/main/resources/data/minecolonies/colony/quests/general/apromisetokeep.json
@@ -72,10 +72,8 @@
       "type": "minecolonies:delivery",
       "details": {
         "target": 0,
-        "item": {
-          "id": "minecraft:paper",
-          "count": 3
-        },
+        "item": "minecraft:paper",
+        "qty": 3,
         "next-objective": 2
       }
     },
@@ -83,10 +81,8 @@
       "type": "minecolonies:delivery",
       "details": {
         "target": 0,
-        "item": {
-          "id": "minecraft:compass",
-          "count": 1
-        },
+        "item": "minecraft:compass",
+        "qty": 1,
         "next-objective": 3
       }
     },
@@ -140,19 +136,15 @@
     {
       "type": "minecolonies:item",
       "details": {
-        "item": {
-          "id": "minecolonies:scroll_tp",
-          "count": 3
-        }
+        "item": "minecolonies:scroll_tp",
+        "qty": 3
       }
     },
     {
       "type": "minecolonies:item",
       "details": {
-        "item": {
-          "id": "minecraft:pumpkin_pie",
-          "count": 1
-        }
+        "item": "minecraft:pumpkin_pie",
+        "qty": 1
       }
     },
     {

--- a/src/main/resources/data/minecolonies/colony/quests/general/bumpinthenight.json
+++ b/src/main/resources/data/minecolonies/colony/quests/general/bumpinthenight.json
@@ -62,10 +62,8 @@
       "type": "minecolonies:delivery",
       "details": {
         "target": 0,
-        "item": {
-          "id": "minecolonies:scroll_tp",
-          "count": 1
-        },
+        "item": "minecolonies:scroll_tp",
+        "qty": 1,
         "next-objective": 2
       }
     },
@@ -73,10 +71,8 @@
       "type": "minecolonies:delivery",
       "details": {
         "target": 0,
-        "item": {
-          "id": "minecraft:lapis_lazuli",
-          "count": 5
-        },
+        "item": "minecraft:lapis_lazuli",
+        "qty": 5,
         "next-objective": 3
       }
     },
@@ -84,10 +80,8 @@
       "type": "minecolonies:delivery",
       "details": {
         "target": 0,
-        "item": {
-          "id": "minecraft:ender_pearl",
-          "count": 1
-        },
+        "item": "minecraft:ender_pearl",
+        "qty": 1,
         "next-objective": 4
       }
     },
@@ -95,10 +89,8 @@
       "type": "minecolonies:delivery",
       "details": {
         "target": 0,
-        "item": {
-          "id": "minecraft:paper",
-          "count": 1
-        },
+        "item": "minecraft:paper",
+        "qty": 1,
         "next-objective": 5
       }
     },
@@ -152,37 +144,29 @@
     {
       "type": "minecolonies:item",
       "details": {
-        "item": {
-          "id": "minecolonies:scroll_guard_help",
-          "count": 3
-        }
+        "item": "minecolonies:scroll_guard_help",
+        "qty": 3
       }
     },
     {
       "type": "minecolonies:item",
       "details": {
-        "item": {
-          "id": "minecraft:lapis_lazuli",
-          "count": 5
-        }
+        "item": "minecraft:lapis_lazuli",
+        "qty": 5
       }
     },
     {
       "type": "minecolonies:item",
       "details": {
-        "item": {
-          "id": "minecraft:ender_pearl",
-          "count": 1
-        }
+        "item": "minecraft:ender_pearl",
+        "qty": 1
       }
     },
     {
       "type": "minecolonies:item",
       "details": {
-        "item": {
-          "id": "minecraft:paper",
-          "count": 1
-        }
+        "item": "minecraft:paper",
+        "qty": 1
       }
     },
     {

--- a/src/main/resources/data/minecolonies/colony/quests/general/wheresthebuilder.json
+++ b/src/main/resources/data/minecolonies/colony/quests/general/wheresthebuilder.json
@@ -72,10 +72,8 @@
       "type": "minecolonies:delivery",
       "details": {
         "target": 0,
-        "item": {
-          "id": "minecolonies:scroll_tp",
-          "count": 3
-        },
+        "item": "minecolonies:scroll_tp",
+        "qty": 3,
         "next-objective": 2
       }
     },
@@ -83,10 +81,8 @@
       "type": "minecolonies:delivery",
       "details": {
         "target": 0,
-        "item": {
-          "id": "minecraft:glowstone_dust",
-          "count": 6
-        },
+        "item": "minecraft:glowstone_dust",
+        "qty": 6,
         "next-objective": 3
       }
     },
@@ -94,10 +90,8 @@
       "type": "minecolonies:delivery",
       "details": {
         "target": 0,
-        "item": {
-          "id": "minecraft:paper",
-          "count": 2
-        },
+        "item": "minecraft:paper",
+        "qty": 2,
         "next-objective": 4
       }
     },
@@ -201,37 +195,29 @@
     {
       "type": "minecolonies:item",
       "details": {
-        "item": {
-          "id": "minecolonies:scroll_highlight",
-          "count": 5
-        }
+        "item": "minecolonies:scroll_highlight",
+        "qty": 5
       }
     },
     {
       "type": "minecolonies:item",
       "details": {
-        "item": {
-          "id": "minecolonies:scroll_tp",
-          "count": 3
-        }
+        "item": "minecolonies:scroll_tp",
+        "qty": 3
       }
     },
     {
       "type": "minecolonies:item",
       "details": {
-        "item": {
-          "id": "minecraft:glowstone_dust",
-          "count": 6
-        }
+        "item": "minecraft:glowstone_dust",
+        "qty": 6
       }
     },
     {
       "type": "minecolonies:item",
       "details": {
-        "item": {
-          "id": "minecraft:paper",
-          "count": 2
-        }
+        "item": "minecraft:paper",
+        "qty": 2
       }
     },
     {


### PR DESCRIPTION
The 5 Enchanter scroll quests added in #11650 use the 1.21.1 quest JSON format (item as an ItemStack object {id,count}, potion data via item components). On 1.20.1 the delivery and item-reward parsers expect a string item id plus a separate "qty" int (and SNBT "nbt" for potions), so each quest failed to load with a NullPointerException on the missing "qty" field ("Skipping quest ... due to parsing error").

Convert the delivery objectives and item rewards to the 1.20.1 format:
  - "item": {"id":X,"count":N}  ->  "item": "X", "qty": N
  - luck potion components       ->  "nbt": "{Potion:\"minecraft:luck\"}"

Dialogue, triggers, and happiness rewards are unchanged.

# Checklist
- [x] I have read and accept the Contributing Guidelines
- [x] I have tested and confirmed my changes are working on the most recent commit of this pull request
<!--
When using AI we require you to confirm the points in this readme.
Please state in which parts of the code AI was used.
-->
- [x] I have used AI in the creation of this pull request
Yes, I made Claude set up the branch cause git and I still aren't real comfortable with each other and I don't want to assplode things

# Changes proposed in this pull request
STOOPID MOJANG can't be assed to not change basic things (like how items are listed) across versions.
REEEEEEEEEEEEEEEEEEEEEEEE

So this is a fix for the 1.20 version

Review please
