### PR TITLE
Make upgradeContainers agree with registerBlockPosition

### DIFF
--- a/src/main/java/com/minecolonies/core/colony/buildings/workerbuildings/BuildingWareHouse.java
+++ b/src/main/java/com/minecolonies/core/colony/buildings/workerbuildings/BuildingWareHouse.java
@@ -164,17 +164,23 @@ public class BuildingWareHouse extends AbstractBuilding implements IWareHouse
     @Override
     public void upgradeContainers(final Level world)
     {
-        if (getFirstModuleOccurance(WarehouseModule.class).getStorageUpgrade() < MAX_STORAGE_UPGRADE)
+        final WarehouseModule module = getFirstModuleOccurance(WarehouseModule.class);
+        if (module.getStorageUpgrade() < MAX_STORAGE_UPGRADE)
         {
+            module.incrementStorageUpgrade();
             for (final BlockPos pos : getContainers())
             {
                 final BlockEntity entity = world.getBlockEntity(pos);
                 if (entity instanceof TileEntityRack && !(entity instanceof TileEntityColonyBuilding))
                 {
-                    ((AbstractTileEntityRack) entity).upgradeRackSize();
+                    // Catch racks up to the storage upgrade level; one that missed an earlier
+                    // upgrade would otherwise stay short of slots until the hut is rebuilt.
+                    while (((AbstractTileEntityRack) entity).getUpgradeSize() < module.getStorageUpgrade())
+                    {
+                        ((AbstractTileEntityRack) entity).upgradeRackSize();
+                    }
                 }
             }
-            getFirstModuleOccurance(WarehouseModule.class).incrementStorageUpgrade();
         }
         markDirty();
     }


### PR DESCRIPTION
Hello, and thank you for maintaining this mod. I want to be upfront that this was investigated and written by an AI assistant (Claude) at my prompting, so please treat it as a suggestion rather than a finished patch, and review it critically.

This is a narrow consistency fix. I am not claiming it resolves any particular bug report.

### The inconsistency

`BuildingWareHouse` maintains the invariant "every rack in the warehouse sits at the current storage upgrade level" in two places, and they do not agree.

`registerBlockPosition` catches a rack up to the current level:

```java
while (((TileEntityRack) entity).getUpgradeSize() < getFirstModuleOccurance(WarehouseModule.class).getStorageUpgrade())
{
    ((TileEntityRack) entity).upgradeRackSize();
}
```

`upgradeContainers` instead steps each rack once, and advances the counter regardless of whether any given rack was actually reached:

```java
for (final BlockPos pos : getContainers())
{
    final BlockEntity entity = world.getBlockEntity(pos);
    if (entity instanceof TileEntityRack && !(entity instanceof TileEntityColonyBuilding))
    {
        ((AbstractTileEntityRack) entity).upgradeRackSize();
    }
}
getFirstModuleOccurance(WarehouseModule.class).incrementStorageUpgrade();
```

So if `world.getBlockEntity(pos)` does not resolve to a rack for one position, that rack is skipped while `storageUpgrade` still increments, and it is left 9 slots short with nothing to correct it later. The second form is self correcting and the first is not.

### Suggested change

Use the same catch up loop in `upgradeContainers`, and increment the counter first so it is the target. That is 9 insertions and 3 deletions in one method.

### Verification

The repository has no test source set enabled, so rather than change build configuration in this PR I have left the test out. I verified the change locally against a temporary JUnit test: with two racks, where one block entity does not resolve during the first storage upgrade and does during the second, the skipped rack ends at upgrade size 1 before the change and 2 after, in line with the counter. `./gradlew build` passes. I am glad to include that test if you would like the test source set turned on.