### PR TITLE
Fixes

### DIFF
--- a/src/main/java/com/minecolonies/api/configuration/ServerConfiguration.java
+++ b/src/main/java/com/minecolonies/api/configuration/ServerConfiguration.java
@@ -169,14 +169,14 @@ public class ServerConfiguration extends AbstractConfiguration
 
         swapToCategory(builder, "combat");
 
-        enableColonyRaids = defineBoolean(builder, "dobarbariansspawn", true);
-        raidDifficulty = defineInteger(builder, "barbarianhordedifficulty", DEFAULT_BARBARIAN_DIFFICULTY, MIN_BARBARIAN_DIFFICULTY, MAX_BARBARIAN_DIFFICULTY);
-        maxRaiders = defineInteger(builder, "maxBarbarianSize", 80, MIN_BARBARIAN_HORDE_SIZE, MAX_BARBARIAN_HORDE_SIZE);
-        raidersbreakblocks = defineBoolean(builder, "dobarbariansbreakthroughwalls", true);
+        enableColonyRaids = defineBoolean(builder, "enablecolonyraids", true);
+        raidDifficulty = defineInteger(builder, "raidDifficulty", DEFAULT_BARBARIAN_DIFFICULTY, MIN_BARBARIAN_DIFFICULTY, MAX_BARBARIAN_DIFFICULTY);
+        maxRaiders = defineInteger(builder, "maxRaiders", 80, MIN_BARBARIAN_HORDE_SIZE, MAX_BARBARIAN_HORDE_SIZE);
+        raidersbreakblocks = defineBoolean(builder, "raidersbreakblocks", true);
         averageNumberOfNightsBetweenRaids = defineInteger(builder, "averagenumberofnightsbetweenraids", 14, 1, 50);
         minimumNumberOfNightsBetweenRaids = defineInteger(builder, "minimumnumberofnightsbetweenraids", 10, 1, 30);
         mobAttackCitizens = defineBoolean(builder, "mobattackcitizens", true);
-        raidersbreakdoors = defineBoolean(builder, "shouldraiderbreakdoors", true);
+        raidersbreakdoors = defineBoolean(builder, "raidersbreakdoors", true);
         guardDamageMultiplier = defineDouble(builder, "guardDamageMultiplier", 1.0, 0.1, 15.0);
         guardHealthMult = defineDouble(builder, "guardhealthmult", 1.0, 0.1, 5.0);
         pvp_mode = defineBoolean(builder, "pvp_mode", false);

--- a/src/main/java/com/minecolonies/core/client/gui/modules/RequestTreeWindowModule.java
+++ b/src/main/java/com/minecolonies/core/client/gui/modules/RequestTreeWindowModule.java
@@ -314,6 +314,11 @@ public abstract class RequestTreeWindowModule implements IWindowWithLayoutModule
     private void cancel(@NotNull final Button button)
     {
         final int row = resourceList.getListElementIndexByPane(button);
+        if (getCachedOpenRequests().isEmpty())
+        {
+            return;
+        }
+
         cancel(getCachedOpenRequests().get(row).request());
     }
 

--- a/src/main/java/com/minecolonies/core/event/EventHandler.java
+++ b/src/main/java/com/minecolonies/core/event/EventHandler.java
@@ -469,9 +469,9 @@ public class EventHandler
         if (event.getEntity() instanceof ServerPlayer)
         {
             final ServerPlayer player = (ServerPlayer) event.getEntity();
-            for (final IColony colony : IColonyManager.getInstance().getColonies(player.level()))
+            for (final IColony colony : IColonyManager.getInstance().getAllColonies())
             {
-                if (colony.getPermissions().getRank(player).isColonyManager())
+                if (colony.getWorld() != null && colony.getPermissions().getRank(player).isColonyManager())
                 {
                     colony.getPackageManager().addImportantColonyPlayer(player);
                     colony.getPackageManager().sendColonyViewPackets();

--- a/src/main/java/com/minecolonies/core/event/EventHandler.java
+++ b/src/main/java/com/minecolonies/core/event/EventHandler.java
@@ -469,7 +469,7 @@ public class EventHandler
         if (event.getEntity() instanceof ServerPlayer)
         {
             final ServerPlayer player = (ServerPlayer) event.getEntity();
-            for (final IColony colony : IColonyManager.getInstance().getAllColonies())
+            for (final IColony colony : IColonyManager.getInstance().getColonies(player.level()))
             {
                 if (colony.getPermissions().getRank(player).isColonyManager())
                 {

--- a/src/main/resources/assets/minecolonies/lang/manual_en_us.json
+++ b/src/main/resources/assets/minecolonies/lang/manual_en_us.json
@@ -56,7 +56,7 @@
   "minecolonies.config.forceloadcolony.comment": "If part of the colony is loaded by an owner/officer, should the colony be kept loaded? (Set how many chunks are loaded with the \"Colony Chunk Loading Strictness\" option.)",
 
   "minecolonies.config.loadtime": "Colony chunk loading duration",
-  "minecolonies.config.loadtime.comment": "Set how long chunks stay loaded after player leaves, does not persist through restarts. Default: 10min",
+  "minecolonies.config.loadtime.comment": "Set how long chunks stay loaded after player leaves, does not persist through restarts.",
 
   "minecolonies.config.colonyloadstrictness": "Colony Chunk Loading Strictness",
   "minecolonies.config.colonyloadstrictness.comment": "This controls how many chunks are loaded with the \"Chunk Load Colony\" option. The higher this value, the fewer chunks will be loaded. (The innermost chunks will be loaded first.) 1 = load all claimed chunks.",


### PR DESCRIPTION
Prevent crash when a colony is in a dynamically loaded world Fix config descriptions, using the wrong key.
Fix config description including default value twice. Prevent crash with the RequestTreeWindowModule with zero Requests left

# Checklist
- [x ] I have read and accept the Contributing Guidelines
- [ ] I have tested and confirmed my changes are working on the most recent commit of this pull request
<!--
When using AI we require you to confirm the points in this readme.
Please state in which parts of the code AI was used.
-->
- [ ] I have used AI in the creation of this pull request

# Related issues
Closes #11743
Closes #11793
Closes #11756

# Changes proposed in this pull request
- Prevent crash when a colony is in a dynamically loaded world
- Fix config descriptions, using the wrong key.
- Fix config description including default value twice.
- Prevent crash with the RequestTreeWindowModule with zero Requests left


Review please
