### PR TITLE
Persist rack size when a warehouse storage upgrade grows it

### DIFF
--- a/src/main/java/com/minecolonies/core/tileentities/TileEntityRack.java
+++ b/src/main/java/com/minecolonies/core/tileentities/TileEntityRack.java
@@ -281,6 +281,9 @@ public class TileEntityRack extends AbstractTileEntityRack implements IMateriall
         final BlockState state = level.getBlockState(worldPosition);
         level.sendBlockUpdated(worldPosition, state, state, 0x03);
         invalidateCap();
+        // Without this the enlarged rack is never written back, so the extra slots are
+        // lost on reload while the warehouse still counts the storage upgrade.
+        setChanged();
     }
 
     @Override


### PR DESCRIPTION
# Checklist
- [x] I have read and accept the [Contributing guidelines](https://github.com/ldtteam/.github/blob/master/CONTRIBUTING.md)
- [x] I have tested and confirmed my changes are working on the most recent commit of this pull request
<!--
When using AI we require you to confirm the points in this [Readme](https://github.com/ldtteam/.github/blob/master/CONTRIBUTING.md#ai-disclosure-policy).
Please state in which parts of the code AI was used.
-->
- [x] I have used AI in the creation of this pull request

To be upfront: AI (Claude) was used for all of this change, at my prompting. That covers finding the cause, the one added line in `TileEntityRack.upgradeRackSize()`, and this description. Please review it critically.

# Related issues
No existing issue. I looked and did not find one covering this.

This does not overlap with my other open pull request, which changes `upgradeContainers`. This one is only about persistence, and the two can be taken independently.

# Changes proposed in this pull request
- Call `setChanged()` at the end of `TileEntityRack.upgradeRackSize()`, so a rack that grows during a warehouse storage upgrade is actually written back.

`upgradeRackSize()` replaced the inventory and sent a block update, but never marked the block entity changed:

```java
        inventory = tempInventory;
        final BlockState state = level.getBlockState(worldPosition);
        level.sendBlockUpdated(worldPosition, state, state, 0x03);
        invalidateCap();
    }
```

Nothing flagged the chunk unsaved, and chunk saving skips chunks that are not marked unsaved, so the larger size existed only in memory. On reload the racks reverted to their previous size, while the storage upgrade counter in the colony data persisted normally. The warehouse then believes it is upgraded while its racks are back to the base slot count, so `searchMostEmptyRack` runs out of completely empty slots earlier than it should and reports the warehouse as full.

I think this may be behind the reports of a warehouse announcing that it is full while its racks still have room, where setting Repair Building restores it. A repair rebuilds the racks through `registerBlockPosition` and dirties those chunks as it places blocks, so that time the sizes survive.

Testing, on 1.21.1 with a level 5 warehouse holding 184 racks across six chunks. Before the change, storage upgrades persisted only in the single chunk holding the hut block, 18 racks, and the remaining 166 were back to the base size after a reload, including after a clean quit to title. With the change, all 184 racks in all six chunks kept their new size, and they were written during an ordinary autosave rather than needing a shutdown. I read the rack sizes back out of the region files directly rather than counting slots in the GUI, because a double rack shows both halves combined and is easy to misread.

Review please
