### PR TITLE
Add-On Mod Happiness Support

### DIFF
--- a/src/main/java/com/minecolonies/api/entity/citizen/happiness/HappinessRegistry.java
+++ b/src/main/java/com/minecolonies/api/entity/citizen/happiness/HappinessRegistry.java
@@ -10,6 +10,7 @@ import net.minecraft.resources.ResourceLocation;
 import net.minecraftforge.registries.IForgeRegistry;
 import net.minecraftforge.registries.RegistryObject;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 import java.util.function.Function;
 import java.util.function.Supplier;
@@ -69,33 +70,35 @@ public class HappinessRegistry
      * @param persist  whether we're reading from persisted data or from networking.
      * @return the modifier instance.
      */
+    @Nullable
     public static IHappinessModifier loadFrom(@NotNull final CompoundTag compound, final boolean persist)
     {
-        final ResourceLocation modifierType = compound.contains(NbtTagConstants.TAG_MODIFIER_TYPE)
-                                                ? new ResourceLocation(compound.getString(NbtTagConstants.TAG_MODIFIER_TYPE))
-                                                : new ResourceLocation(Constants.MOD_ID, "null");
-        final IHappinessModifier modifier = getHappinessTypeRegistry().getValue(modifierType).create();
-
-        if (modifier != null)
+        final ResourceLocation modifierType = ResourceLocation.tryParse(compound.getString(NbtTagConstants.TAG_MODIFIER_TYPE));
+        if (modifierType == null || !getHappinessTypeRegistry().containsKey(modifierType))
         {
-            try
+            Log.getLogger().warn("Unknown Happiness Modifier type '{}', its state cannot be restored.", modifierType);
+            return null;
+        }
+
+        try
+        {
+            final HappinessFactorTypeEntry entry = getHappinessTypeRegistry().getValue(modifierType);
+            final IHappinessModifier modifier = entry == null ? null : entry.create();
+            if (modifier == null)
             {
-                modifier.read(compound, persist);
-            }
-            catch (final RuntimeException ex)
-            {
-                Log.getLogger()
-                  .error(String.format("A Happiness Modifier %s has thrown an exception during loading, its state cannot be restored. Report this to the mod author",
-                    modifierType), ex);
+                Log.getLogger().warn("Happiness Modifier type '{}' has no usable factory, its state cannot be restored.", modifierType);
                 return null;
             }
-        }
-        else
-        {
-            Log.getLogger().warn(String.format("Unknown Happiness Modifier type '%s' or missing constructor of proper format.", modifierType));
-        }
 
-        return modifier;
+            modifier.read(compound, persist);
+            return modifier;
+        }
+        catch (final RuntimeException ex)
+        {
+            Log.getLogger().error("A Happiness Modifier of type '{}' has thrown an exception during loading, its state cannot be restored. Report this to the mod author.",
+              modifierType, ex);
+            return null;
+        }
     }
 
     /**
@@ -126,25 +129,35 @@ public class HappinessRegistry
         }
     }
 
-    public static ResourceLocation STATIC_MODIFIER      = new ResourceLocation(Constants.MOD_ID, "static");
-    public static ResourceLocation EXPIRATION_MODIFIER  = new ResourceLocation(Constants.MOD_ID, "expiration");
-    public static ResourceLocation TIME_PERIOD_MODIFIER = new ResourceLocation(Constants.MOD_ID, "time");
+    /**
+     * Registry ID for happiness modifier types.
+     */
+    public static final ResourceLocation HAPPINESS_FACTOR_TYPE_REGISTRY_ID = new ResourceLocation(Constants.MOD_ID, "happinessfactortypes");
+
+    /**
+     * Registry ID for happiness functions.
+     */
+    public static final ResourceLocation HAPPINESS_FUNCTION_REGISTRY_ID = new ResourceLocation(Constants.MOD_ID, "happinessfunction");
+
+    public static final ResourceLocation STATIC_MODIFIER      = new ResourceLocation(Constants.MOD_ID, "static");
+    public static final ResourceLocation EXPIRATION_MODIFIER  = new ResourceLocation(Constants.MOD_ID, "expiration");
+    public static final ResourceLocation TIME_PERIOD_MODIFIER = new ResourceLocation(Constants.MOD_ID, "time");
 
     public static RegistryObject<HappinessFactorTypeEntry> staticHappinessModifier;
     public static RegistryObject<HappinessFactorTypeEntry> expirationBasedHappinessModifier;
     public static RegistryObject<HappinessFactorTypeEntry> timeBasedHappinessModifier;
 
-    public static ResourceLocation SCHOOL_FUNCTION        = new ResourceLocation(Constants.MOD_ID, "school");
-    public static ResourceLocation SECURITY_FUNCTION      = new ResourceLocation(Constants.MOD_ID, "security");
-    public static ResourceLocation SOCIAL_FUNCTION        = new ResourceLocation(Constants.MOD_ID, "social");
-    public static ResourceLocation MYSTICAL_SITE_FUNCTION = new ResourceLocation(Constants.MOD_ID, "mystical");
+    public static final ResourceLocation SCHOOL_FUNCTION        = new ResourceLocation(Constants.MOD_ID, "school");
+    public static final ResourceLocation SECURITY_FUNCTION      = new ResourceLocation(Constants.MOD_ID, "security");
+    public static final ResourceLocation SOCIAL_FUNCTION        = new ResourceLocation(Constants.MOD_ID, "social");
+    public static final ResourceLocation MYSTICAL_SITE_FUNCTION = new ResourceLocation(Constants.MOD_ID, "mystical");
 
-    public static ResourceLocation HOUSING_FUNCTION      = new ResourceLocation(Constants.MOD_ID, "housing");
-    public static ResourceLocation UNEMPLOYMENT_FUNCTION = new ResourceLocation(Constants.MOD_ID, "unemployment");
-    public static ResourceLocation HEALTH_FUNCTION       = new ResourceLocation(Constants.MOD_ID, "health");
-    public static ResourceLocation IDLEATJOB_FUNCTION    = new ResourceLocation(Constants.MOD_ID, "idleatjob");
-    public static ResourceLocation SLEPTTONIGHT_FUNCTION = new ResourceLocation(Constants.MOD_ID, "slepttonight");
-    public static ResourceLocation FOOD_FUNCTION         = new ResourceLocation(Constants.MOD_ID, "food");
+    public static final ResourceLocation HOUSING_FUNCTION      = new ResourceLocation(Constants.MOD_ID, "housing");
+    public static final ResourceLocation UNEMPLOYMENT_FUNCTION = new ResourceLocation(Constants.MOD_ID, "unemployment");
+    public static final ResourceLocation HEALTH_FUNCTION       = new ResourceLocation(Constants.MOD_ID, "health");
+    public static final ResourceLocation IDLEATJOB_FUNCTION    = new ResourceLocation(Constants.MOD_ID, "idleatjob");
+    public static final ResourceLocation SLEPTTONIGHT_FUNCTION = new ResourceLocation(Constants.MOD_ID, "slepttonight");
+    public static final ResourceLocation FOOD_FUNCTION         = new ResourceLocation(Constants.MOD_ID, "food");
 
     public static RegistryObject<HappinessFunctionEntry> schoolFunction;
     public static RegistryObject<HappinessFunctionEntry> securityFunction;

--- a/src/main/java/com/minecolonies/api/util/constant/HappinessConstants.java
+++ b/src/main/java/com/minecolonies/api/util/constant/HappinessConstants.java
@@ -61,28 +61,6 @@ public final class HappinessConstants
     public static final String HADGREATFOOD     = "greatfood";
 
     /**
-     * Legacy list of MineColonies happiness modifier instance IDs.
-     *
-     * @deprecated Modifier reconstruction is validated through the happiness factor type registry instead.
-     */
-    @Deprecated
-    public static final Set<String> VALID_HAPPINESS_MODIFIERS = ImmutableSet.of(HOMELESSNESS,
-      UNEMPLOYMENT,
-      HEALTH,
-      IDLEATJOB,
-      SCHOOL,
-      MYSTICAL_SITE,
-      SECURITY,
-      SOCIAL,
-      DAMAGE,
-      DEATH,
-      RAIDWITHOUTDEATH,
-      SLEPTTONIGHT,
-      QUEST,
-      FOOD,
-      HADGREATFOOD);
-
-    /**
      * Private constructor to hide implicit public one.
      */
     private HappinessConstants()

--- a/src/main/java/com/minecolonies/api/util/constant/HappinessConstants.java
+++ b/src/main/java/com/minecolonies/api/util/constant/HappinessConstants.java
@@ -60,6 +60,12 @@ public final class HappinessConstants
     public static final String FOOD             = "food";
     public static final String HADGREATFOOD     = "greatfood";
 
+    /**
+     * Legacy list of MineColonies happiness modifier instance IDs.
+     *
+     * @deprecated Modifier reconstruction is validated through the happiness factor type registry instead.
+     */
+    @Deprecated
     public static final Set<String> VALID_HAPPINESS_MODIFIERS = ImmutableSet.of(HOMELESSNESS,
       UNEMPLOYMENT,
       HEALTH,

--- a/src/main/java/com/minecolonies/apiimp/CommonMinecoloniesAPIImpl.java
+++ b/src/main/java/com/minecolonies/apiimp/CommonMinecoloniesAPIImpl.java
@@ -313,13 +313,13 @@ public class CommonMinecoloniesAPIImpl implements IMinecoloniesAPI
                        .setIDRange(0, Integer.MAX_VALUE - 1), (b) -> questDialogueAnswerRegistry = b);
 
         event.create(new RegistryBuilder<HappinessRegistry.HappinessFactorTypeEntry>()
-                       .setName(new ResourceLocation(Constants.MOD_ID, "happinessfactortypes"))
+                       .setName(HappinessRegistry.HAPPINESS_FACTOR_TYPE_REGISTRY_ID)
                        .setDefaultKey(new ResourceLocation(Constants.MOD_ID, "null"))
                        .disableSaving().allowModification()
                        .setIDRange(0, Integer.MAX_VALUE - 1), (b) -> happinessFactorTypeRegistry = b);
 
         event.create(new RegistryBuilder<HappinessRegistry.HappinessFunctionEntry>()
-                       .setName(new ResourceLocation(Constants.MOD_ID, "happinessfunction"))
+                       .setName(HappinessRegistry.HAPPINESS_FUNCTION_REGISTRY_ID)
                        .setDefaultKey(new ResourceLocation(Constants.MOD_ID, "null"))
                        .disableSaving().allowModification()
                        .setIDRange(0, Integer.MAX_VALUE - 1), (b) -> happinessFunctionRegistry = b);

--- a/src/main/java/com/minecolonies/apiimp/initializer/ModHappinessFactorTypeInitializer.java
+++ b/src/main/java/com/minecolonies/apiimp/initializer/ModHappinessFactorTypeInitializer.java
@@ -8,7 +8,6 @@ import com.minecolonies.api.util.constant.Constants;
 import com.minecolonies.core.colony.jobs.AbstractJobGuard;
 import com.minecolonies.core.colony.jobs.JobPupil;
 import com.minecolonies.core.entity.citizen.citizenhandlers.CitizenHappinessHandler;
-import net.minecraft.resources.ResourceLocation;
 import net.minecraftforge.registries.DeferredRegister;
 
 import static com.minecolonies.api.entity.citizen.happiness.HappinessRegistry.*;
@@ -19,8 +18,8 @@ import static com.minecolonies.core.entity.citizen.citizenhandlers.CitizenHappin
  */
 public final class ModHappinessFactorTypeInitializer
 {
-    public final static DeferredRegister<HappinessFactorTypeEntry> DEFERRED_REGISTER_HAPPINESS_FACTOR = DeferredRegister.create(new ResourceLocation(Constants.MOD_ID, "happinessfactortypes"), Constants.MOD_ID);
-    public final static DeferredRegister<HappinessFunctionEntry> DEFERRED_REGISTER_HAPPINESS_FUNCTION = DeferredRegister.create(new ResourceLocation(Constants.MOD_ID, "happinessfunction"), Constants.MOD_ID);
+    public final static DeferredRegister<HappinessFactorTypeEntry> DEFERRED_REGISTER_HAPPINESS_FACTOR = DeferredRegister.create(HAPPINESS_FACTOR_TYPE_REGISTRY_ID, Constants.MOD_ID);
+    public final static DeferredRegister<HappinessFunctionEntry> DEFERRED_REGISTER_HAPPINESS_FUNCTION = DeferredRegister.create(HAPPINESS_FUNCTION_REGISTRY_ID, Constants.MOD_ID);
 
     private ModHappinessFactorTypeInitializer()
     {

--- a/src/main/java/com/minecolonies/core/entity/citizen/citizenhandlers/CitizenHappinessHandler.java
+++ b/src/main/java/com/minecolonies/core/entity/citizen/citizenhandlers/CitizenHappinessHandler.java
@@ -171,7 +171,7 @@ public class CitizenHappinessHandler implements ICitizenHappinessHandler
                 {
                     happinessFactors.get(id).read(compoundTag, persist);
                 }
-                else if (VALID_HAPPINESS_MODIFIERS.contains(id))
+                else
                 {
                     final IHappinessModifier modifier = HappinessRegistry.loadFrom(compoundTag, persist);
                     if (modifier != null)


### PR DESCRIPTION
# Checklist
- [X] I have read and accept the [Contributing guidelines](https://github.com/ldtteam/.github/blob/master/CONTRIBUTING.md)
- [X] I have tested and confirmed my changes are working on the most recent commit of this pull request
<!--
When using AI we require you to confirm the points in this [Readme](https://github.com/ldtteam/.github/blob/master/CONTRIBUTING.md#ai-disclosure-policy).
Please state in which parts of the code AI was used.
-->
- [X] I have used AI in the creation of this pull request
AI was used for analyzing the failure path of why my 3rd party happiness modifiers weren't working, and to review the corrections.

# Related issues
Closes None

# Changes proposed in this pull request
Happiness modifier deserialization was restricted by a hard-coded list of native modifier instance IDs. This changes the logic such that modifier reconstruction is now validated against the registered modifier type stored in the serialized data instead of the modifier’s instance ID.

## Before
When loading saved citizen data or synchronizing citizen data to a client, CitizenHappinessHandler only reconstructed a modifier when its instance ID appeared in VALID_HAPPINESS_MODIFIERS.

As a result, add-on mods could register custom happiness modifier types and functions, but could not successfully persist or synchronize modifier instances with add-on-defined IDs. These modifiers were discarded during deserialization and therefore could not reliably survive world reloads, reach clients, or appear in the existing happiness UI.

Unknown modifier types could also cause unsafe registry lookups during loading.

## After
Modifier reconstruction is now validated against the registered modifier type stored in the serialized data instead of the modifier’s instance ID.

This allows add-on mods to:
- Register custom happiness modifier types and happiness functions.
- Use their own modifier instance IDs.
- Persist custom modifiers across save and reload.
- Synchronize custom modifiers to clients.
- Display custom modifiers in the existing citizen happiness UI.
- Register against stable, public registry ID constants rather than duplicating MineColonies’ registry-name strings.

Missing, malformed, or broken modifier types are logged and safely skipped without interrupting the rest of citizen-data deserialization.

Preconstructed native modifiers continue to be updated in place, preserving runtime-only configuration such as their rollover predicates. The legacy VALID_HAPPINESS_MODIFIERS constant remains available for API compatibility but is deprecated and no longer controls reconstruction.

Review please
