### PR TITLE
Fix nearby building previews rotating differently from the goggles

### DIFF
--- a/src/main/java/com/minecolonies/core/client/render/worldevent/ColonyBlueprintRenderer.java
+++ b/src/main/java/com/minecolonies/core/client/render/worldevent/ColonyBlueprintRenderer.java
@@ -415,6 +415,15 @@ public class ColonyBlueprintRenderer
             final AABB blueprintAABB = AABB.encapsulatingFullBlocks(zeroPos, zeroPos.offset(blueprint.getSizeX() - 1, blueprint.getSizeY() - 1, blueprint.getSizeZ() - 1))
                     .inflate(2 + MinecoloniesAPIProxy.getInstance().getConfig().getClient().neighborbuildingrange.get());
 
+            final Map<BlockPos, RotationMirror> workOrderRotations = new HashMap<>();
+            for (final IWorkOrderView workOrder : ctx.nearestColony.getWorkOrders())
+            {
+                if (workOrder instanceof WorkOrderBuildingView)
+                {
+                    workOrderRotations.put(workOrder.getLocation(), workOrder.getRotationMirror());
+                }
+            }
+
             for (final IBuildingView buildingView : ctx.nearestColony.getClientBuildingManager().getBuildings().values())
             {
                 final BlockPos currentPosition = buildingView.getPosition();
@@ -435,7 +444,8 @@ public class ColonyBlueprintRenderer
                         schemPath = schemPath.substring(0, schemPath.length() - 1) + buildingView.getBuildingMaxLevel() + ".blueprint";
 
                         final String structurePack = buildingView.getStructurePack();
-                        final BlueprintCacheKey key = new BlueprintCacheKey(structurePack, schemPath, buildingView.getRotationMirror());
+                        final RotationMirror rotationMirror = workOrderRotations.getOrDefault(currentPosition, buildingView.getRotationMirror());
+                        final BlueprintCacheKey key = new BlueprintCacheKey(structurePack, schemPath, rotationMirror);
 
                         desired.put(currentPosition,
                             new PendingRenderData(key, currentPosition, 0,

--- a/src/main/java/com/minecolonies/core/tileentities/TileEntityColonyBuilding.java
+++ b/src/main/java/com/minecolonies/core/tileentities/TileEntityColonyBuilding.java
@@ -749,7 +749,8 @@ public class TileEntityColonyBuilding extends AbstractTileEntityColonyBuilding i
             return;
         }
 
-        final int structureRotation = structureState.getValue(AbstractBlockHut.FACING).get2DDataValue();
+        final Mirror mirror = rotationMirror == null ? Mirror.NONE : rotationMirror.mirror();
+        final int structureRotation = mirror.mirror(structureState.getValue(AbstractBlockHut.FACING)).get2DDataValue();
         final int worldRotation = level.getBlockState(this.getPosition()).getValue(AbstractBlockHut.FACING).get2DDataValue();
 
         final int rotation;
@@ -762,7 +763,7 @@ public class TileEntityColonyBuilding extends AbstractTileEntityColonyBuilding i
             rotation = 4 + worldRotation - structureRotation;
         }
 
-        rotationMirror = RotationMirror.of(Rotation.values()[rotation], rotationMirror == null ? Mirror.NONE : rotationMirror.mirror());
+        rotationMirror = RotationMirror.of(Rotation.values()[rotation], mirror);
         blueprint.setRotationMirror(rotationMirror, level);
     }
 


### PR DESCRIPTION
# Checklist
- [x] I have read and accept the [Contributing guidelines](https://github.com/ldtteam/.github/blob/master/CONTRIBUTING.md)
- [ ] I have tested and confirmed my changes are working on the most recent commit of this pull request
<!--
When using AI we require you to confirm the points in this [Readme](https://github.com/ldtteam/.github/blob/master/CONTRIBUTING.md#ai-disclosure-policy).
Please state in which parts of the code AI was used.
-->
- [x] I have used AI in the creation of this pull request

# Related issues
Same symptom as ldtteam/Structurize#609, which was closed without a fix.

# Changes proposed in this pull request
- With the build tool out, the preview of a nearby building could show a different rotation than the goggles show for the same building. The neighbour preview used the building view's rotation while the goggles use the work order's rotation, and the two can differ. The neighbour preview now uses the work order rotation when the building has one.
- `calcRotation` compared the world facing of the hut block against the unmirrored blueprint facing. The mirror is applied before the rotation, so mirrored huts whose hut block faces east or west ended up with a rotation that was 180 degrees off. It now mirrors the blueprint facing before comparing.

Review please
