### PR TITLE
Stats clearing

### DIFF
--- a/src/main/java/com/minecolonies/api/util/constant/translation/CommandTranslationConstants.java
+++ b/src/main/java/com/minecolonies/api/util/constant/translation/CommandTranslationConstants.java
@@ -109,6 +109,9 @@ public class CommandTranslationConstants
     public static final String COMMAND_COLONY_EXPORT_SUCCESS                 = "com.minecolonies.command.export.success";
     @NonNls
     public static final String COMMAND_COLONY_LOAD_BACKUP_SUCCESS            = "com.minecolonies.command.loadbackup.success";
+    /** Translation key for a successful colony statistics reset. */
+    @NonNls
+    public static final String COMMAND_COLONY_RESET_STATS_SUCCESS            = "com.minecolonies.command.resetstats.success";
     @NonNls
     public static final String COMMAND_RAID_NOW_SUCCESS                      = "com.minecolonies.command.raidnow.success";
     @NonNls

--- a/src/main/java/com/minecolonies/core/client/gui/modules/building/WindowStatsModule.java
+++ b/src/main/java/com/minecolonies/core/client/gui/modules/building/WindowStatsModule.java
@@ -76,7 +76,7 @@ public class WindowStatsModule extends AbstractModuleWindow<BuildingStatisticsMo
      * within the filtered interval should be hidden.
      * Useful on buildings with a high number of stats (like the builder).
      */
-    private boolean hideZeroStats = false;
+    private boolean hideZeroStats = true;
 
     /**
      * Constructor for the window of the miner hut.

--- a/src/main/java/com/minecolonies/core/colony/managers/StatisticsManager.java
+++ b/src/main/java/com/minecolonies/core/colony/managers/StatisticsManager.java
@@ -97,8 +97,8 @@ public class StatisticsManager implements IStatisticsManager
     @Override
     public void clear()
     {
+        dirtyStats.addAll(stats.keySet());
         stats.clear();
-        dirtyStats = new HashSet<>();
     }
 
     @Override
@@ -125,9 +125,15 @@ public class StatisticsManager implements IStatisticsManager
         {
             for (final String id : dirtyStats)
             {
-                var dataEntry = stats.get(id);
+                final Int2IntLinkedOpenHashMap dataEntry = stats.get(id);
 
                 buf.writeUtf(id);
+                if (dataEntry == null)
+                {
+                    buf.writeVarInt(0);
+                    continue;
+                }
+
                 buf.writeVarInt(1);
                 buf.writeVarInt(dataEntry.lastIntKey());
                 buf.writeVarInt(dataEntry.get(dataEntry.lastIntKey()));
@@ -154,6 +160,12 @@ public class StatisticsManager implements IStatisticsManager
         {
             final String id = buf.readUtf();
             final int statEntrySize = buf.readVarInt();
+
+            if (!fullSync && statEntrySize == 0)
+            {
+                stats.remove(id);
+                continue;
+            }
 
             final Int2IntLinkedOpenHashMap statValues = (fullSync || !stats.containsKey(id)) ? new Int2IntLinkedOpenHashMap(statEntrySize) : stats.get(id);
             for (int j = 0; j < statEntrySize; j++)

--- a/src/main/java/com/minecolonies/core/commands/EntryPoint.java
+++ b/src/main/java/com/minecolonies/core/commands/EntryPoint.java
@@ -57,6 +57,7 @@ public class EntryPoint
             .addNode(new CommandLoadAllBackups().build())
             .addNode(new CommandColonyInfo().build())
             .addNode(new CommandColonyPrintStats().build())
+            .addNode(new CommandColonyResetStats().build())
             .addNode(new CommandColonyRaidsInfo().build())
             .addNode(new CommandColonyChunks().build())
             .addNode(new CommandRSReset().build())

--- a/src/main/java/com/minecolonies/core/commands/colonycommands/CommandColonyResetStats.java
+++ b/src/main/java/com/minecolonies/core/commands/colonycommands/CommandColonyResetStats.java
@@ -1,0 +1,83 @@
+package com.minecolonies.core.commands.colonycommands;
+
+import com.minecolonies.api.colony.IColony;
+import com.minecolonies.api.colony.buildings.IBuilding;
+import com.minecolonies.core.colony.buildings.modules.BuildingStatisticsModule;
+import com.minecolonies.core.commands.arguments.ColonyIdArgument;
+import com.minecolonies.core.commands.commandTypes.IMCCommand;
+import com.minecolonies.core.commands.commandTypes.IMCOPCommand;
+import com.mojang.brigadier.builder.LiteralArgumentBuilder;
+import com.mojang.brigadier.context.CommandContext;
+import net.minecraft.commands.CommandSourceStack;
+import net.minecraft.network.chat.Component;
+
+import static com.minecolonies.api.util.constant.translation.CommandTranslationConstants.COMMAND_COLONY_RESET_STATS_SUCCESS;
+import static com.minecolonies.core.commands.CommandArgumentNames.COLONYID_ARG;
+
+/**
+ * Command to reset all colony and building statistics for a colony.
+ */
+public class CommandColonyResetStats implements IMCOPCommand
+{
+    /**
+     * Clears the colony-wide statistics and all statistics stored by the colony's building modules.
+     *
+     * @param context the command execution context.
+     * @return {@code 1} when the statistics were successfully reset.
+     */
+    @Override
+    public int onExecute(final CommandContext<CommandSourceStack> context)
+    {
+        final IColony colony = ColonyIdArgument.getColony(context, COLONYID_ARG);
+        colony.getStatisticsManager().clear();
+
+        int buildingCount = 0;
+        for (final IBuilding building : colony.getServerBuildingManager().getBuildings().values())
+        {
+            boolean clearedBuildingStats = false;
+            for (final var module : building.getModules())
+            {
+                if (module instanceof BuildingStatisticsModule statisticsModule)
+                {
+                    statisticsModule.getBuildingStatisticsManager().clear();
+                    clearedBuildingStats = true;
+                }
+            }
+
+            if (clearedBuildingStats)
+            {
+                building.markDirty();
+                buildingCount++;
+            }
+        }
+
+        colony.markDirty();
+        final int clearedBuildingCount = buildingCount;
+        context.getSource().sendSuccess(
+          () -> Component.translatable(COMMAND_COLONY_RESET_STATS_SUCCESS, colony.getID(), colony.getName(), clearedBuildingCount), true);
+        return 1;
+    }
+
+    /**
+     * Gets the literal name used to register this command.
+     *
+     * @return the command name.
+     */
+    @Override
+    public String getName()
+    {
+        return "resetStats";
+    }
+
+    /**
+     * Builds the command with its required colony selector argument.
+     *
+     * @return the command builder.
+     */
+    @Override
+    public LiteralArgumentBuilder<CommandSourceStack> build()
+    {
+        return IMCCommand.newLiteral(getName())
+                 .then(IMCCommand.newArgument(COLONYID_ARG, ColonyIdArgument.id()).executes(this::checkPreConditionAndExecute));
+    }
+}

--- a/src/main/resources/assets/minecolonies/gui/layouthuts/layoutstatsmodule.xml
+++ b/src/main/resources/assets/minecolonies/gui/layouthuts/layoutstatsmodule.xml
@@ -20,7 +20,7 @@
         <text size="105 11" pos="20 220" textalign="MIDDLE_RIGHT" color="black"
             label="$(com.minecolonies.core.gui.modules.stats.hidezerolabel)"/>
         <button id="hidezero" pos="127 218" size="14 15"
-                        source="minecolonies:textures/gui/builderhut/builder_button_mini.png"
+                        source="minecolonies:textures/gui/builderhut/builder_button_mini_check.png"
                         disabled="minecolonies:textures/gui/builderhut/builder_button_mini_disabled.png"/>
     </view>
 </window>

--- a/src/main/resources/assets/minecolonies/lang/manual_en_us.json
+++ b/src/main/resources/assets/minecolonies/lang/manual_en_us.json
@@ -436,6 +436,7 @@
   "com.minecolonies.command.deleteable.success": "Changed deletable flag of colony ID %s. It is now set to %s.",
   "com.minecolonies.command.rsreset.success": "The request system for colony %s has been restarted in 1.618 seconds.",
   "com.minecolonies.command.rsresetall.success": "The request systems for all colonies have been restarted in 1.618 seconds.",
+  "com.minecolonies.command.resetstats.success": "Reset all statistics for colony %s (%s), including statistics for %s buildings.",
 
   "com.minecolonies.command.citizeninfo.desc": "§2ID: §f %d §2 Name: §f %s",
   "com.minecolonies.command.citizeninfo.skills": "§2Athletics: §f%s §2Dexterity: §f%s §2Strength: §f%s\n§2Agility: §f%s §2Stamina: §f%s §2Mana: §f%s\n§2Adaptability: §f%s §2Focus: §f%s §2Creativity: §f%s\n§2Knowledge: §f%s §2Intelligence: §f%s",


### PR DESCRIPTION
# Checklist
- [X] I have read and accept the Contributing Guidelines
- [X] I have tested and confirmed my changes are working on the most recent commit of this pull request
<!--
When using AI we require you to confirm the points in this readme.
Please state in which parts of the code AI was used.
-->
- [X] I have used AI in the creation of this pull request
- AI was used to review code changes and troubleshoot sync problems with clearing the manager.

# Related issues
Closes None

# Changes proposed in this pull request
- Introduce a command to clear colony statistics. This is primarily to support use of building and colony stats in testing.  Stats can be cleared at a particular point in testing, and all stats from that point forward are clearly associated with the code corresponding with that state.
- Defaulted "hide zero stats" button to true.

Review please
