### PR TITLE
Citizens don't choose to eat poisoned food

### DIFF
--- a/src/main/java/com/minecolonies/api/util/FoodUtils.java
+++ b/src/main/java/com/minecolonies/api/util/FoodUtils.java
@@ -10,6 +10,7 @@ import com.minecolonies.api.items.IMinecoloniesFoodItem;
 import com.minecolonies.core.colony.buildings.workerbuildings.BuildingCook;
 import com.minecolonies.core.items.ItemCrop;
 import com.minecolonies.core.tileentities.TileEntityRack;
+import com.minecolonies.api.items.ModTags;
 import net.minecraft.core.BlockPos;
 import net.minecraft.world.food.FoodProperties;
 import net.minecraft.world.item.Item;
@@ -41,7 +42,7 @@ public class FoodUtils
      */
     public static boolean canEat(final ItemStack stack, final IBuilding homeBuilding, final IBuilding workBuilding)
     {
-        if (!EDIBLE.test(stack))
+        if (!EDIBLE.test(stack) || stack.is(ModTags.poisonous_food))
         {
             return false;
         }


### PR DESCRIPTION
# Checklist
- [X] I have read and accept the Contributing Guidelines
- [X] I have tested and confirmed my changes are working on the most recent commit of this pull request
<!--
When using AI we require you to confirm the points in this readme.
Please state in which parts of the code AI was used.
-->
- [ ] I have used AI in the creation of this pull request

# Related issues
Closes - None

# Changes proposed in this pull request
- Citizens will no longer choose to eat poisoned food in their inventory.
- They can still be force-fed poisoned food (as before)

Review please
