### PR TITLE
Fix remote breeding

### DIFF
--- a/src/main/java/com/minecolonies/core/entity/ai/workers/production/herders/AbstractEntityAIHerder.java
+++ b/src/main/java/com/minecolonies/core/entity/ai/workers/production/herders/AbstractEntityAIHerder.java
@@ -645,7 +645,7 @@ public abstract class AbstractEntityAIHerder<J extends AbstractJob<?, J>, B exte
             {
                 it.remove();
             }
-            else if (!walkingToAnimal(animal))
+            else if (walkingToAnimal(animal))
             {
                 break;
             }


### PR DESCRIPTION
# Checklist
- [X] I have read and accept the Contributing Guidelines
- [X] I have tested and confirmed my changes are working on the most recent commit of this pull request
<!--
When using AI we require you to confirm the points in this readme.
Please state in which parts of the code AI was used.
-->
- [ ] I have used AI in the creation of this pull request

# Related issues
Closes None - observed behavior when working on add-on mod breeding behavior.

# Changes proposed in this pull request
- Currently the herders do "remote breeding" - rather than walking to the animal to feed the breeding item, they do it from the hut.  This is because the AbstractEntityAIHerder.breedTwoAnimals() had inverted the walkingToAnimal() check.

This PR fixes this.

# Testing
Before: Re-confirmed observation of "remote breeding" by observing the herder standing at the hut while breeding animations took place in the pasture.
After: Confirmed breeder walks to both animals before triggering the breeding activities.

Review please
