### PR TITLE
Fix/water stuff

### DIFF
--- a/src/datagen/generated/minecolonies/data/minecolonies/tags/block/decoblocks.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/tags/block/decoblocks.json
@@ -12,10 +12,14 @@
     "minecraft:tube_coral_block",
     "minecraft:bell",
     "minecraft:lantern",
+    "minecraft:farmland",
+    "minecraft:sugar_cane",
+    "minecraft:cactus",
     "minecolonies:gate_wood",
     "minecolonies:gate_iron",
     "#minecraft:banners",
     "#minecraft:signs",
-    "#minecraft:campfires"
+    "#minecraft:campfires",
+    "#minecraft:flowers"
   ]
 }

--- a/src/datagen/generated/minecolonies/data/minecolonies/tags/block/decoblocks.json
+++ b/src/datagen/generated/minecolonies/data/minecolonies/tags/block/decoblocks.json
@@ -15,11 +15,27 @@
     "minecraft:farmland",
     "minecraft:sugar_cane",
     "minecraft:cactus",
+    "minecolonies:bell_pepper",
+    "minecolonies:cabbage",
+    "minecolonies:chickpea",
+    "minecolonies:durum",
+    "minecolonies:eggplant",
+    "minecolonies:garlic",
+    "minecolonies:onion",
+    "minecolonies:soybean",
+    "minecolonies:tomato",
+    "minecolonies:rice",
+    "minecolonies:corn",
+    "minecolonies:nether_pepper",
+    "minecolonies:peas",
+    "minecolonies:mint",
+    "minecolonies:butternut_squash",
     "minecolonies:gate_wood",
     "minecolonies:gate_iron",
     "#minecraft:banners",
     "#minecraft:signs",
     "#minecraft:campfires",
-    "#minecraft:flowers"
+    "#minecraft:flowers",
+    "#minecraft:crops"
   ]
 }

--- a/src/main/java/com/minecolonies/api/util/BlockStateUtils.java
+++ b/src/main/java/com/minecolonies/api/util/BlockStateUtils.java
@@ -184,4 +184,43 @@ public class BlockStateUtils
         }
         return true;
     }
+
+    /**
+     * Copy the specified properties from the source to the target, leaving other properties on target untouched.
+     * Safe to call when the given properties don't exist on either.
+     * @param target     the block state to copy properties onto.
+     * @param source     the block state to copy properties from.
+     * @param properties the properties to be copied (if they exist).
+     * @return the target block state with the specified properties copied from the source.
+     */
+    public static BlockState copyProperties(
+        @NotNull final BlockState target,
+        @NotNull final BlockState source,
+        @NotNull final Property<?>... properties)
+    {
+        BlockState result = target;
+        for (final Property<?> property : properties)
+        {
+            result = copyProperty(result, source, property);
+        }
+        return result;
+    }
+
+    /**
+     * Copy the specified property from the source to the target, leaving other properties on target untouched.
+     * Safe to call when the given properties don't exist on either.
+     * @param target     the block state to copy properties onto.
+     * @param source     the block state to copy properties from.
+     * @param property   the property to be copied (if it exists).
+     * @return the target block state with the specified properties copied from the source.
+     */
+    public static <T extends Comparable<T>> BlockState copyProperty(
+        @NotNull final BlockState target,
+        @NotNull final BlockState source,
+        @NotNull final Property<T> property)
+    {
+        return source.hasProperty(property)
+            ? target.trySetValue(property, source.getValue(property))
+            : target;
+    }
 }

--- a/src/main/java/com/minecolonies/core/entity/ai/workers/AbstractEntityAIStructure.java
+++ b/src/main/java/com/minecolonies/core/entity/ai/workers/AbstractEntityAIStructure.java
@@ -312,7 +312,15 @@ public abstract class AbstractEntityAIStructure<J extends AbstractJobStructure<?
      */
     protected static boolean isDecoItem(BlockState block)
     {
-        return block.is(ModTags.decorationItems) || block.getBlock() instanceof BlockFluidSubstitution || !block.getFluidState().isEmpty();
+        return block.is(ModTags.decorationItems);
+    }
+
+    /**
+     * Checks for blocks that need to be treated as fluids
+     */
+    protected static boolean isFluidItem(BlockState block)
+    {
+        return block.getBlock() instanceof BlockFluidSubstitution || !block.getFluidState().isEmpty();
     }
 
     /**
@@ -392,6 +400,11 @@ public abstract class AbstractEntityAIStructure<J extends AbstractJobStructure<?
                                                          !(info.getBlockInfo().getState().getBlock() instanceof AirBlock)
                                                            || (handler.getWorld().isEmptyBlock(pos))
                                                            || DONT_TOUCH_PREDICATE.test(info, pos, handler)), false);
+                break;
+            case BUILD_WATER:
+                // build fluids
+                result = placer.executeStructureStep(world, null, progress, StructurePlacer.Operation.BLOCK_PLACEMENT,
+                    () -> placer.getIterator().increment(this::skipFluid), false);
                 break;
             case DECORATE:
                 // not solid
@@ -546,6 +559,20 @@ public abstract class AbstractEntityAIStructure<J extends AbstractJobStructure<?
     }
 
     /**
+     * Checks which blocks are skipped on fluids
+     *
+     * @param info
+     * @param pos
+     * @param handler
+     * @return
+     */
+    private boolean skipFluid(final BlueprintPositionInfo info, final BlockPos pos, final IStructureHandler handler)
+    {
+        final BlockState blockInfoState = info.getBlockInfo().getState();
+        return !isFluidItem(blockInfoState) || DONT_TOUCH_PREDICATE.test(info, pos, handler);
+    }
+
+    /**
      * Checks wich blocks are skipped on building
      *
      * @param info
@@ -558,6 +585,7 @@ public abstract class AbstractEntityAIStructure<J extends AbstractJobStructure<?
         final BlockState blockInfoState = info.getBlockInfo().getState();
         return !BlockUtils.canBlockFloatInAir(blockInfoState)
                  || isDecoItem(blockInfoState)
+                 || isFluidItem(blockInfoState)
                  || DONT_TOUCH_PREDICATE.test(info, pos, handler);
     }
 
@@ -705,15 +733,15 @@ public abstract class AbstractEntityAIStructure<J extends AbstractJobStructure<?
             {
                 structure = new BuildingStructureHandler<>(world,
                     workOrder,
-                    this, new BuildingProgressStage[] {BUILD_SOLID, WEAK_SOLID, CLEAR_WATER, CLEAR_NON_SOLIDS, DECORATE, SPAWN});
-                building.setTotalStages(5);
+                    this, new BuildingProgressStage[] {BUILD_SOLID, WEAK_SOLID, CLEAR_WATER, CLEAR_NON_SOLIDS, BUILD_WATER, DECORATE, SPAWN});
+                building.setTotalStages(6);
             }
             else
             {
                 structure = new BuildingStructureHandler<>(world,
                     workOrder,
-                    this, new BuildingProgressStage[] {CLEAR, BUILD_SOLID, WEAK_SOLID, CLEAR_WATER, CLEAR_NON_SOLIDS, DECORATE, SPAWN});
-                building.setTotalStages(6);
+                    this, new BuildingProgressStage[] {CLEAR, BUILD_SOLID, WEAK_SOLID, CLEAR_WATER, CLEAR_NON_SOLIDS, BUILD_WATER, DECORATE, SPAWN});
+                building.setTotalStages(7);
             }
 
             setStructurePlacer(structure);

--- a/src/main/java/com/minecolonies/core/entity/ai/workers/production/EntityAIQuarrier.java
+++ b/src/main/java/com/minecolonies/core/entity/ai/workers/production/EntityAIQuarrier.java
@@ -229,8 +229,8 @@ public class EntityAIQuarrier extends AbstractEntityAIStructureWithWorkOrder<Job
             final BuildingStructureHandler<JobQuarrier, BuildingMiner> structure;
             structure = new BuildingStructureHandler<>(world,
                 workOrder,
-                this, new BuildingProgressStage[] {BUILD_SOLID, DECORATE, CLEAR});
-            building.setTotalStages(3);
+                this, new BuildingProgressStage[] {BUILD_SOLID, BUILD_WATER, DECORATE, CLEAR});
+            building.setTotalStages(4);
 
             if (!structure.hasBluePrint())
             {

--- a/src/main/java/com/minecolonies/core/entity/ai/workers/util/BuildingProgressStage.java
+++ b/src/main/java/com/minecolonies/core/entity/ai/workers/util/BuildingProgressStage.java
@@ -14,4 +14,5 @@ public enum BuildingProgressStage
     REMOVE,
     REMOVE_WATER,
     WEAK_SOLID,
+    BUILD_WATER,
 }

--- a/src/main/java/com/minecolonies/core/generation/defaults/DefaultBlockTagsProvider.java
+++ b/src/main/java/com/minecolonies/core/generation/defaults/DefaultBlockTagsProvider.java
@@ -45,11 +45,15 @@ public class DefaultBlockTagsProvider extends BlockTagsProvider
                 .add(Blocks.TUBE_CORAL_BLOCK)
                 .add(Blocks.BELL)
                 .add(Blocks.LANTERN)
+                .add(Blocks.FARMLAND)
+                .add(Blocks.SUGAR_CANE)
+                .add(Blocks.CACTUS)
                 .add(ModBlocks.blockWoodenGate)
                 .add(ModBlocks.blockIronGate)
                 .addTag(BlockTags.BANNERS)
                 .addTag(BlockTags.SIGNS)
-                .addTag(BlockTags.CAMPFIRES);
+                .addTag(BlockTags.CAMPFIRES)
+                .addTag(BlockTags.FLOWERS);
 
         // these tags only exist for backwards compatibility and could be removed in a future Minecraft version
         tag(ModTags.concreteBlocks).addTag(Tags.Blocks.CONCRETES);

--- a/src/main/java/com/minecolonies/core/generation/defaults/DefaultBlockTagsProvider.java
+++ b/src/main/java/com/minecolonies/core/generation/defaults/DefaultBlockTagsProvider.java
@@ -48,12 +48,14 @@ public class DefaultBlockTagsProvider extends BlockTagsProvider
                 .add(Blocks.FARMLAND)
                 .add(Blocks.SUGAR_CANE)
                 .add(Blocks.CACTUS)
+                .add(ModBlocks.getCrops())
                 .add(ModBlocks.blockWoodenGate)
                 .add(ModBlocks.blockIronGate)
                 .addTag(BlockTags.BANNERS)
                 .addTag(BlockTags.SIGNS)
                 .addTag(BlockTags.CAMPFIRES)
-                .addTag(BlockTags.FLOWERS);
+                .addTag(BlockTags.FLOWERS)
+                .addTag(BlockTags.CROPS);
 
         // these tags only exist for backwards compatibility and could be removed in a future Minecraft version
         tag(ModTags.concreteBlocks).addTag(Tags.Blocks.CONCRETES);

--- a/src/main/java/com/minecolonies/core/placementhandlers/GeneralBlockPlacementHandler.java
+++ b/src/main/java/com/minecolonies/core/placementhandlers/GeneralBlockPlacementHandler.java
@@ -7,6 +7,7 @@ import com.ldtteam.structurize.placement.IPlacementContext;
 import com.ldtteam.structurize.placement.handlers.placement.IPlacementHandler;
 import com.ldtteam.structurize.util.BlockUtils;
 import com.minecolonies.api.compatibility.candb.ChiselAndBitsCheck;
+import com.minecolonies.api.util.BlockStateUtils;
 import com.minecolonies.api.util.Log;
 import com.minecolonies.api.util.WorldUtil;
 import net.minecraft.core.BlockPos;
@@ -17,12 +18,10 @@ import net.minecraft.world.InteractionHand;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.context.BlockPlaceContext;
 import net.minecraft.world.level.Level;
-import net.minecraft.world.level.block.FenceBlock;
-import net.minecraft.world.level.block.FenceGateBlock;
-import net.minecraft.world.level.block.IronBarsBlock;
-import net.minecraft.world.level.block.WallBlock;
+import net.minecraft.world.level.block.*;
 import net.minecraft.world.level.block.entity.BlockEntity;
 import net.minecraft.world.level.block.state.BlockState;
+import net.minecraft.world.level.block.state.properties.BlockStateProperties;
 import net.minecraft.world.phys.BlockHitResult;
 import net.minecraft.world.phys.Vec3;
 import org.jetbrains.annotations.NotNull;
@@ -59,7 +58,17 @@ public class GeneralBlockPlacementHandler implements IPlacementHandler
                     new BlockHitResult(new Vec3(0, 0, 0), Direction.DOWN, pos, true)));
                 if (tempState != null)
                 {
-                    placementState = tempState;
+                    placementState = BlockStateUtils.copyProperties(placementState, tempState,
+                        BlockStateProperties.UP,
+                        BlockStateProperties.NORTH,
+                        BlockStateProperties.NORTH_WALL,
+                        BlockStateProperties.EAST,
+                        BlockStateProperties.EAST_WALL,
+                        BlockStateProperties.SOUTH,
+                        BlockStateProperties.SOUTH_WALL,
+                        BlockStateProperties.WEST,
+                        BlockStateProperties.WEST_WALL,
+                        PillarBlock.COLUMN);
                 }
             }
             catch (final Exception ex)


### PR DESCRIPTION
# Checklist
- [x] I have read and accept the Contributing Guidelines
- [x] I have tested and confirmed my changes are working on the most recent commit of this pull request
<!--
When using AI we require you to confirm the points in this readme.
Please state in which parts of the code AI was used.
-->
- [ ] I have used AI in the creation of this pull request

# Related issues
Closes [discord issue](https://discord.com/channels/472875599422291968/1520258678899478698/1520258678899478698)
Closes [discord issue](https://discord.com/channels/139070364159311872/724810019928801290/1520260849636216943)

# Changes proposed in this pull request
- Fixes an unrelated bug where fences and walls didn't get placed waterlogged even when the blueprint said they should.
- Adds a new intermediate build stage to let all water and waterlogged blocks be placed strictly after normal blocks but before decorative blocks, regardless of location.
- Moves farmland and sugarcane to decorative placement since they're water-dependent, and also flowers and crops just because that makes sense.

WARNING: since this adds a build stage it might break work orders already in progress at the DECORATE stage or higher.  They should just need to be restarted or repaired to recover.

Review please (do not port... yet)